### PR TITLE
Fix track analyzer upload

### DIFF
--- a/page-track-analyzer.php
+++ b/page-track-analyzer.php
@@ -18,6 +18,9 @@ get_header();
  * Upload the file and return its path or WP_Error on failure.
  */
 function upload_track_file( array $file ) {
+    if ( ! function_exists( 'wp_handle_upload' ) ) {
+        require_once ABSPATH . 'wp-admin/includes/file.php';
+    }
     if ( UPLOAD_ERR_OK !== $file['error'] ) {
         return new WP_Error( 'upload_error', __( 'Upload failed. Please try again.', 'suzys-music-theme' ) );
     }


### PR DESCRIPTION
## Summary
- require `wp-admin/includes/file.php` in `page-track-analyzer.php` before calling `wp_handle_upload`

## Testing
- `php -l page-track-analyzer.php`


------
https://chatgpt.com/codex/tasks/task_e_68715156ab74832ea001af78b4e066e4