### PR TITLE
Fix namespace declaration in shortcode

### DIFF
--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -1,4 +1,3 @@
-
 <?php
 namespace LousyOutages;
 


### PR DESCRIPTION
## Summary
- remove the leading blank line before the PHP open tag in the shortcode file so the namespace declaration is the first statement

## Testing
- php -l lousy-outages/public/shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68d071281f24832e9d0d54c33ac927e9