### PR TITLE
Refine hero header and add Lousy Outages page

### DIFF
--- a/page-lousy-outages.php
+++ b/page-lousy-outages.php
@@ -1,0 +1,11 @@
+<?php
+/* Template Name: Lousy Outages */
+get_header();
+?>
+
+<main class="lousy-outages-page">
+  <h1 class="retro-title glow-lite">Lousy Outages</h1>
+  <?php echo do_shortcode('[lousy_outages]'); ?>
+</main>
+
+<?php get_footer(); ?>

--- a/style.css
+++ b/style.css
@@ -894,6 +894,22 @@ footer,
   max-width: 800px;
 }
 
+.retro-title {
+  font-family: "Press Start 2P", cursive;
+  -webkit-font-smoothing: none;
+  font-smooth: never;
+  text-rendering: optimizeSpeed;
+  color: var(--primary-color);
+  text-shadow: 0 0 4px var(--primary-color);
+  margin: 0.5rem 0;
+  line-height: 1.2;
+}
+
+.glow-lite {
+  color: var(--primary-color);
+  text-shadow: 0 0 6px rgba(0,255,0,0.6);
+}
+
 .hero-section h1.color-cycle {
   margin-bottom: 1.5rem;
   background: linear-gradient(90deg, #ff004c, #ffcc00, #00ffff, #ff004c);
@@ -924,6 +940,22 @@ footer,
 }
 .hero-section .pixel-intro p {
   margin-bottom: 1.5rem;
+}
+
+.lousy-outages-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+  text-align: center;
+}
+
+.lousy-outages-page h1 {
+  margin-bottom: 1.5rem;
+}
+
+.lousy-outages-page .lousy-outages-list table {
+  font-family: "Press Start 2P", monospace;
+  width: 100%;
 }
 
 .home-link {


### PR DESCRIPTION
## Summary
- polish hero header with crisp retro fonts and subtle glow
- create dedicated Lousy Outages page styled for the theme

## Testing
- `php -l page-lousy-outages.php`
- `php -l style.css`
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab7642bdf0832e99d11fa6cd1ef8d6