### PR TITLE
Improve homepage header visuals and nav

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -20,6 +20,7 @@ function retro_game_music_theme_scripts() {
     wp_enqueue_script('bio-sections', get_template_directory_uri() . '/js/bio-sections.js', [], '1.0.0', true);
     if ( is_front_page() ) {
         wp_enqueue_script('game-init', get_template_directory_uri() . '/js/game-init.js', [], '1.0.0', true);
+        wp_enqueue_script('title-color', get_template_directory_uri() . '/js/title-color.js', [], '1.0.0', true);
     }
 }
 add_action('wp_enqueue_scripts', 'retro_game_music_theme_scripts');

--- a/header.php
+++ b/header.php
@@ -32,12 +32,14 @@
 </head>
 
 <body <?php body_class(); ?>>
-<?php 
+<?php
   // Fires immediately after the opening <body> tag for plugins/themes
   if ( function_exists( 'wp_body_open' ) ) {
     wp_body_open();
   }
 ?>
+
+<a href="/" class="home-link" aria-label="Home">🏠 Home</a>
 
 <!-- Full‑screen moving starfield background -->
 <canvas id="starfield"></canvas>

--- a/js/title-color.js
+++ b/js/title-color.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded',function(){
+  const title=document.getElementById('home-title');
+  if(!title) return;
+  let pos=0;
+  setInterval(()=>{
+    pos=(pos+1)%300;
+    title.style.backgroundPosition=`${pos}%`;
+  },60);
+});

--- a/page-home.php
+++ b/page-home.php
@@ -5,7 +5,7 @@ get_header();
 
 <main id="homepage-content">
     <div class="hero-section">
-        <h1 class="pixel-font">Hi, I&rsquo;m Suzy Easton.</h1>
+        <h1 id="home-title" class="pixel-font color-cycle">Hi, I&rsquo;m Suzy Easton.</h1>
        <section class="pixel-intro" style="max-width: 720px; margin: 0 auto; line-height: 1.8; font-size: 1.05rem;">
     <p>I&rsquo;m a musician, technologist, and creative builder based in Vancouver.</p>
 

--- a/style.css
+++ b/style.css
@@ -810,32 +810,17 @@ footer,
   max-width: 800px;
 }
 
-.hero-section h1.pixel-font {
+.hero-section h1.color-cycle {
   margin-bottom: 1.5rem;
-  color: var(--secondary-color);
-  animation: neonFlicker 4s linear infinite;
-}
-
-@keyframes neonFlicker {
-  0%,
-  18%,
-  22%,
-  25%,
-  53%,
-  57%,
-  100% {
-    text-shadow:
-      0 0 6px var(--secondary-color),
-      0 0 12px var(--secondary-color),
-      0 0 18px var(--secondary-color);
-    opacity: 1;
-  }
-  20%,
-  24%,
-  55% {
-    text-shadow: none;
-    opacity: 0.7;
-  }
+  background-image: linear-gradient(90deg, #ff0099, #00ffff, #00ff00, #ffff00, #ff0099);
+  background-size: 300%;
+  background-position: 0%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  text-shadow:
+    0 0 4px var(--accent-color),
+    0 0 8px var(--accent-color);
 }
 
 .hero-section .pixel-intro {
@@ -846,6 +831,21 @@ footer,
 }
 .hero-section .pixel-intro p {
   margin-bottom: 1.5rem;
+}
+
+.home-link {
+  position: fixed;
+  top: 10px;
+  left: 10px;
+  z-index: 10000;
+  font-family: "Press Start 2P", cursive;
+  font-size: 0.85rem;
+  color: var(--accent-color);
+  text-decoration: none;
+}
+
+.home-link:hover {
+  text-shadow: 0 0 4px var(--accent-color);
 }
 
 .pixel-font {


### PR DESCRIPTION
## Summary
- add multi-color animated effect for the home page title
- reduce blur/flicker and remove old neon keyframes
- add global Home link for easier navigation

## Testing
- `git status --short`
- *No automated tests available*


------
https://chatgpt.com/codex/tasks/task_e_686837e22a84832e87a219bbe2bcacbb