### PR TITLE
Revamp homepage with retro styled intro and buttons

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -34,6 +34,9 @@
         <div class="footer-bottom">
             <p>&copy; <?php echo date('Y'); ?> Suzy Easton. All rights reserved.</p>
         </div>
+        <div class="footer-marquee">
+            <span>Made in Vancouver &middot; Built with coffee, riffs, and command line confidence.</span>
+        </div>
     </div>
 </footer>
 <?php wp_footer(); ?>

--- a/page-home.php
+++ b/page-home.php
@@ -5,22 +5,42 @@ get_header();
 
 <main id="homepage-content">
     <div class="hero-section">
-        <h1 class="pixel-font">Suzy Easton</h1>
-        <p class="tagline">Vancouver musician, Canucks fan, and creative technologist who builds weird musical stuff on the internet.</p>
-        
-        <div class="cta-buttons">
-            <a href="https://suzyeaston.bandcamp.com" class="action-button" target="_blank">🎧 Listen on Bandcamp</a>
-            <a href="/arcade" class="action-button">🎮 Play Canucks Game</a>
-            <a href="/riff-generator" class="action-button">🎸 Riff Generator</a>
-            <a href="/podcast" class="action-button">🎙️ Podcast: Easy Living</a>
-            <a href="/social-media" class="action-button">📡 Watch Livestream</a>
+        <h1 class="pixel-font">Hi, I&rsquo;m Suzy Easton.</h1>
+        <p class="tagline">I&rsquo;ve toured across Canada, recorded with Steve Albini, and now I build QA test suites and odd web tools while fighting for safer housing from a tiny apartment in Gastown. I might run for Vancouver City Council in 2026.</p>
+        <p class="terminal-line">&gt; suzyeaston.ca/_loading // press start to begin your journey</p>
+        <div class="puck-icon">🏒</div>
+
+        <div class="button-cluster">
+            <div class="button-group">
+                <h3 class="group-title">🎵 Listen</h3>
+                <div class="group-buttons">
+                    <a href="https://suzyeaston.bandcamp.com" class="pixel-button" target="_blank">Bandcamp</a>
+                    <a href="/podcast" class="pixel-button">Podcast: Easy Living</a>
+                </div>
+            </div>
+
+            <div class="button-group">
+                <h3 class="group-title">🛠 Play / Build</h3>
+                <div class="group-buttons">
+                    <a href="/riff-generator" class="pixel-button">Riff Generator</a>
+                    <a href="/arcade" class="pixel-button">Canucks Game</a>
+                </div>
+            </div>
+
+            <div class="button-group">
+                <h3 class="group-title">📺 Watch</h3>
+                <div class="group-buttons">
+                    <a href="/social-media" class="pixel-button">Livestream</a>
+                    <a href="/music-releases" class="pixel-button">Upcoming Events</a>
+                </div>
+            </div>
         </div>
 
         <!-- Bio Panel -->
         <div class="bio-panel">
             <div class="bio-content">
-                <p>Former touring bassist turned creative builder.</p>
-                <p>I write music, make tools, break things on purpose, and try to make tech feel human.</p>
+                <p>Ex-touring bassist turned web-weirdness maker and accidental tenant organizer.</p>
+                <p>I mix music, code, and advocacy to build tools that blur the line between art, community, and tech.</p>
                 <p>Based in Gastown.</p>
             </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -575,6 +575,101 @@ header, main, footer, .menu-item, .albini-qa-page {
 }
 
 /* ====================== */
+/*    HOMEPAGE HERO       */
+/* ====================== */
+.hero-section {
+  max-width: 1000px;
+  margin: 0 auto;
+  text-align: center;
+  padding: 40px 20px;
+}
+.tagline {
+  margin: 20px auto;
+  max-width: 800px;
+}
+.terminal-line {
+  color: var(--accent-color);
+  margin: 10px 0 30px;
+  animation: blinkCursor 1s steps(2, start) infinite;
+}
+@keyframes blinkCursor {
+  0%, 50% { opacity: 1; }
+  51%, 100% { opacity: 0; }
+}
+.puck-icon {
+  font-size: 24px;
+  display: inline-block;
+  margin-bottom: 20px;
+  animation: bounce 2s infinite;
+}
+.puck-icon:hover {
+  animation: bounceHover 0.5s infinite;
+}
+@keyframes bounce {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-8px); }
+}
+@keyframes bounceHover {
+  0%, 100% { transform: translateY(-4px); }
+  50% { transform: translateY(0); }
+}
+
+/* ====================== */
+/*   BUTTON CLUSTERS      */
+/* ====================== */
+.button-cluster {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+  margin-top: 30px;
+}
+.button-group { text-align: center; }
+.group-title {
+  margin-bottom: 10px;
+  color: var(--accent-color);
+}
+.group-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+}
+.pixel-button {
+  background: #000;
+  color: var(--primary-color);
+  border: 2px solid var(--primary-color);
+  padding: 10px 16px;
+  text-decoration: none;
+  font-size: 14px;
+  font-family: 'Press Start 2P', cursive;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+.pixel-button:hover {
+  transform: scale(1.05);
+  box-shadow: 0 0 8px var(--accent-color);
+}
+
+/* ====================== */
+/*    FOOTER MARQUEE      */
+/* ====================== */
+.footer-marquee {
+  width: 100%;
+  overflow: hidden;
+  background: #111;
+  border-top: 2px solid var(--primary-color);
+}
+.footer-marquee span {
+  display: inline-block;
+  padding: 10px;
+  white-space: nowrap;
+  animation: marquee 12s linear infinite;
+}
+@keyframes marquee {
+  from { transform: translateX(100%); }
+  to   { transform: translateX(-100%); }
+}
+
+/* ====================== */
 /*    MOBILE ADJUSTMENTS  */
 /* ====================== */
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- update homepage hero text and new grouped button layout
- add pixel-flavored styling for hero, buttons, puck animation and footer marquee
- add scrolling footer tagline

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685bda4f04bc832eb9dfd95326403a2a