### PR TITLE
Polish retro header and Lousy Outages arcade dashboard

### DIFF
--- a/assets/css/buttons.css
+++ b/assets/css/buttons.css
@@ -5,20 +5,17 @@
   z-index: 1000;
   display: inline-block;
   padding: 0.5rem 1rem;
-  border: 2px solid #0f0;
-  border-radius: 9999px;
+  border: 3px solid #0f0;
   background: #111;
   color: #0f0;
   text-decoration: none;
   font-family: 'Press Start 2P', monospace;
   font-size: 0.75rem;
+  box-shadow: 0 0 8px #0f0, inset 0 0 8px #0f0;
 }
 .btn-bmc:hover,
 .btn-bmc:focus {
   background: #0f0;
   color: #111;
-}
-.hero-section .btn-bmc {
-  position: static;
-  margin-top: 1rem;
+  box-shadow: 0 0 12px #0f0, inset 0 0 4px #0f0;
 }

--- a/assets/css/lousy-outages-teaser.css
+++ b/assets/css/lousy-outages-teaser.css
@@ -10,9 +10,16 @@
   margin-bottom: 1rem;
 }
 .lo-teaser .card {
+  display: block;
   background: #111;
   border: 2px solid #0f0;
   padding: 0.5rem;
+  text-decoration: none;
+  color: #0f0;
+}
+.lo-teaser .card:hover {
+  background: #0f0;
+  color: #111;
 }
 .lo-teaser .dot {
   display: inline-block;

--- a/assets/css/retro-title.css
+++ b/assets/css/retro-title.css
@@ -4,8 +4,9 @@
   font-size: clamp(1.6rem, 6vw, 3rem); /* slightly larger for clarity */
   letter-spacing: .01em;
   color: var(--neon);
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: none;
+  font-smooth: never;
+  text-rendering: optimizeSpeed;
   position: relative;
   text-shadow:
     0 0 1px var(--neon),

--- a/assets/js/lousy-outages-teaser.js
+++ b/assets/js/lousy-outages-teaser.js
@@ -2,6 +2,7 @@
   const container = document.getElementById('lousy-outages-teaser');
   if(!container) return;
   const grid = container.querySelector('.providers');
+  const names = { github:'GitHub', slack:'Slack', cloudflare:'Cloudflare', openai:'OpenAI', aws:'AWS', azure:'Azure', gcp:'GCP' };
   function statusClass(s){
     if(s === 'operational') return 'status-up';
     if(s === 'major_outage') return 'status-down';
@@ -11,13 +12,14 @@
     grid.innerHTML='';
     Object.keys(data).slice(0,6).forEach(id => {
       const state = data[id];
-      const card = document.createElement('div');
+      const card = document.createElement('a');
       card.className = 'card';
+      card.href = '/lousy-outages/';
       const dot = document.createElement('span');
       dot.className = 'dot ' + statusClass(state.status);
       card.appendChild(dot);
       const name = document.createElement('span');
-      name.textContent = id;
+      name.textContent = names[id] || id;
       card.appendChild(name);
       grid.appendChild(card);
     });

--- a/functions.php
+++ b/functions.php
@@ -75,6 +75,12 @@ function suzy_enqueue_scripts() {
 }
 add_action( 'wp_enqueue_scripts', 'suzy_enqueue_scripts' );
 
+// Load bundled Lousy Outages plugin so shortcode and REST endpoint work
+$lousy_outages = get_template_directory() . '/lousy-outages/lousy-outages.php';
+if ( file_exists( $lousy_outages ) ) {
+    require_once $lousy_outages;
+}
+
 
 // =========================================
 // 2. DISABLE AUTOMATIC PARAGRAPH FORMATTING

--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -1,20 +1,45 @@
-.lousy-outages-list table {
+.lo-arcade {
+  font-family: 'Press Start 2P', monospace;
+  background: #000;
+  color: #0f0;
+  padding: 1rem;
+  border: 4px solid #0f0;
+  box-shadow: 0 0 10px #0f0;
+  max-width: 960px;
+  margin: 0 auto;
+  text-align: center;
+}
+.lo-arcade table {
   width: 100%;
   border-collapse: collapse;
 }
-.lousy-outages-list th,
-.lousy-outages-list td {
+.lo-arcade th,
+.lo-arcade td {
   padding: 0.5rem;
+  border-bottom: 1px solid #0f0;
   text-align: left;
 }
-.lousy-outages-list .status.operational { color: #0a0; }
-.lousy-outages-list .status.degraded,
-.lousy-outages-list .status.partial_outage { color: #d90; }
-.lousy-outages-list .status.major_outage { color: #d00; }
-.lousy-outages-list .last-updated { font-size: 0.9rem; margin-bottom: 0.5rem; }
-.lo-arcade { text-align: center; font-family: 'Press Start 2P', monospace; }
-.lo-arcade table { width: 100%; border-collapse: collapse; }
-.lo-arcade .ticker { margin-top: 1rem; font-size: 0.8rem; height: 1rem; overflow: hidden; }
-.lo-arcade .coin-btn { margin-top: 1rem; padding: 0.5rem 1rem; background: #111; color: #0f0; border: 2px solid #0f0; cursor: pointer; }
+.lousy-outages-list .last-updated { font-size: 0.8rem; margin-bottom: 0.5rem; color: #0ff; }
+.status { text-transform: capitalize; }
+.status.operational { color: #00ff66; }
+.status.degraded,
+.status.partial_outage { color: #ffcc00; }
+.status.major_outage { color: #ff004c; animation: alert-pulse 1s infinite; }
+@keyframes alert-pulse { 0%{ text-shadow:0 0 2px #ff004c; }50%{ text-shadow:0 0 10px #ff004c; }100%{ text-shadow:0 0 2px #ff004c; } }
+.lo-arcade .ticker { margin-top: 1rem; font-size: 0.8rem; height: 1rem; overflow: hidden; color: #0ff; }
+.lo-arcade .coin-btn {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background: #111;
+  color: #0f0;
+  border: 2px solid #0f0;
+  cursor: pointer;
+  box-shadow: 0 0 6px #0f0;
+}
+.lo-arcade .coin-btn:hover {
+  background: #0f0;
+  color: #111;
+}
 .lo-arcade.spinning .coin-btn { animation: spin 1s linear; }
 @keyframes spin { from { transform: rotate(0); } to { transform: rotate(360deg); } }
+.microcopy { margin-top: 1rem; font-size: 0.7rem; color: #0ff; }

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -4,18 +4,25 @@ namespace LousyOutages;
 add_shortcode( 'lousy_outages', __NAMESPACE__ . '\\render_shortcode' );
 
 function render_shortcode(): string {
-    $base = plugin_dir_path( __DIR__ ) . 'assets/';
+    $base_path = plugin_dir_path( __DIR__ ) . 'assets/';
+    $theme_path = get_template_directory() . '/lousy-outages/assets/';
+    if ( file_exists( $theme_path ) ) {
+        $base_path = $theme_path;
+        $base_url  = get_template_directory_uri() . '/lousy-outages/assets/';
+    } else {
+        $base_url = plugin_dir_url( __DIR__ ) . 'assets/';
+    }
     wp_enqueue_style(
         'lousy-outages',
-        plugins_url( 'assets/lousy-outages.css', dirname( __FILE__ ) ),
+        $base_url . 'lousy-outages.css',
         [],
-        filemtime( $base . 'lousy-outages.css' )
+        filemtime( $base_path . 'lousy-outages.css' )
     );
     wp_enqueue_script(
         'lousy-outages',
-        plugins_url( 'assets/lousy-outages.js', dirname( __FILE__ ) ),
+        $base_url . 'lousy-outages.js',
         [],
-        filemtime( $base . 'lousy-outages.js' ),
+        filemtime( $base_path . 'lousy-outages.js' ),
         true
     );
     wp_localize_script( 'lousy-outages', 'LousyOutages', [ 'endpoint' => rest_url( 'lousy-outages/v1/status' ) ] );
@@ -47,6 +54,7 @@ function render_shortcode(): string {
             </table>
             <div class="ticker" aria-live="polite"></div>
             <button type="button" class="coin-btn">Coin</button>
+            <p class="microcopy">Vancouver weather: cloudy with a chance of outages.</p>
         </div>
     </div>
     <?php

--- a/page-home.php
+++ b/page-home.php
@@ -7,7 +7,6 @@ get_header();
     <div class="hero-section">
         <h1 class="retro-title glow-lite">Suzy Easton &mdash; Vancouver</h1>
         <h2 class="retro-title glow-lite">Musician &amp; Creative Technologist</h2>
-        <?php get_template_part('parts/bmc-button'); ?>
         <section class="pixel-intro" style="max-width: 720px; margin: 0 auto; line-height: 1.8; font-size: 1.05rem;">
     <p>I&rsquo;m a musician, technologist, and creative builder based in Vancouver.</p>
 

--- a/parts/lousy-outages-teaser.php
+++ b/parts/lousy-outages-teaser.php
@@ -1,5 +1,5 @@
 <section id="lousy-outages-teaser" class="lo-teaser" aria-live="polite">
   <div class="providers"></div>
   <p class="caption">insert coin to retry</p>
-  <a class="view-all pixel-button" href="/lousy-outages/">View All →</a>
+  <a class="view-all pixel-button" href="/lousy-outages/">View Full Dashboard →</a>
 </section>


### PR DESCRIPTION
## Summary
- Keep retro header crisp by disabling font smoothing so the title no longer blurs.
- Load and style the bundled Lousy Outages plugin with neon arcade flair and a weather easter egg.
- Add a homepage outages teaser widget with provider names and a full dashboard link.
- Move the Buy Me a Coffee link into a glowing top‑right panel.

## Testing
- `php -l functions.php`
- `php -l page-home.php`
- `php -l page-lousy-outages.php`
- `php -l lousy-outages/public/shortcode.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab794a489c832e94e14197f13002d2