### PR TITLE
Add live Last.fm widget and clean homepage

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -130,8 +130,8 @@ function enqueue_now_playing() {
     [], '1.0', true
   );
   wp_localize_script('now-playing', 'nowPlaying', [
-    'username' => 'YOUR_LASTFM_USER',
-    'api_key'  => 'YOUR_LASTFM_API_KEY'
+    'username' => 'suzyeaston',
+    'api_key'  => 'b8c00d13eccb3a3973dd087d84c0e5b3'
   ]);
 }
 add_action('wp_enqueue_scripts', 'enqueue_now_playing');

--- a/js/now-playing.js
+++ b/js/now-playing.js
@@ -1,19 +1,25 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const cont = document.getElementById('now-playing-container');
-  if (!cont || typeof nowPlaying === 'undefined') return;
+  const container = document.getElementById('now-listening-widget');
+  if (!container || typeof nowPlaying === 'undefined') return;
 
-  const url = `https://ws.audioscrobbler.com/2.0/?method=user.getrecenttracks&user=${nowPlaying.username}&api_key=${nowPlaying.api_key}&format=json&limit=1`;
+  const url = `https://ws.audioscrobbler.com/2.0/?method=user.getrecenttracks&user=${nowPlaying.username}&api_key=${nowPlaying.api_key}&format=json`;
 
   fetch(url)
-    .then(r => r.json())
+    .then(res => res.json())
     .then(data => {
-      const track = data.recenttracks && data.recenttracks.track ? data.recenttracks.track[0] : null;
-      if (!track) return;
-      const img = track.image.pop()['#text'] || '';
+      const track = data.recenttracks.track[0];
+      const title = track.name;
       const artist = track.artist['#text'];
-      const name = track.name;
-      const html = `<div class="news-item"><img src="${img}" alt=""/><p>${artist} - ${name}</p></div>`;
-      cont.innerHTML = html;
+      const image = track.image[2]['#text'];
+      const playing = track['@attr'] && track['@attr'].nowplaying;
+
+      container.innerHTML = `
+        <div class="listening-inner fade-in">
+          <p><strong>Now Listening:</strong></p>
+          <img src="${image}" alt="album art" />
+          <p>${title} — ${artist} ${playing ? '🎵 (Now Playing)' : ''}</p>
+        </div>
+      `;
     })
     .catch(() => {});
 });

--- a/page-home.php
+++ b/page-home.php
@@ -54,27 +54,10 @@ get_header();
         </div>
     </div>
 
-    <!-- What's New Section -->
-    <section class="whats-new-section">
-        <h2 class="pixel-font">In the Wild</h2>
-        <div class="news-grid">
-            <div class="news-item">
-                <h3>Live Jams</h3>
-                <p>Every Friday @ 8PM PST</p>
-                <a href="/social-media" class="more-button">Join the Stream</a>
-            </div>
-        </div>
-    </section>
-
     <section class="featured-content">
         <div class="featured-item">
             <h2 class="pixel-font">What's New</h2>
             <div class="news-grid">
-                <div class="news-item">
-                    <h3>New Album Release</h3>
-                    <p>Pixel Punk Dreams - Available now on all platforms</p>
-                    <a href="https://suzyeaston.bandcamp.com" class="more-button" target="_blank">Listen Now</a>
-                </div>
                 <div class="news-item">
                     <h3>Live Stream Schedule</h3>
                     <p>Join me every Friday at 8PM PST</p>
@@ -108,19 +91,11 @@ get_header();
             ?>
         </div>
 
-        <div class="featured-item">
-            <h2 class="pixel-font">Tech & Music Projects</h2>
-            <ul class="project-list">
-                <li>Live video jam sessions</li>
-                <li>New music releases</li>
-                <li>Comedic documentary filmmaking about life in Vancouver</li>
-            </ul>
-        </div>
     </section>
 
     <section class="now-listening">
         <h2 class="pixel-font">Now Listening</h2>
-        <div id="now-playing-container" class="news-grid"></div>
+        <div id="now-listening-widget"></div>
     </section>
 
     <section class="advocacy-section">
@@ -129,6 +104,7 @@ get_header();
         <div class="group-buttons">
             <a href="/advocacy" class="pixel-button">Learn More</a>
             <a href="/contact" class="pixel-button">Get Involved</a>
+            <a href="https://www.carnegiehousingproject.ca/events" class="pixel-button" target="_blank">See Local Housing Events</a>
         </div>
     </section>
 

--- a/style.css
+++ b/style.css
@@ -728,12 +728,51 @@ header, main, footer, .menu-item, .albini-qa-page {
   background: rgba(255, 255, 255, 0.1);
   border: 2px solid #fff;
   border-radius: 10px;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
 }
 
-#now-playing-container img {
+#now-listening-widget img {
   max-width: 80px;
+  border: 2px solid #00FF00;
   display: block;
   margin: 0 auto 10px;
+}
+
+.listening-inner {
+  font-family: 'Press Start 2P', monospace;
+  color: #00FF00;
+}
+
+.fade-in {
+  animation: fadeIn 1s ease-in;
+}
+
+.now-listening::before {
+  content: "";
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  background: repeating-linear-gradient(
+    to right,
+    rgba(0, 255, 0, 0.2) 0,
+    rgba(0, 255, 0, 0.2) 2px,
+    transparent 2px,
+    transparent 4px
+  );
+  animation: equalizer 1s linear infinite;
+  pointer-events: none;
+}
+
+@keyframes equalizer {
+  0%, 100% { opacity: 0.1; }
+  50% { opacity: 0.3; }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 .advocacy-section {


### PR DESCRIPTION
## Summary
- streamline homepage content
- add 'See Local Housing Events' button
- integrate real-time last.fm feed
- style now listening widget with retro vibes
- store API credentials for the widget

## Testing
- `php -l page-home.php` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685e32b2e5ec832e87709bf79d50f9ba