### PR TITLE
Add Track Analyzer promo on homepage

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -47,6 +47,12 @@ get_header();
           <?php endif; ?>
         </div>
 
+        <section class="track-analyzer-feature">
+            <h2 class="pixel-font">Suzy's Track Analyzer</h2>
+            <p class="pixel-font">Drop an MP3, channel the chaos, get an instant vibe check.</p>
+            <a href="https://www.suzyeaston.ca/suzys-track-analyzer/" class="pixel-button analyzer-cta">Analyze a Track</a>
+        </section>
+
         <div class="button-cluster">
             <div class="button-group">
                 <h3 class="group-title">🎵 Music &amp; Podcasts</h3>

--- a/style.css
+++ b/style.css
@@ -356,6 +356,30 @@ body::before {
 }
 
 /* ====================== */
+/*  TRACK ANALYZER PROMO  */
+/* ====================== */
+.track-analyzer-feature {
+  margin: 40px auto;
+  padding: 25px 20px;
+  max-width: 800px;
+  text-align: center;
+  background: var(--background-medium);
+  border: 4px dotted var(--accent-color);
+  border-radius: 8px;
+  box-shadow: 0 0 10px var(--accent-color);
+}
+
+.track-analyzer-feature .pixel-button.analyzer-cta {
+  margin-top: 15px;
+  border-color: var(--accent-color);
+  color: var(--accent-color);
+}
+
+.track-analyzer-feature .pixel-button.analyzer-cta:hover {
+  box-shadow: 0 0 8px var(--accent-color);
+}
+
+/* ====================== */
 /*    SUPPORT SECTION    */
 /* ====================== */
 .support-section {


### PR DESCRIPTION
## Summary
- showcase Suzy's Track Analyzer above the home page apps
- style the new block with a Pac-Man dotted border and pixel font

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871a733dff8832e9f870f912995e021