### PR TITLE
Fix track analyzer API model & add riff generator highlight

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,4 +1,11 @@
 <?php
+// Auto-configure OpenAI key from environment if not defined
+if ( ! defined( 'OPENAI_API_KEY' ) ) {
+    $env_key = getenv( 'OPENAI_API_KEY' );
+    if ( $env_key ) {
+        define( 'OPENAI_API_KEY', $env_key );
+    }
+}
 /**
  * Functions file for Suzy’s Music Theme
  *   - Canucks App Integration (News + Betting)
@@ -233,7 +240,7 @@ function albini_handle_query( WP_REST_Request $req ) {
             'Content-Type'  => 'application/json',
         ],
         'body'    => wp_json_encode([
-            'model'    => 'gpt-4o-mini',
+            'model'    => 'gpt-4o',
             'messages' => [
                 ['role'=>'system', 'content'=>"You are Steve Albini, legendary producer—blunt, no‑BS. Answer questions as he would."],
                 ['role'=>'user',   'content'=>$question],

--- a/page-home.php
+++ b/page-home.php
@@ -53,6 +53,12 @@ get_header();
             <a href="https://www.suzyeaston.ca/suzys-track-analyzer/" class="pixel-button analyzer-cta">Analyze a Track</a>
         </section>
 
+        <section class="riff-generator-feature">
+            <h2 class="pixel-font">Riff Generator</h2>
+            <p class="pixel-font">Cook up rad riffs with a click &ndash; unleash your inner shredder.</p>
+            <a href="/riff-generator" class="pixel-button riff-cta">Make a Riff</a>
+        </section>
+
         <div class="button-cluster">
             <div class="button-group">
                 <h3 class="group-title">🎵 Music &amp; Podcasts</h3>

--- a/page-track-analyzer.php
+++ b/page-track-analyzer.php
@@ -110,7 +110,7 @@ function gpt4_analyze( $transcript ) {
             'Content-Type'  => 'application/json',
         ],
         'body'    => wp_json_encode( [
-            'model'    => 'gpt-4o-mini',
+            'model'    => 'gpt-4o',
             'messages' => [ [ 'role' => 'user', 'content' => $prompt ] ],
             'max_tokens' => 150,
         ] ),

--- a/style.css
+++ b/style.css
@@ -409,6 +409,49 @@ body::before {
   box-shadow: 0 0 8px var(--accent-color);
 }
 
+/*  RIFF GENERATOR PROMO  */
+.riff-generator-feature {
+  position: relative;
+  margin: 40px auto;
+  padding: 25px 20px;
+  max-width: 800px;
+  text-align: center;
+  background: var(--background-medium);
+  border-radius: 8px;
+  box-shadow: 0 0 10px var(--secondary-color);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.riff-generator-feature::before {
+  content: "";
+  position: absolute;
+  top: -4px;
+  left: -4px;
+  right: -4px;
+  bottom: -4px;
+  border-radius: inherit;
+  pointer-events: none;
+  background:
+    repeating-linear-gradient(90deg, var(--secondary-color) 0 5px, transparent 5px 10px) top/100% 4px repeat-x,
+    repeating-linear-gradient(90deg, var(--secondary-color) 0 5px, transparent 5px 10px) bottom/100% 4px repeat-x,
+    repeating-linear-gradient(0deg,  var(--secondary-color) 0 5px, transparent 5px 10px) left/4px 100% repeat-y,
+    repeating-linear-gradient(0deg,  var(--secondary-color) 0 5px, transparent 5px 10px) right/4px 100% repeat-y;
+  animation: border-dance 4s linear infinite;
+}
+
+.riff-generator-feature .pixel-button.riff-cta {
+  margin-top: 15px;
+  border-color: var(--secondary-color);
+  color: var(--secondary-color);
+}
+
+.riff-generator-feature .pixel-button.riff-cta:hover {
+  box-shadow: 0 0 8px var(--secondary-color);
+}
+
 /* ====================== */
 /*    SUPPORT SECTION    */
 /* ====================== */


### PR DESCRIPTION
## Summary
- read OPENAI key from the environment
- use the official gpt‑4o model for OpenAI calls
- spotlight the Riff Generator on the home page
- add styles for the Riff Generator promo section

## Testing
- `php -l page-track-analyzer.php`
- `php -l functions.php`
- `php -l page-home.php`
- `php -l page-riff-generator.php`


------
https://chatgpt.com/codex/tasks/task_e_687bf59e33e8832eb858238e2dcaf10c