### PR TITLE
Add Albini quote generator and visitor counter

### DIFF
--- a/page-albini-qa.php
+++ b/page-albini-qa.php
@@ -20,49 +20,85 @@ get_header();
                 placeholder="Type your question here…"
                 rows="4"></textarea>
       <button id="albini-submit">Ask Albini</button>
+      <button id="albini-random" title="Random quote">🎲</button>
     </div>
 
     <!-- Response box -->
     <div id="albini-response" class="qa-response">
       <!-- Albini’s answer will appear here -->
     </div>
+<p class="albini-example">Try asking:<br>“Should I record to tape or digital?”<br>“What’s the best mic for snare?”<br>“Do I need a manager?”<br>“How do I split money fairly in a band?”<br>“Will streaming ever pay my rent?”<br>“What would Fugazi do?”<br>“Should we autotune the singer?”</p>
 
   </section>
 
 </main>
 
-<?php get_footer(); ?>
 
-<!-- Inline script to handle the AJAX call -->
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   const qEl = document.getElementById('albini-question');
   const btn = document.getElementById('albini-submit');
+  const randomBtn = document.getElementById('albini-random');
   const resp = document.getElementById('albini-response');
 
-  btn.addEventListener('click', async () => {
-    const question = qEl.value.trim();
-    if (!question) return;
+  const albiniQuotes = [
+    "Record like you mean it. Edit like you don’t care.",
+    "The best mic is the one you already have plugged in.",
+    "Don’t EQ it. Move the mic.",
+    "Analog tape never froze during a plugin update.",
+    "Turn it up until it scares you, then back it off a little.",
+    "You don’t need a compressor. You need to play tighter.",
+    "No one ever said, 'Man, that mix needed more automation.'",
+    "The click track isn’t the problem. You are.",
+    "Stop asking what mic to use. Point something at it and hit record.",
+    "If you’re waiting for Spotify royalties to pay rent, I have bad news.",
+    "Managers are parasites. Work with people, not leeches.",
+    "A record deal is a loan shark with a press kit.",
+    "You’ll earn more playing one honest gig than from 10,000 streams.",
+    "The label will take the master. Keep the friends.",
+    "You don’t own your music if you owe someone money for it.",
+    "Nobody owes you attention.",
+    "Be good to your bandmates. They’re the only ones who’ll carry your amp.",
+    "DIY doesn’t mean amateur. It means accountable.",
+    "Art isn’t a competition unless you’re insecure.",
+    "Being broke together is better than selling out alone.",
+    "Sure, put another fuzz pedal on it. That’ll fix your songwriting.",
+    "Stop tweaking the hi-hat and write a chorus.",
+    "Do you think Fugazi worried about their social media engagement?",
+    "Your bedroom demo has more heart than your $1000/day studio session.",
+    "Loud guitars solve everything except your relationship problems.",
+    "No one cares what DAW you use except you.",
+    "Pro Tools isn’t your enemy. Your taste is."
+  ];
 
-    btn.disabled = true;
-    btn.textContent = 'Thinking…';
-    resp.innerHTML = '';
+  const preambles = [
+    "Look.",
+    "Honestly?",
+    "No.",
+    "Sure, fine.",
+    "Why are you wasting your time asking me that?",
+    "You already know the answer.",
+    "Stop overthinking it.",
+    "Hell if I know, but here’s what I’d do:",
+    ""
+  ];
 
-    try {
-      const r = await fetch('<?php echo esc_url( rest_url('albini/v1/ask') ); ?>', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ question })
-      });
-      const data = await r.json();
-      const answer = data.answer || 'Steve’s probably busy in the studio.';
-      resp.innerHTML = '<p>' + answer.replace(/\n/g,'<br/>') + '</p>';
-    } catch (err) {
-      resp.textContent = 'Uh‑oh, something broke.';
-    }
+  function randomQuote() {
+    const pre = preambles[Math.floor(Math.random() * preambles.length)];
+    const quote = albiniQuotes[Math.floor(Math.random() * albiniQuotes.length)];
+    return `${pre} ${quote}`.trim();
+  }
 
-    btn.disabled = false;
-    btn.textContent = 'Ask Albini';
+  function showQuote() {
+    resp.innerHTML = `<p>${randomQuote()}</p>`;
+  }
+
+  btn.addEventListener('click', () => {
+    if (!qEl.value.trim()) return;
+    showQuote();
   });
+
+  randomBtn.addEventListener('click', showQuote);
 });
 </script>
+<?php get_footer(); ?>

--- a/page-home.php
+++ b/page-home.php
@@ -114,6 +114,14 @@ get_header();
         <p class="pixel-font">If you'd like to support my creative and technical endeavors, consider buying me a coffee on <a href="https://www.buymeacoffee.com/wi0amge" target="_blank" class="support-link">Buy Me a Coffee</a></p>
         <p class="pixel-font">For collaborations or just to chat, reach out at <a href="mailto:suzyeaston@icloud.com" class="support-link">suzyeaston@icloud.com</a></p>
     </section>
+<?php
+$visitor_data = include get_template_directory() . '/visitor-tracker.php';
+arsort($visitor_data['locations']);
+?>
+<div class="visitor-counter">
+  <p>🎯 Visitors since July 3, 2025: <?php echo intval($visitor_data['count']); ?></p>
+  <p>🌍 Top Locations: <?php $locs=[]; foreach($visitor_data['locations'] as $k=>$v){$locs[]=$k.' ('.$v.')';} echo implode(', ', array_slice($locs,0,3)); ?></p>
+</div>
 </main>
 
 <?php get_footer(); ?>

--- a/style.css
+++ b/style.css
@@ -345,6 +345,17 @@ body::before {
 }
 
 /* ====================== */
+/*    VISITOR COUNTER   */
+/* ====================== */
+.visitor-counter {
+  font-family: 'Press Start 2P', monospace;
+  color: #00ff00;
+  margin-top: 2rem;
+  text-align: center;
+  line-height: 1.6;
+}
+
+/* ====================== */
 /*    SUPPORT SECTION    */
 /* ====================== */
 .support-section {
@@ -419,6 +430,23 @@ body::before {
   height: 64px;
   border-radius: 50%;
   margin-bottom: 10px;
+}
+/* Albini Q&A terminal response */
+.qa-response p {
+  font-family: 'Press Start 2P', monospace;
+  color: #00ff00;
+  font-size: 16px;
+  font-weight: bold;
+  margin-top: 20px;
+  white-space: pre-wrap;
+}
+
+.albini-example {
+  font-family: 'Press Start 2P', monospace;
+  color: #00ff00;
+  font-size: 14px;
+  margin-top: 12px;
+  line-height: 1.6;
 }
 
 /* ====================== */

--- a/visitor-count.json
+++ b/visitor-count.json
@@ -1,0 +1,1 @@
+{"count":0,"locations":{}}

--- a/visitor-tracker.php
+++ b/visitor-tracker.php
@@ -1,0 +1,12 @@
+<?php
+$countFile = __DIR__ . '/visitor-count.json';
+$data = file_exists($countFile) ? json_decode(file_get_contents($countFile), true) : ['count' => 0, 'locations' => []];
+$data['count']++;
+
+$country = 'Unknown';
+if (!isset($data['locations'][$country])) {
+    $data['locations'][$country] = 0;
+}
+$data['locations'][$country]++;
+file_put_contents($countFile, json_encode($data));
+return $data;


### PR DESCRIPTION
## Summary
- replace Albini OpenAI call with local random quote generator
- show example questions and dice button
- add terminal-style CSS for responses
- track visitors in a flat JSON file and display counts on the homepage

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68673af30098832e9f99c6f3addbe3b9