### PR TITLE
Enhance homepage banner and outages features

### DIFF
--- a/assets/css/lousy-outages-teaser.css
+++ b/assets/css/lousy-outages-teaser.css
@@ -3,6 +3,9 @@
   text-align: center;
   font-family: 'Press Start 2P', monospace;
 }
+.lo-teaser h2 {
+  margin-bottom: 1rem;
+}
 .lo-teaser .providers {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(120px,1fr));

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -171,7 +171,19 @@ add_action( 'rest_api_init', function () {
         'permission_callback' => '__return_true',
         'callback'            => function () {
             $store = new Store();
-            return rest_ensure_response( $store->get_all() );
+            $data  = $store->get_all();
+            if ( empty( $data ) ) {
+                $fetcher   = new Fetcher();
+                $providers = Providers::enabled();
+                foreach ( $providers as $id => $prov ) {
+                    $state = $fetcher->fetch( $prov );
+                    if ( $state ) {
+                        $data[ $id ] = $state;
+                        $store->update( $id, $state );
+                    }
+                }
+            }
+            return rest_ensure_response( $data );
         },
     ] );
 } );

--- a/parts/bmc-button.php
+++ b/parts/bmc-button.php
@@ -1,1 +1,4 @@
-<a class="btn-bmc" href="https://buymeacoffee.com/wi0amge" target="_blank" rel="noopener" aria-label="Support Suzy on Buy Me a Coffee">☕ Buy me a coffee</a>
+<div class="bmc-container">
+  <a class="btn-bmc" href="https://buymeacoffee.com/wi0amge" target="_blank" rel="noopener" aria-label="Support Suzy on Buy Me a Coffee">☕ Buy me a coffee</a>
+  <script data-name="BMC-Widget" data-cfasync="false" src="https://cdnjs.buymeacoffee.com/1.0.0/widget.prod.min.js" data-id="wi0amge" data-description="Support me on Buy Me a Coffee!" data-message="Thanks for visiting" data-color="#00ff00" data-position="Right" data-x_margin="18" data-y_margin="18"></script>
+</div>

--- a/parts/lousy-outages-teaser.php
+++ b/parts/lousy-outages-teaser.php
@@ -1,5 +1,6 @@
 <section id="lousy-outages-teaser" class="lo-teaser" aria-live="polite">
+  <h2 class="pixel-font">Lousy Outages</h2>
   <div class="providers"></div>
-  <p class="caption">insert coin to retry</p>
+  <p class="caption">Check if your favorite services are up. Insert coin to refresh.</p>
   <a class="view-all pixel-button" href="/lousy-outages/">View Full Dashboard →</a>
 </section>

--- a/style.css
+++ b/style.css
@@ -889,6 +889,14 @@ footer,
   text-align: center;
   padding: 4rem 1rem 2rem;
 }
+
+.hero-section h1 {
+  font-size: 2rem;
+}
+
+.hero-section h2 {
+  font-size: 1.25rem;
+}
 .tagline {
   margin: 20px auto;
   max-width: 800px;


### PR DESCRIPTION
## Summary
- Reduce hero banner font sizes for a sharper look
- Add Buy Me a Coffee widget button
- Highlight Lousy Outages on homepage and ensure status page fetches data when empty

## Testing
- `php -l parts/bmc-button.php`
- `php -l parts/lousy-outages-teaser.php`
- `php -l lousy-outages/lousy-outages.php`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7b984944832e9296114f821418e5