### PR TITLE
Sharpen retro header and add outage monitoring plugin

### DIFF
--- a/assets/css/retro-title.css
+++ b/assets/css/retro-title.css
@@ -1,0 +1,55 @@
+.retro-title {
+  --neon: #00ff66;
+  --neon-dim: #0bff94;
+  --scanline-opacity: 0.07;
+  font-family: 'Press Start 2P', 'VT323', monospace;
+  font-size: clamp(1.2rem, 5vw, 2.5rem);
+  letter-spacing: 0.02em;
+  color: var(--neon);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  position: relative;
+  text-shadow:
+    0 0 1px var(--neon),
+    0 0 2px var(--neon),
+    0 0 6px var(--neon-dim),
+    0 0 14px var(--neon-dim);
+}
+
+.retro-title.glow-lite {
+  text-shadow:
+    0 0 1px var(--neon),
+    0 0 2px var(--neon),
+    0 0 4px var(--neon-dim),
+    0 0 8px var(--neon-dim);
+}
+
+.retro-title.glow-heavy {
+  text-shadow:
+    0 0 2px var(--neon),
+    0 0 4px var(--neon),
+    0 0 8px var(--neon-dim),
+    0 0 16px var(--neon-dim);
+}
+
+.retro-title::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(255,255,255,var(--scanline-opacity)) 0 1px,
+    transparent 1px 3px
+  );
+  mix-blend-mode: overlay;
+  pointer-events: none;
+}
+
+.retro-title:hover {
+  letter-spacing: 0.03em;
+  text-shadow:
+    0 0 2px var(--neon),
+    0 0 4px var(--neon),
+    0 0 8px var(--neon-dim),
+    0 0 16px var(--neon-dim);
+}

--- a/functions.php
+++ b/functions.php
@@ -21,6 +21,9 @@ function retro_game_music_theme_scripts() {
     // Retro font + main stylesheet
     wp_enqueue_style('retro-font', 'https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
     wp_enqueue_style('main-styles', get_stylesheet_uri());
+    if ( is_front_page() ) {
+        wp_enqueue_style('retro-title', get_template_directory_uri() . '/assets/css/retro-title.css', [], '1.0.0');
+    }
 
     // Game & piano scripts
     wp_enqueue_script('piano-script', get_template_directory_uri() . '/js/piano-script.js', [], '1.0.1', true);

--- a/lousy-outages/README.md
+++ b/lousy-outages/README.md
@@ -1,0 +1,36 @@
+# Lousy Outages
+
+Monitor third‑party service status and get SMS alerts when things break.
+
+## Providers
+
+| ID | Name | Endpoint |
+|----|------|----------|
+| github | GitHub | https://www.githubstatus.com/api/v2/summary.json |
+| slack | Slack | https://status.slack.com/api/v2.0.0/summary.json |
+| cloudflare | Cloudflare | https://www.cloudflarestatus.com/api/v2/summary.json |
+| openai | OpenAI | https://status.openai.com/api/v2/summary.json |
+| aws | AWS | https://status.aws.amazon.com/rss/all.rss |
+| azure | Azure | https://azurestatuscdn.azureedge.net/en-us/status/feed/ |
+| gcp | Google Cloud | https://status.cloud.google.com/feed.atom |
+
+To add or remove a provider, edit `includes/Providers.php` or use the checkboxes under **Settings → Lousy Outages** in wp-admin.
+
+## Twilio Setup
+
+1. Sign up for Twilio and obtain your **Account SID**, **Auth Token**, and a verified **From** number.
+2. In wp-admin go to **Settings → Lousy Outages** and enter the SID, token, from number and your destination phone number.
+3. Choose which providers to monitor and set the polling interval (default 5 minutes).
+
+## Shortcode
+
+Place `[lousy_outages]` in any page or post to render the status table. A page titled *Lousy Outages* is created automatically on activation.
+
+## Filters & Actions
+
+- `lousy_outages_providers` – filter the provider array before polling.
+- `lousy_outages_status` – filter normalized status before storage.
+
+## Development
+
+Polling runs via WP-Cron (`lousy_outages_poll`). Results are stored in an option and also exposed at `/wp-json/lousy-outages/v1/status`.

--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -1,0 +1,14 @@
+.lousy-outages-list table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.lousy-outages-list th,
+.lousy-outages-list td {
+  padding: 0.5rem;
+  text-align: left;
+}
+.lousy-outages-list .status.operational { color: #0a0; }
+.lousy-outages-list .status.degraded,
+.lousy-outages-list .status.partial_outage { color: #d90; }
+.lousy-outages-list .status.major_outage { color: #d00; }
+.lousy-outages-list .last-updated { font-size: 0.9rem; margin-bottom: 0.5rem; }

--- a/lousy-outages/assets/lousy-outages.js
+++ b/lousy-outages/assets/lousy-outages.js
@@ -1,0 +1,21 @@
+(function(){
+  function update(){
+    fetch(LousyOutages.endpoint).then(r=>r.json()).then(function(data){
+      var container=document.getElementById('lousy-outages');
+      if(!container) return;
+      var tbody=container.querySelector('tbody');
+      Object.keys(data).forEach(function(id){
+        var row=tbody.querySelector('tr[data-id="'+id+'"]');
+        if(!row) return;
+        var statusCell=row.querySelector('.status');
+        statusCell.textContent=data[id].status;
+        statusCell.className='status '+data[id].status;
+        row.querySelector('.msg').textContent=data[id].message;
+      });
+      var timeSpan=container.querySelector('.last-updated span');
+      if(timeSpan){ timeSpan.textContent=new Date().toUTCString(); }
+    });
+  }
+  setInterval(update,60000);
+  update();
+})();

--- a/lousy-outages/includes/Detector.php
+++ b/lousy-outages/includes/Detector.php
@@ -1,0 +1,23 @@
+<?php
+namespace LousyOutages;
+
+class Detector {
+    private Store $store;
+
+    public function __construct( Store $store ) {
+        $this->store = $store;
+    }
+
+    /**
+     * Compare new data with stored to find transitions.
+     */
+    public function detect( string $id, array $data ): ?array {
+        $existing = $this->store->get( $id );
+        $old      = $existing['status'] ?? 'unknown';
+        $new      = $data['status'];
+        if ( $old === $new ) {
+            return null;
+        }
+        return [ 'old' => $old, 'new' => $new ];
+    }
+}

--- a/lousy-outages/includes/Fetcher.php
+++ b/lousy-outages/includes/Fetcher.php
@@ -1,0 +1,59 @@
+<?php
+namespace LousyOutages;
+
+class Fetcher {
+    /**
+     * Fetch and normalize data for a provider.
+     */
+    public function fetch( array $provider ): ?array {
+        $cache_key = 'lo_fetch_' . $provider['id'];
+        $cached    = get_transient( $cache_key );
+        if ( $cached ) {
+            return $cached;
+        }
+        $response = wp_remote_get( $provider['endpoint'], [ 'timeout' => 8 ] );
+        if ( is_wp_error( $response ) ) {
+            return null;
+        }
+        $body = wp_remote_retrieve_body( $response );
+        $data = null;
+        if ( 'statuspage' === $provider['type'] ) {
+            $decoded = json_decode( $body, true );
+            if ( ! $decoded ) {
+                return null;
+            }
+            $indicator = $decoded['status']['indicator'] ?? 'none';
+            $map       = [
+                'none'     => 'operational',
+                'minor'    => 'degraded',
+                'major'    => 'major_outage',
+                'critical' => 'major_outage',
+            ];
+            $status = $map[ $indicator ] ?? 'operational';
+            $message = $decoded['status']['description'] ?? '';
+            $updated = $decoded['page']['updated_at'] ?? gmdate( 'c' );
+        } else { // rss/atom
+            $xml = @simplexml_load_string( $body );
+            if ( ! $xml ) {
+                return null;
+            }
+            $has_items = isset( $xml->channel->item ) && count( $xml->channel->item ) > 0;
+            if ( ! $has_items && isset( $xml->entry ) ) {
+                $has_items = count( $xml->entry ) > 0;
+            }
+            $status  = $has_items ? 'degraded' : 'operational';
+            $message = $has_items ? (string) ( $xml->channel->item[0]->title ?? $xml->entry[0]->title ) : 'All systems go';
+            $updated = gmdate( 'c' );
+        }
+        $data = [
+            'id'         => $provider['id'],
+            'name'       => $provider['name'],
+            'status'     => $status,
+            'message'    => wp_strip_all_tags( (string) $message ),
+            'updated_at' => $updated,
+            'url'        => $provider['url'],
+        ];
+        set_transient( $cache_key, $data, 120 );
+        return $data;
+    }
+}

--- a/lousy-outages/includes/Providers.php
+++ b/lousy-outages/includes/Providers.php
@@ -1,0 +1,71 @@
+<?php
+namespace LousyOutages;
+
+class Providers {
+    /**
+     * Return all providers.
+     * @return array
+     */
+    public static function list(): array {
+        return [
+            'github' => [
+                'id'       => 'github',
+                'name'     => 'GitHub',
+                'endpoint' => 'https://www.githubstatus.com/api/v2/summary.json',
+                'type'     => 'statuspage',
+                'url'      => 'https://www.githubstatus.com/'
+            ],
+            'slack' => [
+                'id'       => 'slack',
+                'name'     => 'Slack',
+                'endpoint' => 'https://status.slack.com/api/v2.0.0/summary.json',
+                'type'     => 'statuspage',
+                'url'      => 'https://status.slack.com/'
+            ],
+            'cloudflare' => [
+                'id'       => 'cloudflare',
+                'name'     => 'Cloudflare',
+                'endpoint' => 'https://www.cloudflarestatus.com/api/v2/summary.json',
+                'type'     => 'statuspage',
+                'url'      => 'https://www.cloudflarestatus.com/'
+            ],
+            'openai' => [
+                'id'       => 'openai',
+                'name'     => 'OpenAI',
+                'endpoint' => 'https://status.openai.com/api/v2/summary.json',
+                'type'     => 'statuspage',
+                'url'      => 'https://status.openai.com/'
+            ],
+            'aws' => [
+                'id'       => 'aws',
+                'name'     => 'AWS',
+                'endpoint' => 'https://status.aws.amazon.com/rss/all.rss',
+                'type'     => 'rss',
+                'url'      => 'https://status.aws.amazon.com/'
+            ],
+            'azure' => [
+                'id'       => 'azure',
+                'name'     => 'Azure',
+                'endpoint' => 'https://azurestatuscdn.azureedge.net/en-us/status/feed/',
+                'type'     => 'rss',
+                'url'      => 'https://status.azure.com/'
+            ],
+            'gcp' => [
+                'id'       => 'gcp',
+                'name'     => 'Google Cloud',
+                'endpoint' => 'https://status.cloud.google.com/feed.atom',
+                'type'     => 'rss',
+                'url'      => 'https://status.cloud.google.com/'
+            ],
+        ];
+    }
+
+    /**
+     * Return enabled providers from options or default all.
+     */
+    public static function enabled(): array {
+        $all     = self::list();
+        $enabled = get_option( 'lousy_outages_providers', array_keys( $all ) );
+        return array_intersect_key( $all, array_flip( $enabled ) );
+    }
+}

--- a/lousy-outages/includes/SMS.php
+++ b/lousy-outages/includes/SMS.php
@@ -1,0 +1,36 @@
+<?php
+namespace LousyOutages;
+
+class SMS {
+    private function send( string $body ): void {
+        $sid   = get_option( 'lousy_outages_twilio_sid' );
+        $token = get_option( 'lousy_outages_twilio_token' );
+        $from  = get_option( 'lousy_outages_twilio_from' );
+        $to    = get_option( 'lousy_outages_phone' );
+        if ( ! $sid || ! $token || ! $from || ! $to ) {
+            return;
+        }
+        $url = sprintf( 'https://api.twilio.com/2010-04-01/Accounts/%s/Messages.json', $sid );
+        wp_remote_post( $url, [
+            'timeout' => 10,
+            'headers' => [
+                'Authorization' => 'Basic ' . base64_encode( $sid . ':' . $token ),
+            ],
+            'body'    => [
+                'From' => $from,
+                'To'   => $to,
+                'Body' => $body,
+            ],
+        ] );
+    }
+
+    public function send_alert( string $provider, string $status, string $message, string $link ): void {
+        $body = sprintf( '🚨 Lousy Outages: %s -> %s. %s (%s)', $provider, $status, $message, $link );
+        $this->send( $body );
+    }
+
+    public function send_recovery( string $provider, string $link ): void {
+        $body = sprintf( '✅ Lousy Outages: %s recovered. (%s)', $provider, $link );
+        $this->send( $body );
+    }
+}

--- a/lousy-outages/includes/Store.php
+++ b/lousy-outages/includes/Store.php
@@ -1,0 +1,32 @@
+<?php
+namespace LousyOutages;
+
+class Store {
+    private string $option = 'lousy_outages_states';
+    private string $log_option = 'lousy_outages_log';
+
+    public function get_all(): array {
+        return get_option( $this->option, [] );
+    }
+
+    public function get( string $id ): ?array {
+        $all = $this->get_all();
+        return $all[ $id ] ?? null;
+    }
+
+    public function update( string $id, array $data ): void {
+        $all        = $this->get_all();
+        $all[ $id ] = $data;
+        update_option( $this->option, $all, false );
+        $this->log( $id, $data['status'] );
+    }
+
+    private function log( string $id, string $status ): void {
+        $log   = get_option( $this->log_option, [] );
+        $log[] = [ 'id' => $id, 'status' => $status, 'time' => time() ];
+        if ( count( $log ) > 50 ) {
+            $log = array_slice( $log, -50 );
+        }
+        update_option( $this->log_option, $log, false );
+    }
+}

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -1,0 +1,177 @@
+<?php
+declare( strict_types=1 );
+/**
+ * Plugin Name: Lousy Outages
+ * Description: Aggregates service status and sends SMS alerts on incidents.
+ * Version: 0.1.0
+ * Author: Suzy Easton
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+define( 'LOUSY_OUTAGES_PATH', plugin_dir_path( __FILE__ ) );
+
+require_once LOUSY_OUTAGES_PATH . 'includes/Providers.php';
+require_once LOUSY_OUTAGES_PATH . 'includes/Store.php';
+require_once LOUSY_OUTAGES_PATH . 'includes/Fetcher.php';
+require_once LOUSY_OUTAGES_PATH . 'includes/Detector.php';
+require_once LOUSY_OUTAGES_PATH . 'includes/SMS.php';
+require_once LOUSY_OUTAGES_PATH . 'public/shortcode.php';
+
+use LousyOutages\Providers;
+use LousyOutages\Store;
+use LousyOutages\Fetcher;
+use LousyOutages\Detector;
+use LousyOutages\SMS;
+
+/**
+ * Schedule polling event on activation and create page.
+ */
+function lousy_outages_activate() {
+    if ( ! wp_next_scheduled( 'lousy_outages_poll' ) ) {
+        $interval = (int) get_option( 'lousy_outages_interval', 300 );
+        wp_schedule_event( time() + 60, 'lousy_outages_interval', 'lousy_outages_poll' );
+    }
+    lousy_outages_create_page();
+}
+register_activation_hook( __FILE__, 'lousy_outages_activate' );
+
+/**
+ * Clear cron on deactivation.
+ */
+function lousy_outages_deactivate() {
+    wp_clear_scheduled_hook( 'lousy_outages_poll' );
+}
+register_deactivation_hook( __FILE__, 'lousy_outages_deactivate' );
+
+/**
+ * Add custom interval for cron based on setting.
+ */
+add_filter( 'cron_schedules', function ( $schedules ) {
+    $interval                      = (int) get_option( 'lousy_outages_interval', 300 );
+    $schedules['lousy_outages_interval'] = [
+        'interval' => max( 60, $interval ),
+        'display'  => 'Lousy Outages Interval',
+    ];
+    return $schedules;
+} );
+
+/**
+ * Poll providers and handle transitions.
+ */
+add_action( 'lousy_outages_poll', 'lousy_outages_run_poll' );
+function lousy_outages_run_poll() {
+    $fetcher  = new Fetcher();
+    $store    = new Store();
+    $detector = new Detector( $store );
+    $sms      = new SMS();
+    $providers = Providers::enabled();
+    foreach ( $providers as $id => $prov ) {
+        $data = $fetcher->fetch( $prov );
+        if ( ! $data ) {
+            continue;
+        }
+        $transition = $detector->detect( $id, $data );
+        $store->update( $id, $data );
+        if ( $transition ) {
+            if ( in_array( $transition['new'], [ 'degraded', 'partial_outage', 'major_outage' ], true ) ) {
+                $sms->send_alert( $prov['name'], $transition['new'], $data['message'], $prov['url'] );
+            } elseif ( 'operational' === $transition['new'] && in_array( $transition['old'], [ 'degraded', 'partial_outage', 'major_outage' ], true ) ) {
+                $sms->send_recovery( $prov['name'], $prov['url'] );
+            }
+        }
+    }
+}
+
+/**
+ * Create public page if missing.
+ */
+function lousy_outages_create_page() {
+    $page = get_page_by_path( 'lousy-outages' );
+    if ( ! $page ) {
+        wp_insert_post( [
+            'post_title'   => 'Lousy Outages',
+            'post_name'    => 'lousy-outages',
+            'post_content' => '[lousy_outages]',
+            'post_status'  => 'publish',
+            'post_type'    => 'page',
+        ] );
+    }
+}
+
+/**
+ * Settings page.
+ */
+add_action( 'admin_menu', function () {
+    add_options_page( 'Lousy Outages', 'Lousy Outages', 'manage_options', 'lousy-outages', 'lousy_outages_settings_page' );
+} );
+
+add_action( 'admin_init', function () {
+    register_setting( 'lousy_outages', 'lousy_outages_twilio_sid' );
+    register_setting( 'lousy_outages', 'lousy_outages_twilio_token' );
+    register_setting( 'lousy_outages', 'lousy_outages_twilio_from' );
+    register_setting( 'lousy_outages', 'lousy_outages_phone' );
+    register_setting( 'lousy_outages', 'lousy_outages_interval' );
+    register_setting( 'lousy_outages', 'lousy_outages_providers' );
+} );
+
+function lousy_outages_settings_page() {
+    $providers = Providers::list();
+    $enabled   = get_option( 'lousy_outages_providers', array_keys( $providers ) );
+    $interval  = get_option( 'lousy_outages_interval', 300 );
+    ?>
+    <div class="wrap">
+        <h1>Lousy Outages Settings</h1>
+        <form method="post" action="options.php">
+            <?php settings_fields( 'lousy_outages' ); ?>
+            <table class="form-table" role="presentation">
+                <tr>
+                    <th scope="row"><label for="lo_sid">Twilio SID</label></th>
+                    <td><input id="lo_sid" type="text" name="lousy_outages_twilio_sid" value="<?php echo esc_attr( get_option( 'lousy_outages_twilio_sid' ) ); ?>" class="regular-text"></td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="lo_token">Twilio Auth Token</label></th>
+                    <td><input id="lo_token" type="text" name="lousy_outages_twilio_token" value="<?php echo esc_attr( get_option( 'lousy_outages_twilio_token' ) ); ?>" class="regular-text"></td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="lo_from">Twilio From Number</label></th>
+                    <td><input id="lo_from" type="text" name="lousy_outages_twilio_from" value="<?php echo esc_attr( get_option( 'lousy_outages_twilio_from' ) ); ?>" class="regular-text"></td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="lo_phone">Destination Phone</label></th>
+                    <td><input id="lo_phone" type="text" name="lousy_outages_phone" value="<?php echo esc_attr( get_option( 'lousy_outages_phone' ) ); ?>" class="regular-text"></td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="lo_interval">Poll Interval (seconds)</label></th>
+                    <td><input id="lo_interval" type="number" min="60" name="lousy_outages_interval" value="<?php echo esc_attr( $interval ); ?>"></td>
+                </tr>
+                <tr>
+                    <th scope="row">Providers</th>
+                    <td>
+                        <?php foreach ( $providers as $id => $prov ) : ?>
+                            <label><input type="checkbox" name="lousy_outages_providers[]" value="<?php echo esc_attr( $id ); ?>" <?php checked( in_array( $id, $enabled, true ) ); ?>> <?php echo esc_html( $prov['name'] ); ?></label><br>
+                        <?php endforeach; ?>
+                    </td>
+                </tr>
+            </table>
+            <?php submit_button(); ?>
+        </form>
+    </div>
+    <?php
+}
+
+/**
+ * REST endpoint exposing current status.
+ */
+add_action( 'rest_api_init', function () {
+    register_rest_route( 'lousy-outages/v1', '/status', [
+        'methods'             => 'GET',
+        'permission_callback' => '__return_true',
+        'callback'            => function () {
+            $store = new Store();
+            return rest_ensure_response( $store->get_all() );
+        },
+    ] );
+} );

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -1,0 +1,38 @@
+<?php
+namespace LousyOutages;
+
+add_shortcode( 'lousy_outages', __NAMESPACE__ . '\\render_shortcode' );
+
+function render_shortcode(): string {
+    wp_enqueue_style( 'lousy-outages', plugins_url( 'assets/lousy-outages.css', dirname( __FILE__ ) ), [], '1.0.0' );
+    wp_enqueue_script( 'lousy-outages', plugins_url( 'assets/lousy-outages.js', dirname( __FILE__ ) ), [], '1.0.0', true );
+    wp_localize_script( 'lousy-outages', 'LousyOutages', [ 'endpoint' => rest_url( 'lousy-outages/v1/status' ) ] );
+
+    $store     = new Store();
+    $providers = Providers::list();
+    $states    = $store->get_all();
+
+    ob_start();
+    ?>
+    <div id="lousy-outages" class="lousy-outages-list" aria-live="polite">
+        <p class="last-updated">Updated: <span></span></p>
+        <table>
+            <thead><tr><th>Provider</th><th>Status</th><th>Message</th></tr></thead>
+            <tbody>
+            <?php foreach ( $providers as $id => $prov ) :
+                $state   = $states[ $id ] ?? [ 'status' => 'unknown', 'message' => '' ];
+                $status  = esc_html( $state['status'] );
+                $message = esc_html( $state['message'] );
+                ?>
+                <tr data-id="<?php echo esc_attr( $id ); ?>">
+                    <td><?php echo esc_html( $prov['name'] ); ?></td>
+                    <td class="status <?php echo $status; ?>"><?php echo $status; ?></td>
+                    <td class="msg"><?php echo $message; ?></td>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+    <?php
+    return (string) ob_get_clean();
+}

--- a/page-home.php
+++ b/page-home.php
@@ -5,7 +5,7 @@ get_header();
 
 <main id="homepage-content">
     <div class="hero-section">
-        <h1 id="home-title" class="pixel-font color-cycle">Suzy Easton &ndash; Vancouver Musician &amp; Creative Technologist</h1>
+        <?php get_template_part( 'parts/hero-title' ); ?>
        <section class="pixel-intro" style="max-width: 720px; margin: 0 auto; line-height: 1.8; font-size: 1.05rem;">
     <p>I&rsquo;m a musician, technologist, and creative builder based in Vancouver.</p>
 

--- a/parts/hero-title.php
+++ b/parts/hero-title.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Hero title component for retro neon heading.
+ *
+ * @package SuzysMusicTheme
+ */
+?>
+<h1 class="retro-title glow-lite">Suzy Easton &ndash; Vancouver Musician &amp; Creative Technologist</h1>


### PR DESCRIPTION
## Summary
- refine home page hero text into reusable template with adjustable retro glow
- introduce `lousy-outages` plugin to monitor service status and send Twilio SMS alerts
- document plugin usage and configuration

## Testing
- `php -l parts/hero-title.php`
- `php -l functions.php`
- `php -l page-home.php`
- `php -l lousy-outages/lousy-outages.php`
- `php -l lousy-outages/includes/Providers.php`
- `php -l lousy-outages/includes/Store.php`
- `php -l lousy-outages/includes/Fetcher.php`
- `php -l lousy-outages/includes/Detector.php`
- `php -l lousy-outages/includes/SMS.php`
- `php -l lousy-outages/public/shortcode.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab6d6cd72c832e84bc9be5c56a5c38