### PR TITLE
Refine homepage intro and softer arcade subtext

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -6,8 +6,8 @@ get_header();
 <main id="homepage-content">
     <div class="hero-section">
         <h1 class="pixel-font">Hi, I&rsquo;m Suzy Easton.</h1>
-        <p class="tagline">I&rsquo;ve toured across Canada, recorded with Steve Albini, and now I build QA test suites and odd web tools while fighting for safer housing from a tiny apartment in Gastown. I might run for Vancouver City Council in 2026.</p>
-        <p class="terminal-line">&gt; suzyeaston.ca/_loading // press start to begin your journey</p>
+        <p class="tagline">I&rsquo;m a musician, technologist, and creative builder based in Vancouver.<br>I&rsquo;ve toured across Canada, recorded with Steve Albini, and I&rsquo;m currently releasing new music while building QA systems and interactive tools online.<br>I&rsquo;m also active in local advocacy work—and exploring a run for Vancouver City Council in 2026.</p>
+        <p class="arcade-subtext">Insert coin to explore</p>
         <div class="puck-icon">🏒</div>
 
         <div class="button-cluster">

--- a/style.css
+++ b/style.css
@@ -596,6 +596,19 @@ header, main, footer, .menu-item, .albini-qa-page {
   0%, 50% { opacity: 1; }
   51%, 100% { opacity: 0; }
 }
+.arcade-subtext {
+  font-family: 'Press Start 2P', monospace;
+  color: #ffcc00;
+  opacity: 0.8;
+  animation: pulse 3s infinite ease-in-out;
+}
+
+@keyframes pulse {
+  0% { opacity: 0.8; }
+  50% { opacity: 1; }
+  100% { opacity: 0.8; }
+}
+
 .puck-icon {
   font-size: 24px;
   display: inline-block;


### PR DESCRIPTION
## Summary
- refresh homepage intro copy
- remove blinking loading line and replace with gentle arcade subtext
- add pulsing animation style for the new subtext

## Testing
- `php -l page-home.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bdcf21a3c832ea86b34fe9d1edd2e