### PR TITLE
Fix arcade assets and scripts

### DIFF
--- a/albini-qa/build/static/css/main.css
+++ b/albini-qa/build/static/css/main.css
@@ -1,0 +1,1 @@
+/* Albini QA placeholder */

--- a/albini-qa/build/static/js/main.js
+++ b/albini-qa/build/static/js/main.js
@@ -1,0 +1,1 @@
+console.log('Albini QA placeholder');

--- a/js/hockey-game.js
+++ b/js/hockey-game.js
@@ -3,6 +3,12 @@
 
 (function() {
   const canvas = document.getElementById('canucks-game');
+  if (!canvas || !canvas.getContext) {
+    console.warn('Game canvas not found');
+    const overlayEl = document.getElementById('game-overlay');
+    if (overlayEl) overlayEl.textContent = 'Game failed to load';
+    return;
+  }
   const ctx = canvas.getContext('2d');
   const scoreboardEl = document.getElementById('scoreboard');
   const overlay = document.getElementById('game-overlay');

--- a/js/piano-script.js
+++ b/js/piano-script.js
@@ -1,6 +1,10 @@
-document.addEventListener('DOMContentLoaded', (event) => {
+document.addEventListener('DOMContentLoaded', () => {
   const keys = ['C', 'D', 'E', 'F', 'G', 'A', 'B', 'C2'];
   const piano = document.getElementById('piano-container');
+
+  if (!piano) {
+    return;
+  }
 
   keys.forEach((key) => {
     let pianoKey = document.createElement('div');
@@ -15,4 +19,4 @@ document.addEventListener('DOMContentLoaded', (event) => {
     let audio = new Audio(`.wav`);
     audio.play();
   }
-})
+});

--- a/js/starfield.js
+++ b/js/starfield.js
@@ -36,7 +36,7 @@
       const k = 128.0 / s.z;
       const px = (s.x - width/2) * k + width/2;
       const py = (s.y - height/2) * k + height/2;
-      const size = (1 - s.z/width) * 3;
+      const size = Math.max((1 - s.z/width) * 3, 0);
       ctx.beginPath();
       ctx.fillStyle = `rgba(255,255,255,${s.o})`;
       ctx.arc(px, py, size, 0, Math.PI*2);

--- a/page-arcade.php
+++ b/page-arcade.php
@@ -13,7 +13,7 @@ get_header();
             <div class="game-selection">
                 <div class="game-card">
                     <h2 class="pixel-font">Canucks Puck Bash</h2>
-                    <div id="canucks-game" class="game-canvas"></div>
+                    <canvas id="canucks-game" class="game-canvas"></canvas>
                     <div id="scoreboard" class="scoreboard">Score: 0</div>
                     <div id="game-overlay" class="game-overlay">Click to Start</div>
                     <div class="controls">


### PR DESCRIPTION
## Summary
- create placeholder Albini QA assets so they're not missing
- use `<canvas>` element for Canucks game
- guard hockey-game.js if canvas is missing
- ensure piano-script only runs when container exists
- prevent negative radius in starfield animation

## Testing
- `pytest`