### PR TITLE
Add outage summary banner and surface RSS alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The neon dashboard now streams live provider data from `/api/outages` on load an
 
 The legacy REST endpoint at `/wp-json/lousy-outages/v1/status` still works and returns the expanded payload, while the new `/api/outages` edge route emits uncached JSON with `Cache-Control: no-store`. WordPress cron keeps polling in the background—run `wp cron event run lousy_outages_poll` if you need to warm the datastore manually.
 
+The status arcade now opens with an "at-a-glance" headline that calls out any degraded providers, links straight to the custom RSS feed at `/outages/feed/` and highlights the alerts inbox (`suzanneeaston@gmail.com`) so you can wire it into whatever mail filters you prefer. Unknown telemetry also surfaces in the banner, making it obvious when a provider's API stops responding.
+
 ## Track Analyzer
 Uploads are sent to OpenAI's Whisper and GPT‑4 APIs for a quick analysis of your
 MP3. Results appear with a fun retro overlay and clear loading indicators. For

--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -58,6 +58,154 @@
   z-index: 1;
 }
 
+.status-summary {
+  background: rgba(0, 26, 0, 0.75);
+  border: 2px solid rgba(0, 255, 170, 0.45);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  display: grid;
+  gap: 0.75rem;
+  text-align: left;
+  font-family: 'IBM Plex Sans', sans-serif;
+  color: #d8ffef;
+  z-index: 1;
+}
+
+.status-summary.has-alerts {
+  border-color: rgba(255, 95, 137, 0.85);
+  box-shadow: 0 0 16px rgba(255, 95, 137, 0.35);
+}
+
+.status-summary.has-unknown {
+  border-color: rgba(255, 218, 106, 0.75);
+}
+
+.status-summary.is-offline {
+  border-color: rgba(255, 218, 106, 0.85);
+  box-shadow: 0 0 14px rgba(255, 218, 106, 0.35);
+}
+
+.status-summary__headline {
+  font-size: 1rem;
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #7af7c9;
+}
+
+.status-summary.has-alerts .status-summary__headline {
+  color: #ff8fb4;
+}
+
+.status-summary__details {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #c9ffe9;
+}
+
+.status-summary__details[hidden] {
+  display: none;
+}
+
+.status-summary__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.status-summary__list[hidden] {
+  display: none;
+}
+
+.status-summary__item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  color: #e6ffee;
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.status-summary__provider {
+  font-weight: 600;
+}
+
+.status-summary__note {
+  color: #9fffd6;
+  font-size: 0.75rem;
+}
+
+.status-summary__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: #afffdf;
+}
+
+.status-summary__rss {
+  color: #afffdf;
+  text-decoration: none;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.status-summary__rss::before {
+  content: '📡';
+}
+
+.status-summary__rss:hover,
+.status-summary__rss:focus {
+  color: #ffffff;
+  text-decoration: underline;
+}
+
+.status-summary__email {
+  margin: 0;
+  color: #afffdf;
+}
+
+.status-summary__email a {
+  color: #ffffff;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.status-summary__email a:hover,
+.status-summary__email a:focus {
+  text-decoration: underline;
+}
+
+@media (min-width: 640px) {
+  .status-summary {
+    grid-template-columns: 2fr 1fr;
+    align-items: center;
+  }
+
+  .status-summary__actions {
+    align-items: flex-end;
+    text-align: right;
+  }
+}
+
 .providers-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -38,6 +38,11 @@ function lousy_outages_activate() {
         wp_schedule_event( time() + 60, 'lousy_outages_interval', 'lousy_outages_poll' );
     }
     lousy_outages_create_page();
+    $default_email = 'suzanneeaston@gmail.com';
+    $stored_email  = get_option( 'lousy_outages_email' );
+    if ( empty( $stored_email ) && is_email( $default_email ) ) {
+        update_option( 'lousy_outages_email', sanitize_email( $default_email ) );
+    }
     if ( function_exists( 'flush_rewrite_rules' ) ) {
         flush_rewrite_rules( false );
     }


### PR DESCRIPTION
## Summary
- add a status overview banner to the Lousy Outages board so issues are visible at a glance
- surface the custom RSS feed and dedicated alert email within the UI and default the notification inbox
- extend the front-end logic and styling to keep the summary live-updated and highlight degraded/unknown providers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eb59dbfcac832ebb7d70b8438752be