### PR TITLE
Improve track analyzer error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ A custom WordPress theme powering [suzyeaston.ca](https://suzyeaston.ca), comple
 - Custom REST endpoints for Canucks news and betting odds
 - Mobile friendly with drag & tap controls
 
+## Track Analyzer
+Uploads are sent to OpenAI's Whisper and GPT‑4 APIs for a quick analysis of your
+MP3. Errors are surfaced on the page. For production use, consider exposing this
+feature through a custom REST endpoint and caching results in case OpenAI is
+unavailable.
+
 ## About Suzy Easton
 Suzy is a Vancouver-based musician, technologist and all-around creative builder. She toured Canada playing bass, recorded with Steve Albini and once appeared on MuchMusic. By day she wrangles IT operations and QA work; by night she makes pixel games, releases music and tinkers with civic tech projects. Suzy loves hockey, punk rock, 8-bit aesthetics and fixing things that break in production. She's even considering a run for Vancouver City Council in 2026.
 

--- a/page-track-analyzer.php
+++ b/page-track-analyzer.php
@@ -6,29 +6,46 @@ Template Name: Track Analyzer
 get_header();
 
 /**
- * Analyze an uploaded MP3 using the OpenAI API.
+ * Track Analyzer helpers
  *
- * Requires the OPENAI_API_KEY constant to be defined in wp-config.php or
- * the theme's functions.php file:
+ * Requires the OPENAI_API_KEY constant to be defined in wp-config.php or the
+ * theme's functions.php file:
  *
  *     define( 'OPENAI_API_KEY', 'your-openai-api-key' );
- *
- * @param string $filepath Absolute path to the uploaded MP3.
- * @return string Friendly critique text or an error message.
  */
-function analyze_audio( $filepath ) {
-    if ( ! defined( 'OPENAI_API_KEY' ) || ! OPENAI_API_KEY ) {
-        return __( 'OpenAI API key is not configured.', 'suzys-music-theme' );
+
+/**
+ * Upload the file and return its path or WP_Error on failure.
+ */
+function upload_track_file( array $file ) {
+    if ( UPLOAD_ERR_OK !== $file['error'] ) {
+        return new WP_Error( 'upload_error', __( 'Upload failed. Please try again.', 'suzys-music-theme' ) );
     }
 
+    $type = wp_check_filetype( $file['name'], [ 'mp3' => 'audio/mpeg' ] );
+    if ( ! $type['ext'] ) {
+        return new WP_Error( 'invalid_format', __( 'Please upload a valid MP3 file.', 'suzys-music-theme' ) );
+    }
+
+    $upload = wp_handle_upload( $file, [ 'test_form' => false ] );
+    if ( isset( $upload['file'] ) ) {
+        return $upload['file'];
+    }
+
+    $msg = isset( $upload['error'] ) ? $upload['error'] : __( 'There was an error uploading your file.', 'suzys-music-theme' );
+    return new WP_Error( 'upload_error', $msg );
+}
+
+/**
+ * Send audio file to Whisper API and return the transcript or WP_Error.
+ */
+function whisper_transcribe( $filepath ) {
     if ( ! file_exists( $filepath ) ) {
-        error_log( 'Whisper API: file missing - ' . $filepath );
-        return __( 'Uploaded file missing on server.', 'suzys-music-theme' );
+        return new WP_Error( 'file_missing', __( 'Uploaded file missing on server.', 'suzys-music-theme' ) );
     }
 
     if ( ! function_exists( 'curl_file_create' ) ) {
-        error_log( 'curl_file_create function missing.' );
-        return __( 'Server misconfiguration: cURL support missing.', 'suzys-music-theme' );
+        return new WP_Error( 'curl_missing', __( 'Server misconfiguration: cURL support missing.', 'suzys-music-theme' ) );
     }
 
     $file_resource = curl_file_create( $filepath, 'audio/mpeg', basename( $filepath ) );
@@ -48,9 +65,10 @@ function analyze_audio( $filepath ) {
 
     $body = curl_exec( $ch );
     if ( false === $body ) {
-        error_log( 'Whisper cURL error: ' . curl_error( $ch ) );
+        $err = curl_error( $ch );
         curl_close( $ch );
-        return __( 'Failed to transcribe audio.', 'suzys-music-theme' );
+        error_log( 'Whisper cURL error: ' . $err );
+        return new WP_Error( 'whisper_curl', __( 'Failed to transcribe audio.', 'suzys-music-theme' ) . ' ' . $err );
     }
 
     $code = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
@@ -59,23 +77,29 @@ function analyze_audio( $filepath ) {
 
     if ( 200 !== $code ) {
         error_log( 'Whisper API HTTP ' . $code . ': ' . $body );
-        return sprintf( __( 'Audio transcription failed (HTTP %s).', 'suzys-music-theme' ), $code );
+        return new WP_Error( 'whisper_http', sprintf( __( 'Audio transcription failed (HTTP %s).', 'suzys-music-theme' ), $code ) );
     }
-
 
     $data = json_decode( $body, true );
     if ( null === $data || json_last_error() !== JSON_ERROR_NONE ) {
         error_log( 'Whisper JSON error: ' . json_last_error_msg() . ' - ' . $body );
-        return __( 'Invalid transcription response.', 'suzys-music-theme' );
+        return new WP_Error( 'whisper_json', __( 'Invalid transcription response.', 'suzys-music-theme' ) );
     }
-    $text = $data['text'] ?? '';
 
+    $text = $data['text'] ?? '';
     if ( ! $text ) {
         error_log( 'Whisper API missing text: ' . $body );
-        return __( 'Audio transcription failed.', 'suzys-music-theme' );
+        return new WP_Error( 'whisper_empty', __( 'Audio transcription failed.', 'suzys-music-theme' ) );
     }
 
-    $prompt = 'Provide a playful yet insightful critique of this track. Channel the futuristic vibes of Grimes with the dance-floor savvy of James Murphy. Transcript: ' . $text;
+    return $text;
+}
+
+/**
+ * Send transcript to GPT-4 and return analysis or WP_Error.
+ */
+function gpt4_analyze( $transcript ) {
+    $prompt = 'Provide a playful yet insightful critique of this track. Channel the futuristic vibes of Grimes with the dance-floor savvy of James Murphy. Transcript: ' . $transcript;
 
     $response = wp_remote_post( 'https://api.openai.com/v1/chat/completions', [
         'headers' => [
@@ -92,58 +116,65 @@ function analyze_audio( $filepath ) {
 
     if ( is_wp_error( $response ) ) {
         error_log( 'GPT-4 request error: ' . $response->get_error_message() );
-        return __( 'Analysis request failed.', 'suzys-music-theme' );
+        return new WP_Error( 'gpt_request', __( 'Analysis request failed.', 'suzys-music-theme' ) );
     }
 
     $code = wp_remote_retrieve_response_code( $response );
     $body = wp_remote_retrieve_body( $response );
     error_log( 'GPT response (' . $code . '): ' . substr( $body, 0, 200 ) );
+
     if ( 200 !== $code ) {
         error_log( 'GPT-4 HTTP ' . $code . ': ' . $body );
-        return sprintf( __( 'Analysis failed (HTTP %s).', 'suzys-music-theme' ), $code );
+        return new WP_Error( 'gpt_http', sprintf( __( 'Analysis failed (HTTP %s).', 'suzys-music-theme' ), $code ) );
     }
 
     $data = json_decode( $body, true );
     if ( null === $data || json_last_error() !== JSON_ERROR_NONE ) {
         error_log( 'GPT JSON error: ' . json_last_error_msg() . ' - ' . $body );
-        return __( 'Invalid analysis response.', 'suzys-music-theme' );
+        return new WP_Error( 'gpt_json', __( 'Invalid analysis response.', 'suzys-music-theme' ) );
     }
-    $analysis = $data['choices'][0]['message']['content'] ?? '';
 
+    $analysis = $data['choices'][0]['message']['content'] ?? '';
     if ( ! $analysis ) {
         error_log( 'GPT-4 missing content: ' . $body );
-        return __( 'Could not generate analysis.', 'suzys-music-theme' );
+        return new WP_Error( 'gpt_missing', __( 'Could not generate analysis.', 'suzys-music-theme' ) );
     }
 
     return $analysis;
+}
+
+/**
+ * Orchestrate upload -> transcription -> analysis.
+ */
+function analyze_audio( $filepath ) {
+    if ( ! defined( 'OPENAI_API_KEY' ) || ! OPENAI_API_KEY ) {
+        return new WP_Error( 'no_key', __( 'OpenAI API key is not configured.', 'suzys-music-theme' ) );
+    }
+
+    $text     = whisper_transcribe( $filepath );
+    if ( is_wp_error( $text ) ) {
+        return $text;
+    }
+
+    return gpt4_analyze( $text );
 }
 
 $analysis = '';
 $error    = '';
 
 if ( 'POST' === $_SERVER['REQUEST_METHOD'] && isset( $_FILES['track_file'] ) ) {
-    $file = $_FILES['track_file'];
+    $upload_result = upload_track_file( $_FILES['track_file'] );
 
-    if ( UPLOAD_ERR_OK === $file['error'] ) {
-        $filetype = wp_check_filetype( $file['name'], [ 'mp3' => 'audio/mpeg' ] );
-
-        if ( $filetype['ext'] ) {
-            $upload = wp_handle_upload( $file, [ 'test_form' => false ] );
-
-            if ( isset( $upload['file'] ) ) {
-                $analysis = analyze_audio( $upload['file'] );
-                @unlink( $upload['file'] );
-            } else {
-                $error_msg = isset( $upload['error'] ) ? $upload['error'] : __( 'There was an error uploading your file.', 'suzys-music-theme' );
-                error_log( 'File upload error: ' . $error_msg );
-                $error = $error_msg;
-            }
-        } else {
-            $error = __( 'Please upload a valid MP3 file.', 'suzys-music-theme' );
-        }
+    if ( is_wp_error( $upload_result ) ) {
+        $error = $upload_result->get_error_message();
     } else {
-        error_log( 'Upload failed code: ' . $file['error'] );
-        $error = __( 'Upload failed. Please try again.', 'suzys-music-theme' );
+        $analysis_result = analyze_audio( $upload_result );
+        if ( is_wp_error( $analysis_result ) ) {
+            $error = $analysis_result->get_error_message();
+        } else {
+            $analysis = $analysis_result;
+        }
+        @unlink( $upload_result );
     }
 }
 ?>


### PR DESCRIPTION
## Summary
- refactor track analyzer into smaller helper functions
- return WP_Error objects for clearer errors
- display the exact upload or API error on the page
- note production considerations in the README

## Testing
- `git diff --check`
- *No automated tests included*

------
https://chatgpt.com/codex/tasks/task_e_686e1a3c1674832e8df8b660318f58b9