### PR TITLE
Improve homepage visitor stats and navigation

### DIFF
--- a/page-albini-qa.php
+++ b/page-albini-qa.php
@@ -100,6 +100,6 @@ document.addEventListener('DOMContentLoaded', () => {
   randomBtn.addEventListener('click', showQuote);
 });
 </script>
-<p style="text-align:center;">🎶 <a href="https://suzyeaston.bandcamp.com" target="_blank">Support on Bandcamp</a></p>
+<p style="text-align:center;">🎶 <a href="https://suzyeaston.bandcamp.com" target="_blank">Support my music on Bandcamp</a></p>
 <p style="text-align:center;">New demo drops this weekend. Stay noisy.</p>
 <?php get_footer(); ?>

--- a/page-home.php
+++ b/page-home.php
@@ -16,10 +16,18 @@ get_header();
 
         <p class="arcade-subtext">Insert coin to explore</p>
         <div class="puck-icon">🏒</div>
+        <?php
+        $visitor_data = include get_template_directory() . '/visitor-tracker.php';
+        $total = intval($visitor_data['count']);
+        $countries = implode(', ', array_keys($visitor_data['locations']));
+        ?>
+        <div class="visitor-counter">
+          <p><?php echo "$total people from $countries have dared to ask Albini."; ?></p>
+        </div>
 
         <div class="button-cluster">
             <div class="button-group">
-                <h3 class="group-title">🎵 Listen</h3>
+                <h3 class="group-title">🎵 Music &amp; Podcasts</h3>
                 <div class="group-buttons">
                     <a href="https://suzyeaston.bandcamp.com" class="pixel-button" target="_blank">Bandcamp</a>
                     <a href="/podcast" class="pixel-button">Podcast: Easy Living</a>
@@ -27,15 +35,16 @@ get_header();
             </div>
 
             <div class="button-group">
-                <h3 class="group-title">🛠 Play / Build</h3>
+                <h3 class="group-title">🎮 Games &amp; Tools</h3>
                 <div class="group-buttons">
                     <a href="/riff-generator" class="pixel-button">Riff Generator</a>
                     <a href="/arcade" class="pixel-button">Canucks Game</a>
+                    <a href="/albini-qa" class="pixel-button">Albini Q&amp;A</a>
                 </div>
             </div>
 
             <div class="button-group">
-                <h3 class="group-title">📺 Watch</h3>
+                <h3 class="group-title">📺 Livestream &amp; Events</h3>
                 <div class="group-buttons">
                     <a href="/social-media" class="pixel-button">Livestream</a>
                     <a href="/music-releases" class="pixel-button">Upcoming Events</a>
@@ -43,10 +52,9 @@ get_header();
             </div>
 
             <div class="button-group">
-                <h3 class="group-title">📖 Read</h3>
+                <h3 class="group-title">📚 About &amp; Info</h3>
                 <div class="group-buttons">
                     <a href="/bio" class="pixel-button">About Suzy</a>
-                    <a href="/albini-qa" class="pixel-button">Albini Q&A</a>
                 </div>
             </div>
         </div>
@@ -112,17 +120,9 @@ get_header();
     <section class="support-section">
         <h2 class="pixel-font">Support My Creative Journey</h2>
         <p class="pixel-font">For collaborations or just to chat, reach out at <a href="mailto:suzyeaston@icloud.com" class="support-link">suzyeaston@icloud.com</a></p>
-        <p style="text-align:center;">🎶 <a href="https://suzyeaston.bandcamp.com" target="_blank">Support on Bandcamp</a></p>
+        <p style="text-align:center;">🎶 <a href="https://suzyeaston.bandcamp.com" target="_blank">Support my music on Bandcamp</a></p>
         <p style="text-align:center;">New demo drops this weekend. Stay noisy.</p>
     </section>
-<?php
-$visitor_data = include get_template_directory() . '/visitor-tracker.php';
-$total = intval($visitor_data['count']);
-$countries = implode(', ', array_keys($visitor_data['locations']));
-?>
-<div class="visitor-counter">
-  <p><?php echo "$total people from $countries have dared to ask Albini."; ?></p>
-</div>
 </main>
 
 <?php get_footer(); ?>

--- a/page-social-media.php
+++ b/page-social-media.php
@@ -15,7 +15,6 @@ get_header();
         <div class="menu-item" onclick="location.href='https://suzyeaston.bandcamp.com/'">Bandcamp</div>
         <div class="menu-item" onclick="location.href='https://www.youtube.com/user/anabsolutepitch'">YouTube</div>
         <div class="menu-item" onclick="location.href='https://www.instagram.com/officialsuzyeaston/'">Instagram</div>
-        <div class="menu-item" onclick="location.href='https://www.patreon.com/SuzyEaston'">Patreon</div>
         
     </section>
 </main>

--- a/visitor-tracker.php
+++ b/visitor-tracker.php
@@ -7,11 +7,24 @@ $data = file_exists($countFile)
 $data['count']++;
 
 $country = 'Unknown';
+
+// Try ipapi first
 $apiResp = @file_get_contents('https://ipapi.co/json/');
 if ($apiResp !== false) {
     $info = json_decode($apiResp, true);
     if (json_last_error() === JSON_ERROR_NONE && !empty($info['country_name'])) {
         $country = $info['country_name'];
+    }
+}
+
+// Fallback to ipinfo if needed
+if ($country === 'Unknown') {
+    $apiResp = @file_get_contents('https://ipinfo.io/json');
+    if ($apiResp !== false) {
+        $info = json_decode($apiResp, true);
+        if (json_last_error() === JSON_ERROR_NONE && !empty($info['country'])) {
+            $country = $info['country'];
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- detect visitor country via ipapi with ipinfo fallback
- show visitor stats near the "Insert coin" tagline
- reorganise homepage button groups for clarity
- remove Patreon link from social page
- update Bandcamp support text

## Testing
- `php -l visitor-tracker.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686742034d30832ebebefc8597518aca