### PR TITLE
Create retro header bar

### DIFF
--- a/assets/css/buttons.css
+++ b/assets/css/buttons.css
@@ -1,8 +1,4 @@
 .btn-bmc {
-  position: fixed;
-  top: 10px;
-  right: 10px;
-  z-index: 1000;
   display: inline-block;
   padding: 0.5rem 1rem;
   border: 3px solid #0f0;

--- a/header.php
+++ b/header.php
@@ -87,8 +87,10 @@
   }
 ?>
 
-<a href="/" class="home-link" aria-label="Home">🏠 Home</a>
-<?php get_template_part('parts/bmc-button'); ?>
+<header class="main-header">
+  <a href="/" class="logo">Suzy Easton</a>
+  <?php get_template_part( 'parts/bmc-button' ); ?>
+</header>
 
 <!-- Full‑screen moving starfield background -->
 <canvas id="starfield" role="img" aria-label="Animated starfield background"></canvas>

--- a/style.css
+++ b/style.css
@@ -968,18 +968,33 @@ footer,
   width: 100%;
 }
 
-.home-link {
+
+body {
+  padding-top: 60px;
+}
+
+.main-header {
   position: fixed;
-  top: 10px;
-  left: 10px;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px;
+  background: rgba(0, 0, 0, 0.85);
+  border-bottom: 2px solid var(--accent-color);
   z-index: 10000;
+}
+
+.main-header .logo {
   font-family: "Press Start 2P", cursive;
   font-size: 0.85rem;
   color: var(--accent-color);
   text-decoration: none;
 }
 
-.home-link:hover {
+.main-header .logo:hover {
   text-shadow: 0 0 4px var(--accent-color);
 }
 


### PR DESCRIPTION
## Summary
- Replace minimal home link with fixed retro header bar containing site title and coffee support button
- Style new header with retro theme and add top padding for page content
- Simplify Buy Me a Coffee button CSS for header placement

## Testing
- `php -l header.php`
- `php -l parts/bmc-button.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab81a52704832ea8f389a22924fa2c