### PR TITLE
Revamp homepage with advocacy and music feed

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -123,6 +123,19 @@ function enqueue_starfield() {
 }
 add_action('wp_enqueue_scripts', 'enqueue_starfield');
 
+function enqueue_now_playing() {
+  wp_enqueue_script(
+    'now-playing',
+    get_template_directory_uri() . '/js/now-playing.js',
+    [], '1.0', true
+  );
+  wp_localize_script('now-playing', 'nowPlaying', [
+    'username' => 'YOUR_LASTFM_USER',
+    'api_key'  => 'YOUR_LASTFM_API_KEY'
+  ]);
+}
+add_action('wp_enqueue_scripts', 'enqueue_now_playing');
+
 
 // =========================================
 // 6. SHORTCODE: DISPLAY THE CANUCKS APP

--- a/js/now-playing.js
+++ b/js/now-playing.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const cont = document.getElementById('now-playing-container');
+  if (!cont || typeof nowPlaying === 'undefined') return;
+
+  const url = `https://ws.audioscrobbler.com/2.0/?method=user.getrecenttracks&user=${nowPlaying.username}&api_key=${nowPlaying.api_key}&format=json&limit=1`;
+
+  fetch(url)
+    .then(r => r.json())
+    .then(data => {
+      const track = data.recenttracks && data.recenttracks.track ? data.recenttracks.track[0] : null;
+      if (!track) return;
+      const img = track.image.pop()['#text'] || '';
+      const artist = track.artist['#text'];
+      const name = track.name;
+      const html = `<div class="news-item"><img src="${img}" alt=""/><p>${artist} - ${name}</p></div>`;
+      cont.innerHTML = html;
+    })
+    .catch(() => {});
+});

--- a/page-advocacy.php
+++ b/page-advocacy.php
@@ -1,0 +1,17 @@
+<?php
+/* Template Name: Advocacy Updates */
+get_header();
+?>
+<main id="main-content">
+    <section class="page-content">
+        <h1 class="pixel-font">DTES & City Council Advocacy</h1>
+        <p>I regularly work with residents of the Downtown Eastside to address housing and overdose issues. My current focus is organizing tenant committees and connecting people with city services.</p>
+        <p>I'm also exploring a 2026 run for Vancouver City Council, centering affordable housing and harm reduction.</p>
+        <p>Reach out if you'd like to get involved or share your thoughts.</p>
+        <div class="group-buttons">
+            <a href="mailto:suzyeaston@icloud.com" class="pixel-button">Email Me</a>
+            <a href="https://suzyeaston.ca/contact" class="pixel-button">Contact Page</a>
+        </div>
+    </section>
+</main>
+<?php get_footer(); ?>

--- a/page-home.php
+++ b/page-home.php
@@ -34,6 +34,14 @@ get_header();
                     <a href="/music-releases" class="pixel-button">Upcoming Events</a>
                 </div>
             </div>
+
+            <div class="button-group">
+                <h3 class="group-title">📖 Read</h3>
+                <div class="group-buttons">
+                    <a href="/bio" class="pixel-button">About Suzy</a>
+                    <a href="/albini-qa" class="pixel-button">Albini Q&A</a>
+                </div>
+            </div>
         </div>
 
         <!-- Bio Panel -->
@@ -62,11 +70,6 @@ get_header();
         <div class="featured-item">
             <h2 class="pixel-font">What's New</h2>
             <div class="news-grid">
-                <div class="news-item">
-                    <h3>Featured in Vancouver Weekly</h3>
-                    <p>"Suzy Easton's retro arcade brings Vancouver's music scene to life"</p>
-                    <a href="#" class="more-button">Read More</a>
-                </div>
                 <div class="news-item">
                     <h3>New Album Release</h3>
                     <p>Pixel Punk Dreams - Available now on all platforms</p>
@@ -115,11 +118,20 @@ get_header();
         </div>
     </section>
 
-    <section class="newsletter">
-        <h2 class="pixel-font">Join the Pixel Punk Squad</h2>
-        <p class="pixel-font">Get exclusive updates, new music drops, and secret arcade codes!</p>
-        <?php echo do_shortcode('[newsletter_form]'); ?>
+    <section class="now-listening">
+        <h2 class="pixel-font">Now Listening</h2>
+        <div id="now-playing-container" class="news-grid"></div>
     </section>
+
+    <section class="advocacy-section">
+        <h2 class="pixel-font">DTES & City Council Advocacy</h2>
+        <p>I'm working with neighbours in the Downtown Eastside to keep vulnerable residents housed and heard. I'm also laying the groundwork for a 2026 City Council campaign focused on housing justice.</p>
+        <div class="group-buttons">
+            <a href="/advocacy" class="pixel-button">Learn More</a>
+            <a href="/contact" class="pixel-button">Get Involved</a>
+        </div>
+    </section>
+
 
     <section class="support-section">
         <h2 class="pixel-font">Support My Creative Journey</h2>

--- a/style.css
+++ b/style.css
@@ -718,6 +718,32 @@ header, main, footer, .menu-item, .albini-qa-page {
   white-space: nowrap;
   animation: marquee 12s linear infinite;
 }
+
+/* ================================== */
+/*   NOW LISTENING & ADVOCACY STYLES  */
+/* ================================== */
+.now-listening {
+  margin: 40px 0;
+  padding: 20px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 2px solid #fff;
+  border-radius: 10px;
+}
+
+#now-playing-container img {
+  max-width: 80px;
+  display: block;
+  margin: 0 auto 10px;
+}
+
+.advocacy-section {
+  margin: 40px 0;
+  padding: 20px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 2px solid #fff;
+  border-radius: 10px;
+  text-align: center;
+}
 @keyframes marquee {
   from { transform: translateX(100%); }
   to   { transform: translateX(-100%); }


### PR DESCRIPTION
## Summary
- rework navigation on the homepage with a new **Read** section
- drop outdated Vancouver Weekly and Pixel Punk Squad sections
- add dynamic **Now Listening** block pulling from Last.fm
- include a DTES/City Council advocacy section
- provide new page template for advocacy updates
- enqueue new script and styles

## Testing
- `php` not available: could not run linting

------
https://chatgpt.com/codex/tasks/task_e_685e2e25ac84832e86d2ffa607cb6f9d