### PR TITLE
Add Zscaler provider and early-warning risk engine

### DIFF
--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -124,6 +124,10 @@
 .lo-pill.maintenance {
   color: #aaa;
 }
+.lo-pill.risk {
+  color: #ffb347;
+  border-color: #ffb347;
+}
 
 .lo-summary,
 .lo-snark {
@@ -147,6 +151,31 @@
 .lo-status-link:hover,
 .lo-status-link:focus {
   text-decoration: underline;
+}
+.lo-prealert {
+  background: rgba(255, 179, 71, 0.15);
+  border: 1px solid rgba(255, 179, 71, 0.4);
+  border-radius: 10px;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: #ffe9c2;
+}
+.lo-prealert strong {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.lo-prealert-summary {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #fff2d6;
+}
+.lo-prealert-metrics {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #ffd9a0;
 }
 
 .lo-inc {

--- a/lousy-outages/assets/lousy-outages.js
+++ b/lousy-outages/assets/lousy-outages.js
@@ -122,6 +122,12 @@
     card.className = 'lo-card';
     card.dataset.providerId = provider.id;
 
+    var prealert = provider && typeof provider.prealert === 'object' ? provider.prealert : {};
+    var risk = Number(prealert && prealert.risk != null ? prealert.risk : provider.risk || 0);
+    if (!isFinite(risk)) {
+      risk = 0;
+    }
+
     var head = document.createElement('div');
     head.className = 'lo-head';
 
@@ -136,6 +142,13 @@
     pill.textContent = provider.state || formatImpact(stateCode);
     head.appendChild(pill);
 
+    if (risk >= 20) {
+      var riskPill = document.createElement('span');
+      riskPill.className = 'lo-pill risk';
+      riskPill.textContent = 'RISK: ' + Math.round(risk) + '/100';
+      head.appendChild(riskPill);
+    }
+
     card.appendChild(head);
 
     if (provider.error) {
@@ -149,6 +162,39 @@
     summary.className = 'lo-summary';
     summary.textContent = provider.summary || 'No status summary available.';
     card.appendChild(summary);
+
+    if (risk > 0) {
+      var measures = prealert && typeof prealert.measures === 'object' ? prealert.measures : {};
+      var measureBits = [];
+      if (measures && measures.latency_ms !== undefined && measures.latency_ms !== null && measures.latency_ms !== '') {
+        measureBits.push('Latency ' + Number(measures.latency_ms) + ' ms');
+      }
+      if (measures && measures.baseline_ms !== undefined && measures.baseline_ms !== null && measures.baseline_ms !== '') {
+        measureBits.push('Baseline ' + Number(measures.baseline_ms) + ' ms');
+      }
+
+      var prealertBlock = document.createElement('div');
+      prealertBlock.className = 'lo-prealert';
+
+      var preTitle = document.createElement('strong');
+      preTitle.textContent = 'Pre-alerts';
+      prealertBlock.appendChild(preTitle);
+
+      var preSummary = document.createElement('p');
+      preSummary.className = 'lo-prealert-summary';
+      var summaryText = prealert && prealert.summary ? String(prealert.summary) : 'Early warning signals detected.';
+      preSummary.textContent = summaryText;
+      prealertBlock.appendChild(preSummary);
+
+      if (measureBits.length) {
+        var preMeasures = document.createElement('p');
+        preMeasures.className = 'lo-prealert-metrics';
+        preMeasures.textContent = measureBits.join(' • ');
+        prealertBlock.appendChild(preMeasures);
+      }
+
+      card.appendChild(prealertBlock);
+    }
 
     if (provider.snark) {
       var snark = document.createElement('p');

--- a/lousy-outages/includes/Precursor.php
+++ b/lousy-outages/includes/Precursor.php
@@ -1,0 +1,161 @@
+<?php
+declare(strict_types=1);
+
+namespace LousyOutages;
+
+class Precursor {
+    private $timeout;
+
+    public function __construct($timeout = 5) {
+        $this->timeout = max(2, (int) $timeout);
+    }
+
+    public function evaluate(array $provider, array $current_state): array {
+        $risk     = 0;
+        $signals  = array();
+        $measures = array('latency_ms' => null, 'baseline_ms' => null, 'http_ok' => null);
+        $summary  = 'No early signals';
+        $probes   = $this->probe_urls_for($provider);
+
+        $lat_ms  = null;
+        $http_ok = true;
+
+        if (!empty($probes)) {
+            $probe_url = $probes[0];
+            $t0        = microtime(true);
+            $resp      = wp_remote_request($probe_url, array(
+                'method'  => 'HEAD',
+                'timeout' => $this->timeout,
+            ));
+            $lat_ms = (int) round((microtime(true) - $t0) * 1000);
+            $measures['latency_ms'] = $lat_ms;
+
+            if (is_wp_error($resp)) {
+                $http_ok = false;
+            } else {
+                $code = (int) wp_remote_retrieve_response_code($resp);
+                if (405 === $code) {
+                    $t0   = microtime(true);
+                    $resp = wp_remote_request($probe_url, array(
+                        'method'  => 'GET',
+                        'timeout' => $this->timeout,
+                    ));
+                    $lat_ms = (int) round((microtime(true) - $t0) * 1000);
+                    $measures['latency_ms'] = $lat_ms;
+                    if (is_wp_error($resp)) {
+                        $http_ok = false;
+                    } else {
+                        $code = (int) wp_remote_retrieve_response_code($resp);
+                        $http_ok = ($code >= 200 && $code < 400);
+                    }
+                } else {
+                    $http_ok = ($code >= 200 && $code < 400);
+                }
+            }
+
+            $measures['http_ok'] = $http_ok;
+
+            $baseline = $this->update_and_get_baseline(isset($provider['id']) ? $provider['id'] : '', $lat_ms, $http_ok);
+            if (null !== $baseline) {
+                $measures['baseline_ms'] = $baseline;
+            }
+
+            if ($baseline && $lat_ms > (int) round($baseline * 1.8)) {
+                $risk += 40;
+                $signals[] = 'latency_spike';
+            }
+            if (!$http_ok) {
+                $risk += 40;
+                $signals[] = 'http_errors';
+            }
+        }
+
+        $status       = strtolower((string) ($current_state['status'] ?? 'unknown'));
+        $summary_text = (string) ($current_state['summary'] ?? '');
+        $sniff_text   = strtolower($summary_text);
+        if ('operational' === $status && (false !== strpos($sniff_text, 'degrad') || false !== strpos($sniff_text, 'partial'))) {
+            $risk += 20;
+            $signals[] = 'component_degraded';
+        }
+
+        if ($risk > 0) {
+            $summary = 'Early warning: ' . implode(', ', $signals);
+        }
+
+        return array(
+            'risk'       => min(100, $risk),
+            'summary'    => $summary,
+            'signals'    => $signals,
+            'measures'   => $measures,
+            'updated_at' => gmdate('c'),
+        );
+    }
+
+    private function probe_urls_for(array $provider): array {
+        $settings = get_option('lousy_outages_probes', array());
+        if (!is_array($settings)) {
+            $settings = array();
+        }
+        $id = isset($provider['id']) ? (string) $provider['id'] : '';
+        if ('' !== $id && isset($settings[$id]) && is_array($settings[$id]) && !empty($settings[$id])) {
+            $urls = array();
+            foreach ($settings[$id] as $url) {
+                if (is_string($url) && '' !== trim($url)) {
+                    $urls[] = trim($url);
+                }
+            }
+            if (!empty($urls)) {
+                return $urls;
+            }
+        }
+        if ('zscaler' === $id) {
+            return array('https://status.zscaler.com/');
+        }
+        return array();
+    }
+
+    private function update_and_get_baseline($provider_id, $latest_ms, $http_ok) {
+        $provider_id = (string) $provider_id;
+        if ('' === $provider_id) {
+            return is_int($latest_ms) ? $latest_ms : null;
+        }
+
+        if (null === $latest_ms) {
+            return null;
+        }
+
+        $latest_ms = (int) $latest_ms;
+        if ($latest_ms <= 0) {
+            $stored = get_option('lousy_outages_precursor_baselines', array());
+            if (!is_array($stored) || !isset($stored[$provider_id]['avg'])) {
+                return null;
+            }
+            return (int) round((float) $stored[$provider_id]['avg']);
+        }
+
+        $key = 'lousy_outages_precursor_baselines';
+        $all = get_option($key, array());
+        if (!is_array($all)) {
+            $all = array();
+        }
+        $entry = isset($all[$provider_id]) && is_array($all[$provider_id]) ? $all[$provider_id] : array('avg' => null, 'n' => 0);
+
+        if (!$http_ok && null !== $entry['avg']) {
+            return (int) round((float) $entry['avg']);
+        }
+
+        if (null === $entry['avg'] || !$entry['n']) {
+            $entry['avg'] = (float) $latest_ms;
+            $entry['n']   = 1;
+        } else {
+            $alpha        = 0.2;
+            $entry['avg'] = (1.0 - $alpha) * (float) $entry['avg'] + $alpha * (float) $latest_ms;
+            $entry['n']   = (int) $entry['n'] + 1;
+        }
+
+        $all[$provider_id] = $entry;
+        update_option($key, $all, false);
+
+        return (int) round((float) $entry['avg']);
+    }
+}

--- a/lousy-outages/includes/Providers.php
+++ b/lousy-outages/includes/Providers.php
@@ -23,6 +23,12 @@ class Providers {
                     'current'    => 'https://status.slack.com/api/v2.0.0/current',
                     'status_url' => 'https://status.slack.com/',
                 ],
+                'zscaler' => [
+                    'name'       => 'Zscaler',
+                    'type'       => 'statuspage',
+                    'summary'    => 'https://status.zscaler.com/api/v2/summary.json',
+                    'status_url' => 'https://status.zscaler.com/',
+                ],
                 'cloudflare' => [
                     'name'   => 'Cloudflare',
                     'type'   => 'statuspage',


### PR DESCRIPTION
## Summary
- add the Zscaler Statuspage feed to the provider registry
- introduce an early-warning "Precursor" engine with configurable probes, thresholds, and notification controls surfaced in settings
- surface risk scores and pre-alert details across the dashboard UI, RSS feed, and stored provider payloads

## Testing
- php -l lousy-outages/includes/Providers.php
- php -l lousy-outages/includes/Precursor.php
- php -l lousy-outages/lousy-outages.php
- php -l lousy-outages/public/shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68ecb06dceb0832e8b5595f50db44648