### PR TITLE
Fix Slack and Google Cloud polling and expose outage RSS feed

### DIFF
--- a/lousy-outages/includes/Providers.php
+++ b/lousy-outages/includes/Providers.php
@@ -20,9 +20,10 @@ class Providers {
                 'id'       => 'slack',
                 'name'     => 'Slack',
                 'provider' => 'Slack',
-                'endpoint' => 'https://status.slack.com/api/v2.0.0/summary.json',
-                'type'     => 'statuspage',
-                'url'      => 'https://status.slack.com/'
+                'endpoint' => 'https://status.slack.com/api/v2.0.0/current',
+                'type'     => 'slack',
+                'url'      => 'https://status.slack.com/',
+                'scrape'   => true,
             ],
             'cloudflare' => [
                 'id'       => 'cloudflare',
@@ -68,9 +69,10 @@ class Providers {
                 'id'       => 'gcp',
                 'name'     => 'Google Cloud',
                 'provider' => 'Google Cloud',
-                'endpoint' => 'https://status.cloud.google.com/feed.json',
+                'endpoint' => 'https://status.cloud.google.com/incidents.json',
                 'type'     => 'json',
-                'url'      => 'https://status.cloud.google.com/'
+                'url'      => 'https://status.cloud.google.com/',
+                'scrape'   => true,
             ],
         ];
     }


### PR DESCRIPTION
## Summary
- update the Slack provider to use the current API, normalize its payload, and fall back to HTML scraping when the API is unavailable
- point Google Cloud polling at the incidents JSON feed and enable the same scraping fallback
- add an `/outages/feed` RSS endpoint that surfaces active incidents or degraded providers for subscribers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9e4ece2c4832ea6b6e3ecda1589d2