### PR TITLE
Add animated border for Track Analyzer promo

### DIFF
--- a/style.css
+++ b/style.css
@@ -359,14 +359,44 @@ body::before {
 /*  TRACK ANALYZER PROMO  */
 /* ====================== */
 .track-analyzer-feature {
+  position: relative;
   margin: 40px auto;
   padding: 25px 20px;
   max-width: 800px;
   text-align: center;
   background: var(--background-medium);
-  border: 4px dotted var(--accent-color);
   border-radius: 8px;
   box-shadow: 0 0 10px var(--accent-color);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.track-analyzer-feature::before {
+  content: "";
+  position: absolute;
+  top: -4px;
+  left: -4px;
+  right: -4px;
+  bottom: -4px;
+  border-radius: inherit;
+  pointer-events: none;
+  background:
+    repeating-linear-gradient(90deg, var(--accent-color) 0 5px, transparent 5px 10px) top/100% 4px repeat-x,
+    repeating-linear-gradient(90deg, var(--accent-color) 0 5px, transparent 5px 10px) bottom/100% 4px repeat-x,
+    repeating-linear-gradient(0deg,  var(--accent-color) 0 5px, transparent 5px 10px) left/4px 100% repeat-y,
+    repeating-linear-gradient(0deg,  var(--accent-color) 0 5px, transparent 5px 10px) right/4px 100% repeat-y;
+  animation: border-dance 4s linear infinite;
+}
+
+@keyframes border-dance {
+  from {
+    background-position: 0 0, 0 100%, 0 0, 100% 0;
+  }
+  to {
+    background-position: 10px 0, -10px 100%, 0 -10px, 100% 10px;
+  }
 }
 
 .track-analyzer-feature .pixel-button.analyzer-cta {


### PR DESCRIPTION
## Summary
- center elements in the Track Analyzer promo box
- create animated dotted border that moves clockwise

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871aa31bd28832ea889e676a6f30151