### PR TITLE
Add RSS subscribe entry points for Lousy Outages

### DIFF
--- a/assets/css/lousy-outages-teaser.css
+++ b/assets/css/lousy-outages-teaser.css
@@ -91,3 +91,9 @@
   justify-content: center;
   margin-top: 0;
 }
+
+.lo-teaser { max-width: 820px; margin: 0 auto; text-align: center; padding: 8px 16px; }
+.lo-actions { display:flex; gap:10px; align-items:center; justify-content:center; flex-wrap:wrap; margin:10px 0 16px; }
+.lo-link { display:inline-flex; align-items:center; gap:8px; border:2px solid #2af200; color:#2af200; background:transparent; padding:6px 12px; border-radius:10px; text-decoration:none; font-weight:700; }
+.lo-link:hover { text-decoration:underline; }
+.lo-icon { width:16px; height:16px; display:inline-block; }

--- a/functions.php
+++ b/functions.php
@@ -309,3 +309,11 @@ add_action('template_redirect', function() {
         exit;
     }
 });
+
+// Advertise Lousy Outages RSS feed for readers (auto-discovery)
+add_action('wp_head', function () {
+    if (function_exists('home_url')) {
+        $href = esc_url( home_url('/outages/feed') );
+        echo "<link rel=\"alternate\" type=\"application/rss+xml\" title=\"Lousy Outages Alerts\" href=\"{$href}\" />\n";
+    }
+});

--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -11,11 +11,10 @@
   color: #2af200;
 }
 
+
 .lo-header {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 12px;
   margin-bottom: 14px;
 }
@@ -23,40 +22,33 @@
 .lo-meta {
   color: #a7ff9a;
   font-size: 0.95rem;
-  display: flex;
-  gap: 12px;
+  display: inline-flex;
+  gap: 8px;
   align-items: center;
   flex-wrap: wrap;
-}
-
-.lo-meta span {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
 }
 
 .lo-actions {
   display: flex;
   gap: 10px;
   align-items: center;
+  justify-content: center;
   flex-wrap: wrap;
-  margin-bottom: 10px;
+  margin: 10px 0 16px;
 }
 
 .lo-link {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: 6px;
-  border: 1px solid #2af200;
-  padding: 4px 10px;
-  border-radius: 8px;
-  text-decoration: none;
+  gap: 8px;
+  border: 2px solid #2af200;
   color: #2af200;
   background: transparent;
-  font-size: 0.9rem;
+  padding: 6px 12px;
+  border-radius: 10px;
+  text-decoration: none;
+  font-weight: 700;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
 }
 
 .lo-link:hover,
@@ -67,6 +59,12 @@
 .lo-link[disabled] {
   opacity: 0.5;
   cursor: progress;
+}
+
+.lo-icon {
+  width: 16px;
+  height: 16px;
+  display: inline-block;
 }
 
 .lo-grid {

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -84,22 +84,30 @@ function render_shortcode(): string {
         return wp_date( $format, $timestamp );
     };
 
-    $feed_url         = home_url( '/outages/feed/' );
-    $feed_refresh_url = add_query_arg( 'refresh', '1', $feed_url );
+    $raw_feed_url  = home_url( '/outages/feed' );
+    $feed_url      = esc_url( $raw_feed_url );
+    $fallback_feed = esc_url( add_query_arg( 'lousy_outages_feed', '1', home_url( '/' ) ) );
 
     ob_start();
     ?>
     <div class="lousy-outages" data-lo-endpoint="<?php echo esc_url( $config['endpoint'] ); ?>">
         <div class="lo-header">
-            <div class="lo-meta" aria-live="polite">
-                <span>Fetched at <strong data-lo-fetched><?php echo esc_html( $format_datetime( $fetched_at ) ); ?></strong></span>
-                <span data-lo-countdown>Calculating refresh…</span>
-            </div>
             <div class="lo-actions">
-                <button type="button" class="lo-link" data-lo-refresh>Refresh now</button>
-                <a class="lo-link" href="<?php echo esc_url( $feed_url ); ?>" target="_blank" rel="noopener noreferrer">Subscribe (RSS)</a>
-                <a class="lo-link" href="<?php echo esc_url( $feed_refresh_url ); ?>" target="_blank" rel="noopener noreferrer">Refresh RSS</a>
+                <span class="lo-meta" aria-live="polite">
+                    Fetched: <strong id="lo-fetched-at" data-lo-fetched><?php echo esc_html( $format_datetime( $fetched_at ) ); ?></strong>
+                    <span id="lo-countdown" data-lo-countdown>Calculating refresh…</span>
+                </span>
+                <button type="button" class="lo-link" id="lo-refresh-btn" data-lo-refresh>Refresh now</button>
+                <a class="lo-link" href="<?php echo $feed_url; ?>" target="_blank" rel="noopener">
+                    <svg class="lo-icon" viewBox="0 0 24 24" aria-hidden="true">
+                        <path fill="currentColor" d="M6 17a2 2 0 11.001 3.999A2 2 0 016 17zm-2-7v3a8 8 0 018 8h3c0-6.075-4.925-11-11-11zm0-5v3c9.389 0 17 7.611 17 17h3C24 13.85 10.15 0 4 0z" />
+                    </svg>
+                    Subscribe (RSS)
+                </a>
             </div>
+            <noscript>
+                <p><a class="lo-link" href="<?php echo $fallback_feed; ?>">RSS (fallback)</a></p>
+            </noscript>
         </div>
         <div class="lo-grid" data-lo-grid>
             <?php foreach ( $provider_payloads as $provider ) :

--- a/parts/lousy-outages-teaser.php
+++ b/parts/lousy-outages-teaser.php
@@ -6,6 +6,9 @@ $teaser_strings = [
     'viewDashboard' => 'View Full Dashboard →',
 ];
 
+$feed_url     = esc_url( home_url('/outages/feed') );
+$fallback_url = esc_url( add_query_arg('lousy_outages_feed', '1', home_url('/') ) );
+
 if ( class_exists( '\\LousyOutages\\I18n' ) ) {
     $locale         = I18n::determine_locale();
     $localized      = I18n::strings( $locale );
@@ -18,6 +21,17 @@ if ( class_exists( '\\LousyOutages\\I18n' ) ) {
     <div class="lo-teaser-meta">
       <div class="providers"></div>
       <p class="caption"><?php echo esc_html( $teaser_strings['teaserCaption'] ); ?></p>
+    </div>
+    <div class="lo-actions">
+      <a class="lo-link" href="<?php echo $feed_url; ?>" target="_blank" rel="noopener">
+        <svg class="lo-icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path fill="currentColor" d="M6 17a2 2 0 11.001 3.999A2 2 0 016 17zm-2-7v3a8 8 0 018 8h3c0-6.075-4.925-11-11-11zm0-5v3c9.389 0 17 7.611 17 17h3C24 13.85 10.15 0 4 0z"/>
+        </svg>
+        Subscribe (RSS)
+      </a>
+      <noscript>
+        <p><a class="lo-link" href="<?php echo $fallback_url; ?>">RSS (fallback)</a></p>
+      </noscript>
     </div>
     <div class="lo-actions">
       <a class="view-all pixel-button" href="/lousy-outages/"><?php echo esc_html( $teaser_strings['viewDashboard'] ); ?></a>


### PR DESCRIPTION
## Summary
- advertise the Lousy Outages RSS feed in the document head for autodiscovery
- add a neon "Subscribe (RSS)" call-to-action with fallback links to the homepage teaser and dashboard header
- align teaser and dashboard styles so the new RSS button and icon share the retro look

## Testing
- php -l functions.php
- php -l parts/lousy-outages-teaser.php
- php -l lousy-outages/public/shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68ec98eb4c54832eb7f23de8d1c5767f