### PR TITLE
Add outage arcade board and coffee support links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A custom WordPress theme powering [suzyeaston.ca](https://suzyeaston.ca), comple
 - Music releases, livestream schedules and a "Now Listening" section featuring a static YouTube embed
 - Downtown Eastside advocacy section and notes on Suzy's possible 2026 city council run
 - Custom REST endpoints for Canucks news and betting odds
+- **Lousy Outages** arcade‑style status board with homepage teaser
+- "Buy Me a Coffee" buttons to support Suzy's work
 - Mobile friendly with drag & tap controls
 
 ## Track Analyzer

--- a/assets/css/buttons.css
+++ b/assets/css/buttons.css
@@ -1,0 +1,24 @@
+.btn-bmc {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  z-index: 1000;
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  border: 2px solid #0f0;
+  border-radius: 9999px;
+  background: #111;
+  color: #0f0;
+  text-decoration: none;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 0.75rem;
+}
+.btn-bmc:hover,
+.btn-bmc:focus {
+  background: #0f0;
+  color: #111;
+}
+.hero-section .btn-bmc {
+  position: static;
+  margin-top: 1rem;
+}

--- a/assets/css/lousy-outages-teaser.css
+++ b/assets/css/lousy-outages-teaser.css
@@ -1,0 +1,28 @@
+.lo-teaser {
+  margin: 2rem auto;
+  text-align: center;
+  font-family: 'Press Start 2P', monospace;
+}
+.lo-teaser .providers {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px,1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+.lo-teaser .card {
+  background: #111;
+  border: 2px solid #0f0;
+  padding: 0.5rem;
+}
+.lo-teaser .dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 4px;
+}
+.lo-teaser .status-up { background: #00ff66; }
+.lo-teaser .status-warn { background: #ffcc00; }
+.lo-teaser .status-down { background: #ff004c; }
+.lo-teaser .caption { font-size: 0.75rem; margin: 0.5rem 0; }
+.lo-teaser .view-all { display: inline-block; margin-top: 0.5rem; }

--- a/assets/css/retro-title.css
+++ b/assets/css/retro-title.css
@@ -1,10 +1,8 @@
 .retro-title {
-  --neon: #00ff66;
-  --neon-dim: #0bff94;
-  --scanline-opacity: 0.07;
-  font-family: 'Press Start 2P', 'VT323', monospace;
-  font-size: clamp(1.2rem, 5vw, 2.5rem);
-  letter-spacing: 0.02em;
+  --neon: #00ff66; --neon-dim: #0bff94; --scanline-opacity: 0.07;
+  font-family: 'Press Start 2P','VT323',monospace;
+  font-size: clamp(1.6rem, 6vw, 3rem); /* slightly larger for clarity */
+  letter-spacing: .01em;
   color: var(--neon);
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
@@ -14,6 +12,7 @@
     0 0 2px var(--neon),
     0 0 6px var(--neon-dim),
     0 0 14px var(--neon-dim);
+  will-change: letter-spacing;
 }
 
 .retro-title.glow-lite {
@@ -45,11 +44,4 @@
   pointer-events: none;
 }
 
-.retro-title:hover {
-  letter-spacing: 0.03em;
-  text-shadow:
-    0 0 2px var(--neon),
-    0 0 4px var(--neon),
-    0 0 8px var(--neon-dim),
-    0 0 16px var(--neon-dim);
-}
+.retro-title:hover { letter-spacing: .015em; }  /* no extra blur */

--- a/assets/js/lousy-outages-teaser.js
+++ b/assets/js/lousy-outages-teaser.js
@@ -1,0 +1,34 @@
+(function(){
+  const container = document.getElementById('lousy-outages-teaser');
+  if(!container) return;
+  const grid = container.querySelector('.providers');
+  function statusClass(s){
+    if(s === 'operational') return 'status-up';
+    if(s === 'major_outage') return 'status-down';
+    return 'status-warn';
+  }
+  function render(data){
+    grid.innerHTML='';
+    Object.keys(data).slice(0,6).forEach(id => {
+      const state = data[id];
+      const card = document.createElement('div');
+      card.className = 'card';
+      const dot = document.createElement('span');
+      dot.className = 'dot ' + statusClass(state.status);
+      card.appendChild(dot);
+      const name = document.createElement('span');
+      name.textContent = id;
+      card.appendChild(name);
+      grid.appendChild(card);
+    });
+  }
+  async function update(){
+    try {
+      const res = await fetch('/wp-json/lousy-outages/v1/status');
+      const data = await res.json();
+      render(data);
+    } catch(e) {}
+  }
+  update();
+  setInterval(update, 60000);
+})();

--- a/functions.php
+++ b/functions.php
@@ -21,8 +21,25 @@ function retro_game_music_theme_scripts() {
     // Retro font + main stylesheet
     wp_enqueue_style('retro-font', 'https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
     wp_enqueue_style('main-styles', get_stylesheet_uri());
+    wp_enqueue_style(
+        'buttons',
+        get_template_directory_uri() . '/assets/css/buttons.css',
+        [],
+        filemtime( get_template_directory() . '/assets/css/buttons.css' )
+    );
     if ( is_front_page() ) {
-        wp_enqueue_style('retro-title', get_template_directory_uri() . '/assets/css/retro-title.css', [], '1.0.0');
+        wp_enqueue_style(
+            'retro-title',
+            get_template_directory_uri() . '/assets/css/retro-title.css',
+            [],
+            filemtime( get_template_directory() . '/assets/css/retro-title.css' )
+        );
+        wp_enqueue_style(
+            'lousy-outages-teaser',
+            get_template_directory_uri() . '/assets/css/lousy-outages-teaser.css',
+            [],
+            filemtime( get_template_directory() . '/assets/css/lousy-outages-teaser.css' )
+        );
     }
 
     // Game & piano scripts
@@ -31,6 +48,13 @@ function retro_game_music_theme_scripts() {
     if ( is_front_page() ) {
         wp_enqueue_script('game-init', get_template_directory_uri() . '/js/game-init.js', [], '1.0.0', true);
         wp_enqueue_script('title-color', get_template_directory_uri() . '/js/title-color.js', [], '1.0.0', true);
+        wp_enqueue_script(
+            'lousy-outages-teaser',
+            get_template_directory_uri() . '/assets/js/lousy-outages-teaser.js',
+            [],
+            filemtime( get_template_directory() . '/assets/js/lousy-outages-teaser.js' ),
+            true
+        );
     }
 }
 add_action('wp_enqueue_scripts', 'retro_game_music_theme_scripts');

--- a/header.php
+++ b/header.php
@@ -88,6 +88,7 @@
 ?>
 
 <a href="/" class="home-link" aria-label="Home">🏠 Home</a>
+<?php get_template_part('parts/bmc-button'); ?>
 
 <!-- Full‑screen moving starfield background -->
 <canvas id="starfield" role="img" aria-label="Animated starfield background"></canvas>

--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -12,3 +12,9 @@
 .lousy-outages-list .status.partial_outage { color: #d90; }
 .lousy-outages-list .status.major_outage { color: #d00; }
 .lousy-outages-list .last-updated { font-size: 0.9rem; margin-bottom: 0.5rem; }
+.lo-arcade { text-align: center; font-family: 'Press Start 2P', monospace; }
+.lo-arcade table { width: 100%; border-collapse: collapse; }
+.lo-arcade .ticker { margin-top: 1rem; font-size: 0.8rem; height: 1rem; overflow: hidden; }
+.lo-arcade .coin-btn { margin-top: 1rem; padding: 0.5rem 1rem; background: #111; color: #0f0; border: 2px solid #0f0; cursor: pointer; }
+.lo-arcade.spinning .coin-btn { animation: spin 1s linear; }
+@keyframes spin { from { transform: rotate(0); } to { transform: rotate(360deg); } }

--- a/lousy-outages/assets/lousy-outages.js
+++ b/lousy-outages/assets/lousy-outages.js
@@ -1,19 +1,57 @@
 (function(){
+  var container = document.getElementById('lousy-outages');
+  if(!container) return;
+  var tbody = container.querySelector('tbody');
+  var tickerEl = container.querySelector('.ticker');
+  var tickerMsgs = [], tickerIdx = 0, tickerTimer;
+  function updateTicker(){
+    if(!tickerEl) return;
+    if(!tickerMsgs.length){ tickerEl.textContent=''; return; }
+    tickerEl.textContent = tickerMsgs[tickerIdx];
+    tickerIdx = (tickerIdx + 1) % tickerMsgs.length;
+  }
+  function setTicker(msgs){
+    tickerMsgs = msgs;
+    tickerIdx = 0;
+    clearInterval(tickerTimer);
+    updateTicker();
+    if(msgs.length && !window.matchMedia('(prefers-reduced-motion: reduce)').matches){
+      tickerTimer = setInterval(updateTicker,3000);
+    }
+  }
+  function render(data){
+    Object.keys(data).forEach(function(id){
+      var row = tbody.querySelector('tr[data-id="'+id+'"]');
+      if(!row) return;
+      var statusCell = row.querySelector('.status');
+      statusCell.textContent = data[id].status;
+      statusCell.className = 'status '+data[id].status;
+      row.querySelector('.msg').textContent = data[id].message;
+    });
+    var messages = Object.values(data).filter(function(s){ return s.message; }).map(function(s){ return s.message; });
+    setTicker(messages);
+    var timeSpan = container.querySelector('.last-updated span');
+    if(timeSpan){ timeSpan.textContent = new Date().toUTCString(); }
+  }
   function update(){
-    fetch(LousyOutages.endpoint).then(r=>r.json()).then(function(data){
-      var container=document.getElementById('lousy-outages');
-      if(!container) return;
-      var tbody=container.querySelector('tbody');
-      Object.keys(data).forEach(function(id){
-        var row=tbody.querySelector('tr[data-id="'+id+'"]');
-        if(!row) return;
-        var statusCell=row.querySelector('.status');
-        statusCell.textContent=data[id].status;
-        statusCell.className='status '+data[id].status;
-        row.querySelector('.msg').textContent=data[id].message;
-      });
-      var timeSpan=container.querySelector('.last-updated span');
-      if(timeSpan){ timeSpan.textContent=new Date().toUTCString(); }
+    fetch(LousyOutages.endpoint).then(function(r){ return r.json(); }).then(render);
+  }
+  var coin = container.querySelector('.coin-btn');
+  if(coin){
+    coin.addEventListener('click', function(){
+      if(!window.matchMedia('(prefers-reduced-motion: reduce)').matches){
+        container.classList.add('spinning');
+        setTimeout(function(){ container.classList.remove('spinning'); },1000);
+      }
+      if(window.AudioContext){
+        var ctx = new AudioContext();
+        var osc = ctx.createOscillator();
+        osc.frequency.value = 880;
+        osc.connect(ctx.destination);
+        osc.start();
+        setTimeout(function(){ osc.stop(); ctx.close(); },150);
+      }
+      update();
     });
   }
   setInterval(update,60000);

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -4,8 +4,20 @@ namespace LousyOutages;
 add_shortcode( 'lousy_outages', __NAMESPACE__ . '\\render_shortcode' );
 
 function render_shortcode(): string {
-    wp_enqueue_style( 'lousy-outages', plugins_url( 'assets/lousy-outages.css', dirname( __FILE__ ) ), [], '1.0.0' );
-    wp_enqueue_script( 'lousy-outages', plugins_url( 'assets/lousy-outages.js', dirname( __FILE__ ) ), [], '1.0.0', true );
+    $base = plugin_dir_path( __DIR__ ) . 'assets/';
+    wp_enqueue_style(
+        'lousy-outages',
+        plugins_url( 'assets/lousy-outages.css', dirname( __FILE__ ) ),
+        [],
+        filemtime( $base . 'lousy-outages.css' )
+    );
+    wp_enqueue_script(
+        'lousy-outages',
+        plugins_url( 'assets/lousy-outages.js', dirname( __FILE__ ) ),
+        [],
+        filemtime( $base . 'lousy-outages.js' ),
+        true
+    );
     wp_localize_script( 'lousy-outages', 'LousyOutages', [ 'endpoint' => rest_url( 'lousy-outages/v1/status' ) ] );
 
     $store     = new Store();
@@ -14,24 +26,28 @@ function render_shortcode(): string {
 
     ob_start();
     ?>
-    <div id="lousy-outages" class="lousy-outages-list" aria-live="polite">
-        <p class="last-updated">Updated: <span></span></p>
-        <table>
-            <thead><tr><th>Provider</th><th>Status</th><th>Message</th></tr></thead>
-            <tbody>
-            <?php foreach ( $providers as $id => $prov ) :
-                $state   = $states[ $id ] ?? [ 'status' => 'unknown', 'message' => '' ];
-                $status  = esc_html( $state['status'] );
-                $message = esc_html( $state['message'] );
-                ?>
-                <tr data-id="<?php echo esc_attr( $id ); ?>">
-                    <td><?php echo esc_html( $prov['name'] ); ?></td>
-                    <td class="status <?php echo $status; ?>"><?php echo $status; ?></td>
-                    <td class="msg"><?php echo $message; ?></td>
-                </tr>
-            <?php endforeach; ?>
-            </tbody>
-        </table>
+    <div class="lo-arcade">
+        <div id="lousy-outages" class="lousy-outages-list" aria-live="polite">
+            <p class="last-updated">Updated: <span></span></p>
+            <table>
+                <thead><tr><th>Provider</th><th>Status</th><th>Message</th></tr></thead>
+                <tbody>
+                <?php foreach ( $providers as $id => $prov ) :
+                    $state   = $states[ $id ] ?? [ 'status' => 'unknown', 'message' => '' ];
+                    $status  = esc_html( $state['status'] );
+                    $message = esc_html( $state['message'] );
+                    ?>
+                    <tr data-id="<?php echo esc_attr( $id ); ?>">
+                        <td><?php echo esc_html( $prov['name'] ); ?></td>
+                        <td class="status <?php echo $status; ?>"><?php echo $status; ?></td>
+                        <td class="msg"><?php echo $message; ?></td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+            <div class="ticker" aria-live="polite"></div>
+            <button type="button" class="coin-btn">Coin</button>
+        </div>
     </div>
     <?php
     return (string) ob_get_clean();

--- a/page-home.php
+++ b/page-home.php
@@ -5,8 +5,10 @@ get_header();
 
 <main id="homepage-content">
     <div class="hero-section">
-        <?php get_template_part( 'parts/hero-title' ); ?>
-       <section class="pixel-intro" style="max-width: 720px; margin: 0 auto; line-height: 1.8; font-size: 1.05rem;">
+        <h1 class="retro-title glow-lite">Suzy Easton &mdash; Vancouver</h1>
+        <h2 class="retro-title glow-lite">Musician &amp; Creative Technologist</h2>
+        <?php get_template_part('parts/bmc-button'); ?>
+        <section class="pixel-intro" style="max-width: 720px; margin: 0 auto; line-height: 1.8; font-size: 1.05rem;">
     <p>I&rsquo;m a musician, technologist, and creative builder based in Vancouver.</p>
 
     <p>Toured nationally as a bassist, recorded with Steve Albini in Chicago, and appeared on MuchMusic. Today, I keep creating, playing around with programming/coding and releasing new music at night while shipping infrastructure code by day hah!</p>
@@ -84,6 +86,8 @@ get_header();
         </div>
 
     </div>
+
+    <?php get_template_part('parts/lousy-outages-teaser'); ?>
 
     <section class="now-listening">
         <h2 class="pixel-font">Now Listening</h2>

--- a/parts/bmc-button.php
+++ b/parts/bmc-button.php
@@ -1,0 +1,1 @@
+<a class="btn-bmc" href="https://buymeacoffee.com/wi0amge" target="_blank" rel="noopener" aria-label="Support Suzy on Buy Me a Coffee">☕ Buy me a coffee</a>

--- a/parts/lousy-outages-teaser.php
+++ b/parts/lousy-outages-teaser.php
@@ -1,0 +1,5 @@
+<section id="lousy-outages-teaser" class="lo-teaser" aria-live="polite">
+  <div class="providers"></div>
+  <p class="caption">insert coin to retry</p>
+  <a class="view-all pixel-button" href="/lousy-outages/">View All →</a>
+</section>

--- a/style.css
+++ b/style.css
@@ -65,7 +65,7 @@ body::before {
       rgba(0, 255, 0, 0.1) 4px,
       rgba(0, 255, 0, 0.1) 8px
     );
-  z-index: 9999;
+  z-index: 0;
   animation: screen-flicker 1s infinite;
 }
 
@@ -633,26 +633,6 @@ body::before {
 }
 
 /* ====================== */
-/*    CRT SCAN‑LINES      */
-/* ====================== */
-body::before {
-  content: "";
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-  background: repeating-linear-gradient(
-    to bottom,
-    rgba(0, 0, 0, 0) 0,
-    rgba(0, 0, 0, 0) 2px,
-    rgba(0, 0, 0, 0.1) 2px,
-    rgba(0, 0, 0, 0.1) 4px
-  );
-  z-index: 9999;
-}
-
 /* ====================== */
 /*        HERO AREA       */
 /* ====================== */
@@ -804,9 +784,6 @@ body::before {
     0 0 4px #0f0,
     0 0 8px #0f0,
     0 0 12px #0f0;
-  animation:
-    neonPulse 1.5s ease-in-out infinite alternate,
-    flickerSlow 3s infinite;
 }
 @keyframes neonPulse {
   from {
@@ -931,9 +908,6 @@ footer,
     gradientShift 8s linear infinite,
     neonPulse 1.5s ease-in-out infinite alternate,
     flickerSlow 3s infinite;
-  -webkit-font-smoothing: none;
-  font-smooth: never;
-  text-rendering: optimizeSpeed;
 }
 
 @keyframes gradientShift {


### PR DESCRIPTION
## Summary
- fix doubled CRT scanlines and lower overlay to keep titles crisp
- add retro neon heading styles with smoother hover
- show Lousy Outages teaser on home and full arcade board with ticker & coin refresh
- add Buy Me a Coffee buttons in header and hero
- document outages board and support buttons

## Testing
- `php -l functions.php`
- `php -l header.php`
- `php -l page-home.php`
- `php -l parts/bmc-button.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab71f29680832eb4a85b004ce54867