### PR TITLE
Keep Lousy Outages live with auto-refresh and en-CA copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ A custom WordPress theme powering [suzyeaston.ca](https://suzyeaston.ca), comple
 - "Buy Me a Coffee" buttons to support Suzy's work
 - Mobile friendly with drag & tap controls
 
+## Lousy Outages refresh
+The arcade-style status board now pulls fresh data from `/wp-json/lousy-outages/v1/status` on load and every five minutes (override with the `LOUSY_OUTAGES_POLL_INTERVAL` env var or the `lousy_outages_interval` option). Each request skips caches, times out quickly and stores per-provider results so one failure shows as **Unknown** without blocking the others. WordPress cron still drives the background poller—run `wp cron event run lousy_outages_poll` (or let traffic trigger it) to keep the datastore warm between interactive refreshes.
+
 ## Track Analyzer
 Uploads are sent to OpenAI's Whisper and GPT‑4 APIs for a quick analysis of your
 MP3. Results appear with a fun retro overlay and clear loading indicators. For

--- a/__tests__/helpers.js
+++ b/__tests__/helpers.js
@@ -1,0 +1,319 @@
+const { TextEncoder, TextDecoder } = require('util');
+
+if (typeof global.TextEncoder === 'undefined') {
+  global.TextEncoder = TextEncoder;
+}
+if (typeof global.TextDecoder === 'undefined') {
+  global.TextDecoder = TextDecoder;
+}
+if (typeof global.matchMedia === 'undefined') {
+  global.matchMedia = () => ({
+    matches: false,
+    addListener() {},
+    removeListener() {}
+  });
+}
+
+function defaultResponse() {
+  return {
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        providers: [],
+        meta: { fetchedAt: new Date().toISOString() }
+      })
+  };
+}
+
+function createClassList(element) {
+  const classes = new Set();
+  const sync = value => {
+    classes.clear();
+    (value || '')
+      .split(/\s+/)
+      .filter(Boolean)
+      .forEach(cls => classes.add(cls));
+  };
+
+  return {
+    _syncFromString: sync,
+    add(cls) {
+      if (!classes.has(cls)) {
+        classes.add(cls);
+        element._className = Array.from(classes).join(' ');
+      }
+    },
+    remove(cls) {
+      if (classes.has(cls)) {
+        classes.delete(cls);
+        element._className = Array.from(classes).join(' ');
+      }
+    },
+    toggle(cls, force) {
+      if (force === true) {
+        this.add(cls);
+        return true;
+      }
+      if (force === false) {
+        this.remove(cls);
+        return false;
+      }
+      if (classes.has(cls)) {
+        this.remove(cls);
+        return false;
+      }
+      this.add(cls);
+      return true;
+    },
+    contains(cls) {
+      return classes.has(cls);
+    }
+  };
+}
+
+class TestElement {
+  constructor(tagName, options = {}) {
+    this.tagName = tagName.toUpperCase();
+    this.children = [];
+    this.parentNode = null;
+    this.attributes = {};
+    this.dataset = options.dataset ? { ...options.dataset } : {};
+    this._listeners = {};
+    this._className = '';
+    this.classList = createClassList(this);
+    this.textContent = options.textContent || '';
+    if (options.id) {
+      this.setAttribute('id', options.id);
+    }
+    if (options.className) {
+      this.className = options.className;
+    }
+  }
+
+  appendChild(child) {
+    child.parentNode = this;
+    this.children.push(child);
+    return child;
+  }
+
+  set className(value) {
+    this._className = value || '';
+    this.classList._syncFromString(this._className);
+  }
+
+  get className() {
+    return this._className;
+  }
+
+  set textContent(value) {
+    this._textContent = String(value || '');
+  }
+
+  get textContent() {
+    return this._textContent || '';
+  }
+
+  setAttribute(name, value) {
+    const stringValue = String(value);
+    this.attributes[name] = stringValue;
+    if (name === 'id') {
+      this.id = stringValue;
+    }
+    if (name === 'class') {
+      this.className = stringValue;
+    }
+    if (name === 'title') {
+      this.title = stringValue;
+    }
+    if (name.startsWith('data-')) {
+      const key = name
+        .slice(5)
+        .replace(/-([a-z])/g, (_, chr) => chr.toUpperCase());
+      this.dataset[key] = stringValue;
+    }
+  }
+
+  removeAttribute(name) {
+    delete this.attributes[name];
+    if (name === 'id') {
+      delete this.id;
+    }
+    if (name === 'title') {
+      delete this.title;
+    }
+    if (name.startsWith('data-')) {
+      const key = name
+        .slice(5)
+        .replace(/-([a-z])/g, (_, chr) => chr.toUpperCase());
+      delete this.dataset[key];
+    }
+  }
+
+  getAttribute(name) {
+    return Object.prototype.hasOwnProperty.call(this.attributes, name)
+      ? this.attributes[name]
+      : null;
+  }
+
+  addEventListener(type, handler) {
+    if (!this._listeners[type]) {
+      this._listeners[type] = [];
+    }
+    this._listeners[type].push(handler);
+  }
+
+  dispatchEvent(event) {
+    const listeners = this._listeners[event.type] || [];
+    listeners.forEach(listener => listener.call(this, event));
+    return true;
+  }
+
+  querySelector(selector) {
+    return querySelectorFrom(this, selector);
+  }
+}
+
+function matches(element, selector) {
+  if (!selector) {
+    return false;
+  }
+  if (selector.startsWith('.')) {
+    const target = selector.slice(1);
+    return element.className.split(/\s+/).includes(target);
+  }
+  const attrMatch = selector.match(/^([a-z]+)\[data-id="([^"]+)"\]$/i);
+  if (attrMatch) {
+    const [, tag, value] = attrMatch;
+    return (
+      element.tagName === tag.toUpperCase() &&
+      (element.dataset.id === value || element.attributes['data-id'] === value)
+    );
+  }
+  if (/^[a-z]+$/i.test(selector)) {
+    return element.tagName === selector.toUpperCase();
+  }
+  return false;
+}
+
+function querySelectorFrom(root, selector) {
+  if (!selector) {
+    return null;
+  }
+  const parts = selector.trim().split(/\s+/);
+  let scope = [root];
+  for (const part of parts) {
+    let found = null;
+    for (const node of scope) {
+      found = findInChildren(node, part);
+      if (found) {
+        break;
+      }
+    }
+    if (!found) {
+      return null;
+    }
+    scope = [found];
+  }
+  return scope[0] === root ? null : scope[0];
+}
+
+function findInChildren(node, selector) {
+  for (const child of node.children) {
+    if (matches(child, selector)) {
+      return child;
+    }
+    const nested = findInChildren(child, selector);
+    if (nested) {
+      return nested;
+    }
+  }
+  return null;
+}
+
+function buildDashboardDom(providers) {
+  const container = new TestElement('div', {
+    id: 'lousy-outages',
+    className: 'lousy-outages-list'
+  });
+  const lastUpdated = container.appendChild(
+    new TestElement('p', { className: 'last-updated' })
+  );
+  const span = lastUpdated.appendChild(new TestElement('span'));
+  span.setAttribute('data-initial', '');
+  const table = container.appendChild(new TestElement('table'));
+  const tbody = table.appendChild(new TestElement('tbody'));
+
+  providers.forEach(provider => {
+    const row = tbody.appendChild(new TestElement('tr'));
+    row.setAttribute('data-id', provider.id);
+    row.dataset.id = provider.id;
+    row.appendChild(new TestElement('td', { textContent: provider.name }));
+    const statusCell = row.appendChild(
+      new TestElement('td', {
+        className: provider.statusClass || 'status status--operational',
+        textContent: provider.statusLabel || 'Operational'
+      })
+    );
+    statusCell.dataset.status = provider.statusCode || 'operational';
+    const messageCell = row.appendChild(
+      new TestElement('td', {
+        className: 'msg',
+        textContent: provider.message || ''
+      })
+    );
+    messageCell.dataset.id = provider.id + '-message';
+  });
+
+  const ticker = container.appendChild(new TestElement('div', { className: 'ticker' }));
+  const button = container.appendChild(
+    new TestElement('button', { className: 'coin-btn' })
+  );
+  button.setAttribute('data-loading-label', 'Loading…');
+  button.appendChild(new TestElement('span', { className: 'label', textContent: 'Insert coin' }));
+  button.appendChild(new TestElement('span', { className: 'loader' }));
+
+  const doc = {
+    readyState: 'complete',
+    getElementById(id) {
+      return id === 'lousy-outages' ? container : null;
+    },
+    querySelector(selector) {
+      return container.querySelector(selector);
+    },
+    addEventListener() {},
+    body: { }
+  };
+
+  return { container, document: doc };
+}
+
+function installMockFetch() {
+  const calls = [];
+  const fetchFn = function (...args) {
+    calls.push(args);
+    return fetchFn.impl(...args);
+  };
+  fetchFn.impl = () => Promise.resolve(defaultResponse());
+  fetchFn.mockImplementation = fn => {
+    fetchFn.impl = fn;
+  };
+  fetchFn.mockClear = () => {
+    calls.length = 0;
+    fetchFn.impl = () => Promise.resolve(defaultResponse());
+  };
+  Object.defineProperty(fetchFn, 'calls', {
+    get() {
+      return calls.slice();
+    }
+  });
+  fetchFn.callCount = () => calls.length;
+  global.fetch = fetchFn;
+  return fetchFn;
+}
+
+module.exports = {
+  installMockFetch,
+  defaultResponse,
+  TestElement,
+  buildDashboardDom
+};

--- a/__tests__/integration.test.js
+++ b/__tests__/integration.test.js
@@ -1,0 +1,82 @@
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { setTimeout: wait } = require('node:timers/promises');
+const { installMockFetch, buildDashboardDom } = require('./helpers');
+const app = require('../lousy-outages/assets/lousy-outages.js');
+
+let mockFetch;
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await wait(0);
+}
+
+beforeEach(() => {
+  mockFetch = installMockFetch();
+  mockFetch.mockClear();
+  const dom = buildDashboardDom([
+    { id: 'openai', name: 'OpenAI', statusCode: 'operational', statusLabel: 'Operational', message: 'All systems go' },
+    { id: 'github', name: 'GitHub', statusCode: 'operational', statusLabel: 'Operational' }
+  ]);
+  global.document = dom.document;
+});
+
+afterEach(() => {
+  app.stopAutoRefresh();
+  delete global.document;
+  mockFetch.mockClear();
+});
+
+test('renders Unknown when a provider times out', async () => {
+  const now = new Date().toISOString();
+  mockFetch.mockImplementation(() =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          providers: [
+            {
+              provider: 'openai',
+              name: 'OpenAI',
+              statusCode: 'unknown',
+              status: 'Unknown',
+              message: 'Request timed out',
+              error: 'timeout',
+              updatedAt: now
+            },
+            {
+              provider: 'github',
+              name: 'GitHub',
+              statusCode: 'operational',
+              status: 'Operational',
+              message: '',
+              updatedAt: now
+            }
+          ],
+          meta: { fetchedAt: now }
+        })
+    })
+  );
+
+  app.init({
+    endpoint: '/api/status',
+    pollInterval: 50,
+    providers: [
+      { id: 'openai', name: 'OpenAI' },
+      { id: 'github', name: 'GitHub' }
+    ],
+    strings: {},
+    fallbackStrings: {},
+    debug: true,
+    fetchTimeout: 100
+  });
+
+  await flushPromises();
+
+  const openAiRow = document.querySelector('tr[data-id="openai"] .status');
+  const messageCell = document.querySelector('tr[data-id="openai"] .msg');
+  assert.equal(openAiRow.textContent, 'Unknown');
+  assert.ok(openAiRow.className.includes('status--unknown'));
+  assert.equal(messageCell.textContent, 'Request timed out');
+});

--- a/__tests__/normalizer.test.js
+++ b/__tests__/normalizer.test.js
@@ -1,0 +1,23 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { installMockFetch } = require('./helpers');
+
+installMockFetch();
+
+const app = require('../lousy-outages/assets/lousy-outages.js');
+
+test('normalizeStatus returns normalized code and label for operational', () => {
+  const normalized = app.normalizeStatus('operational');
+  assert.deepEqual(normalized, {
+    code: 'operational',
+    label: 'Operational',
+    className: 'status--operational'
+  });
+});
+
+test('normalizeStatus falls back to unknown for unexpected values', () => {
+  const normalized = app.normalizeStatus('critical');
+  assert.equal(normalized.code, 'unknown');
+  assert.equal(normalized.label, 'Unknown');
+  assert.equal(normalized.className, 'status--unknown');
+});

--- a/__tests__/refresh-loop.test.js
+++ b/__tests__/refresh-loop.test.js
@@ -1,0 +1,70 @@
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { setTimeout: wait } = require('node:timers/promises');
+const { installMockFetch, buildDashboardDom } = require('./helpers');
+const app = require('../lousy-outages/assets/lousy-outages.js');
+
+let mockFetch;
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  mockFetch = installMockFetch();
+  mockFetch.mockClear();
+  const dom = buildDashboardDom([
+    { id: 'github', name: 'GitHub', statusCode: 'operational', statusLabel: 'Operational' }
+  ]);
+  global.document = dom.document;
+
+  mockFetch.mockImplementation(() =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          providers: [
+            {
+              provider: 'github',
+              name: 'GitHub',
+              statusCode: 'operational',
+              status: 'Operational',
+              message: '',
+              updatedAt: new Date().toISOString()
+            }
+          ],
+          meta: { fetchedAt: new Date().toISOString() }
+        })
+    })
+  );
+});
+
+afterEach(() => {
+  app.stopAutoRefresh();
+  delete global.document;
+  mockFetch.mockClear();
+});
+
+test('polls at configured interval without stacking timers', async () => {
+  app.init({
+    endpoint: '/api/status',
+    pollInterval: 25,
+    providers: [{ id: 'github', name: 'GitHub' }],
+    strings: {},
+    fallbackStrings: {},
+    fetchTimeout: 100,
+    debug: true
+  });
+
+  await flushPromises();
+  assert.equal(mockFetch.callCount(), 1);
+
+  await wait(30);
+  await flushPromises();
+  assert.equal(mockFetch.callCount(), 2);
+
+  await wait(30);
+  await flushPromises();
+  assert.equal(mockFetch.callCount(), 3);
+});

--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -19,14 +19,15 @@
   border-bottom: 1px solid #0f0;
   text-align: left;
 }
+.lousy-outages-list table { transition: opacity 0.2s ease-in-out; }
 .lousy-outages-list .last-updated { font-size: 0.8rem; margin-bottom: 0.5rem; color: #0ff; }
 .status { text-transform: capitalize; }
-.status.operational { color: #00ff66; }
-.status.degraded,
-.status.partial_outage { color: #ffcc00; }
-.status.major_outage { color: #ff004c; animation: alert-pulse 1s infinite; }
+.status--operational { color: #00ff66; }
+.status--degraded { color: #ffcc00; }
+.status--outage { color: #ff004c; animation: alert-pulse 1s infinite; }
+.status--unknown { color: #cccccc; }
 @keyframes alert-pulse { 0%{ text-shadow:0 0 2px #ff004c; }50%{ text-shadow:0 0 10px #ff004c; }100%{ text-shadow:0 0 2px #ff004c; } }
-.lo-arcade .ticker { margin-top: 1rem; font-size: 0.8rem; height: 1rem; overflow: hidden; color: #0ff; }
+.lo-arcade .ticker { margin-top: 1rem; font-size: 0.8rem; min-height: 1rem; overflow: hidden; color: #0ff; transition: opacity 0.2s ease-in-out; }
 .lo-arcade .coin-btn {
   margin-top: 1rem;
   padding: 0.5rem 1rem;
@@ -35,11 +36,32 @@
   border: 2px solid #0f0;
   cursor: pointer;
   box-shadow: 0 0 6px #0f0;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 .lo-arcade .coin-btn:hover {
   background: #0f0;
   color: #111;
 }
-.lo-arcade.spinning .coin-btn { animation: spin 1s linear; }
-@keyframes spin { from { transform: rotate(0); } to { transform: rotate(360deg); } }
+.coin-btn .loader {
+  width: 0.75rem;
+  height: 0.75rem;
+  border: 2px solid rgba(0, 255, 0, 0.3);
+  border-top-color: #0f0;
+  border-radius: 50%;
+  animation: coin-spin 0.8s linear infinite;
+  display: none;
+}
+.coin-btn.is-loading .loader { display: inline-block; }
+.coin-btn.is-loading .label { opacity: 0.6; }
+.lousy-outages-list.is-refreshing table,
+.lousy-outages-list.is-refreshing .ticker,
+.lousy-outages-list.is-refreshing .status,
+.lousy-outages-list.is-refreshing .msg {
+  opacity: 0.85;
+}
+@keyframes coin-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
 .microcopy { margin-top: 1rem; font-size: 0.7rem; color: #0ff; }
+.weather { margin-top: 0.5rem; font-size: 0.7rem; color: #0ff; }

--- a/lousy-outages/assets/lousy-outages.js
+++ b/lousy-outages/assets/lousy-outages.js
@@ -1,59 +1,389 @@
-(function(){
-  var container = document.getElementById('lousy-outages');
-  if(!container) return;
-  var tbody = container.querySelector('tbody');
-  var tickerEl = container.querySelector('.ticker');
-  var tickerMsgs = [], tickerIdx = 0, tickerTimer;
-  function updateTicker(){
-    if(!tickerEl) return;
-    if(!tickerMsgs.length){ tickerEl.textContent=''; return; }
-    tickerEl.textContent = tickerMsgs[tickerIdx];
-    tickerIdx = (tickerIdx + 1) % tickerMsgs.length;
+(function (global, factory) {
+  if (typeof module === 'object' && typeof module.exports === 'object') {
+    module.exports = factory(global);
+  } else {
+    global.LousyOutagesApp = factory(global);
   }
-  function setTicker(msgs){
-    tickerMsgs = msgs;
-    tickerIdx = 0;
-    clearInterval(tickerTimer);
-    updateTicker();
-    if(msgs.length && !window.matchMedia('(prefers-reduced-motion: reduce)').matches){
-      tickerTimer = setInterval(updateTicker,3000);
+})(typeof window !== 'undefined' ? window : globalThis, function (global) {
+  'use strict';
+
+  var defaultStrings = {
+    updatedLabel: 'Updated:',
+    providerHeader: 'Provider',
+    statusHeader: 'Status',
+    messageHeader: 'Message',
+    buttonLabel: 'Insert coin to refresh',
+    buttonShortLabel: 'Insert coin',
+    buttonLoading: 'Loading…',
+    teaserCaption: 'Check if your favourite services are up. Insert coin to refresh.',
+    microcopy: 'Vancouver weather: cloudy with a chance of outages.',
+    offlineMessage: 'Unable to reach the arcade right now. Try again soon.',
+    tickerFallback: 'All quiet on the outage front.',
+    unknownStatus: 'Unknown',
+    noPublicStatus: 'No public status API'
+  };
+
+  var state = {
+    container: null,
+    tableBody: null,
+    tickerEl: null,
+    tickerMessages: [],
+    tickerIndex: 0,
+    tickerTimer: null,
+    refreshButton: null,
+    lastUpdatedSpan: null,
+    pollTimer: null,
+    inFlight: null,
+    lastFetchedAt: null,
+    strings: defaultStrings,
+    config: {
+      endpoint: '',
+      pollInterval: 300000,
+      fetchTimeout: 8000,
+      locale: 'en-CA',
+      providers: [],
+      debug: false
+    }
+  };
+
+  function readConfig(customConfig) {
+    var baseConfig = global.LousyOutagesConfig || global.LousyOutages || {};
+    if (customConfig && typeof customConfig === 'object') {
+      baseConfig = Object.assign({}, baseConfig, customConfig);
+    }
+    state.config.endpoint = baseConfig.endpoint || state.config.endpoint;
+    var interval = Number(baseConfig.pollInterval);
+    var timeout = Number(baseConfig.fetchTimeout);
+    state.config.pollInterval = interval && interval > 0 ? interval : state.config.pollInterval;
+    state.config.fetchTimeout = timeout && timeout > 0 ? timeout : state.config.fetchTimeout;
+    state.config.locale = baseConfig.locale || state.config.locale;
+    state.config.providers = Array.isArray(baseConfig.providers) ? baseConfig.providers : state.config.providers;
+    state.config.debug = Boolean(baseConfig.debug);
+    if (state.config.debug) {
+      state.config.pollInterval = Math.max(10, state.config.pollInterval);
+      state.config.fetchTimeout = Math.max(500, state.config.fetchTimeout);
+    } else {
+      state.config.pollInterval = Math.max(60000, state.config.pollInterval);
+      state.config.fetchTimeout = Math.max(2000, state.config.fetchTimeout);
+    }
+    var mergedStrings = Object.assign({}, defaultStrings);
+    if (baseConfig.fallbackStrings && typeof baseConfig.fallbackStrings === 'object') {
+      mergedStrings = Object.assign(mergedStrings, baseConfig.fallbackStrings);
+    }
+    if (baseConfig.strings && typeof baseConfig.strings === 'object') {
+      mergedStrings = Object.assign(mergedStrings, baseConfig.strings);
+    }
+    state.strings = mergedStrings;
+  }
+
+  function normalizeStatus(statusCode, label) {
+    var code = (statusCode || '').toLowerCase();
+    var known = {
+      operational: label || 'Operational',
+      degraded: label || 'Degraded',
+      outage: label || 'Outage',
+      unknown: label || state.strings.unknownStatus || 'Unknown'
+    };
+    if (!known[code]) {
+      code = 'unknown';
+    }
+    var resolved = known[code];
+    var className = 'status--' + code;
+    return {
+      code: code,
+      label: label || resolved,
+      className: className
+    };
+  }
+
+  function formatTimestamp(isoString) {
+    if (!isoString) {
+      return '';
+    }
+    var date = new Date(isoString);
+    if (isNaN(date.getTime())) {
+      return '';
+    }
+    var localFormatter = new Intl.DateTimeFormat(undefined, {
+      weekday: 'short',
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+      timeZoneName: 'short'
+    });
+    var gmtFormatter = new Intl.DateTimeFormat('en-GB', {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+      timeZone: 'UTC'
+    });
+    return localFormatter.format(date) + ' (' + gmtFormatter.format(date) + ' GMT)';
+  }
+
+  function tickTicker() {
+    if (!state.tickerEl) {
+      return;
+    }
+    if (!state.tickerMessages.length) {
+      state.tickerEl.textContent = '';
+      return;
+    }
+    state.tickerEl.textContent = state.tickerMessages[state.tickerIndex];
+    state.tickerIndex = (state.tickerIndex + 1) % state.tickerMessages.length;
+  }
+
+  function updateTicker(messages) {
+    if (!state.tickerEl) {
+      return;
+    }
+    if (state.tickerTimer) {
+      global.clearInterval(state.tickerTimer);
+      state.tickerTimer = null;
+    }
+    state.tickerMessages = messages && messages.length ? messages : [];
+    state.tickerIndex = 0;
+    tickTicker();
+    if (state.tickerMessages.length > 1 && !global.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      state.tickerTimer = global.setInterval(tickTicker, 4000);
     }
   }
-  function render(data){
-    Object.keys(data).forEach(function(id){
-      var row = tbody.querySelector('tr[data-id="'+id+'"]');
-      if(!row) return;
-      var statusCell = row.querySelector('.status');
-      statusCell.textContent = data[id].status;
-      statusCell.className = 'status '+data[id].status;
-      row.querySelector('.msg').textContent = data[id].message;
-    });
-    var messages = Object.values(data).filter(function(s){ return s.message; }).map(function(s){ return s.message; });
-    setTicker(messages);
-    var timeSpan = container.querySelector('.last-updated span');
-    if(timeSpan){ timeSpan.textContent = new Date().toUTCString(); }
-  }
-  function update(){
-    fetch(LousyOutages.endpoint).then(function(r){ return r.json(); }).then(render);
-  }
-  var coin = container.querySelector('.coin-btn');
-  if(coin){
-    coin.addEventListener('click', function(){
-      if(!window.matchMedia('(prefers-reduced-motion: reduce)').matches){
-        container.classList.add('spinning');
-        setTimeout(function(){ container.classList.remove('spinning'); },1000);
+
+  function setLoading(isLoading) {
+    if (!state.container) {
+      return;
+    }
+    state.container.classList.toggle('is-refreshing', Boolean(isLoading));
+    state.container.setAttribute('aria-busy', isLoading ? 'true' : 'false');
+    if (state.refreshButton) {
+      state.refreshButton.classList.toggle('is-loading', Boolean(isLoading));
+      var loadingLabel = state.refreshButton.getAttribute('data-loading-label') || state.strings.buttonLoading;
+      if (isLoading) {
+        state.refreshButton.setAttribute('aria-label', loadingLabel);
+      } else {
+        state.refreshButton.removeAttribute('aria-label');
       }
-      if(window.AudioContext){
-        var ctx = new AudioContext();
-        var osc = ctx.createOscillator();
-        osc.frequency.value = 880;
-        osc.connect(ctx.destination);
-        osc.start();
-        setTimeout(function(){ osc.stop(); ctx.close(); },150);
+    }
+  }
+
+  function logError(error) {
+    if (!error) {
+      return;
+    }
+    if (state.config.debug) {
+      console.error('Lousy Outages fetch failed', error);
+    } else if (error && error.message) {
+      console.error('Lousy Outages fetch failed:', error.message);
+    }
+  }
+
+  function ensureAllProviders(providers) {
+    var existing = Object.create(null);
+    if (Array.isArray(providers)) {
+      providers.forEach(function (provider) {
+        existing[provider.provider] = provider;
+      });
+    }
+    state.config.providers.forEach(function (meta) {
+      if (!existing[meta.id]) {
+        providers.push({
+          provider: meta.id,
+          name: meta.name,
+          statusCode: 'unknown',
+          status: state.strings.unknownStatus,
+          message: state.strings.noPublicStatus,
+          updatedAt: state.lastFetchedAt || new Date().toISOString(),
+          url: ''
+        });
       }
-      update();
+    });
+    return providers;
+  }
+
+  function renderProviders(providers) {
+    if (!state.tableBody || !Array.isArray(providers)) {
+      return Promise.resolve([]);
+    }
+    var updatePromises = providers.map(function (provider) {
+      return Promise.resolve().then(function () {
+        var row = state.tableBody.querySelector('tr[data-id="' + provider.provider + '"]');
+        if (!row) {
+          return provider;
+        }
+        var statusCell = row.querySelector('.status');
+        var messageCell = row.querySelector('.msg');
+        var normalized = normalizeStatus(provider.statusCode, provider.status);
+        statusCell.textContent = normalized.label;
+        statusCell.dataset.status = normalized.code;
+        statusCell.className = 'status ' + normalized.className;
+        var message = provider.message || '';
+        messageCell.textContent = message;
+        if (normalized.code === 'unknown' && provider.error) {
+          messageCell.title = provider.error;
+        } else if (messageCell.title) {
+          messageCell.removeAttribute('title');
+        }
+        return provider;
+      });
+    });
+    return Promise.allSettled(updatePromises).then(function (results) {
+      return results
+        .filter(function (result) { return result.status === 'fulfilled'; })
+        .map(function (result) { return result.value; });
     });
   }
-  setInterval(update,60000);
-  update();
-})();
+
+  function updateTimestamp(iso) {
+    if (!state.lastUpdatedSpan) {
+      return;
+    }
+    var formatted = formatTimestamp(iso);
+    state.lastUpdatedSpan.textContent = formatted || '--';
+    state.lastFetchedAt = iso;
+  }
+
+  function handleSuccess(payload) {
+    var providers = Array.isArray(payload.providers) ? payload.providers.slice() : [];
+    providers = ensureAllProviders(providers);
+    return renderProviders(providers).then(function (updatedProviders) {
+      var tickerMessages = updatedProviders
+        .map(function (provider) { return provider.message ? provider.message.trim() : ''; })
+        .filter(function (msg, index, arr) { return msg && arr.indexOf(msg) === index; });
+      updateTicker(tickerMessages.length ? tickerMessages : [state.strings.tickerFallback]);
+      var fetchedAt = payload.meta && payload.meta.fetchedAt ? payload.meta.fetchedAt : new Date().toISOString();
+      updateTimestamp(fetchedAt);
+      return updatedProviders;
+    });
+  }
+
+  function handleFailure(error) {
+    logError(error);
+    if (state.tickerEl) {
+      state.tickerEl.textContent = state.strings.offlineMessage || '';
+    }
+    return [];
+  }
+
+  function fetchStatuses(options) {
+    options = options || {};
+    if (state.inFlight && !options.force) {
+      return state.inFlight;
+    }
+    if (!state.config.endpoint) {
+      return Promise.resolve([]);
+    }
+    setLoading(true);
+    var controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
+    var timeoutId = null;
+    if (controller) {
+      timeoutId = global.setTimeout(function () {
+        controller.abort();
+      }, state.config.fetchTimeout);
+    }
+    var fetchOptions = {
+      method: 'GET',
+      headers: { 'Cache-Control': 'no-cache' },
+      cache: 'no-store'
+    };
+    if (controller) {
+      fetchOptions.signal = controller.signal;
+    }
+    state.inFlight = global.fetch(state.config.endpoint, fetchOptions)
+      .then(function (response) {
+        if (!response.ok) {
+          throw new Error('Network response was not ok (' + response.status + ')');
+        }
+        return response.json();
+      })
+      .then(handleSuccess)
+      .catch(handleFailure)
+      .finally(function () {
+        setLoading(false);
+        if (timeoutId) {
+          global.clearTimeout(timeoutId);
+        }
+        state.inFlight = null;
+      });
+
+    return state.inFlight;
+  }
+
+  function startAutoRefresh() {
+    if (state.pollTimer) {
+      global.clearInterval(state.pollTimer);
+    }
+    state.pollTimer = global.setInterval(function () {
+      fetchStatuses();
+    }, state.config.pollInterval);
+    return state.pollTimer;
+  }
+
+  function stopAutoRefresh() {
+    if (state.pollTimer) {
+      global.clearInterval(state.pollTimer);
+      state.pollTimer = null;
+    }
+  }
+
+  function attachButton() {
+    if (!state.refreshButton) {
+      return;
+    }
+    state.refreshButton.addEventListener('click', function () {
+      fetchStatuses({ force: true });
+    });
+  }
+
+  function init(customConfig) {
+    readConfig(customConfig);
+    if (!global.document) {
+      return state;
+    }
+    state.container = global.document.getElementById('lousy-outages');
+    if (!state.container) {
+      return state;
+    }
+    state.tableBody = state.container.querySelector('tbody');
+    state.tickerEl = state.container.querySelector('.ticker');
+    state.refreshButton = state.container.querySelector('.coin-btn');
+    state.lastUpdatedSpan = state.container.querySelector('.last-updated span');
+
+    if (state.lastUpdatedSpan) {
+      var initial = state.lastUpdatedSpan.getAttribute('data-initial');
+      if (initial) {
+        updateTimestamp(initial);
+      } else {
+        state.lastUpdatedSpan.textContent = '--';
+      }
+    }
+
+    attachButton();
+    fetchStatuses({ force: true });
+    startAutoRefresh();
+    return state;
+  }
+
+  if (global.document) {
+    if (global.document.readyState !== 'loading') {
+      init();
+    } else {
+      global.document.addEventListener('DOMContentLoaded', function () {
+        init();
+      });
+    }
+  }
+
+  return {
+    init: init,
+    refresh: fetchStatuses,
+    startAutoRefresh: startAutoRefresh,
+    stopAutoRefresh: stopAutoRefresh,
+    normalizeStatus: normalizeStatus,
+    formatTimestamp: formatTimestamp,
+    _state: state
+  };
+});

--- a/lousy-outages/includes/I18n.php
+++ b/lousy-outages/includes/I18n.php
@@ -1,0 +1,67 @@
+<?php
+namespace LousyOutages;
+
+class I18n {
+    private const STRINGS = [
+        'en-CA' => [
+            'updatedLabel'      => 'Updated:',
+            'providerHeader'    => 'Provider',
+            'statusHeader'      => 'Status',
+            'messageHeader'     => 'Message',
+            'buttonLabel'       => 'Insert coin to refresh',
+            'buttonShortLabel'  => 'Insert coin',
+            'buttonLoading'     => 'Loading…',
+            'teaserCaption'     => 'Check if your favourite services are up. Insert coin to refresh.',
+            'microcopy'         => 'Vancouver weather: cloudy with a chance of outages.',
+            'offlineMessage'    => 'Unable to reach the arcade right now. Try again soon.',
+            'tickerFallback'    => 'All quiet on the outage front.',
+            'unknownStatus'     => 'Unknown',
+            'noPublicStatus'    => 'No public status API',
+            'viewDashboard'     => 'View Full Dashboard →',
+        ],
+        'en-US' => [
+            'updatedLabel'      => 'Updated:',
+            'providerHeader'    => 'Provider',
+            'statusHeader'      => 'Status',
+            'messageHeader'     => 'Message',
+            'buttonLabel'       => 'Insert coin to refresh',
+            'buttonShortLabel'  => 'Insert coin',
+            'buttonLoading'     => 'Loading…',
+            'teaserCaption'     => 'Check if your favorite services are up. Insert coin to refresh.',
+            'microcopy'         => 'Vancouver weather: cloudy with a chance of outages.',
+            'offlineMessage'    => 'Unable to reach the arcade right now. Try again soon.',
+            'tickerFallback'    => 'All quiet on the outage front.',
+            'unknownStatus'     => 'Unknown',
+            'noPublicStatus'    => 'No public status API',
+            'viewDashboard'     => 'View Full Dashboard →',
+        ],
+    ];
+
+    public static function determine_locale(): string {
+        $default = 'en-CA';
+        $site    = function_exists( '\\get_locale' ) ? (string) get_locale() : $default;
+        $site    = str_replace( '_', '-', $site );
+
+        if ( isset( self::STRINGS[ $site ] ) ) {
+            return $site;
+        }
+
+        if ( 0 === strpos( strtolower( $site ), 'en-us' ) ) {
+            return 'en-US';
+        }
+
+        return $default;
+    }
+
+    public static function strings( ?string $locale = null ): array {
+        $locale   = $locale ? str_replace( '_', '-', $locale ) : self::determine_locale();
+        $fallback = self::STRINGS['en-US'];
+        $primary  = self::STRINGS[ $locale ] ?? [];
+
+        return array_merge( $fallback, $primary );
+    }
+
+    public static function all(): array {
+        return self::STRINGS;
+    }
+}

--- a/lousy-outages/includes/Store.php
+++ b/lousy-outages/includes/Store.php
@@ -15,10 +15,14 @@ class Store {
     }
 
     public function update( string $id, array $data ): void {
+        $status = $data['status'] ?? 'unknown';
+        if ( empty( $data['status_label'] ) ) {
+            $data['status_label'] = Fetcher::status_label( $status );
+        }
         $all        = $this->get_all();
         $all[ $id ] = $data;
         update_option( $this->option, $all, false );
-        $this->log( $id, $data['status'] );
+        $this->log( $id, $status );
     }
 
     private function log( string $id, string $status ): void {

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -4,7 +4,7 @@ namespace LousyOutages;
 add_shortcode( 'lousy_outages', __NAMESPACE__ . '\\render_shortcode' );
 
 function render_shortcode(): string {
-    $base_path = plugin_dir_path( __DIR__ ) . 'assets/';
+    $base_path  = plugin_dir_path( __DIR__ ) . 'assets/';
     $theme_path = get_template_directory() . '/lousy-outages/assets/';
     if ( file_exists( $theme_path ) ) {
         $base_path = $theme_path;
@@ -12,12 +12,14 @@ function render_shortcode(): string {
     } else {
         $base_url = plugin_dir_url( __DIR__ ) . 'assets/';
     }
+
     wp_enqueue_style(
         'lousy-outages',
         $base_url . 'lousy-outages.css',
         [],
         filemtime( $base_path . 'lousy-outages.css' )
     );
+
     wp_enqueue_script(
         'lousy-outages',
         $base_url . 'lousy-outages.js',
@@ -25,36 +27,85 @@ function render_shortcode(): string {
         filemtime( $base_path . 'lousy-outages.js' ),
         true
     );
-    wp_localize_script( 'lousy-outages', 'LousyOutages', [ 'endpoint' => rest_url( 'lousy-outages/v1/status' ) ] );
 
-    $store     = new Store();
-    $providers = Providers::list();
-    $states    = $store->get_all();
+    $locale           = I18n::determine_locale();
+    $strings          = I18n::strings( $locale );
+    $fallback_strings = I18n::strings( 'en-US' );
+    $store            = new Store();
+    $providers        = Providers::enabled();
+    $states           = $store->get_all();
+    $initial_iso      = '';
+
+    foreach ( $states as $state ) {
+        if ( empty( $state['updated_at'] ) ) {
+            continue;
+        }
+        $timestamp = strtotime( (string) $state['updated_at'] );
+        if ( ! $timestamp ) {
+            continue;
+        }
+        if ( ! $initial_iso || $timestamp > strtotime( $initial_iso ) ) {
+            $initial_iso = gmdate( 'c', $timestamp );
+        }
+    }
+
+    $config = [
+        'endpoint'        => esc_url_raw( rest_url( 'lousy-outages/v1/status' ) ),
+        'pollInterval'    => lousy_outages_get_poll_interval(),
+        'fetchTimeout'    => 8000,
+        'locale'          => $locale,
+        'strings'         => $strings,
+        'fallbackStrings' => $fallback_strings,
+        'providers'       => array_values(
+            array_map(
+                static fn( $prov ) => [
+                    'id'   => $prov['id'],
+                    'name' => $prov['name'],
+                ],
+                $providers
+            )
+        ),
+        'initialTimestamp' => $initial_iso,
+        'debug'            => function_exists( 'wp_get_environment_type' ) ? 'production' !== wp_get_environment_type() : ( defined( 'WP_DEBUG' ) && WP_DEBUG ),
+    ];
+
+    wp_localize_script( 'lousy-outages', 'LousyOutagesConfig', $config );
 
     ob_start();
     ?>
     <div class="lo-arcade">
         <div id="lousy-outages" class="lousy-outages-list" aria-live="polite">
-            <p class="last-updated">Updated: <span></span></p>
+            <p class="last-updated"><?php echo esc_html( $strings['updatedLabel'] ); ?> <span data-initial="<?php echo esc_attr( $initial_iso ); ?>"></span></p>
             <table>
-                <thead><tr><th>Provider</th><th>Status</th><th>Message</th></tr></thead>
+                <thead>
+                    <tr>
+                        <th><?php echo esc_html( $strings['providerHeader'] ); ?></th>
+                        <th><?php echo esc_html( $strings['statusHeader'] ); ?></th>
+                        <th><?php echo esc_html( $strings['messageHeader'] ); ?></th>
+                    </tr>
+                </thead>
                 <tbody>
                 <?php foreach ( $providers as $id => $prov ) :
-                    $state   = $states[ $id ] ?? [ 'status' => 'unknown', 'message' => '' ];
-                    $status  = esc_html( $state['status'] );
-                    $message = esc_html( $state['message'] );
+                    $state        = $states[ $id ] ?? [];
+                    $status_code  = $state['status'] ?? 'unknown';
+                    $status_label = $state['status_label'] ?? Fetcher::status_label( $status_code );
+                    $message      = $state['message'] ?? '';
                     ?>
-                    <tr data-id="<?php echo esc_attr( $id ); ?>">
+                    <tr data-id="<?php echo esc_attr( $id ); ?>" data-name="<?php echo esc_attr( $prov['name'] ); ?>">
                         <td><?php echo esc_html( $prov['name'] ); ?></td>
-                        <td class="status <?php echo $status; ?>"><?php echo $status; ?></td>
-                        <td class="msg"><?php echo $message; ?></td>
+                        <td class="status status--<?php echo esc_attr( $status_code ); ?>" data-status="<?php echo esc_attr( $status_code ); ?>"><?php echo esc_html( $status_label ); ?></td>
+                        <td class="msg"><?php echo esc_html( $message ); ?></td>
                     </tr>
                 <?php endforeach; ?>
                 </tbody>
             </table>
             <div class="ticker" aria-live="polite"></div>
-            <button type="button" class="coin-btn">Coin</button>
-            <p class="microcopy">Vancouver weather: cloudy with a chance of outages.</p>
+            <button type="button" class="coin-btn" data-loading-label="<?php echo esc_attr( $strings['buttonLoading'] ); ?>">
+                <span class="label"><?php echo esc_html( $strings['buttonShortLabel'] ); ?></span>
+                <span class="loader" aria-hidden="true"></span>
+            </button>
+            <p class="microcopy"><?php echo esc_html( $strings['buttonLabel'] ); ?></p>
+            <p class="weather"><?php echo esc_html( $strings['microcopy'] ); ?></p>
         </div>
     </div>
     <?php

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "suzyeastonca",
+  "private": true,
+  "type": "commonjs",
+  "scripts": {
+    "test": "node --test \"./__tests__/**/*.test.js\""
+  }
+}

--- a/parts/lousy-outages-teaser.php
+++ b/parts/lousy-outages-teaser.php
@@ -1,6 +1,20 @@
+<?php
+use LousyOutages\I18n;
+
+$teaser_strings = [
+    'teaserCaption' => 'Check if your favourite services are up. Insert coin to refresh.',
+    'viewDashboard' => 'View Full Dashboard →',
+];
+
+if ( class_exists( '\\LousyOutages\\I18n' ) ) {
+    $locale         = I18n::determine_locale();
+    $localized      = I18n::strings( $locale );
+    $teaser_strings = array_merge( $teaser_strings, array_intersect_key( $localized, $teaser_strings ) );
+}
+?>
 <section id="lousy-outages-teaser" class="lo-teaser" aria-live="polite">
   <h2 class="pixel-font">Lousy Outages</h2>
   <div class="providers"></div>
-  <p class="caption">Check if your favorite services are up. Insert coin to refresh.</p>
-  <a class="view-all pixel-button" href="/lousy-outages/">View Full Dashboard →</a>
+  <p class="caption"><?php echo esc_html( $teaser_strings['teaserCaption'] ); ?></p>
+  <a class="view-all pixel-button" href="/lousy-outages/"><?php echo esc_html( $teaser_strings['viewDashboard'] ); ?></a>
 </section>


### PR DESCRIPTION
## Summary
- refactor the Lousy Outages fetch pipeline to stream fresh provider data, emit cache-busting headers, and document the live refresh cadence
- modernize the dashboard front end with abortable polling, five-minute auto refresh, loader styling, and resilient ticker updates
- add an en-CA/en-US string map so "favourite" copy and teaser text localize cleanly
- wire up a Node-based test harness that covers normalization, the polling loop, and Unknown fallback behaviour

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c8c741f30c832e838bc52b5bbfeb08