### PR TITLE
Enable voiceover on outage details

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -81,6 +81,8 @@ if ( file_exists( $lousy_outages ) ) {
     require_once $lousy_outages;
 }
 
+add_filter( 'lousy_outages_voice_enabled', '__return_true' );
+
 
 // =========================================
 // 2. DISABLE AUTOMATIC PARAGRAPH FORMATTING

--- a/page-home.php
+++ b/page-home.php
@@ -108,7 +108,7 @@ get_header();
     <section class="party-announcement crt-block">
         <h2>Grunge &amp; Rock Video Party (Instagram)</h2>
         <p>We’re cueing up a feed of loud guitars, grainy VHS vibes, and deep cuts.
-           Follow <a href="https://instagram.com/your-handle" target="_blank">@your-handle</a>
+           Follow <a href="https://instagram.com/officialsuzyeaston" target="_blank">@officialsuzyeaston</a>
            for the kickoff date &amp; set list. Requests welcome. Bring flannel.</p>
     </section>
 


### PR DESCRIPTION
## Summary
- update the homepage Instagram CTA to point at @officialsuzyeaston
- enable the bundled Lousy Outages voice-over feature and announce provider status when users open details
- turn on the voice filter from the theme so audio playback is active on the outages page

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0760ca0b8832e81a7d85a8b62ce51