### PR TITLE
Implement updated Albini Q&A and visitor counter

### DIFF
--- a/page-albini-qa.php
+++ b/page-albini-qa.php
@@ -27,7 +27,6 @@ get_header();
     <div id="albini-response" class="qa-response">
       <!-- Albini’s answer will appear here -->
     </div>
-<p class="albini-example">Try asking:<br>“Should I record to tape or digital?”<br>“What’s the best mic for snare?”<br>“Do I need a manager?”<br>“How do I split money fairly in a band?”<br>“Will streaming ever pay my rent?”<br>“What would Fugazi do?”<br>“Should we autotune the singer?”</p>
 
   </section>
 
@@ -101,4 +100,6 @@ document.addEventListener('DOMContentLoaded', () => {
   randomBtn.addEventListener('click', showQuote);
 });
 </script>
+<p style="text-align:center;">🎶 <a href="https://suzyeaston.bandcamp.com" target="_blank">Support on Bandcamp</a></p>
+<p style="text-align:center;">New demo drops this weekend. Stay noisy.</p>
 <?php get_footer(); ?>

--- a/page-bio.php
+++ b/page-bio.php
@@ -14,7 +14,9 @@ get_header();
             
             <p>My creative pursuits include live video jam sessions, new music releases, and comedic documentary filmmaking about life in Vancouver. I'm also excited to announce my brand-new podcast, <strong>“Easy Living with Suzy Easton”</strong>, where I share stories, insights, and laughter about life in Vancouver.</p>
             
-            <p>For collaborations or just to chat, reach out at <a href="mailto:suzyeaston@icloud.com">suzyeaston@icloud.com</a>. If you'd like to support my creative and technical endeavors, consider buying me a coffee on <a href="https://www.buymeacoffee.com/wi0amge" target="_blank">Buy Me a Coffee</a></p>
+            <p>For collaborations or just to chat, reach out at <a href="mailto:suzyeaston@icloud.com">suzyeaston@icloud.com</a>.</p>
+            <p style="text-align:center;">🎶 <a href="https://suzyeaston.bandcamp.com" target="_blank">Support on Bandcamp</a></p>
+            <p style="text-align:center;">New demo drops this weekend. Stay noisy.</p>
         </div>
     </section>
 </main>

--- a/page-contact.php
+++ b/page-contact.php
@@ -70,22 +70,8 @@ get_header(); ?>
         “Early Riser Challenge” QA post</a> <!-- :contentReference[oaicite:8]{index=8} -->
     </p>
 
-    <p>
-      <strong>Buy Me a Coffee:</strong><br>
-      <script
-        type="text/javascript"
-        src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js"
-        data-name="bmc-button"
-        data-slug="wi0amge"
-        data-color="#FFDD00"
-        data-emoji="🍺"
-        data-font="Cookie"
-        data-text="Buy me a beer"
-        data-outline-color="#000000"
-        data-font-color="#000000"
-        data-coffee-color="#ffffff">
-      </script>
-    </p>
+    <p style="text-align:center;">🎶 <a href="https://suzyeaston.bandcamp.com" target="_blank">Support on Bandcamp</a></p>
+    <p style="text-align:center;">New demo drops this weekend. Stay noisy.</p>
 
   </section>
 </main>

--- a/page-home.php
+++ b/page-home.php
@@ -111,16 +111,17 @@ get_header();
 
     <section class="support-section">
         <h2 class="pixel-font">Support My Creative Journey</h2>
-        <p class="pixel-font">If you'd like to support my creative and technical endeavors, consider buying me a coffee on <a href="https://www.buymeacoffee.com/wi0amge" target="_blank" class="support-link">Buy Me a Coffee</a></p>
         <p class="pixel-font">For collaborations or just to chat, reach out at <a href="mailto:suzyeaston@icloud.com" class="support-link">suzyeaston@icloud.com</a></p>
+        <p style="text-align:center;">🎶 <a href="https://suzyeaston.bandcamp.com" target="_blank">Support on Bandcamp</a></p>
+        <p style="text-align:center;">New demo drops this weekend. Stay noisy.</p>
     </section>
 <?php
 $visitor_data = include get_template_directory() . '/visitor-tracker.php';
-arsort($visitor_data['locations']);
+$total = intval($visitor_data['count']);
+$countries = implode(', ', array_keys($visitor_data['locations']));
 ?>
 <div class="visitor-counter">
-  <p>🎯 Visitors since July 3, 2025: <?php echo intval($visitor_data['count']); ?></p>
-  <p>🌍 Top Locations: <?php $locs=[]; foreach($visitor_data['locations'] as $k=>$v){$locs[]=$k.' ('.$v.')';} echo implode(', ', array_slice($locs,0,3)); ?></p>
+  <p><?php echo "$total people from $countries have dared to ask Albini."; ?></p>
 </div>
 </main>
 

--- a/visitor-tracker.php
+++ b/visitor-tracker.php
@@ -1,12 +1,24 @@
 <?php
 $countFile = __DIR__ . '/visitor-count.json';
-$data = file_exists($countFile) ? json_decode(file_get_contents($countFile), true) : ['count' => 0, 'locations' => []];
+$data = file_exists($countFile)
+    ? json_decode(file_get_contents($countFile), true)
+    : ['count' => 0, 'locations' => []];
+
 $data['count']++;
 
 $country = 'Unknown';
+$apiResp = @file_get_contents('https://ipapi.co/json/');
+if ($apiResp !== false) {
+    $info = json_decode($apiResp, true);
+    if (json_last_error() === JSON_ERROR_NONE && !empty($info['country_name'])) {
+        $country = $info['country_name'];
+    }
+}
+
 if (!isset($data['locations'][$country])) {
     $data['locations'][$country] = 0;
 }
 $data['locations'][$country]++;
+
 file_put_contents($countFile, json_encode($data));
 return $data;


### PR DESCRIPTION
## Summary
- clean up Albini Q&A template and add Bandcamp footer blurb
- replace all Buy Me a Coffee links with Bandcamp link & new demo note
- show visitor totals on homepage
- fetch visitor country from ipapi.co

## Testing
- `php -l` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68673eaeda5c832e876ef5654f8a154d