### PR TITLE
Replace Spotify widget with YouTube embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A custom WordPress theme powering [suzyeaston.ca](https://suzyeaston.ca), comple
 - **Riff Generator 8000** for instant rock, punk, metal or jazz riffs
 - **Easy Living with Suzy Easton** podcast page with embeds from PodBean, iHeartRadio and YouTube
 - **Albini Q&A** widget that channels legendary producer Steve Albini via OpenAI
-- Music releases, livestream schedules and a "Now Listening" widget
+- Music releases, livestream schedules and a "Now Listening" section featuring a static YouTube embed
 - Downtown Eastside advocacy section and notes on Suzy's possible 2026 city council run
 - Custom REST endpoints for Canucks news and betting odds
 - Mobile friendly with drag & tap controls

--- a/footer.php
+++ b/footer.php
@@ -5,10 +5,6 @@
             <span class="icon">🎵</span>
             <span class="label">Bandcamp</span>
         </a>
-        <a href="https://open.spotify.com/artist/your-spotify-id" target="_blank" class="floating-link">
-            <span class="icon">🎶</span>
-            <span class="label">Spotify</span>
-        </a>
         <a href="https://soundcloud.com/suzyeaston" target="_blank" class="floating-link">
             <span class="icon">🔊</span>
             <span class="label">SoundCloud</span>

--- a/page-contact.php
+++ b/page-contact.php
@@ -36,10 +36,6 @@ get_header(); ?>
       <a href="https://suzyeaston.bandcamp.com/" target="_blank">suzyeaston.bandcamp.com</a> <!-- :contentReference[oaicite:3]{index=3} -->
     </p>
 
-    <p><strong>Spotify (Single “A Little Louder”):</strong>
-      <a href="https://open.spotify.com/album/6Q42CjL7OnDlip49fp7dRE?si=xGIWlKm0QSm7nFEPBL6roA" target="_blank">
-        open.spotify.com/album/6Q42CjL7…</a> <!-- :contentReference[oaicite:4]{index=4} -->
-    </p>
 
     <p><strong>Podcast (Easy Living with Suzy Easton):</strong><br>
       <iframe title="Suzy's Guide to Vancouver's April 5th By-Election"

--- a/page-home.php
+++ b/page-home.php
@@ -85,7 +85,13 @@ get_header();
 
     <section class="now-listening">
         <h2 class="pixel-font">Now Listening</h2>
-        <div id="now-listening-widget"></div>
+        <iframe width="100%" height="360" src="https://www.youtube.com/embed/GwetNnBkgQM?autoplay=0" title="Metric – Full Performance (Live on KEXP)" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <p class="pixel-font now-listening-caption">🎶 Metric — Live on KEXP. Raw energy, shimmering synths, no AI weapons funding here.</p>
+        <div class="info-callout pixel-font">
+            <p>Spotify CEO Daniel Ek used his investment firm Prima Materia to lead a <strong>€600M (~US $694M)</strong> Series D funding round in June 2025 for Helsing, a German defense‑AI startup now valued at $12&nbsp;billion.</p>
+            <p>Helsing develops AI‑enabled drones, aircraft and submarines for defense, and Ek also sits on its board as chairman.</p>
+            <p>At least one indie band – Deerhoof – pulled their music from Spotify in protest, citing ethical concerns over music &ldquo;killing people&rdquo; due to this connection.</p>
+        </div>
     </section>
 
     <section class="advocacy-section">

--- a/style.css
+++ b/style.css
@@ -1001,6 +1001,23 @@ footer,
   animation: fadeIn 1s ease-in;
 }
 
+.now-listening-caption {
+  margin-top: 10px;
+  margin-bottom: 15px;
+}
+
+.info-callout {
+  background: rgba(255, 255, 255, 0.05);
+  border: 2px dashed var(--secondary-color);
+  padding: 15px;
+  margin-top: 10px;
+  text-align: left;
+}
+
+.info-callout p {
+  margin: 0 0 10px;
+}
+
 .now-listening::before {
   content: "";
   position: absolute;


### PR DESCRIPTION
## Summary
- swap old Now Listening widget for a static YouTube embed and add context on Spotify CEO Daniel Ek's Helsing investment
- drop Spotify links from footer and contact page
- note static embed in README
- style new callout box

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686843ffd284832e8fcc73b29ab82019