### PR TITLE
Improve arcade hockey controls

### DIFF
--- a/style.css
+++ b/style.css
@@ -260,6 +260,16 @@ body::before {
   z-index: 5;
 }
 
+.goal-animation {
+  animation: goalPop 0.8s ease-out;
+}
+
+@keyframes goalPop {
+  0% { transform: scale(0.5); opacity: 0; }
+  50% { transform: scale(1.2); opacity: 1; }
+  100% { transform: scale(1); opacity: 1; }
+}
+
 /* ====================== */
 /*    FEATURED CONTENT   */
 /* ====================== */


### PR DESCRIPTION
## Summary
- prevent page scrolling while using game controls
- make puck rebound off walls and reset when stuck
- add goal animation, sound, and improved win screen
- support WASD controls

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685e294fc40c832e83c3f0363a6ec4d8