### PR TITLE
Add mobile viewport and touch support to Canucks game

### DIFF
--- a/header.php
+++ b/header.php
@@ -11,7 +11,6 @@
 <html <?php language_attributes(); ?>>
 <head>
   <meta charset="<?php bloginfo( 'charset' ); ?>">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="profile" href="http://gmpg.org/xfn/11">
 
   <title><?php wp_title( '|', true, 'right' ); bloginfo( 'name' ); ?></title>
@@ -22,6 +21,7 @@
   <!-- Retro arcade font -->
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
 
+  <meta name="viewport" content="width=device-width,initial-scale=1">
   <?php wp_head(); ?>
 </head>
 

--- a/style.css
+++ b/style.css
@@ -852,3 +852,18 @@ header, main, footer, .menu-item, .albini-qa-page {
     font-size: 0.95rem;
   }
 }
+
+#touch-controls {
+  position: fixed; bottom: 12px; left: 0; right: 0;
+  display: flex; justify-content: center; gap: 16px;
+  pointer-events: none;
+}
+#touch-controls button {
+  pointer-events: auto;
+  background: rgba(0,255,0,0.15);
+  border: 2px solid #0f0;
+  border-radius: 10px;
+  padding: 14px;
+  font-size: 22px;
+}
+@media (hover: hover) { #touch-controls { display:none; } }


### PR DESCRIPTION
## Summary
- improve meta viewport in header
- make hockey game canvas responsive
- add touch controls overlay for mobile
- play a melody for the goal horn
- style the on-screen touch controls

## Testing
- `node -c js/hockey-game.js`

------
https://chatgpt.com/codex/tasks/task_e_68672c0ee804832eb81425fe2fb3e3af