### PR TITLE
Enhance homepage, bio and tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ A custom WordPress theme powering [suzyeaston.ca](https://suzyeaston.ca), comple
 - Retro pixel-art inspired design with neon CRT vibes
 - **Canucks Puck Bash** – an 80s style hockey game built with HTML5 canvas
 - **Riff Generator 8000** for instant rock, punk, metal or jazz riffs
-- **Easy Living with Suzy Easton** podcast page with embeds from PodBean, iHeartRadio and YouTube
+- **Track Analyzer** for quick MP3 vibe checks using OpenAI
+- Album reviews of classic jazz and rock discovered during Suzy's HMV days
 - **Albini Q&A** widget that channels legendary producer Steve Albini via OpenAI
 - Music releases, livestream schedules and a "Now Listening" section featuring a static YouTube embed
 - Downtown Eastside advocacy section and notes on Suzy's possible 2026 city council run
@@ -14,12 +15,12 @@ A custom WordPress theme powering [suzyeaston.ca](https://suzyeaston.ca), comple
 
 ## Track Analyzer
 Uploads are sent to OpenAI's Whisper and GPT‑4 APIs for a quick analysis of your
-MP3. Errors are surfaced on the page. For production use, consider exposing this
-feature through a custom REST endpoint and caching results in case OpenAI is
-unavailable.
+MP3. Results appear with a fun retro overlay and clear loading indicators. For
+production use, consider exposing this feature through a custom REST endpoint
+and caching results in case OpenAI is unavailable.
 
 ## About Suzy Easton
-Suzy is a Vancouver-based musician, technologist and all-around creative builder. She toured Canada playing bass, recorded with Steve Albini and once appeared on MuchMusic. By day she wrangles IT operations and QA work; by night she makes pixel games, releases music and tinkers with civic tech projects. Suzy loves hockey, punk rock, 8-bit aesthetics and fixing things that break in production. She's even considering a run for Vancouver City Council in 2026.
+Suzy is a Vancouver-based musician, technologist and all-around creative builder. She toured Canada playing bass, recorded with Steve Albini and once appeared on MuchMusic. These days she writes album reviews of jazz and rock classics found during her time at HMV (2007–2012). Inspired by the single "A Little Louder" airing on CiTR, she's crafting new hard rock demos. Suzy loves hockey, punk rock, 8-bit aesthetics and fixing things that break in production, and she's considering a run for Vancouver City Council in 2026.
 
 ## License
 MIT License. Play nice.

--- a/header.php
+++ b/header.php
@@ -19,8 +19,8 @@
     $default_img = 'https://suzyeaston.ca/arcade/og-image.png';
 
     if ( is_front_page() ) {
-      $meta_title = 'Suzy Easton – Retro Music Tools, Games & AI Experiments';
-      $meta_desc  = 'Home base for Vancouver musician and developer Suzy Easton. Explore retro arcade games, AI music tools and podcasts.';
+      $meta_title = 'Suzy Easton – Vancouver Musician & Creative Technologist';
+      $meta_desc  = 'Home base for Vancouver, BC, Canada musician Suzy Easton. Explore music reviews, rock demos, retro games and AI-powered tools.';
       $meta_img   = $default_img;
     } elseif ( is_page_template( 'page-track-analyzer.php' ) ) {
       $meta_title = "Suzy's Track Analyzer – AI Vibe Checker for Musicians";
@@ -59,7 +59,13 @@
       "@type": "PostalAddress",
       "addressLocality": "Vancouver",
       "addressCountry": "CA"
-    }
+    },
+    "sameAs": [
+      "https://suzyeaston.bandcamp.com",
+      "https://soundcloud.com/suzyeaston",
+      "https://instagram.com/suzyeaston",
+      "https://youtube.com/@suzyeaston"
+    ]
   }
   </script>
 

--- a/js/riff-generator.js
+++ b/js/riff-generator.js
@@ -99,13 +99,24 @@ const app = Vue.createApp({
   },
   methods:{
     async generate(){
+      const statusEl = document.getElementById('riff-status');
+      if(statusEl){
+        statusEl.textContent = 'Generating...';
+        statusEl.style.display = 'block';
+      }
       const root = NOTE_NAMES[Math.floor(Math.random()*NOTE_NAMES.length)];
       const pattern = PROGRESSIONS[Math.floor(Math.random()*PROGRESSIONS.length)];
       const chords = pattern.map(d=> chordNotes(root,this.mode,d));
       const scale = scaleSemis(root,this.mode);
       const melody = chords.flatMap(ch => generateMelody(scale,ch.map(n=>NOTE_NAMES.indexOf(n.slice(0,-1))),2));
       this.progressionText = chords.map(c=>c.map(n=>n.slice(0,-1)).join('-')).join(' | ');
-      await this.play(chords, melody);
+      try {
+        await this.play(chords, melody);
+        if(statusEl) statusEl.textContent = 'Riff ready!';
+      } catch(e){
+        if(statusEl) statusEl.textContent = 'Error generating riff';
+        console.error(e);
+      }
       this.tip = TIPS[Math.floor(Math.random()*TIPS.length)];
     },
     async play(chords, melody){

--- a/page-bio.php
+++ b/page-bio.php
@@ -12,7 +12,7 @@ get_header();
             
             <p>Alongside music, I ventured into technology, building a successful career in IT, QA, WebDev, Software Development and software operations, self-taught, building experience through contracting. It's been awesome, I've worked with companies like Electronic Arts, IBM, Western Forest Products, ADP Canada, Crisis Intervention & Suicide Prevention Centre of BC, WineDirect, and Alida.</p>
             
-            <p>My creative pursuits include live video jam sessions, new music releases, and comedic documentary filmmaking about life in Vancouver. I'm also excited to announce my brand-new podcast, <strong>“Easy Living with Suzy Easton”</strong>, where I share stories, insights, and laughter about life in Vancouver.</p>
+            <p>My creative pursuits include live video jam sessions, new music releases, and comedic documentary filmmaking about life in Vancouver. Lately I'm focused on writing album reviews of classic jazz and rock records I uncovered while working at HMV (2007&ndash;2012, Burrard &amp; Robson). After the single <em>A Little Louder</em> aired on CiTR, I'm shifting toward producing a series of hard rock demos. CiTR even spun my electronica track <em>Obsolete</em> again &mdash; it's not my favourite anymore, but I love CiTR!</p>
             
             <p>For collaborations or just to chat, reach out at <a href="mailto:suzyeaston@icloud.com">suzyeaston@icloud.com</a>.</p>
             <p style="text-align:center;">🎶 <a href="https://suzyeaston.bandcamp.com" target="_blank">Support on Bandcamp</a></p>

--- a/page-home.php
+++ b/page-home.php
@@ -96,9 +96,15 @@ get_header();
         </div>
     </section>
 
+    <section class="track-analyzer-feature">
+        <h2 class="pixel-font">Track Analyzer</h2>
+        <p class="pixel-font">Upload an MP3 and get instant feedback on your mix.</p>
+        <a href="/suzys-track-analyzer" class="pixel-button analyzer-cta">Analyze Your Track</a>
+    </section>
+
     <section class="roommate-callout">
         <h2 class="pixel-font">Seeking Musical Roommate! 🎸</h2>
-        <p class="pixel-font">Moving at the end of October 2025—if you're a creative soul looking to jam, collaborate, or simply coexist in harmony, reach out!</p>
+        <p class="pixel-font">Moving at the end of October 2025. If you're a fellow musician or creative looking for a rad roommate situation in Vancouver, let's connect!</p>
         <p class="pixel-font">Contact: <a href="mailto:suzyeaston@icloud.com" class="pixel-button">suzyeaston@icloud.com</a></p>
     </section>
 

--- a/page-riff-generator.php
+++ b/page-riff-generator.php
@@ -12,6 +12,7 @@ get_header();
       <h3 class="pixel-font">Your Riff:</h3>
       <p id="riff-text"></p>
       <audio id="riff-audio" controls style="display:none;"></audio>
+      <p id="riff-status" class="pixel-font" style="display:none;"></p>
     </div>
   </main>
 </div>

--- a/style.css
+++ b/style.css
@@ -452,6 +452,15 @@ body::before {
   box-shadow: 0 0 8px var(--secondary-color);
 }
 
+@media (max-width: 600px) {
+  .track-analyzer-feature,
+  .riff-generator-feature,
+  .roommate-callout {
+    margin: 20px 10px;
+    padding: 15px;
+  }
+}
+
 /* ====================== */
 /*    SUPPORT SECTION    */
 /* ====================== */
@@ -1177,8 +1186,11 @@ footer,
   text-align: center;
 }
 .roommate-callout {
-  margin: 40px 0;
+  position: relative;
+  z-index: 1;
+  margin: 40px auto;
   padding: 20px;
+  max-width: 800px;
   background: rgba(255, 255, 255, 0.1);
   border: 2px solid #fff;
   border-radius: 10px;


### PR DESCRIPTION
## Summary
- refresh homepage layout and highlight Track Analyzer
- improve roommate callout and responsive styles
- update bio with new projects and remove old podcast blurb
- refine SEO metadata and add social links via schema markup
- add status messages for Riff Generator
- revise README with current focus

## Testing
- `php -l page-bio.php`
- `php -l page-home.php`
- `php -l header.php`
- `php -l page-riff-generator.php`
- `node --check js/riff-generator.js`


------
https://chatgpt.com/codex/tasks/task_e_687c0716e398832e9055231a68e78db7