### PR TITLE
Polish Lousy Outages feed, Slack integration, and SMS tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ The legacy REST endpoint at `/wp-json/lousy-outages/v1/status` still works and r
 
 The status arcade now opens with an "at-a-glance" headline that calls out any degraded providers, links straight to the custom RSS feed at `/outages/feed/` and highlights the alerts inbox (`suzanneeaston@gmail.com`) so you can wire it into whatever mail filters you prefer. Unknown telemetry also surfaces in the banner, making it obvious when a provider's API stops responding.
 
+## Get alerts on your phone
+- **RSS**: Subscribe to https://<your-site>/outages/feed in any mobile RSS app (NetNewsWire, Reeder, Feedly). You’ll get a push/badge when incidents publish.
+- **SMS (optional)**: Enter your Twilio SID/Auth/From and your phone under Settings → Lousy Outages. Use “Send Test SMS” to verify.
+
 ## Track Analyzer
 Uploads are sent to OpenAI's Whisper and GPT‑4 APIs for a quick analysis of your
 MP3. Results appear with a fun retro overlay and clear loading indicators. For

--- a/assets/css/lousy-outages-teaser.css
+++ b/assets/css/lousy-outages-teaser.css
@@ -1,17 +1,42 @@
-.lo-teaser {
+#lousy-outages-teaser {
   margin: 2rem auto;
+}
+
+.lo-teaser {
+  max-width: 820px;
+  margin: 0 auto;
   text-align: center;
+  padding: 8px 16px;
   font-family: 'Press Start 2P', monospace;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
 }
+
 .lo-teaser h2 {
-  margin-bottom: 1rem;
+  margin: 0 0 12px;
 }
+
+.lo-teaser p {
+  margin: 6px 0 12px;
+  color: #a7ff9a;
+}
+
+.lo-teaser .lo-teaser-meta {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
 .lo-teaser .providers {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(120px,1fr));
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
   gap: 1rem;
-  margin-bottom: 1rem;
+  margin: 0 auto;
 }
+
 .lo-teaser .card {
   display: block;
   background: #111;
@@ -20,10 +45,12 @@
   text-decoration: none;
   color: #0f0;
 }
+
 .lo-teaser .card:hover {
   background: #0f0;
   color: #111;
 }
+
 .lo-teaser .dot {
   display: inline-block;
   width: 8px;
@@ -31,8 +58,36 @@
   border-radius: 50%;
   margin-right: 4px;
 }
-.lo-teaser .status-up { background: #00ff66; }
-.lo-teaser .status-warn { background: #ffcc00; }
-.lo-teaser .status-down { background: #ff004c; }
-.lo-teaser .caption { font-size: 0.75rem; margin: 0.5rem 0; }
-.lo-teaser .view-all { display: inline-block; margin-top: 0.5rem; }
+
+.lo-teaser .status-up {
+  background: #00ff66;
+}
+
+.lo-teaser .status-warn {
+  background: #ffcc00;
+}
+
+.lo-teaser .status-down {
+  background: #ff004c;
+}
+
+.lo-teaser .caption {
+  font-size: 0.75rem;
+}
+
+.lo-teaser .lo-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+}
+
+.lo-teaser .lo-link {
+  font-weight: 700;
+}
+
+.lo-teaser .view-all {
+  display: inline-flex;
+  justify-content: center;
+  margin-top: 0;
+}

--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -11,6 +11,15 @@
   color: #2af200;
 }
 
+.lo-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
 .lo-meta {
   color: #a7ff9a;
   font-size: 0.95rem;
@@ -18,7 +27,6 @@
   gap: 12px;
   align-items: center;
   flex-wrap: wrap;
-  margin-bottom: 12px;
 }
 
 .lo-meta span {
@@ -27,24 +35,36 @@
   gap: 4px;
 }
 
-.lo-btn {
+.lo-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+
+.lo-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
   border: 1px solid #2af200;
-  color: #2af200;
-  background: transparent;
   padding: 4px 10px;
   border-radius: 8px;
-  cursor: pointer;
+  text-decoration: none;
+  color: #2af200;
+  background: transparent;
   font-size: 0.9rem;
+  cursor: pointer;
   transition: background 0.2s ease, color 0.2s ease;
 }
 
-.lo-btn:hover,
-.lo-btn:focus {
-  background: #2af200;
-  color: #000;
+.lo-link:hover,
+.lo-link:focus {
+  text-decoration: underline;
 }
 
-.lo-btn[disabled] {
+.lo-link[disabled] {
   opacity: 0.5;
   cursor: progress;
 }
@@ -185,7 +205,7 @@
     font-size: 0.85rem;
   }
 
-  .lo-btn {
+  .lo-link {
     width: 100%;
     text-align: center;
   }

--- a/lousy-outages/includes/Providers.php
+++ b/lousy-outages/includes/Providers.php
@@ -18,9 +18,9 @@ class Providers {
                     'status_url' => 'https://www.githubstatus.com/',
                 ],
                 'slack' => [
-                    'name'   => 'Slack',
-                    'type'   => 'statuspage',
-                    'summary'=> 'https://status.slack.com/api/v2.0.0/summary.json',
+                    'name'       => 'Slack',
+                    'type'       => 'slack',
+                    'current'    => 'https://status.slack.com/api/v2.0.0/current',
                     'status_url' => 'https://status.slack.com/',
                 ],
                 'cloudflare' => [

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -84,13 +84,22 @@ function render_shortcode(): string {
         return wp_date( $format, $timestamp );
     };
 
+    $feed_url         = home_url( '/outages/feed/' );
+    $feed_refresh_url = add_query_arg( 'refresh', '1', $feed_url );
+
     ob_start();
     ?>
     <div class="lousy-outages" data-lo-endpoint="<?php echo esc_url( $config['endpoint'] ); ?>">
-        <div class="lo-meta" aria-live="polite">
-            <span>Fetched: <strong data-lo-fetched><?php echo esc_html( $format_datetime( $fetched_at ) ); ?></strong></span>
-            <span data-lo-countdown>Refreshing…</span>
-            <button type="button" class="lo-btn" data-lo-refresh>Refresh now</button>
+        <div class="lo-header">
+            <div class="lo-meta" aria-live="polite">
+                <span>Fetched at <strong data-lo-fetched><?php echo esc_html( $format_datetime( $fetched_at ) ); ?></strong></span>
+                <span data-lo-countdown>Calculating refresh…</span>
+            </div>
+            <div class="lo-actions">
+                <button type="button" class="lo-link" data-lo-refresh>Refresh now</button>
+                <a class="lo-link" href="<?php echo esc_url( $feed_url ); ?>" target="_blank" rel="noopener noreferrer">Subscribe (RSS)</a>
+                <a class="lo-link" href="<?php echo esc_url( $feed_refresh_url ); ?>" target="_blank" rel="noopener noreferrer">Refresh RSS</a>
+            </div>
         </div>
         <div class="lo-grid" data-lo-grid>
             <?php foreach ( $provider_payloads as $provider ) :

--- a/parts/lousy-outages-teaser.php
+++ b/parts/lousy-outages-teaser.php
@@ -12,9 +12,15 @@ if ( class_exists( '\\LousyOutages\\I18n' ) ) {
     $teaser_strings = array_merge( $teaser_strings, array_intersect_key( $localized, $teaser_strings ) );
 }
 ?>
-<section id="lousy-outages-teaser" class="lo-teaser" aria-live="polite">
-  <h2 class="pixel-font">Lousy Outages</h2>
-  <div class="providers"></div>
-  <p class="caption"><?php echo esc_html( $teaser_strings['teaserCaption'] ); ?></p>
-  <a class="view-all pixel-button" href="/lousy-outages/"><?php echo esc_html( $teaser_strings['viewDashboard'] ); ?></a>
+<section id="lousy-outages-teaser" aria-live="polite">
+  <div class="lo-teaser">
+    <h2 class="pixel-font">Lousy Outages</h2>
+    <div class="lo-teaser-meta">
+      <div class="providers"></div>
+      <p class="caption"><?php echo esc_html( $teaser_strings['teaserCaption'] ); ?></p>
+    </div>
+    <div class="lo-actions">
+      <a class="view-all pixel-button" href="/lousy-outages/"><?php echo esc_html( $teaser_strings['viewDashboard'] ); ?></a>
+    </div>
+  </div>
 </section>


### PR DESCRIPTION
## Summary
- add a dashboard header that surfaces the fetched timestamp alongside refresh and RSS actions with matching styles
- switch the Slack provider to the v2 current endpoint and parse it into the existing schema
- refine the homepage teaser layout, expose a Twilio test SMS button with helper copy, and document mobile alert options

## Testing
- php -l lousy-outages/public/shortcode.php
- php -l lousy-outages/includes/Fetcher.php
- php -l lousy-outages/includes/Providers.php
- php -l lousy-outages/lousy-outages.php
- php -l parts/lousy-outages-teaser.php

------
https://chatgpt.com/codex/tasks/task_e_68ec44e0d94c832eadac5b87feb4499f