### PR TITLE
Add fun visitor stats

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -18,11 +18,33 @@ get_header();
         <div class="puck-icon">🏒</div>
         <?php
         $visitor_data = include get_template_directory() . '/visitor-tracker.php';
-        $total = intval($visitor_data['count']);
-        $countries = implode(', ', array_keys($visitor_data['locations']));
+        $phrases = [
+            '⚡ %d poor souls from %s woke the Albini bot today.',
+            '🎸 %d noise-makers from %s just asked why their band sucks.',
+            '🤖 Albini\'s circuit board has processed %d fragile egos from %s.',
+            '👁️ %d lurkers from %s looking for validation. None found.',
+            '🔥 %d punks from %s have faced the wrath of Albini\'s sarcasm.',
+            '💀 %d existential crises triggered in %s.',
+            '🚀 %s launched %d useless questions into the void.'
+        ];
         ?>
         <div class="visitor-counter">
-          <p><?php echo "$total people from $countries have dared to ask Albini."; ?></p>
+          <?php foreach ($visitor_data['locations'] as $c => $cnt): ?>
+            <p><?php printf(esc_html($phrases[array_rand($phrases)]), $cnt, $c); ?></p>
+          <?php endforeach; ?>
+          <?php if (!empty($visitor_data['locations'])): ?>
+            <p>
+              <?php
+              arsort($visitor_data['locations']);
+              $leaders = array_slice($visitor_data['locations'], 0, 3, true);
+              $leaderboard = [];
+              foreach ($leaders as $cc => $ct) {
+                  $leaderboard[] = "$cc ($ct)";
+              }
+              echo 'Leaderboard: ' . esc_html(implode(', ', $leaderboard));
+              ?>
+            </p>
+          <?php endif; ?>
         </div>
 
         <div class="button-cluster">

--- a/visitor-count.json
+++ b/visitor-count.json
@@ -1,1 +1,1 @@
-{"count":0,"locations":{}}
+{"count":0,"locations":{},"ipCache":{},"visits":[]}

--- a/visitor-tracker.php
+++ b/visitor-tracker.php
@@ -2,30 +2,20 @@
 $countFile = __DIR__ . '/visitor-count.json';
 $data = file_exists($countFile)
     ? json_decode(file_get_contents($countFile), true)
-    : ['count' => 0, 'locations' => []];
+    : ['count' => 0, 'locations' => [], 'ipCache' => [], 'visits' => []];
 
-$data['count']++;
-
-$country = 'Unknown';
-
-// Try ipapi first
-$apiResp = @file_get_contents('https://ipapi.co/json/');
-if ($apiResp !== false) {
-    $info = json_decode($apiResp, true);
-    if (json_last_error() === JSON_ERROR_NONE && !empty($info['country_name'])) {
-        $country = $info['country_name'];
-    }
+if (!is_array($data)) {
+    $data = ['count' => 0, 'locations' => [], 'ipCache' => [], 'visits' => []];
 }
 
-// Fallback to ipinfo if needed
-if ($country === 'Unknown') {
-    $apiResp = @file_get_contents('https://ipinfo.io/json');
-    if ($apiResp !== false) {
-        $info = json_decode($apiResp, true);
-        if (json_last_error() === JSON_ERROR_NONE && !empty($info['country'])) {
-            $country = $info['country'];
-        }
-    }
+$data['count']++;
+$ip = $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
+
+if (isset($data['ipCache'][$ip])) {
+    $country = $data['ipCache'][$ip];
+} else {
+    $country = fetch_country();
+    $data['ipCache'][$ip] = $country;
 }
 
 if (!isset($data['locations'][$country])) {
@@ -33,5 +23,28 @@ if (!isset($data['locations'][$country])) {
 }
 $data['locations'][$country]++;
 
+$data['visits'][] = ['time' => date('c'), 'country' => $country];
+
 file_put_contents($countFile, json_encode($data));
 return $data;
+
+function fetch_country() {
+    $urls = ['https://ipapi.co/json/', 'https://ipinfo.io/json'];
+    foreach ($urls as $url) {
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 3);
+        $resp = curl_exec($ch);
+        curl_close($ch);
+        if ($resp !== false) {
+            $info = json_decode($resp, true);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                if (!empty($info['country_name'])) return $info['country_name'];
+                if (!empty($info['country'])) return $info['country'];
+            }
+        }
+    }
+    return 'Unknown';
+}
+?>


### PR DESCRIPTION
## Summary
- track visits per IP with cURL-based lookup and timestamp
- randomize the Albini visitor phrases
- display a simple leaderboard

## Testing
- `php -l visitor-tracker.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868408667f8832e9ae32c806b9b88ab