### PR TITLE
Enhance Lousy Outages UI, providers, and admin diagnostics

### DIFF
--- a/lousy-outages/README.md
+++ b/lousy-outages/README.md
@@ -16,6 +16,9 @@ Monitor third‑party service status and get SMS and email alerts when things br
 | digitalocean | DigitalOcean | https://status.digitalocean.com/api/v2/summary.json |
 | netlify | Netlify | https://www.netlifystatus.com/api/v2/summary.json |
 | vercel | Vercel | https://www.vercel-status.com/api/v2/summary.json |
+| downdetector-ca | Downdetector (CA Aggregate) | https://downdetector.ca/archive/?format=rss |
+
+Downdetector is disabled by default because the RSS feed is unofficial and can disappear; enable it from the settings page if it loads for you. When the feed is unreachable, the adapter reports an `unknown` state with an error badge rather than failing the whole poll.
 
 To add or remove a provider, edit `includes/Providers.php` or use the checkboxes under **Settings → Lousy Outages** in wp-admin.
 
@@ -24,6 +27,9 @@ To add or remove a provider, edit `includes/Providers.php` or use the checkboxes
 1. (Optional) Sign up for Twilio and obtain your **Account SID**, **Auth Token**, and a verified **From** number to enable SMS alerts.
 2. In wp-admin go to **Settings → Lousy Outages** and enter the SID, token, from number, your destination phone number, and a notification email address.
 3. Choose which providers to monitor and set the polling interval (default 5 minutes).
+4. Click **Send Test Email** to verify delivery; the panel shows the status and the latest subject/recipient recorded.
+
+Use the **Poll Now** button in the debug panel to run an immediate poll. The panel also shows the last poll timestamp, each provider’s most recent status, and any fetch errors captured during the run.
 
 ## Shortcode
 

--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -1,510 +1,192 @@
-
-.lo-arcade {
-  font-family: 'Press Start 2P', monospace;
-  background: radial-gradient(circle at top left, #020d02, #000);
-  color: #0f0;
-  padding: 1.25rem;
-  border: 4px solid #0f0;
-  box-shadow: 0 0 12px #0f0;
-  max-width: 1080px;
+.lousy-outages {
+  max-width: 960px;
   margin: 0 auto;
-  text-align: center;
+  padding: 8px 16px;
+  font-family: 'IBM Plex Mono', 'Courier New', monospace;
+  background: #000;
+  color: #2af200;
 }
 
-.lousy-outages-board {
-  position: relative;
+.lousy-outages a {
+  color: #2af200;
+}
+
+.lo-meta {
+  color: #a7ff9a;
+  font-size: 0.95rem;
   display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-}
-
-.lousy-outages-board::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background: repeating-linear-gradient(
-    180deg,
-    rgba(0, 255, 170, 0.03) 0,
-    rgba(0, 255, 170, 0.03) 2px,
-    transparent 2px,
-    transparent 4px
-  );
-  opacity: 0.7;
-  mix-blend-mode: screen;
-}
-
-.board-header {
-  display: flex;
+  gap: 12px;
   align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
   flex-wrap: wrap;
-  z-index: 1;
+  margin-bottom: 12px;
 }
 
-.lousy-outages-board .last-updated {
-  font-size: 0.85rem;
-  margin: 0;
-  color: #7af7c9;
+.lo-meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
 }
 
-.board-subtitle {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: #afffdf;
-  margin: 0;
-  z-index: 1;
+.lo-btn {
+  border: 1px solid #2af200;
+  color: #2af200;
+  background: transparent;
+  padding: 4px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background 0.2s ease, color 0.2s ease;
 }
 
-.status-summary {
-  background: rgba(0, 26, 0, 0.75);
-  border: 2px solid rgba(0, 255, 170, 0.45);
-  border-radius: 12px;
-  padding: 1rem 1.25rem;
+.lo-btn:hover,
+.lo-btn:focus {
+  background: #2af200;
+  color: #000;
+}
+
+.lo-btn[disabled] {
+  opacity: 0.5;
+  cursor: progress;
+}
+
+.lo-grid {
   display: grid;
-  gap: 0.75rem;
-  text-align: left;
-  font-family: 'IBM Plex Sans', sans-serif;
-  color: #d8ffef;
-  z-index: 1;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
 }
 
-.status-summary.has-alerts {
-  border-color: rgba(255, 95, 137, 0.85);
-  box-shadow: 0 0 16px rgba(255, 95, 137, 0.35);
-}
-
-.status-summary.has-unknown {
-  border-color: rgba(255, 218, 106, 0.75);
-}
-
-.status-summary.is-offline {
-  border-color: rgba(255, 218, 106, 0.85);
-  box-shadow: 0 0 14px rgba(255, 218, 106, 0.35);
-}
-
-.status-summary__headline {
-  font-size: 1rem;
-  margin: 0;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: #7af7c9;
-}
-
-.status-summary.has-alerts .status-summary__headline {
-  color: #ff8fb4;
-}
-
-.status-summary__details {
-  margin: 0;
-  font-size: 0.85rem;
-  color: #c9ffe9;
-}
-
-.status-summary__details[hidden] {
-  display: none;
-}
-
-.status-summary__list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+.lo-card {
+  background: #000;
+  border: 2px solid #2af200;
+  border-radius: 14px;
+  padding: 12px;
+  box-shadow: 0 0 8px rgba(42, 242, 0, 0.2);
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 8px;
 }
 
-.status-summary__list[hidden] {
-  display: none;
+.lo-title {
+  color: #2af200;
+  font-weight: 700;
+  margin: 0 0 6px;
+  font-size: 1.05rem;
 }
 
-.status-summary__item {
+.lo-head {
   display: flex;
-  flex-wrap: wrap;
+  justify-content: space-between;
   align-items: center;
-  gap: 0.35rem;
-  font-size: 0.8rem;
-  color: #e6ffee;
+  gap: 8px;
 }
 
-.status-chip {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 0.65rem;
+.lo-pill {
+  display: inline-block;
+  padding: 2px 8px;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  padding: 0.15rem 0.45rem;
-  border-radius: 999px;
-  border: 1px solid currentColor;
-  background: rgba(0, 0, 0, 0.4);
 }
 
-.status-summary__provider {
-  font-weight: 600;
+.lo-pill.operational {
+  color: #2af200;
 }
 
-.status-summary__note {
-  color: #9fffd6;
-  font-size: 0.75rem;
+.lo-pill.degraded {
+  color: #ffd400;
 }
 
-.status-summary__actions {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  font-size: 0.75rem;
-  color: #afffdf;
+.lo-pill.outage {
+  color: #ff3b3b;
 }
 
-.status-summary__rss {
-  color: #afffdf;
-  text-decoration: none;
-  font-weight: 600;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
+.lo-pill.unknown,
+.lo-pill.maintenance {
+  color: #aaa;
 }
 
-.status-summary__rss::before {
-  content: '📡';
-}
-
-.status-summary__rss:hover,
-.status-summary__rss:focus {
-  color: #ffffff;
-  text-decoration: underline;
-}
-
-.status-summary__email {
+.lo-summary,
+.lo-snark {
   margin: 0;
-  color: #afffdf;
+  color: #c9ffc4;
+  font-size: 0.95rem;
+  line-height: 1.4;
 }
 
-.status-summary__email a {
-  color: #ffffff;
+.lo-snark {
+  color: #8cff72;
+  font-style: italic;
+}
+
+.lo-status-link {
+  margin-top: auto;
   font-weight: 700;
   text-decoration: none;
 }
 
-.status-summary__email a:hover,
-.status-summary__email a:focus {
+.lo-status-link:hover,
+.lo-status-link:focus {
   text-decoration: underline;
 }
 
-@media (min-width: 640px) {
-  .status-summary {
-    grid-template-columns: 2fr 1fr;
-    align-items: center;
-  }
-
-  .status-summary__actions {
-    align-items: flex-end;
-    text-align: right;
-  }
+.lo-inc {
+  margin-top: 8px;
+  font-size: 0.9rem;
+  line-height: 1.3;
+  color: #defcce;
 }
 
-.providers-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 1rem;
-  position: relative;
-  z-index: 1;
-}
-
-.provider-card {
-  background: rgba(0, 32, 0, 0.65);
-  border: 2px solid rgba(0, 255, 170, 0.4);
-  border-radius: 12px;
-  box-shadow: inset 0 0 8px rgba(0, 255, 170, 0.15);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.provider-card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 0 12px rgba(0, 255, 170, 0.35);
-}
-
-.provider-card__inner {
-  padding: 1.1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  text-align: left;
-}
-
-.provider-card__header {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 0.75rem;
-}
-
-.provider-card__name {
-  font-size: 0.85rem;
-  margin: 0;
-  color: #d8ffef;
-}
-
-.status-badge {
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  padding: 0.25rem 0.5rem;
-  border-radius: 999px;
-  border: 1px solid currentColor;
-  white-space: nowrap;
-}
-
-.status--operational {
-  color: #3cff9a;
-}
-
-.status--degraded {
-  color: #ffda6a;
-}
-
-.status--outage {
-  color: #ff5f89;
-  animation: alert-pulse 1s ease-in-out infinite;
-}
-
-.status--maintenance {
-  color: #8fd1ff;
-}
-
-.status--unknown {
-  color: #c6c6c6;
-}
-
-.provider-card__summary {
-  font-family: 'IBM Plex Sans', sans-serif;
-  font-size: 0.85rem;
-  line-height: 1.5;
-  color: #c9ffe9;
-  margin: 0;
-  min-height: 2.6em;
-}
-
-.provider-card__snark {
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 0.75rem;
-  color: #9fffd6;
-  min-height: 2.2em;
-  margin: 0;
-}
-
-.details-toggle {
-  align-self: flex-start;
-  background: rgba(0, 0, 0, 0.6);
-  color: #afffdf;
-  border: 1px solid rgba(175, 255, 223, 0.6);
-  border-radius: 6px;
-  padding: 0.35rem 0.75rem;
-  font-family: 'IBM Plex Sans', sans-serif;
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
-}
-
-.details-toggle:hover,
-.details-toggle:focus {
-  background: rgba(175, 255, 223, 0.2);
-  color: #fff;
-}
-
-.provider-details {
-  background: rgba(0, 0, 0, 0.35);
-  border-radius: 8px;
-  padding: 0.75rem;
-  border: 1px solid rgba(0, 255, 170, 0.15);
-}
-
-.provider-details[hidden] {
-  display: none;
-}
-
-.incidents {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.incident-list {
+.lo-inc-list {
   list-style: none;
+  margin: 8px 0 0;
   padding: 0;
-  margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 6px;
 }
 
-.incident-item {
-  border: 1px solid rgba(0, 255, 170, 0.2);
+.lo-inc-item {
+  background: rgba(42, 242, 0, 0.08);
+  border-left: 3px solid rgba(42, 242, 0, 0.35);
+  padding: 6px 8px;
   border-radius: 6px;
-  padding: 0.65rem 0.75rem;
-  background: rgba(0, 16, 0, 0.5);
-  font-family: 'IBM Plex Sans', sans-serif;
 }
 
-.incident-title {
+.lo-inc-title {
+  font-weight: 600;
+  margin: 0 0 4px;
+  color: #f3fff1;
+}
+
+.lo-inc-meta {
   font-size: 0.8rem;
-  margin: 0 0 0.35rem;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  color: #e6ffee;
-}
-
-.impact-badge {
-  font-size: 0.65rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  padding: 0.15rem 0.4rem;
-  border-radius: 999px;
-  border: 1px solid currentColor;
-}
-
-.impact--minor .impact-badge {
-  color: #7fffd4;
-}
-
-.impact--major .impact-badge {
-  color: #ffd166;
-}
-
-.impact--critical .impact-badge {
-  color: #ff6b81;
-}
-
-.incident-start,
-.incident-summary,
-.incident-eta,
-.incident-updated {
-  font-size: 0.72rem;
-  margin: 0.25rem 0;
-  color: #c1ffe4;
-}
-
-.incident-summary {
-  color: #f1fff7;
-}
-
-.incident-empty {
-  font-size: 0.75rem;
-  color: #94ffce;
+  color: #a7ff9a;
   margin: 0;
 }
 
-.provider-link {
+.lo-empty {
+  font-size: 0.85rem;
+  color: #7ddd6d;
+}
+
+.lo-error {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  margin-top: 0.75rem;
-  font-size: 0.75rem;
-  color: #9fffd6;
-  text-decoration: none;
-}
-
-.provider-link:hover,
-.provider-link:focus {
-  text-decoration: underline;
-  color: #fff;
-}
-
-.lousy-outages-board .ticker {
-  margin-top: 0.5rem;
-  font-size: 0.75rem;
-  min-height: 1rem;
-  color: #7af7c9;
-  z-index: 1;
-}
-
-.lousy-outages-board.is-refreshing .provider-card__inner,
-.lousy-outages-board.is-refreshing .ticker,
-.lousy-outages-board.is-refreshing .provider-card__summary,
-.lousy-outages-board.is-refreshing .provider-card__snark {
-  opacity: 0.85;
-}
-
-.coin-btn {
-  margin-left: auto;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 1rem;
-  background: #111;
-  color: #0f0;
-  border: 2px solid #0f0;
-  cursor: pointer;
-  box-shadow: 0 0 6px #0f0;
-  position: relative;
-  font-size: 0.75rem;
+  gap: 4px;
+  color: #ff6b6b;
+  font-size: 0.8rem;
   text-transform: uppercase;
 }
 
-.coin-btn:hover {
-  background: #0f0;
-  color: #111;
-}
-
-.coin-btn .loader {
-  width: 0.75rem;
-  height: 0.75rem;
-  border: 2px solid rgba(0, 255, 0, 0.3);
-  border-top-color: #0f0;
-  border-radius: 50%;
-  animation: coin-spin 0.8s linear infinite;
-  display: none;
-}
-
-.coin-btn.is-loading .loader {
-  display: inline-block;
-}
-
-.coin-btn.is-loading .label {
-  opacity: 0.6;
-}
-
-.microcopy,
-.weather {
-  font-size: 0.7rem;
-  color: #7fffd4;
-  margin: 0;
-  z-index: 1;
-}
-
-.weather {
-  opacity: 0.8;
-}
-
-@keyframes alert-pulse {
-  0% {
-    text-shadow: 0 0 2px currentColor;
+@media (max-width: 480px) {
+  .lo-meta {
+    font-size: 0.85rem;
   }
-  50% {
-    text-shadow: 0 0 10px currentColor;
-  }
-  100% {
-    text-shadow: 0 0 2px currentColor;
-  }
-}
 
-@keyframes coin-spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
-}
-
-@media (max-width: 640px) {
-  .board-header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-  .coin-btn {
-    margin-left: 0;
+  .lo-btn {
+    width: 100%;
+    text-align: center;
   }
 }

--- a/lousy-outages/assets/lousy-outages.js
+++ b/lousy-outages/assets/lousy-outages.js
@@ -1,1161 +1,281 @@
-
-(function (global, factory) {
-  if (typeof module === 'object' && typeof module.exports === 'object') {
-    module.exports = factory(global);
-  } else {
-    global.LousyOutagesApp = factory(global);
-  }
-})(typeof window !== 'undefined' ? window : globalThis, function (global) {
+(function (window) {
   'use strict';
 
-  var defaultStrings = {
-    updatedLabel: 'Updated:',
-    providerHeader: 'Provider',
-    statusHeader: 'Status',
-    messageHeader: 'Message',
-    buttonLabel: 'Insert coin to refresh',
-    buttonShortLabel: 'Insert coin',
-    buttonLoading: 'Refreshing…',
-    teaserCaption: 'Check if your favourite services are up. Insert coin to refresh.',
-    microcopy: 'Vancouver weather: cloudy with a chance of outages.',
-    offlineMessage: 'Arcade link is jittery. Data might be stale—try again soon.',
-    tickerFallback: 'All quiet on the outage front.',
-    unknownStatus: 'Unknown',
-    noPublicStatus: 'No public status API',
-    detailsLabel: 'Details',
-    detailsHide: 'Hide details',
-    noIncidents: 'No active incidents. Go write a chorus.',
-    degradedNoIncidents: 'Status page shows degraded performance. Pop over there for the detailed log.',
-    etaInvestigating: 'ETA: investigating — translation: nobody knows yet.',
-    viewProvider: 'View provider status →'
-  };
-
-  var snarkPre = ['Look.', 'Honestly?', 'Sure, fine.', 'Stop overthinking it.', ''];
-  var snarkLines = {
-    Operational: [
-      "It works. Don’t write a post-mortem for uptime.",
-      "Green light means ‘go’. Resist the urge to refactor prod."
-    ],
-    Degraded: [
-      "It’s limping, not dying. Tape it up and keep playing.",
-      "Minor outage. Major panic in Slack. Breathe."
-    ],
-    Outage: [
-      "It’s down. Stop refreshing and start reading logs.",
-      "Put the runbook where your anxiety is."
-    ],
-    Maintenance: [
-      "Scheduled pain now so you don’t suffer later."
-    ],
-    Unknown: [
-      "No signal. Either it’s fine or they’re hiding."
-    ],
-    byProvider: {
-      Cloudflare: [
-        "If the edge sneezes, your site catches a cold."
-      ],
-      OpenAI: [
-        "The model’s fine. Your prompt isn’t. Kidding. It’s probably rate limits."
-      ],
-      AWS: [
-        "us-east-1 is a lifestyle choice. You chose chaos."
-      ],
-      Azure: [
-        "Azure’s blue because you are. Keep refreshing the portal."
-      ],
-      'Google Cloud': [
-        "If it ain’t in Stackdriver, did it even happen?"
-      ],
-      GitHub: [
-        "If pushes fail, touch grass. CI will still betray you later."
-      ],
-      Slack: [
-        "When Slack dies, meetings rise. Choose wisely."
-      ],
-      Zscaler: [
-        "Secure edge hiccup? Double-check the tunnels before blaming the Wi-Fi."
-      ]
-    }
-  };
-
-  var state = {
-    container: null,
-    grid: null,
-    tickerEl: null,
-    refreshButton: null,
-    lastUpdatedSpan: null,
-    summarySection: null,
-    summaryPrimary: null,
-    summarySecondary: null,
-    summaryList: null,
-    feedLink: null,
-    emailLink: null,
-    pollTimer: null,
-    inFlight: null,
-    lastFetchedAt: null,
-    cards: Object.create(null),
-    strings: defaultStrings,
-    config: {
-      endpoint: '',
-      pollInterval: 300000,
-      fetchTimeout: 10000,
-      locale: 'en-CA',
-      providers: [],
-      voiceEnabled: false,
-      debug: false,
-      feedUrl: '',
-      alertEmail: '',
-      initialSummary: null
-    }
-  };
-
-  function readConfig(customConfig) {
-    var baseConfig = global.LousyOutagesConfig || global.LousyOutages || {};
-    if (customConfig && typeof customConfig === 'object') {
-      baseConfig = Object.assign({}, baseConfig, customConfig);
-    }
-
-    state.config.endpoint = baseConfig.endpoint || state.config.endpoint;
-    var interval = Number(baseConfig.pollInterval);
-    var timeout = Number(baseConfig.fetchTimeout);
-    state.config.pollInterval = interval && interval > 0 ? interval : state.config.pollInterval;
-    state.config.fetchTimeout = timeout && timeout > 0 ? timeout : state.config.fetchTimeout;
-    state.config.locale = baseConfig.locale || state.config.locale;
-    state.config.providers = Array.isArray(baseConfig.providers) ? baseConfig.providers : state.config.providers;
-    state.config.voiceEnabled = Boolean(baseConfig.voiceEnabled);
-    state.config.debug = Boolean(baseConfig.debug);
-    state.config.feedUrl = baseConfig.feedUrl || state.config.feedUrl;
-    state.config.alertEmail = baseConfig.alertEmail || state.config.alertEmail;
-    state.config.initialSummary = baseConfig.initialSummary || state.config.initialSummary;
-
-    if (state.config.debug) {
-      state.config.pollInterval = Math.max(10, state.config.pollInterval);
-      state.config.fetchTimeout = Math.max(500, state.config.fetchTimeout);
-    } else {
-      state.config.pollInterval = Math.max(60000, state.config.pollInterval);
-      state.config.fetchTimeout = Math.max(3000, state.config.fetchTimeout);
-    }
-
-    var mergedStrings = Object.assign({}, defaultStrings);
-    if (baseConfig.fallbackStrings && typeof baseConfig.fallbackStrings === 'object') {
-      mergedStrings = Object.assign(mergedStrings, baseConfig.fallbackStrings);
-    }
-    if (baseConfig.strings && typeof baseConfig.strings === 'object') {
-      mergedStrings = Object.assign(mergedStrings, baseConfig.strings);
-    }
-    state.strings = mergedStrings;
+  var config = window.LousyOutagesConfig || {};
+  var container = document.querySelector('.lousy-outages');
+  if (!container) {
+    return;
   }
 
-  function sanitizeText(text) {
-    if (typeof text !== 'string') {
-      return '';
-    }
-    return text.replace(/\s+/g, ' ').trim();
-  }
+  var metaFetched = container.querySelector('[data-lo-fetched]');
+  var metaCountdown = container.querySelector('[data-lo-countdown]');
+  var refreshButton = container.querySelector('[data-lo-refresh]');
+  var grid = container.querySelector('[data-lo-grid]');
 
-  function formatTimestamp(isoString) {
-    if (!isoString) {
+  var pollMs = Number(config.pollInterval) || 300000;
+  var countdownTimer = null;
+  var lastFetched = config.initial && config.initial.meta ? config.initial.meta.fetchedAt : null;
+  var providers = (config.initial && config.initial.providers) || [];
+
+  function formatTimestamp(iso) {
+    if (!iso) {
       return '';
     }
-    var date = new Date(isoString);
+    var date = new Date(iso);
     if (isNaN(date.getTime())) {
       return '';
     }
-    var localFormatter = new Intl.DateTimeFormat(undefined, {
+    return new Intl.DateTimeFormat(undefined, {
       weekday: 'short',
-      day: '2-digit',
-      month: 'short',
       year: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-      second: '2-digit',
-      hour12: true,
-      timeZoneName: 'short'
-    });
-    var gmtFormatter = new Intl.DateTimeFormat('en-GB', {
+      month: 'short',
+      day: '2-digit',
       hour: '2-digit',
       minute: '2-digit',
-      second: '2-digit',
-      hour12: false,
-      timeZone: 'UTC'
-    });
-    return localFormatter.format(date) + ' (' + gmtFormatter.format(date) + ' GMT)';
+      second: '2-digit'
+    }).format(date);
   }
 
-  function formatRelativeShort(diffMs) {
-    if (!isFinite(diffMs)) {
+  function formatRelative(ms) {
+    if (!isFinite(ms)) {
       return '';
     }
-    var abs = Math.abs(diffMs);
-    var minute = 60 * 1000;
-    var hour = 60 * minute;
-    var day = 24 * hour;
-    if (abs < minute) {
-      return 'just now';
+    if (ms <= 0) {
+      return 'Ready to refresh';
     }
-    if (abs < hour) {
-      return Math.round(abs / minute) + 'm ago';
+    var seconds = Math.round(ms / 1000);
+    if (seconds < 60) {
+      return seconds + 's until refresh';
     }
-    if (abs < day) {
-      return Math.round(abs / hour) + 'h ago';
-    }
-    return Math.round(abs / day) + 'd ago';
-  }
-
-  function buildStartLine(isoString) {
-    if (!isoString) {
-      return '';
-    }
-    var date = new Date(isoString);
-    if (isNaN(date.getTime())) {
-      return '';
-    }
-    var startFormatter = new Intl.DateTimeFormat(undefined, {
-      month: 'short',
-      day: '2-digit',
-      hour: 'numeric',
-      minute: '2-digit'
-    });
-    var relative = formatRelativeShort(Date.now() - date.getTime());
-    var label = 'Started: ' + startFormatter.format(date);
-    if (relative) {
-      label += ' (' + relative + ')';
-    }
-    return label;
-  }
-
-  function buildUpdatedLine(isoString) {
-    if (!isoString) {
-      return '';
-    }
-    var date = new Date(isoString);
-    if (isNaN(date.getTime())) {
-      return '';
-    }
-    var formatter = new Intl.DateTimeFormat(undefined, {
-      month: 'short',
-      day: '2-digit',
-      hour: 'numeric',
-      minute: '2-digit'
-    });
-    var relative = formatRelativeShort(Date.now() - date.getTime());
-    var label = 'Latest update: ' + formatter.format(date);
-    if (relative) {
-      label += ' (' + relative + ')';
-    }
-    return label;
-  }
-
-  function normalizeStatus(statusCode, label) {
-    var code = (statusCode || '').toLowerCase();
-    var known = {
-      operational: label || 'Operational',
-      degraded: label || 'Degraded',
-      outage: label || 'Outage',
-      maintenance: label || 'Maintenance',
-      unknown: label || state.strings.unknownStatus || 'Unknown'
-    };
-    if (!known[code]) {
-      code = 'unknown';
-    }
-    var resolved = known[code];
-    var className = 'status--' + code;
-    return {
-      code: code,
-      label: label || resolved,
-      className: className
-    };
-  }
-
-  function computeSummary(providers) {
-    var summary = {
-      total: 0,
-      affected: 0,
-      unknown: 0,
-      providers: [],
-      feedUrl: state.config.feedUrl,
-      alertEmail: state.config.alertEmail
-    };
-    if (!Array.isArray(providers)) {
-      return summary;
-    }
-    summary.total = providers.length;
-    providers.forEach(function (provider) {
-      if (!provider) {
-        return;
-      }
-      var status = sanitizeText(provider.stateCode || provider.statusCode || provider.status || '').toLowerCase();
-      if (status === 'unknown') {
-        summary.unknown += 1;
-      }
-      var incidents = Array.isArray(provider.incidents) ? provider.incidents.length : 0;
-      var hasIssue = incidents > 0 || status === 'degraded' || status === 'outage' || status === 'maintenance';
-      if (!status && hasIssue) {
-        status = 'degraded';
-      }
-      if (!hasIssue) {
-        return;
-      }
-      summary.affected += 1;
-      summary.providers.push({
-        id: provider.id || provider.provider || provider.name || '',
-        name: sanitizeText(provider.name || provider.provider || provider.id || 'Unknown provider'),
-        label: sanitizeText(provider.state || provider.status || ''),
-        status: status || 'unknown',
-        summary: sanitizeText(provider.summary || provider.message || '')
-      });
-    });
-    return summary;
-  }
-
-  function renderSummary(summary) {
-    if (!state.summarySection) {
-      return;
-    }
-    state.summarySection.classList.remove('is-offline');
-
-    summary = summary || {};
-    var total = Number(summary.total);
-    if (!isFinite(total)) {
-      total = state.config.providers.length;
-    }
-    var affected = Number(summary.affected) || 0;
-    var unknown = Number(summary.unknown) || 0;
-    var providers = Array.isArray(summary.providers) ? summary.providers.slice(0, 4) : [];
-    var feedUrl = summary.feedUrl || state.config.feedUrl || '';
-    var alertEmail = summary.alertEmail || state.config.alertEmail || '';
-
-    state.config.feedUrl = feedUrl;
-    state.config.alertEmail = alertEmail;
-    state.config.lastSummary = summary;
-
-    state.summarySection.classList.toggle('has-alerts', affected > 0);
-    state.summarySection.classList.toggle('has-unknown', affected === 0 && unknown > 0);
-
-    if (state.feedLink) {
-      if (feedUrl) {
-        state.feedLink.href = feedUrl;
-        state.feedLink.removeAttribute('hidden');
-      } else {
-        state.feedLink.setAttribute('hidden', 'hidden');
-      }
-    }
-
-    if (state.emailLink) {
-      if (alertEmail) {
-        state.emailLink.textContent = alertEmail;
-        state.emailLink.href = 'mailto:' + alertEmail + '?subject=' + encodeURIComponent('Lousy Outages alerts');
-        state.emailLink.removeAttribute('hidden');
-      } else {
-        state.emailLink.setAttribute('hidden', 'hidden');
-      }
-    }
-
-    var headline = '';
-    var details = '';
-
-    if (affected > 0) {
-      headline = affected === 1
-        ? 'Heads up: one provider is having trouble.'
-        : 'Heads up: ' + affected + ' providers are having trouble.';
-      var names = providers.map(function (prov) {
-        var normalized = normalizeStatus(prov.status, prov.label);
-        var label = sanitizeText(normalized.label);
-        return prov.name + (label ? ' (' + label + ')' : '');
-      });
-      if (names.length) {
-        details = names.join(', ');
-        var remainder = affected - names.length;
-        if (remainder > 0) {
-          details += ' +' + remainder + ' more';
-        }
-      }
-    } else if (unknown > 0) {
-      headline = 'Monitoring ' + (total || state.config.providers.length || 0) + ' providers.';
-      var plural = unknown === 1 ? 'provider is' : 'providers are';
-      details = unknown + ' ' + plural + ' currently unknown.';
-    } else {
-      var count = total || state.config.providers.length || 0;
-      headline = count
-        ? 'All systems operational across ' + count + ' providers.'
-        : 'All systems operational.';
-      details = 'No incidents detected right now.';
-    }
-
-    if (state.summaryPrimary) {
-      state.summaryPrimary.textContent = headline;
-    }
-    if (state.summarySecondary) {
-      state.summarySecondary.textContent = details;
-      state.summarySecondary.hidden = !details;
-    }
-
-    if (state.summaryList) {
-      while (state.summaryList.firstChild) {
-        state.summaryList.removeChild(state.summaryList.firstChild);
-      }
-      if (affected > 0 && providers.length && global.document) {
-        state.summaryList.hidden = false;
-        providers.forEach(function (prov) {
-          var item = global.document.createElement('li');
-          item.className = 'status-summary__item';
-          var normalized = normalizeStatus(prov.status, prov.label);
-          var chip = global.document.createElement('span');
-          chip.className = 'status-chip ' + normalized.className;
-          chip.textContent = normalized.label;
-          item.appendChild(chip);
-          var name = global.document.createElement('span');
-          name.className = 'status-summary__provider';
-          name.textContent = ' ' + prov.name;
-          item.appendChild(name);
-          if (prov.summary) {
-            var note = global.document.createElement('span');
-            note.className = 'status-summary__note';
-            note.textContent = ' — ' + prov.summary;
-            item.appendChild(note);
-          }
-          state.summaryList.appendChild(item);
-        });
-      } else {
-        state.summaryList.hidden = true;
-      }
-    }
-  }
-
-  function snarkOutage(providerName, stateLabel, summary) {
-    var provider = sanitizeText(providerName) || 'Unknown';
-    var status = sanitizeText(stateLabel);
-    if (!status) {
-      status = 'Unknown';
-    }
-    var cleanedSummary = sanitizeText(summary);
-    var stateLines = snarkLines[status] || snarkLines.Unknown;
-    var pre = snarkPre[Math.floor(Math.random() * snarkPre.length)];
-    var stateLine = stateLines[Math.floor(Math.random() * stateLines.length)];
-    var providerQuips = snarkLines.byProvider[provider] || (function () {
-      if (!Array.isArray(state.config.providers)) {
-        return [];
-      }
-      for (var i = 0; i < state.config.providers.length; i += 1) {
-        var meta = state.config.providers[i];
-        if (meta && meta.name === provider && snarkLines.byProvider[meta.name]) {
-          return snarkLines.byProvider[meta.name];
-        }
-      }
-      return [];
-    })();
-    var providerLine = providerQuips.length
-      ? providerQuips[Math.floor(Math.random() * providerQuips.length)]
-      : '';
-    var parts = [pre, stateLine];
-    if (providerLine) {
-      parts.push(providerLine);
-    } else if (cleanedSummary) {
-      parts.push(cleanedSummary);
-    }
-    var text = sanitizeText(parts.join(' '));
-    if (!text && cleanedSummary) {
-      text = cleanedSummary;
-    }
-    return text;
-  }
-
-  function setLoading(isLoading) {
-    if (!state.container) {
-      return;
-    }
-    state.container.classList.toggle('is-refreshing', Boolean(isLoading));
-    state.container.setAttribute('aria-busy', isLoading ? 'true' : 'false');
-    if (state.refreshButton) {
-      state.refreshButton.classList.toggle('is-loading', Boolean(isLoading));
-      var loadingLabel = state.refreshButton.getAttribute('data-loading-label') || state.strings.buttonLoading;
-      if (isLoading) {
-        state.refreshButton.setAttribute('aria-label', loadingLabel);
-      } else {
-        state.refreshButton.removeAttribute('aria-label');
-      }
-    }
-  }
-
-  function speakText(text) {
-    if (!text || !state.config.voiceEnabled) {
-      return;
-    }
-    var synth = global.speechSynthesis;
-    var Utterance = global.SpeechSynthesisUtterance;
-    if (!synth || typeof synth.cancel !== 'function' || typeof Utterance !== 'function') {
-      return;
-    }
-    var utterance = new Utterance(text);
-    var voices = typeof synth.getVoices === 'function' ? synth.getVoices() : [];
-    var preferred = voices.find(function (voice) {
-      return /English/i.test(voice.lang) && /Google UK English Male|Microsoft David/i.test(voice.name);
-    }) || voices.find(function (voice) {
-      return /en/i.test(voice.lang);
-    });
-    if (preferred) {
-      utterance.voice = preferred;
-    }
-    utterance.pitch = 0.7;
-    utterance.rate = 0.7;
-    synth.cancel();
-    synth.speak(utterance);
-  }
-
-  function speakSnark(text) {
-    speakText(text);
-  }
-
-  function announceProviderStatus(record) {
-    if (!record) {
-      return;
-    }
-    var parts = [];
-    if (record.nameEl && record.nameEl.textContent) {
-      parts.push(sanitizeText(record.nameEl.textContent));
-    }
-    if (record.statusEl && record.statusEl.textContent) {
-      parts.push('Status: ' + sanitizeText(record.statusEl.textContent));
-    }
-    if (record.summaryEl && record.summaryEl.textContent) {
-      parts.push(sanitizeText(record.summaryEl.textContent));
-    }
-    if (record.details && typeof record.details.querySelector === 'function') {
-      var incidentSummary = record.details.querySelector('.incident-item .incident-summary');
-      if (!incidentSummary) {
-        incidentSummary = record.details.querySelector('.incident-empty');
-      }
-      if (incidentSummary && incidentSummary.textContent) {
-        var incidentText = sanitizeText(incidentSummary.textContent);
-        if (incidentText) {
-          parts.push(incidentText);
-        }
-      }
-    }
-    var announcement = sanitizeText(parts.join('. '));
-    if (announcement) {
-      speakText(announcement);
-    }
-  }
-
-  function prefersReducedMotion() {
-    if (!global.matchMedia) {
-      return false;
-    }
-    return global.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  }
-
-  function typewriter(element, text) {
-    if (!element) {
-      return;
-    }
-    if (!text) {
-      element.textContent = '';
-      return;
-    }
-    if (prefersReducedMotion()) {
-      element.textContent = text;
-      return;
-    }
-    element.textContent = '';
-    var i = 0;
-    var chars = text.split('');
-    var timer = global.setInterval(function () {
-      element.textContent += chars[i++];
-      if (i >= chars.length) {
-        global.clearInterval(timer);
-      }
-    }, 30);
-  }
-
-  function applySnark(record, provider) {
-    if (!record || !record.snarkEl) {
-      return;
-    }
-    var text = snarkOutage(provider.name || provider.provider, provider.state || provider.stateCode, provider.summary || '');
-    if (!text) {
-      record.snarkEl.textContent = '';
-      return;
-    }
-    if (record.lastSnark === text) {
-      return;
-    }
-    record.lastSnark = text;
-    typewriter(record.snarkEl, text);
-    speakSnark(text);
-  }
-
-  function updateTimestamp(iso) {
-    if (!state.lastUpdatedSpan) {
-      return;
-    }
-    var formatted = formatTimestamp(iso);
-    state.lastUpdatedSpan.textContent = formatted || '--';
-    state.lastFetchedAt = iso;
-  }
-
-  function ensureCard(meta) {
-    var id = meta && (meta.id || meta.provider || meta.name);
-    if (!id) {
-      return null;
-    }
-    if (state.cards[id]) {
-      return state.cards[id];
-    }
-    if (!state.grid || !global.document) {
-      return null;
-    }
-    var card = createCard(meta);
-    state.grid.appendChild(card.card);
-    state.cards[id] = card;
-    return card;
-  }
-
-  function createCard(meta) {
-    var doc = global.document;
-    var card = doc.createElement('article');
-    card.className = 'provider-card';
-    card.setAttribute('role', 'listitem');
-    card.setAttribute('data-id', meta.id);
-    card.setAttribute('data-name', meta.name || meta.provider || meta.id);
-
-    var inner = doc.createElement('div');
-    inner.className = 'provider-card__inner';
-    card.appendChild(inner);
-
-    var header = doc.createElement('header');
-    header.className = 'provider-card__header';
-    inner.appendChild(header);
-
-    var nameEl = doc.createElement('h3');
-    nameEl.className = 'provider-card__name';
-    nameEl.textContent = meta.name || meta.provider || meta.id;
-    header.appendChild(nameEl);
-
-    var status = doc.createElement('span');
-    status.className = 'status-badge status--unknown';
-    status.setAttribute('data-status', 'unknown');
-    status.textContent = state.strings.unknownStatus;
-    header.appendChild(status);
-
-    var summary = doc.createElement('p');
-    summary.className = 'provider-card__summary';
-    summary.textContent = '';
-    inner.appendChild(summary);
-
-    var snark = doc.createElement('p');
-    snark.className = 'provider-card__snark';
-    snark.setAttribute('data-snark', 'true');
-    snark.innerHTML = '&nbsp;';
-    inner.appendChild(snark);
-
-    var toggle = doc.createElement('button');
-    toggle.type = 'button';
-    toggle.className = 'details-toggle';
-    toggle.setAttribute('aria-expanded', 'false');
-    var toggleLabel = doc.createElement('span');
-    toggleLabel.className = 'toggle-label';
-    toggleLabel.textContent = state.strings.detailsLabel;
-    toggle.appendChild(toggleLabel);
-    inner.appendChild(toggle);
-
-    var details = doc.createElement('section');
-    var detailsId = 'lo-details-' + meta.id;
-    details.className = 'provider-details';
-    details.id = detailsId;
-    details.hidden = true;
-    toggle.setAttribute('aria-controls', detailsId);
-    inner.appendChild(details);
-
-    var incidents = doc.createElement('div');
-    incidents.className = 'incidents';
-    incidents.setAttribute('data-empty-text', state.strings.noIncidents);
-    var empty = doc.createElement('p');
-    empty.className = 'incident-empty';
-    empty.textContent = state.strings.noIncidents;
-    incidents.appendChild(empty);
-    details.appendChild(incidents);
-
-    var link = doc.createElement('a');
-    link.className = 'provider-link';
-    link.setAttribute('data-default-url', meta.url || '');
-    link.href = meta.url || '#';
-    link.target = '_blank';
-    link.rel = 'noopener';
-    link.textContent = state.strings.viewProvider;
-    details.appendChild(link);
-
-    toggle.addEventListener('click', function () {
-      toggleDetails(id);
-    });
-
-    return {
-      card: card,
-      header: header,
-      nameEl: nameEl,
-      statusEl: status,
-      summaryEl: summary,
-      snarkEl: snark,
-      toggle: toggle,
-      details: details,
-      incidents: incidents,
-      link: link,
-      lastSnark: ''
-    };
-  }
-
-  function prepareExistingCards() {
-    if (!state.container || !global.document) {
-      return;
-    }
-    state.cards = Object.create(null);
-    var cards = state.container.querySelectorAll('.provider-card');
-    cards.forEach(function (card) {
-      var id = card.getAttribute('data-id');
-      if (!id) {
-        return;
-      }
-      var record = {
-        card: card,
-        header: card.querySelector('.provider-card__header'),
-        nameEl: card.querySelector('.provider-card__name'),
-        statusEl: card.querySelector('.status-badge'),
-        summaryEl: card.querySelector('.provider-card__summary'),
-        snarkEl: card.querySelector('.provider-card__snark'),
-        toggle: card.querySelector('.details-toggle'),
-        details: card.querySelector('.provider-details'),
-        incidents: card.querySelector('.provider-details .incidents'),
-        link: card.querySelector('.provider-link'),
-        lastSnark: ''
-      };
-      state.cards[id] = record;
-      if (record.toggle) {
-        record.toggle.addEventListener('click', function () {
-          toggleDetails(id);
-        });
-      }
-    });
-  }
-
-  function toggleDetails(id) {
-    var record = state.cards[id];
-    if (!record || !record.details || !record.toggle) {
-      return;
-    }
-    var isExpanded = record.toggle.getAttribute('aria-expanded') === 'true';
-    var nextExpanded = !isExpanded;
-    record.toggle.setAttribute('aria-expanded', nextExpanded ? 'true' : 'false');
-    record.details.hidden = !nextExpanded;
-    var label = nextExpanded ? state.strings.detailsHide : state.strings.detailsLabel;
-    var labelEl = record.toggle.querySelector('.toggle-label');
-    if (labelEl) {
-      labelEl.textContent = label;
-    } else {
-      record.toggle.textContent = label;
-    }
-    if (nextExpanded) {
-      announceProviderStatus(record);
-    }
+    var minutes = Math.floor(seconds / 60);
+    var rem = seconds % 60;
+    return minutes + 'm ' + rem + 's until refresh';
   }
 
   function formatImpact(impact) {
-    var value = sanitizeText(impact).toLowerCase();
-    if (value === 'critical' || value === 'major' || value === 'minor') {
-      return value;
+    if (!impact) {
+      return 'Unknown impact';
     }
-    return 'minor';
+    impact = String(impact);
+    return impact.charAt(0).toUpperCase() + impact.slice(1);
   }
 
-  function impactLabel(impact) {
-    var value = formatImpact(impact);
-    return value.charAt(0).toUpperCase() + value.slice(1);
-  }
+  function buildIncidents(incidentList) {
+    var wrapper = document.createElement('div');
+    wrapper.className = 'lo-inc';
 
-  function updateIncidents(record, provider) {
-    if (!record || !record.incidents) {
-      return;
-    }
-    var stateCode = sanitizeText(provider.stateCode || provider.statusCode || '').toLowerCase();
-    var degraded = stateCode && stateCode !== 'operational' && stateCode !== 'unknown';
-    while (record.incidents.firstChild) {
-      record.incidents.removeChild(record.incidents.firstChild);
-    }
-    var incidents = Array.isArray(provider.incidents) ? provider.incidents : [];
-    if (!incidents.length) {
-      var empty = global.document ? global.document.createElement('p') : { textContent: '' };
-      empty.className = 'incident-empty';
-      var emptyMessage = degraded && state.strings.degradedNoIncidents
-        ? state.strings.degradedNoIncidents
-        : state.strings.noIncidents;
-      empty.textContent = emptyMessage;
-      record.incidents.setAttribute('data-empty-text', emptyMessage);
-      record.incidents.appendChild(empty);
-      return;
-    }
-    record.incidents.setAttribute('data-empty-text', state.strings.noIncidents);
-    var list = global.document ? global.document.createElement('ul') : null;
-    if (list) {
-      list.className = 'incident-list';
-      record.incidents.appendChild(list);
-    }
-    incidents.forEach(function (incident) {
-      var item = global.document ? global.document.createElement('li') : null;
-      if (!item) {
-        return;
-      }
-      var impact = formatImpact(incident.impact);
-      item.className = 'incident-item impact--' + impact;
-      item.setAttribute('data-impact', impact);
+    var heading = document.createElement('strong');
+    heading.textContent = 'Incidents';
+    wrapper.appendChild(heading);
 
-      var title = global.document.createElement('h4');
-      title.className = 'incident-title';
+    if (!incidentList || !incidentList.length) {
+      var empty = document.createElement('p');
+      empty.className = 'lo-empty';
+      empty.textContent = 'No active incidents';
+      wrapper.appendChild(empty);
+      return wrapper;
+    }
+
+    var list = document.createElement('ul');
+    list.className = 'lo-inc-list';
+
+    incidentList.forEach(function (incident) {
+      var item = document.createElement('li');
+      item.className = 'lo-inc-item';
+
+      var title = document.createElement('p');
+      title.className = 'lo-inc-title';
       title.textContent = incident.title || 'Incident';
       item.appendChild(title);
 
-      var badge = global.document.createElement('span');
-      badge.className = 'impact-badge';
-      badge.textContent = impactLabel(impact);
-      title.appendChild(badge);
+      var meta = document.createElement('p');
+      meta.className = 'lo-inc-meta';
+      var bits = [];
+      if (incident.impact) {
+        bits.push(formatImpact(incident.impact));
+      }
+      if (incident.updatedAt) {
+        bits.push(formatTimestamp(incident.updatedAt));
+      }
+      meta.textContent = bits.join(' • ');
+      item.appendChild(meta);
 
-      var startedLine = buildStartLine(incident.startedAt || incident.started_at);
-      if (startedLine) {
-        var startEl = global.document.createElement('p');
-        startEl.className = 'incident-start';
-        startEl.textContent = startedLine;
-        item.appendChild(startEl);
+      if (incident.url) {
+        var link = document.createElement('a');
+        link.href = incident.url;
+        link.textContent = 'Open incident';
+        link.className = 'lo-status-link';
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        item.appendChild(link);
       }
 
-      var summary = sanitizeText(incident.summary || '');
-      if (summary) {
-        var summaryEl = global.document.createElement('p');
-        summaryEl.className = 'incident-summary';
-        summaryEl.textContent = summary;
-        item.appendChild(summaryEl);
-      }
-
-      var eta = sanitizeText(incident.eta || '');
-      var etaLabel = eta && eta.toLowerCase() !== 'investigating'
-        ? 'ETA: ' + eta
-        : state.strings.etaInvestigating;
-      var etaEl = global.document.createElement('p');
-      etaEl.className = 'incident-eta';
-      etaEl.textContent = etaLabel;
-      item.appendChild(etaEl);
-
-      var updatedLine = buildUpdatedLine(incident.updatedAt || incident.updated_at);
-      if (updatedLine) {
-        var updatedEl = global.document.createElement('p');
-        updatedEl.className = 'incident-updated';
-        updatedEl.textContent = updatedLine;
-        item.appendChild(updatedEl);
-      }
-
-      if (list) {
-        list.appendChild(item);
-      } else {
-        record.incidents.appendChild(item);
-      }
+      list.appendChild(item);
     });
+
+    wrapper.appendChild(list);
+    return wrapper;
   }
 
-  function updateProviderLink(record, provider) {
-    if (!record || !record.link) {
+  function buildCard(provider) {
+    var card = document.createElement('article');
+    card.className = 'lo-card';
+    card.dataset.providerId = provider.id;
+
+    var head = document.createElement('div');
+    head.className = 'lo-head';
+
+    var title = document.createElement('h3');
+    title.className = 'lo-title';
+    title.textContent = provider.name || provider.provider || provider.id;
+    head.appendChild(title);
+
+    var pill = document.createElement('span');
+    var stateCode = provider.stateCode || 'unknown';
+    pill.className = 'lo-pill ' + stateCode;
+    pill.textContent = provider.state || formatImpact(stateCode);
+    head.appendChild(pill);
+
+    card.appendChild(head);
+
+    if (provider.error) {
+      var error = document.createElement('span');
+      error.className = 'lo-error';
+      error.textContent = 'Error: ' + provider.error;
+      card.appendChild(error);
+    }
+
+    var summary = document.createElement('p');
+    summary.className = 'lo-summary';
+    summary.textContent = provider.summary || 'No status summary available.';
+    card.appendChild(summary);
+
+    if (provider.snark) {
+      var snark = document.createElement('p');
+      snark.className = 'lo-snark';
+      snark.textContent = provider.snark;
+      card.appendChild(snark);
+    }
+
+    card.appendChild(buildIncidents(provider.incidents || []));
+
+    if (provider.url) {
+      var view = document.createElement('a');
+      view.href = provider.url;
+      view.target = '_blank';
+      view.rel = 'noopener noreferrer';
+      view.className = 'lo-status-link';
+      view.textContent = 'View status →';
+      card.appendChild(view);
+    }
+
+    return card;
+  }
+
+  function renderProviders(list) {
+    providers = Array.isArray(list) ? list : [];
+    if (!grid) {
       return;
     }
-    var url = sanitizeText(provider.url || (provider.metaUrl || ''));
-    if (!url) {
-      url = record.link.getAttribute('data-default-url') || '#';
-    }
-    record.link.href = url || '#';
-    if (url === '#') {
-      record.link.setAttribute('aria-disabled', 'true');
-    } else {
-      record.link.removeAttribute('aria-disabled');
-    }
-  }
+    grid.innerHTML = '';
 
-  function ensureAllProviders(providers) {
-    var existing = Object.create(null);
-    if (Array.isArray(providers)) {
-      providers.forEach(function (provider) {
-        var id = provider.id || provider.provider;
-        if (id) {
-          existing[id] = true;
-        }
-      });
-    }
-    state.config.providers.forEach(function (meta) {
-      if (!existing[meta.id]) {
-        var record = ensureCard(meta);
-        if (!record) {
-          providers.push({
-            id: meta.id,
-            provider: meta.name,
-            name: meta.name,
-            state: state.strings.unknownStatus,
-            stateCode: 'unknown',
-            summary: state.strings.noPublicStatus,
-            incidents: [],
-            url: meta.url || ''
-          });
-        }
-      }
-    });
-    return providers;
-  }
-
-  function updateTicker(messages) {
-    if (!state.tickerEl) {
+    if (!providers.length) {
+      var emptyCard = document.createElement('article');
+      emptyCard.className = 'lo-card';
+      var message = document.createElement('p');
+      message.className = 'lo-summary';
+      message.textContent = 'No providers selected yet.';
+      emptyCard.appendChild(message);
+      grid.appendChild(emptyCard);
       return;
     }
-    if (!messages || !messages.length) {
-      state.tickerEl.textContent = state.strings.tickerFallback || '';
-      return;
-    }
-    var unique = [];
-    messages.forEach(function (message) {
-      if (!message) {
-        return;
-      }
-      if (unique.indexOf(message) === -1) {
-        unique.push(message);
-      }
-    });
-    state.tickerEl.textContent = unique.join(' • ');
-  }
 
-  function renderProviders(providers) {
-    if (!Array.isArray(providers)) {
-      return [];
-    }
-    providers = ensureAllProviders(providers);
-    var summaries = [];
     providers.forEach(function (provider) {
-      var id = provider.id || provider.provider;
-      if (!id) {
-        return;
-      }
-      var record = state.cards[id];
-      if (!record) {
-        record = ensureCard({ id: id, name: provider.name || provider.provider || id, url: provider.url || '' });
-      }
-      if (!record) {
-        return;
-      }
-      record.nameEl.textContent = provider.name || provider.provider || id;
-      var normalized = normalizeStatus(provider.stateCode || provider.statusCode, provider.state || provider.status);
-      record.statusEl.textContent = normalized.label;
-      record.statusEl.dataset.status = normalized.code;
-      record.statusEl.className = 'status-badge ' + normalized.className;
-      var summary = sanitizeText(provider.summary || provider.message || '');
-      record.summaryEl.textContent = summary;
-      updateIncidents(record, provider);
-      updateProviderLink(record, provider);
-      applySnark(record, provider);
-      summaries.push(summary);
+      grid.appendChild(buildCard(provider));
     });
-    return summaries;
   }
 
-  function logError(error) {
-    if (!error) {
+  function updateMeta(meta) {
+    if (!meta) {
       return;
     }
-    if (state.config.debug) {
-      console.error('Lousy Outages fetch failed', error);
-    } else if (error && error.message) {
-      console.error('Lousy Outages fetch failed:', error.message);
+    lastFetched = meta.fetchedAt || lastFetched;
+    if (metaFetched) {
+      metaFetched.textContent = lastFetched ? formatTimestamp(lastFetched) : '—';
     }
   }
 
-  function handleSuccess(payload) {
-    var providers = Array.isArray(payload.providers) ? payload.providers.slice() : [];
-    var summaries = renderProviders(providers);
-    var tickerMessages = summaries.filter(function (msg) {
-      return sanitizeText(msg);
-    });
-    updateTicker(tickerMessages.length ? tickerMessages : [state.strings.tickerFallback]);
-    var fetchedAt = payload.meta && payload.meta.fetchedAt ? payload.meta.fetchedAt : new Date().toISOString();
-    updateTimestamp(fetchedAt);
-    renderSummary(computeSummary(providers));
-    return providers;
+  function tickCountdown() {
+    if (!metaCountdown) {
+      return;
+    }
+    if (!lastFetched) {
+      metaCountdown.textContent = 'Waiting for first refresh…';
+      return;
+    }
+    var diff = pollMs - (Date.now() - new Date(lastFetched).getTime());
+    metaCountdown.textContent = formatRelative(diff);
   }
 
-  function handleFailure(error) {
-    logError(error);
-    if (state.tickerEl) {
-      state.tickerEl.textContent = state.strings.offlineMessage || '';
+  function startCountdown() {
+    if (countdownTimer) {
+      window.clearInterval(countdownTimer);
     }
-    if (state.summarySection) {
-      state.summarySection.classList.add('is-offline');
-      state.summarySection.classList.remove('has-alerts');
-      state.summarySection.classList.remove('has-unknown');
-    }
-    if (state.summaryPrimary) {
-      state.summaryPrimary.textContent = state.strings.offlineMessage || 'Status feed unreachable. Data might be stale.';
-    }
-    if (state.summarySecondary) {
-      var fallback = '';
-      if (state.lastFetchedAt) {
-        var last = new Date(state.lastFetchedAt);
-        if (!isNaN(last.getTime())) {
-          fallback = 'Last good update ' + formatRelativeShort(Date.now() - last.getTime()) + '.';
-        }
-      }
-      state.summarySecondary.textContent = fallback;
-      state.summarySecondary.hidden = !fallback;
-    }
-    if (state.summaryList) {
-      while (state.summaryList.firstChild) {
-        state.summaryList.removeChild(state.summaryList.firstChild);
-      }
-      state.summaryList.hidden = true;
-    }
-    return [];
+    tickCountdown();
+    countdownTimer = window.setInterval(tickCountdown, 1000);
   }
 
-  function fetchStatuses(options) {
-    options = options || {};
-    if (state.inFlight && !options.force) {
-      return state.inFlight;
+  function setLoading(isLoading) {
+    if (!refreshButton) {
+      return;
     }
-    if (!state.config.endpoint) {
-      return Promise.resolve([]);
+    refreshButton.disabled = isLoading;
+  }
+
+  function refreshNow(force) {
+    if (!config.endpoint) {
+      return;
     }
     setLoading(true);
-    var controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
-    var timeoutId = null;
-    if (controller) {
-      timeoutId = global.setTimeout(function () {
-        controller.abort();
-      }, state.config.fetchTimeout);
+    var url = config.endpoint;
+    var separator = url.indexOf('?') === -1 ? '?' : '&';
+    url += separator + '_=' + Date.now();
+    if (force) {
+      url += '&refresh=1';
     }
-    var fetchOptions = {
-      method: 'GET',
-      headers: { 'Cache-Control': 'no-cache' },
-      cache: 'no-store'
-    };
-    if (controller) {
-      fetchOptions.signal = controller.signal;
-    }
-    state.inFlight = global.fetch(state.config.endpoint, fetchOptions)
-      .then(function (response) {
-        if (!response.ok) {
-          throw new Error('Network response was not ok (' + response.status + ')');
+
+    fetch(url, { credentials: 'same-origin' })
+      .then(function (res) {
+        if (!res.ok) {
+          throw new Error('HTTP ' + res.status);
         }
-        return response.json();
+        return res.json();
       })
-      .then(handleSuccess)
-      .catch(handleFailure)
+      .then(function (payload) {
+        if (!payload) {
+          throw new Error('Empty payload');
+        }
+        renderProviders(payload.providers || []);
+        updateMeta(payload.meta || {});
+        startCountdown();
+      })
+      .catch(function (error) {
+        if (metaCountdown) {
+          metaCountdown.textContent = 'Refresh failed: ' + error.message;
+        }
+      })
       .finally(function () {
         setLoading(false);
-        if (timeoutId) {
-          global.clearTimeout(timeoutId);
-        }
-        state.inFlight = null;
       });
-
-    return state.inFlight;
   }
 
-  function startAutoRefresh() {
-    if (state.pollTimer) {
-      global.clearInterval(state.pollTimer);
-    }
-    state.pollTimer = global.setInterval(function () {
-      fetchStatuses();
-    }, state.config.pollInterval);
-    return state.pollTimer;
-  }
-
-  function stopAutoRefresh() {
-    if (state.pollTimer) {
-      global.clearInterval(state.pollTimer);
-      state.pollTimer = null;
-    }
-  }
-
-  function attachButton() {
-    if (!state.refreshButton) {
-      return;
-    }
-    state.refreshButton.addEventListener('click', function () {
-      fetchStatuses({ force: true });
+  if (refreshButton) {
+    refreshButton.addEventListener('click', function () {
+      refreshNow(true);
     });
   }
 
-  function init(customConfig) {
-    readConfig(customConfig);
-    if (!global.document) {
-      return state;
-    }
-    state.container = global.document.getElementById('lousy-outages');
-    if (!state.container) {
-      return state;
-    }
-    state.grid = state.container.querySelector('.providers-grid');
-    state.tickerEl = state.container.querySelector('.ticker');
-    state.refreshButton = state.container.querySelector('.coin-btn');
-    state.lastUpdatedSpan = state.container.querySelector('.last-updated span');
-    state.summarySection = state.container.querySelector('[data-summary]');
-    state.summaryPrimary = state.container.querySelector('[data-summary-primary]');
-    state.summarySecondary = state.container.querySelector('[data-summary-secondary]');
-    state.summaryList = state.container.querySelector('[data-summary-list]');
-    state.feedLink = state.container.querySelector('[data-feed-link]');
-    state.emailLink = state.container.querySelector('[data-email-link]');
-    state.config.voiceEnabled = state.config.voiceEnabled || state.container.getAttribute('data-voice-enabled') === '1';
-
-    if (state.feedLink && state.config.feedUrl) {
-      state.feedLink.href = state.config.feedUrl;
-    }
-    if (state.emailLink && state.config.alertEmail) {
-      state.emailLink.textContent = state.config.alertEmail;
-      state.emailLink.href = 'mailto:' + state.config.alertEmail + '?subject=' + encodeURIComponent('Lousy Outages alerts');
-    }
-
-    prepareExistingCards();
-    attachButton();
-
-    if (state.config.initialSummary) {
-      renderSummary(state.config.initialSummary);
-    } else {
-      renderSummary(computeSummary([]));
-    }
-
-    if (state.lastUpdatedSpan) {
-      var initial = state.lastUpdatedSpan.getAttribute('data-initial');
-      if (initial) {
-        updateTimestamp(initial);
-      } else {
-        state.lastUpdatedSpan.textContent = '--';
-      }
-    }
-
-    global.setTimeout(function () {
-      fetchStatuses({ force: true });
-    }, 100);
-    startAutoRefresh();
-    return state;
-  }
-
-  if (global.document) {
-    if (global.document.readyState !== 'loading') {
-      init();
-    } else {
-      global.document.addEventListener('DOMContentLoaded', function () {
-        init();
-      });
-    }
-  }
-
-  return {
-    init: init,
-    refresh: fetchStatuses,
-    startAutoRefresh: startAutoRefresh,
-    stopAutoRefresh: stopAutoRefresh,
-    normalizeStatus: normalizeStatus,
-    formatTimestamp: formatTimestamp,
-    snarkOutage: snarkOutage,
-    _state: state
-  };
-});
+  renderProviders(providers);
+  updateMeta(config.initial ? config.initial.meta : null);
+  startCountdown();
+})(window);

--- a/lousy-outages/includes/Email.php
+++ b/lousy-outages/includes/Email.php
@@ -1,17 +1,39 @@
 <?php
+declare(strict_types=1);
+
 namespace LousyOutages;
 
 class Email {
     private function send( string $subject, string $body ): void {
         $to = get_option( 'lousy_outages_email', get_option( 'admin_email' ) );
-        if ( ! $to ) {
+        if ( ! $to || ! is_email( $to ) ) {
+            do_action( 'lousy_outages_log', 'email_skip', [ 'reason' => 'invalid_to' ] );
             return;
         }
-        wp_mail( $to, $subject, $body );
+
+        $headers = [];
+        $host    = parse_url( home_url(), PHP_URL_HOST ) ?: wp_parse_url( home_url(), PHP_URL_HOST ) ?: 'localhost';
+        $from    = get_option( 'blogname' ) . ' <no-reply@' . $host . '>';
+        $headers[] = 'From: ' . $from;
+        $headers[] = 'Content-Type: text/plain; charset=UTF-8';
+
+        $ok = wp_mail( $to, $subject, $body, $headers );
+        update_option(
+            'lousy_outages_last_email',
+            [
+                'to'      => $to,
+                'subject' => $subject,
+                'ok'      => $ok,
+                'ts'      => gmdate( 'c' ),
+            ],
+            false
+        );
+
+        do_action( 'lousy_outages_log', 'email_send', [ 'ok' => $ok, 'to' => $to, 'subject' => $subject ] );
     }
 
     public function send_alert( string $provider, string $status, string $message, string $link ): void {
-        $subject = sprintf( '🚨 Lousy Outages: %s %s', $provider, $status );
+        $subject = sprintf( '⚠️ Lousy Outages: %s %s', $provider, $status );
         $body    = sprintf( "%s\n\nMore info: %s", $message, $link );
         $this->send( $subject, $body );
     }

--- a/lousy-outages/includes/Fetcher.php
+++ b/lousy-outages/includes/Fetcher.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace LousyOutages;
 
 class Fetcher {
@@ -9,8 +11,6 @@ class Fetcher {
         'maintenance' => 'Maintenance',
         'unknown'     => 'Unknown',
     ];
-
-    private const IMPACT_LEVELS = ['minor', 'major', 'critical'];
 
     private int $timeout;
 
@@ -23,131 +23,130 @@ class Fetcher {
         return self::STATUS_LABELS[ $code ] ?? self::STATUS_LABELS['unknown'];
     }
 
-    /**
-     * Fetch and normalize data for a provider.
-     */
     public function fetch( array $provider ): array {
+        $id        = (string) ( $provider['id'] ?? '' );
+        $name      = (string) ( $provider['name'] ?? $id );
+        $type      = strtolower( (string) ( $provider['type'] ?? 'statuspage' ) );
+        $endpoint  = $this->resolve_endpoint( $provider );
+        $statusUrl = $provider['status_url'] ?? ( $provider['url'] ?? '' );
+
         $defaults = [
-            'id'           => $provider['id'],
-            'name'         => $provider['name'],
-            'provider'     => $provider['provider'] ?? $provider['name'],
+            'id'           => $id,
+            'name'         => $name,
+            'provider'     => $provider['provider'] ?? $name,
             'status'       => 'unknown',
             'status_label' => self::status_label( 'unknown' ),
-            'summary'      => isset( $provider['note'] ) ? $this->sanitize( (string) $provider['note'] ) : '',
-            'message'      => isset( $provider['note'] ) ? $this->sanitize( (string) $provider['note'] ) : '',
+            'summary'      => 'Waiting for status…',
+            'message'      => 'Waiting for status…',
             'updated_at'   => gmdate( 'c' ),
-            'url'          => $provider['url'] ?? '',
+            'url'          => is_string( $statusUrl ) ? $statusUrl : '',
             'incidents'    => [],
             'error'        => null,
         ];
 
-        if ( empty( $provider['endpoint'] ) ) {
-            if ( empty( $defaults['summary'] ) ) {
-                $defaults['summary'] = 'No public status API';
-                $defaults['message'] = $defaults['summary'];
-            }
+        if ( ! $endpoint ) {
+            $defaults['summary'] = 'No public status endpoint available';
+            $defaults['message'] = $defaults['summary'];
             return $defaults;
         }
 
         $response = wp_remote_get(
-            $provider['endpoint'],
+            $endpoint,
             [
                 'timeout' => $this->timeout,
                 'headers' => [
-                    'Accept'        => 'application/json, text/xml;q=0.9,*/*;q=0.8',
+                    'Accept'        => 'application/json, application/xml, text/xml;q=0.9,*/*;q=0.8',
                     'Cache-Control' => 'no-cache',
-                    'User-Agent'    => 'LousyOutagesBot/2.0 (' . home_url() . ')',
+                    'User-Agent'    => 'LousyOutagesBot/3.0 (' . home_url() . ')',
                 ],
             ]
         );
 
+        $optional = ( 'rss-optional' === $type );
+
         if ( is_wp_error( $response ) ) {
-            $defaults['summary'] = 'Request failed';
-            $defaults['message'] = $defaults['summary'];
-            $defaults['error']   = $response->get_error_message();
-            return $defaults;
+            if ( $optional ) {
+                return $this->optional_unavailable( $defaults, $response->get_error_message() );
+            }
+
+            return $this->failed_defaults( $defaults, 'request_failed', $response->get_error_message() );
         }
 
         $code = (int) wp_remote_retrieve_response_code( $response );
-        if ( $code < 200 || $code >= 400 ) {
-            $fallback = $this->scrape_status_page( $provider );
-            if ( $fallback ) {
-                return array_merge( $defaults, $fallback );
+        if ( $code >= 400 ) {
+            if ( $optional ) {
+                return $this->optional_unavailable( $defaults, 'HTTP ' . $code );
             }
 
-            $defaults['summary'] = sprintf( 'HTTP %d from status API', $code );
-            $defaults['message'] = $defaults['summary'];
-            $defaults['error']   = 'http_error';
-            return $defaults;
+            return $this->failed_defaults( $defaults, 'http_error', sprintf( 'HTTP %d response', $code ) );
         }
 
-        $body = wp_remote_retrieve_body( $response );
-        if ( ! $body ) {
-            $fallback = $this->scrape_status_page( $provider );
-            if ( $fallback ) {
-                return array_merge( $defaults, $fallback );
+        $body = (string) wp_remote_retrieve_body( $response );
+        if ( '' === trim( $body ) ) {
+            if ( $optional ) {
+                return $this->optional_unavailable( $defaults, 'Empty body' );
             }
 
-            $defaults['summary'] = 'Empty response from status API';
-            $defaults['message'] = $defaults['summary'];
-            $defaults['error']   = 'empty_body';
-            return $defaults;
+            return $this->failed_defaults( $defaults, 'empty_body', 'Empty response from status endpoint' );
         }
 
-        $parsed  = $this->parse_body( $provider, $body );
-        if ( ! empty( $provider['scrape'] ) ) {
-            if ( empty( $parsed['summary'] ) || 'unknown' === ( $parsed['status'] ?? 'unknown' ) ) {
-                $fallback = $this->scrape_status_page( $provider );
-                if ( $fallback ) {
-                    $parsed = array_merge( $parsed, $fallback );
-                }
-            }
+        switch ( $type ) {
+            case 'atom':
+                $parsed = $this->parse_feed( $provider, $body, 'atom' );
+                break;
+            case 'rss':
+            case 'rss-optional':
+                $parsed = $this->parse_feed( $provider, $body, 'rss' );
+                break;
+            case 'statuspage':
+            default:
+                $parsed = $this->parse_statuspage( $body );
+                break;
         }
-        $result  = array_merge( $defaults, $parsed );
-        $summary = $result['summary'] ?? $result['message'] ?? '';
-        if ( ! $summary ) {
-            $summary = self::status_label( $result['status'] ?? 'unknown' );
-        }
-        $summary             = $this->sanitize( $summary );
-        $result['summary']   = $summary;
-        $result['message']   = $summary;
-        $result['status']    = $result['status'] ?? 'unknown';
+
+        $result = array_merge( $defaults, $parsed );
+
+        $result['status']       = $this->normalize_status_code( $result['status'] ?? 'unknown' );
         $result['status_label'] = self::status_label( $result['status'] );
+        $result['summary']      = $this->sanitize( $result['summary'] ?? '' ) ?: self::status_label( $result['status'] );
+        $result['message']      = $result['summary'];
         $result['updated_at']   = $result['updated_at'] ?? gmdate( 'c' );
-        $result['incidents']    = array_values( array_filter( $result['incidents'] ?? [], 'is_array' ) );
+        $result['incidents']    = $this->normalize_incidents( $result['incidents'] ?? [] );
 
         return $result;
     }
 
-    private function parse_body( array $provider, string $body ): array {
-        $type = strtolower( $provider['type'] ?? 'statuspage' );
-        if ( 'slack' === $type ) {
-            return $this->parse_slack( $provider, $body );
-        }
-        if ( 'statuspage' === $type ) {
-            return $this->parse_statuspage( $body );
+    private function resolve_endpoint( array $provider ): ?string {
+        $type = strtolower( (string) ( $provider['type'] ?? 'statuspage' ) );
+        $keys = [
+            'statuspage'   => 'summary',
+            'rss'          => 'rss',
+            'rss-optional' => 'rss',
+            'atom'         => 'atom',
+        ];
+
+        $key = $keys[ $type ] ?? 'summary';
+        $url = $provider[ $key ] ?? ( $provider['endpoint'] ?? null );
+
+        if ( ! $url || ! is_string( $url ) ) {
+            return null;
         }
 
-        if ( 'json' === $type ) {
-            return $this->parse_json_feed( $provider, $body );
-        }
-
-        return $this->parse_feed( $provider, $body );
+        return $url;
     }
 
     private function parse_statuspage( string $body ): array {
         $decoded = json_decode( $body, true );
         if ( ! is_array( $decoded ) ) {
             return [
-                'status'    => 'unknown',
-                'summary'   => 'Unrecognized response payload',
-                'incidents' => [],
+                'status'  => 'unknown',
+                'summary' => 'Unrecognized Statuspage payload',
             ];
         }
 
-        $indicator    = strtolower( (string) ( $decoded['status']['indicator'] ?? '' ) );
-        $description  = strtolower( (string) ( $decoded['status']['description'] ?? '' ) );
-        $map       = [
+        $indicator   = strtolower( (string) ( $decoded['status']['indicator'] ?? '' ) );
+        $description = (string) ( $decoded['status']['description'] ?? '' );
+        $map         = [
             'none'           => 'operational',
             'minor'          => 'degraded',
             'major'          => 'outage',
@@ -155,20 +154,9 @@ class Fetcher {
             'maintenance'    => 'maintenance',
             'partial_outage' => 'degraded',
         ];
-        $status    = $map[ $indicator ] ?? 'unknown';
-        if ( 'unknown' === $status && $description ) {
-            if ( false !== strpos( $description, 'operational' ) ) {
-                $status = 'operational';
-            } elseif ( false !== strpos( $description, 'degrad' ) || false !== strpos( $description, 'partial' ) ) {
-                $status = 'degraded';
-            } elseif ( false !== strpos( $description, 'outage' ) || false !== strpos( $description, 'disruption' ) ) {
-                $status = 'outage';
-            }
-        }
-        $summary   = $decoded['status']['description'] ?? '';
+        $status      = $map[ $indicator ] ?? $this->guess_status_from_text( $description );
 
         $incidents = [];
-        $sources   = [];
         foreach ( [ 'incidents', 'active_incidents' ] as $key ) {
             if ( empty( $decoded[ $key ] ) || ! is_array( $decoded[ $key ] ) ) {
                 continue;
@@ -177,35 +165,139 @@ class Fetcher {
                 if ( ! is_array( $incident ) ) {
                     continue;
                 }
-                $state = strtolower( (string) ( $incident['status'] ?? '' ) );
-                if ( in_array( $state, [ 'resolved', 'completed', 'postmortem', 'scheduled' ], true ) ) {
-                    continue;
+                $normalized = $this->normalize_statuspage_incident( $incident );
+                if ( $normalized ) {
+                    $incidents[] = $normalized;
                 }
-                $normalised = $this->normalize_statuspage_incident( $incident );
-                if ( $normalised['id'] && isset( $sources[ $normalised['id'] ] ) ) {
-                    continue;
-                }
-                if ( $normalised['id'] ) {
-                    $sources[ $normalised['id'] ] = true;
-                }
-                $incidents[] = $normalised;
             }
         }
 
-        $updated = $this->iso( $decoded['page']['updated_at'] ?? null );
+        $summary = $description ?: ( $incidents[0]['title'] ?? '' );
         if ( ! $summary ) {
-            $summary = $incidents ? ( $incidents[0]['title'] ?? 'Investigating incidents' ) : 'All systems operational';
+            $summary = 'All systems operational';
         }
 
         return [
             'status'     => $status,
             'summary'    => $summary,
             'incidents'  => $incidents,
-            'updated_at' => $updated ?: gmdate( 'c' ),
+            'updated_at' => $this->iso( $decoded['page']['updated_at'] ?? null ) ?? gmdate( 'c' ),
         ];
     }
 
-    private function normalize_statuspage_incident( array $incident ): array {
+    private function parse_feed( array $provider, string $body, string $format ): array {
+        $previous = libxml_use_internal_errors( true );
+        $xml      = simplexml_load_string( $body );
+        libxml_clear_errors();
+        libxml_use_internal_errors( $previous );
+
+        if ( ! $xml ) {
+            return [
+                'status'  => 'unknown',
+                'summary' => 'Unable to parse status feed',
+            ];
+        }
+
+        $entries = [];
+        if ( 'atom' === $format && isset( $xml->entry ) ) {
+            foreach ( $xml->entry as $entry ) {
+                $entries[] = $entry;
+            }
+        } elseif ( isset( $xml->channel->item ) ) {
+            foreach ( $xml->channel->item as $item ) {
+                $entries[] = $item;
+            }
+        }
+
+        if ( ! $entries ) {
+            return [
+                'status'  => 'operational',
+                'summary' => 'All systems operational',
+                'incidents' => [],
+            ];
+        }
+
+        $incidents = [];
+        $highest   = 'operational';
+        foreach ( $entries as $entry ) {
+            $data = $this->normalize_feed_entry( $entry, $provider );
+            if ( ! $data ) {
+                continue;
+            }
+
+            $incidents[] = $data;
+            if ( 'outage' === $data['impact'] ) {
+                $highest = 'outage';
+            } elseif ( 'degraded' === $data['impact'] && 'outage' !== $highest ) {
+                $highest = 'degraded';
+            }
+        }
+
+        $status  = $highest;
+        if ( 'operational' === $status && ! empty( $incidents ) ) {
+            $status = 'degraded';
+        }
+
+        $summary = $incidents ? ( $incidents[0]['title'] ?? 'Service disruption detected' ) : 'All systems operational';
+        $updated = $incidents ? ( $incidents[0]['updated_at'] ?? $incidents[0]['started_at'] ?? null ) : null;
+
+        return [
+            'status'     => $status,
+            'summary'    => $summary,
+            'incidents'  => $incidents,
+            'updated_at' => $updated ? $this->iso( $updated ) : gmdate( 'c' ),
+        ];
+    }
+
+    private function normalize_feed_entry( \SimpleXMLElement $entry, array $provider ): ?array {
+        $title   = $this->sanitize( (string) ( $entry->title ?? '' ) );
+        $summary = $this->sanitize( (string) ( $entry->summary ?? $entry->description ?? '' ) );
+        $link    = '';
+
+        if ( isset( $entry->link ) ) {
+            if ( isset( $entry->link['href'] ) ) {
+                $link = (string) $entry->link['href'];
+            } else {
+                $link = (string) $entry->link;
+            }
+        }
+
+        if ( isset( $entry->guid ) && ! $link ) {
+            $link = (string) $entry->guid;
+        }
+
+        $published = (string) ( $entry->pubDate ?? $entry->published ?? $entry->updated ?? '' );
+        $timestamp = $published ? strtotime( $published ) : false;
+        if ( $timestamp && $timestamp < strtotime( '-7 days' ) ) {
+            return null;
+        }
+        $isoStart = $this->iso( $published );
+
+        $text     = strtolower( $title . ' ' . $summary );
+        $impact   = $this->guess_status_from_text( $text );
+
+        if ( 'operational' === $impact && ! $summary ) {
+            return null;
+        }
+
+        return [
+            'id'         => substr( md5( (string) ( $entry->guid ?? $title ) . $published ), 0, 12 ),
+            'title'      => $title ?: 'Incident',
+            'summary'    => $summary ?: $title,
+            'started_at' => $isoStart,
+            'updated_at' => $this->iso( (string) ( $entry->updated ?? $published ) ) ?? $isoStart,
+            'impact'     => $impact,
+            'eta'        => '',
+            'url'        => $link ?: ( $provider['status_url'] ?? '' ),
+        ];
+    }
+
+    private function normalize_statuspage_incident( array $incident ): ?array {
+        $state = strtolower( (string) ( $incident['status'] ?? '' ) );
+        if ( in_array( $state, [ 'resolved', 'completed', 'postmortem' ], true ) ) {
+            return null;
+        }
+
         $updates = [];
         if ( ! empty( $incident['incident_updates'] ) && is_array( $incident['incident_updates'] ) ) {
             $updates = $incident['incident_updates'];
@@ -220,8 +312,7 @@ class Fetcher {
         }
 
         $latest = $updates[0] ?? [];
-        $body   = $latest['body'] ?? '';
-        $eta    = $this->extract_eta_from_updates( $updates );
+        $body   = is_array( $latest ) ? ( $latest['body'] ?? $latest['display_at'] ?? '' ) : '';
 
         return [
             'id'         => (string) ( $incident['id'] ?? md5( wp_json_encode( $incident ) ) ),
@@ -229,457 +320,117 @@ class Fetcher {
             'summary'    => $this->sanitize( $body ?: ( $incident['impact_override'] ?? '' ) ),
             'started_at' => $this->iso( $incident['started_at'] ?? $incident['created_at'] ?? null ),
             'updated_at' => $this->iso( $incident['updated_at'] ?? null ),
-            'impact'     => $this->normalize_impact( $incident['impact'] ?? null ),
-            'eta'        => $eta,
+            'impact'     => $this->map_impact( $incident['impact'] ?? $state ),
+            'eta'        => '',
             'url'        => $incident['shortlink'] ?? $incident['postmortem_body'] ?? '',
         ];
     }
 
-    private function parse_feed( array $provider, string $body ): array {
-        $previous = libxml_use_internal_errors( true );
-        $xml      = simplexml_load_string( $body );
-        libxml_clear_errors();
-        libxml_use_internal_errors( $previous );
-
-        if ( ! $xml ) {
-            return [
-                'status'    => 'unknown',
-                'summary'   => 'Unable to read status feed',
-                'incidents' => [],
-            ];
-        }
-
-        $entries = [];
-        if ( isset( $xml->channel->item ) ) {
-            foreach ( $xml->channel->item as $item ) {
-                $entries[] = $item;
-            }
-        } elseif ( isset( $xml->entry ) ) {
-            foreach ( $xml->entry as $entry ) {
-                $entries[] = $entry;
-            }
-        }
-
-        $incidents = [];
-        $now       = time();
-        foreach ( $entries as $entry ) {
-            $title     = isset( $entry->title ) ? (string) $entry->title : 'Incident';
-            $summary   = isset( $entry->summary ) ? (string) $entry->summary : ( isset( $entry->description ) ? (string) $entry->description : '' );
-            $published = isset( $entry->published ) ? (string) $entry->published : ( isset( $entry->pubDate ) ? (string) $entry->pubDate : '' );
-            $updated   = isset( $entry->updated ) ? (string) $entry->updated : $published;
-            $link      = '';
-            if ( isset( $entry->link ) ) {
-                if ( isset( $entry->link['href'] ) ) {
-                    $link = (string) $entry->link['href'];
-                } else {
-                    $link = (string) $entry->link;
-                }
-            }
-
-            $ts = $published ? strtotime( $published ) : false;
-            if ( $ts && $ts < strtotime( '-7 days', $now ) ) {
-                continue;
-            }
-
-            $incidents[] = [
-                'id'         => substr( md5( (string) ( $entry->guid ?? $entry->id ?? $title ) . $published ), 0, 12 ),
-                'title'      => $this->sanitize( $title ),
-                'summary'    => $this->sanitize( $summary ),
-                'started_at' => $this->iso( $published ),
-                'updated_at' => $this->iso( $updated ),
-                'impact'     => 'major',
-                'eta'        => 'investigating',
-                'url'        => $link ?: ( $provider['url'] ?? '' ),
-            ];
-        }
-
-        $status  = $incidents ? 'degraded' : 'operational';
-        $summary = $incidents ? ( $incidents[0]['title'] ?? 'Service disruption detected' ) : 'All systems operational';
-        $updated = $incidents && ! empty( $incidents[0]['updated_at'] ) ? $incidents[0]['updated_at'] : gmdate( 'c' );
-
-        return [
-            'status'     => $status,
-            'summary'    => $summary,
-            'incidents'  => $incidents,
-            'updated_at' => $updated,
-        ];
-    }
-
-    private function parse_json_feed( array $provider, string $body ): array {
-        $decoded = json_decode( $body, true );
-        if ( ! is_array( $decoded ) ) {
-            return [
-                'status'    => 'unknown',
-                'summary'   => 'Unrecognized response payload',
-                'incidents' => [],
-            ];
-        }
-
-        $items = [];
-        if ( isset( $decoded['items'] ) && is_array( $decoded['items'] ) ) {
-            $items = $decoded['items'];
-        } elseif ( isset( $decoded[0] ) ) {
-            $items = $decoded;
-        }
-
-        $incidents = [];
-        foreach ( $items as $item ) {
-            if ( ! is_array( $item ) ) {
-                continue;
-            }
-
-            $state = strtolower( $item['status'] ?? $item['state'] ?? '' );
-            if ( in_array( $state, [ 'closed', 'resolved', 'completed' ], true ) ) {
-                continue;
-            }
-
-            $updates = [];
-            if ( isset( $item['most_recent_update'] ) ) {
-                $updates = is_array( $item['most_recent_update'] ) ? [ $item['most_recent_update'] ] : [ [ 'text' => $item['most_recent_update'] ] ];
-            } elseif ( isset( $item['updates'] ) && is_array( $item['updates'] ) ) {
-                $updates = $item['updates'];
-            }
-
-            $latest = $updates[0] ?? [];
-            $summary = '';
-            if ( is_array( $latest ) ) {
-                $summary = $latest['text'] ?? $latest['body'] ?? '';
-            } elseif ( is_string( $latest ) ) {
-                $summary = $latest;
-            }
-
-            $incidents[] = [
-                'id'         => (string) ( $item['id'] ?? md5( wp_json_encode( $item ) ) ),
-                'title'      => $this->sanitize( $item['title'] ?? $item['summary'] ?? 'Incident' ),
-                'summary'    => $this->sanitize( $summary ?: ( $item['summary'] ?? '' ) ),
-                'started_at' => $this->iso( $item['begin'] ?? $item['created'] ?? null ),
-                'updated_at' => $this->iso( $item['end'] ?? $item['modified'] ?? ( $latest['when'] ?? null ) ),
-                'impact'     => $this->normalize_impact( $item['severity'] ?? ( $item['impact'] ?? null ) ),
-                'eta'        => $this->extract_eta_from_text( $item['eta'] ?? ( is_array( $latest ) ? ( $latest['eta'] ?? '' ) : '' ) ),
-                'url'        => $item['externalUrl'] ?? $item['uri'] ?? $provider['url'] ?? '',
-            ];
-        }
-
-        $status  = $incidents ? 'degraded' : 'operational';
-        $summary = $incidents ? ( $incidents[0]['title'] ?? 'Active incident reported' ) : 'All systems operational';
-        $updated = $incidents && ! empty( $incidents[0]['updated_at'] ) ? $incidents[0]['updated_at'] : gmdate( 'c' );
-
-        return [
-            'status'     => $status,
-            'summary'    => $summary,
-            'incidents'  => $incidents,
-            'updated_at' => $updated,
-        ];
-    }
-
-    private function parse_slack( array $provider, string $body ): array {
-        $decoded = json_decode( $body, true );
-        if ( ! is_array( $decoded ) ) {
-            return [
-                'status'    => 'unknown',
-                'summary'   => 'Unrecognized response payload',
-                'incidents' => [],
-            ];
-        }
-
-        $raw_incidents = [];
-        if ( isset( $decoded['active_incidents'] ) && is_array( $decoded['active_incidents'] ) ) {
-            $raw_incidents = $decoded['active_incidents'];
-        } elseif ( isset( $decoded['incidents'] ) && is_array( $decoded['incidents'] ) ) {
-            $raw_incidents = $decoded['incidents'];
-        }
-
-        $incidents = [];
-        foreach ( $raw_incidents as $incident ) {
+    private function normalize_incidents( array $incidents ): array {
+        $normalized = [];
+        foreach ( $incidents as $incident ) {
             if ( ! is_array( $incident ) ) {
                 continue;
             }
 
-            $updates = [];
-            if ( isset( $incident['updates'] ) && is_array( $incident['updates'] ) ) {
-                $updates = $incident['updates'];
-                $self    = $this;
-                usort(
-                    $updates,
-                    static function ( $a, $b ) use ( $self ) {
-                        $aTime = $self->slack_update_timestamp( $a );
-                        $bTime = $self->slack_update_timestamp( $b );
-                        return $bTime <=> $aTime;
-                    }
-                );
-            }
-
-            $latest  = $updates[0] ?? [];
-            $summary = '';
-            if ( is_array( $latest ) ) {
-                $summary = $latest['body'] ?? $latest['text'] ?? ( $latest['description'] ?? '' );
-            } elseif ( is_string( $latest ) ) {
-                $summary = $latest;
-            }
-
-            if ( ! $summary && isset( $incident['summary'] ) ) {
-                $summary = $incident['summary'];
-            }
-
-            $start = $incident['created'] ?? $incident['begin'] ?? $this->combine_datetime( $incident['date'] ?? '', $incident['time'] ?? '' );
-            $end   = $incident['updated'] ?? ( is_array( $latest ) ? ( $latest['updated'] ?? $this->combine_datetime( $latest['date'] ?? '', $latest['time'] ?? '' ) ) : null );
-
-            $incidents[] = [
+            $normalized[] = [
                 'id'         => (string) ( $incident['id'] ?? md5( wp_json_encode( $incident ) ) ),
-                'title'      => $this->sanitize( $incident['title'] ?? $incident['name'] ?? 'Incident' ),
-                'summary'    => $this->sanitize( $summary ?: ( $incident['description'] ?? '' ) ),
-                'started_at' => $this->iso( $start ),
-                'updated_at' => $this->iso( $end ),
-                'impact'     => $this->normalize_impact( $incident['status'] ?? 'major' ),
-                'eta'        => $this->extract_eta_from_text( $incident['next_update'] ?? ( is_array( $latest ) ? ( $latest['next_update'] ?? $latest['next'] ?? '' ) : '' ) ),
-                'url'        => $incident['url'] ?? $incident['permalink'] ?? $provider['url'] ?? '',
+                'title'      => $this->sanitize( $incident['title'] ?? 'Incident' ),
+                'summary'    => $this->sanitize( $incident['summary'] ?? '' ),
+                'started_at' => $this->iso( $incident['started_at'] ?? null ),
+                'updated_at' => $this->iso( $incident['updated_at'] ?? null ),
+                'impact'     => $this->map_impact( $incident['impact'] ?? 'minor' ),
+                'eta'        => $this->sanitize( $incident['eta'] ?? '' ),
+                'url'        => $incident['url'] ?? '',
             ];
         }
 
-        $status_code = strtolower( (string) ( $decoded['status'] ?? '' ) );
-        $map         = [
-            'ok'          => 'operational',
-            'active'      => 'degraded',
-            'incident'    => 'degraded',
-            'minor'       => 'degraded',
-            'notice'      => 'maintenance',
-            'maintenance' => 'maintenance',
-            'major'       => 'outage',
-            'critical'    => 'outage',
-            'outage'      => 'outage',
-        ];
-        $status      = $map[ $status_code ] ?? 'unknown';
-        if ( 'unknown' === $status ) {
-            $status = $incidents ? 'degraded' : 'operational';
-        }
-
-        $summary = '';
-        if ( isset( $decoded['current_status'] ) && is_array( $decoded['current_status'] ) ) {
-            $summary = $decoded['current_status']['title'] ?? $decoded['current_status']['body'] ?? '';
-        }
-        if ( ! $summary ) {
-            $summary = $incidents ? ( $incidents[0]['title'] ?? '' ) : '';
-        }
-        if ( ! $summary ) {
-            $summary = 'All systems operational';
-        }
-
-        $updated = $this->iso( $this->combine_datetime( $decoded['date'] ?? '', $decoded['time'] ?? '' ) );
-        if ( ! $updated && $incidents ) {
-            $updated = $incidents[0]['updated_at'] ?? '';
-        }
-        if ( ! $updated ) {
-            $updated = gmdate( 'c' );
-        }
-
-        return [
-            'status'     => $status,
-            'summary'    => $summary,
-            'incidents'  => $incidents,
-            'updated_at' => $updated,
-        ];
+        return $normalized;
     }
 
-    private function slack_update_timestamp( $update ): int {
-        if ( ! is_array( $update ) ) {
-            return 0;
-        }
-
-        foreach ( [ 'updated', 'timestamp', 'ts', 'created', 'when' ] as $field ) {
-            if ( ! empty( $update[ $field ] ) ) {
-                $time = strtotime( (string) $update[ $field ] );
-                if ( $time ) {
-                    return $time;
-                }
-            }
-        }
-
-        $combined = $this->combine_datetime( $update['date'] ?? '', $update['time'] ?? '' );
-        if ( $combined ) {
-            $time = strtotime( $combined );
-            if ( $time ) {
-                return $time;
-            }
-        }
-
-        return 0;
+    private function optional_unavailable( array $defaults, string $error ): array {
+        $defaults['status']  = 'unknown';
+        $defaults['summary'] = 'Optional source unavailable';
+        $defaults['message'] = $defaults['summary'];
+        $defaults['error']   = $error ? 'optional_unavailable: ' . $error : 'optional_unavailable';
+        return $defaults;
     }
 
-    private function combine_datetime( ?string $date, ?string $time ): string {
-        $date = $date ? trim( $date ) : '';
-        $time = $time ? trim( $time ) : '';
-        if ( ! $date && ! $time ) {
+    private function failed_defaults( array $defaults, string $code, string $message ): array {
+        $defaults['status']  = 'unknown';
+        $defaults['summary'] = 'Status fetch failed';
+        $defaults['message'] = $defaults['summary'];
+        $defaults['error']   = $code . ( $message ? ': ' . $message : '' );
+        return $defaults;
+    }
+
+    private function sanitize( ?string $text ): string {
+        if ( ! $text ) {
             return '';
         }
-        if ( $date && $time ) {
-            return $date . ' ' . $time;
-        }
-        return $date ?: $time;
+        return trim( wp_strip_all_tags( $text ) );
     }
 
-    private function scrape_status_page( array $provider ): ?array {
-        if ( empty( $provider['scrape'] ) ) {
+    private function iso( $value ): ?string {
+        if ( ! $value ) {
             return null;
         }
-
-        $url = $provider['scrape_url'] ?? $provider['url'] ?? '';
-        if ( ! $url ) {
+        if ( $value instanceof \DateTimeInterface ) {
+            return gmdate( 'c', (int) $value->getTimestamp() );
+        }
+        $timestamp = strtotime( (string) $value );
+        if ( ! $timestamp ) {
             return null;
         }
-
-        $response = wp_remote_get(
-            $url,
-            [
-                'timeout' => min( $this->timeout, 6 ),
-                'headers' => [
-                    'Accept'     => 'text/html,application/xhtml+xml;q=0.9,*/*;q=0.8',
-                    'User-Agent' => 'LousyOutagesBot/2.0 (' . home_url() . ')',
-                ],
-            ]
-        );
-
-        if ( is_wp_error( $response ) ) {
-            return null;
-        }
-
-        $code = (int) wp_remote_retrieve_response_code( $response );
-        if ( $code < 200 || $code >= 400 ) {
-            return null;
-        }
-
-        $body = wp_remote_retrieve_body( $response );
-        if ( ! $body ) {
-            return null;
-        }
-
-        $summary = $this->extract_summary_from_html( $body );
-        if ( ! $summary ) {
-            return null;
-        }
-
-        $status = $this->infer_status_from_text( $summary );
-
-        return [
-            'status'     => $status,
-            'summary'    => $summary,
-            'message'    => $summary,
-            'incidents'  => [],
-            'updated_at' => gmdate( 'c' ),
-        ];
+        return gmdate( 'c', $timestamp );
     }
 
-    private function extract_summary_from_html( string $html ): string {
-        $candidates = [];
-        if ( preg_match( '/<meta[^>]+name=["\']description["\'][^>]+content=["\']([^"\']+)/i', $html, $matches ) ) {
-            $candidates[] = $matches[1];
-        }
-        if ( preg_match( '/<meta[^>]+property=["\']og:description["\'][^>]+content=["\']([^"\']+)/i', $html, $matches ) ) {
-            $candidates[] = $matches[1];
-        }
-        if ( preg_match( '/<h1[^>]*>(.*?)<\/h1>/is', $html, $matches ) ) {
-            $candidates[] = $matches[1];
-        }
-
-        foreach ( $candidates as $candidate ) {
-            $decoded = html_entity_decode( $candidate, ENT_QUOTES | ENT_HTML5 );
-            $clean   = $this->sanitize( $decoded );
-            if ( $clean ) {
-                return $clean;
-            }
-        }
-
-        return '';
+    private function map_impact( $impact ): string {
+        $impact = strtolower( (string) $impact );
+        return match ( $impact ) {
+            'critical', 'major', 'outage' => 'outage',
+            'maintenance'                => 'maintenance',
+            'minor', 'degraded', 'partial', 'partial_outage' => 'degraded',
+            default                      => 'minor',
+        };
     }
 
-    private function infer_status_from_text( string $text ): string {
+    private function guess_status_from_text( string $text ): string {
         $text = strtolower( $text );
-        if ( preg_match( '/maintenance|scheduled work|planned work/', $text ) ) {
-            return 'maintenance';
+        if ( ! $text ) {
+            return 'unknown';
         }
-        if ( preg_match( '/outage|disruption|downtime|major incident|service interruption|degraded/', $text ) ) {
-            if ( preg_match( '/partial|intermittent|degrad/', $text ) ) {
-                return 'degraded';
-            }
-            return 'outage';
-        }
-        if ( preg_match( '/degrad|intermittent|partial outage/', $text ) ) {
+        if (
+            false !== strpos( $text, 'partial outage' ) ||
+            false !== strpos( $text, 'degrad' ) ||
+            false !== strpos( $text, 'partial' ) ||
+            false !== strpos( $text, 'performance' )
+        ) {
             return 'degraded';
         }
-        if ( preg_match( '/all systems operational|no incidents reported|operating normally|running normally/', $text ) ) {
+        if (
+            false !== strpos( $text, 'outage' ) ||
+            false !== strpos( $text, 'disruption' ) ||
+            false !== strpos( $text, 'major' ) ||
+            false !== strpos( $text, 'critical' ) ||
+            false !== strpos( $text, 'down' )
+        ) {
+            return 'outage';
+        }
+        if ( false !== strpos( $text, 'operational' ) || false !== strpos( $text, 'normal' ) ) {
             return 'operational';
         }
         return 'unknown';
     }
 
-    private function normalize_impact( $value ): string {
-        $value = strtolower( (string) $value );
-        if ( in_array( $value, self::IMPACT_LEVELS, true ) ) {
-            return $value;
-        }
-        if ( 'critical' === $value || 'severe' === $value ) {
-            return 'critical';
-        }
-        if ( 'major' === $value || 'medium' === $value ) {
-            return 'major';
-        }
-        if ( 'minor' === $value || 'low' === $value ) {
-            return 'minor';
-        }
-        return 'minor';
-    }
-
-    private function extract_eta_from_updates( array $updates ): string {
-        foreach ( $updates as $update ) {
-            if ( ! is_array( $update ) ) {
-                continue;
-            }
-            if ( ! empty( $update['eta'] ) ) {
-                return $this->sanitize( (string) $update['eta'] );
-            }
-            if ( ! empty( $update['metadata']['eta'] ) ) {
-                return $this->sanitize( (string) $update['metadata']['eta'] );
-            }
-            if ( ! empty( $update['next_update'] ) ) {
-                return $this->sanitize( (string) $update['next_update'] );
-            }
-            $body = (string) ( $update['body'] ?? '' );
-            if ( preg_match( '/ETA[^:]*[:\-]\s*([^
-]+)/i', $body, $matches ) ) {
-                return $this->sanitize( $matches[1] );
-            }
-        }
-        return 'investigating';
-    }
-
-    private function extract_eta_from_text( $value ): string {
-        if ( is_string( $value ) && $value ) {
-            return $this->sanitize( $value );
-        }
-        if ( is_array( $value ) && isset( $value['text'] ) ) {
-            return $this->sanitize( (string) $value['text'] );
-        }
-        return 'investigating';
-    }
-
-    private function iso( $time ): string {
-        if ( empty( $time ) ) {
-            return '';
-        }
-        if ( is_numeric( $time ) ) {
-            $timestamp = (int) $time;
-        } else {
-            $timestamp = strtotime( (string) $time );
-        }
-        if ( ! $timestamp ) {
-            return '';
-        }
-        return gmdate( 'c', $timestamp );
-    }
-
-    private function sanitize( string $text ): string {
-        if ( function_exists( 'wp_strip_all_tags' ) ) {
-            return trim( wp_strip_all_tags( $text ) );
-        }
-        return trim( strip_tags( $text ) );
+    private function normalize_status_code( string $status ): string {
+        $status = strtolower( $status );
+        return match ( $status ) {
+            'operational', 'up'     => 'operational',
+            'degraded', 'partial', 'minor' => 'degraded',
+            'outage', 'major', 'critical', 'down' => 'outage',
+            'maintenance', 'scheduled' => 'maintenance',
+            default => 'unknown',
+        };
     }
 }

--- a/lousy-outages/includes/Providers.php
+++ b/lousy-outages/includes/Providers.php
@@ -1,88 +1,147 @@
 <?php
+declare(strict_types=1);
+
 namespace LousyOutages;
 
 class Providers {
     /**
-     * Return all providers.
-     * @return array
+     * Return the provider configuration map.
      */
     public static function list(): array {
-        return [
-            'github' => [
-                'id'       => 'github',
-                'name'     => 'GitHub',
-                'provider' => 'GitHub',
-                'endpoint' => 'https://www.githubstatus.com/api/v2/summary.json',
-                'type'     => 'statuspage',
-                'url'      => 'https://www.githubstatus.com/'
-            ],
-            'slack' => [
-                'id'       => 'slack',
-                'name'     => 'Slack',
-                'provider' => 'Slack',
-                'endpoint' => 'https://status.slack.com/api/v2.0.0/current',
-                'type'     => 'slack',
-                'url'      => 'https://status.slack.com/',
-                'scrape'   => true,
-            ],
-            'cloudflare' => [
-                'id'       => 'cloudflare',
-                'name'     => 'Cloudflare',
-                'provider' => 'Cloudflare',
-                'endpoint' => 'https://www.cloudflarestatus.com/api/v2/summary.json',
-                'type'     => 'statuspage',
-                'url'      => 'https://www.cloudflarestatus.com/'
-            ],
-            'zscaler' => [
-                'id'       => 'zscaler',
-                'name'     => 'Zscaler',
-                'provider' => 'Zscaler',
-                'endpoint' => 'https://status.zscaler.com/api/v2/summary.json',
-                'type'     => 'statuspage',
-                'url'      => 'https://status.zscaler.com/'
-            ],
-            'openai' => [
-                'id'       => 'openai',
-                'name'     => 'OpenAI',
-                'provider' => 'OpenAI',
-                'endpoint' => 'https://status.openai.com/api/v2/summary.json',
-                'type'     => 'statuspage',
-                'url'      => 'https://status.openai.com/'
-            ],
-            'aws' => [
-                'id'       => 'aws',
-                'name'     => 'AWS',
-                'provider' => 'AWS',
-                'endpoint' => 'https://status.aws.amazon.com/rss/all.rss',
-                'type'     => 'rss',
-                'url'      => 'https://status.aws.amazon.com/'
-            ],
-            'azure' => [
-                'id'       => 'azure',
-                'name'     => 'Azure',
-                'provider' => 'Azure',
-                'endpoint' => 'https://status.azure.com/en-us/status/feed',
-                'type'     => 'rss',
-                'url'      => 'https://status.azure.com/'
-            ],
-            'gcp' => [
-                'id'       => 'gcp',
-                'name'     => 'Google Cloud',
-                'provider' => 'Google Cloud',
-                'endpoint' => 'https://status.cloud.google.com/incidents.json',
-                'type'     => 'json',
-                'url'      => 'https://status.cloud.google.com/',
-                'scrape'   => true,
-            ],
-        ];
+        $providers = apply_filters(
+            'lousy_outages_providers',
+            [
+                'github' => [
+                    'name'   => 'GitHub',
+                    'type'   => 'statuspage',
+                    'summary'=> 'https://www.githubstatus.com/api/v2/summary.json',
+                    'status_url' => 'https://www.githubstatus.com/',
+                ],
+                'slack' => [
+                    'name'   => 'Slack',
+                    'type'   => 'statuspage',
+                    'summary'=> 'https://status.slack.com/api/v2.0.0/summary.json',
+                    'status_url' => 'https://status.slack.com/',
+                ],
+                'cloudflare' => [
+                    'name'   => 'Cloudflare',
+                    'type'   => 'statuspage',
+                    'summary'=> 'https://www.cloudflarestatus.com/api/v2/summary.json',
+                    'status_url' => 'https://www.cloudflarestatus.com/',
+                ],
+                'openai' => [
+                    'name'   => 'OpenAI',
+                    'type'   => 'statuspage',
+                    'summary'=> 'https://status.openai.com/api/v2/summary.json',
+                    'status_url' => 'https://status.openai.com/',
+                ],
+                'aws' => [
+                    'name'      => 'AWS',
+                    'type'      => 'rss',
+                    'rss'       => 'https://status.aws.amazon.com/rss/all.rss',
+                    'status_url'=> 'https://status.aws.amazon.com/',
+                ],
+                'azure' => [
+                    'name'      => 'Azure',
+                    'type'      => 'rss',
+                    'rss'       => 'https://azurestatuscdn.azureedge.net/en-us/status/feed/',
+                    'status_url'=> 'https://status.azure.com/',
+                ],
+                'gcp' => [
+                    'name'      => 'Google Cloud',
+                    'type'      => 'atom',
+                    'atom'      => 'https://status.cloud.google.com/feed.atom',
+                    'status_url'=> 'https://status.cloud.google.com/',
+                ],
+                'digitalocean' => [
+                    'name'   => 'DigitalOcean',
+                    'type'   => 'statuspage',
+                    'summary'=> 'https://status.digitalocean.com/api/v2/summary.json',
+                    'status_url' => 'https://status.digitalocean.com/',
+                ],
+                'netlify' => [
+                    'name'   => 'Netlify',
+                    'type'   => 'statuspage',
+                    'summary'=> 'https://www.netlifystatus.com/api/v2/summary.json',
+                    'status_url' => 'https://www.netlifystatus.com/',
+                ],
+                'vercel' => [
+                    'name'   => 'Vercel',
+                    'type'   => 'statuspage',
+                    'summary'=> 'https://www.vercel-status.com/api/v2/summary.json',
+                    'status_url' => 'https://www.vercel-status.com/',
+                ],
+                'downdetector-ca' => [
+                    'name'      => 'Downdetector (CA Aggregate)',
+                    'type'      => 'rss-optional',
+                    'enabled'   => false,
+                    'rss'       => 'https://downdetector.ca/archive/?format=rss',
+                    'status_url'=> 'https://downdetector.ca/',
+                ],
+            ]
+        );
+
+        foreach ( $providers as $id => &$provider ) {
+            if ( ! is_array( $provider ) ) {
+                unset( $providers[ $id ] );
+                continue;
+            }
+
+            $provider['id']       = $provider['id'] ?? $id;
+            $provider['enabled']  = array_key_exists( 'enabled', $provider ) ? (bool) $provider['enabled'] : true;
+            $provider['status_url'] = $provider['status_url'] ?? self::derive_status_url( $provider );
+        }
+        unset( $provider );
+
+        return $providers;
     }
 
     /**
-     * Return enabled providers from options or default all.
+     * Return enabled providers from options or defaults.
      */
     public static function enabled(): array {
-        $all     = self::list();
-        $enabled = get_option( 'lousy_outages_providers', array_keys( $all ) );
-        return array_intersect_key( $all, array_flip( $enabled ) );
+        $all            = self::list();
+        $default_enabled = array_keys( array_filter( $all, static fn( array $prov ): bool => $prov['enabled'] ) );
+        $saved           = get_option( 'lousy_outages_providers', false );
+        $enabled_ids     = is_array( $saved ) ? $saved : $default_enabled;
+
+        $enabled = [];
+        foreach ( $enabled_ids as $id ) {
+            if ( isset( $all[ $id ] ) ) {
+                $enabled[ $id ] = $all[ $id ];
+            }
+        }
+
+        return $enabled;
+    }
+
+    private static function derive_status_url( array $provider ): string {
+        foreach ( ['summary', 'rss', 'atom'] as $key ) {
+            if ( empty( $provider[ $key ] ) || ! is_string( $provider[ $key ] ) ) {
+                continue;
+            }
+
+            $url = $provider[ $key ];
+            if ( 'summary' === $key ) {
+                $url = preg_replace( '#/api/v\d+(?:\.\d+)*?/summary\.json$#', '/', $url );
+            }
+
+            $parts = wp_parse_url( $url );
+            if ( empty( $parts['scheme'] ) || empty( $parts['host'] ) ) {
+                continue;
+            }
+
+            $base = $parts['scheme'] . '://' . $parts['host'];
+            if ( 'summary' === $key ) {
+                $path = isset( $parts['path'] ) ? trim( (string) $parts['path'], '/' ) : '';
+                if ( $path && '/' !== $path ) {
+                    $base .= '/' . $path;
+                }
+            }
+
+            return trailingslashit( $base );
+        }
+
+        return trailingslashit( home_url( '/' ) );
     }
 }


### PR DESCRIPTION
## Summary
- restyle the public Lousy Outages shortcode into a retro status grid with live refresh controls
- expand provider definitions and fetch adapters to cover Statuspage, RSS/Atom, and optional Downdetector sources with resilient error handling
- harden email delivery while adding admin test/poll tools, logging hooks, and documentation for the new workflows

## Testing
- php -l lousy-outages/includes/Fetcher.php
- php -l lousy-outages/public/shortcode.php
- php -l lousy-outages/lousy-outages.php

------
https://chatgpt.com/codex/tasks/task_e_68eb5f21f8c4832e967d3734a58003f2