### PR TITLE
Improve outages refresh UX and RSS feed

### DIFF
--- a/assets/css/lousy-outages-teaser.css
+++ b/assets/css/lousy-outages-teaser.css
@@ -23,52 +23,40 @@
   color: #a7ff9a;
 }
 
-.lo-teaser .lo-teaser-meta {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+.lo-status-line {
+  font-size: 0.95rem;
+  margin-bottom: 4px;
+  font-weight: 700;
 }
 
-.lo-teaser .providers {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-  gap: 1rem;
-  margin: 0 auto;
+.lo-status-line--alert {
+  color: #ff8299;
 }
 
-.lo-teaser .card {
-  display: block;
-  background: #111;
-  border: 2px solid #0f0;
-  padding: 0.5rem;
+.lo-status-line--ok {
+  color: #a7ff9a;
+}
+
+.lo-status-line .lo-status-link {
+  color: inherit;
   text-decoration: none;
-  color: #0f0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
 
-.lo-teaser .card:hover {
-  background: #0f0;
-  color: #111;
+.lo-status-line .lo-status-link:hover {
+  text-decoration: underline;
 }
 
-.lo-teaser .dot {
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  margin-right: 4px;
-}
-
-.lo-teaser .status-up {
-  background: #00ff66;
-}
-
-.lo-teaser .status-warn {
-  background: #ffcc00;
-}
-
+.lo-teaser .lo-teaser-meta,
+.lo-teaser .providers,
+.lo-teaser .card,
+.lo-teaser .dot,
+.lo-teaser .status-up,
+.lo-teaser .status-warn,
 .lo-teaser .status-down {
-  background: #ff004c;
+  display: none;
 }
 
 .lo-teaser .caption {

--- a/functions.php
+++ b/functions.php
@@ -82,6 +82,13 @@ if ( file_exists( $lousy_outages ) ) {
 
 add_filter( 'lousy_outages_voice_enabled', '__return_true' );
 
+function lousy_outages_feed_autodiscovery() {
+    if ( is_front_page() || is_page_template( 'page-lousy-outages.php' ) || is_page( 'lousy-outages' ) ) {
+        echo '\n<link rel="alternate" type="application/rss+xml" title="Lousy Outages" href="' . esc_url( home_url( '/lousy-outages/feed/' ) ) . '" />\n';
+    }
+}
+add_action( 'wp_head', 'lousy_outages_feed_autodiscovery' );
+
 // =========================================
 // 2. DISABLE AUTOMATIC PARAGRAPH FORMATTING
 // =========================================

--- a/lousy-outages/README.md
+++ b/lousy-outages/README.md
@@ -50,3 +50,8 @@ Place `[lousy_outages]` in any page or post to render the status table. A page t
 ## Development
 
 Polling runs via WP-Cron (`lousy_outages_poll`). Results are stored in an option and also exposed at `/wp-json/lousy-outages/v1/status`.
+
+## How to subscribe to RSS
+
+- RSS reader: add `https://suzyeaston.ca/lousy-outages/feed/` to NetNewsWire, Feedly, or your preferred client to receive incident alerts.
+- Slack or email: point an automation tool such as IFTTT or Zapier at the same feed (trigger: “New RSS item”) and forward the payload to a Slack webhook, email address, or other notification channel.

--- a/lousy-outages/includes/Api.php
+++ b/lousy-outages/includes/Api.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace LousyOutages;
+
+use WP_REST_Request;
+use WP_REST_Response;
+
+class Api {
+    public static function bootstrap(): void {
+        add_action('rest_api_init', [self::class, 'register_routes']);
+    }
+
+    public static function register_routes(): void {
+        register_rest_route(
+            'lousy/v1',
+            '/refresh',
+            [
+                'methods'             => 'POST',
+                'permission_callback' => [self::class, 'verify_nonce'],
+                'callback'            => [self::class, 'handle_refresh'],
+            ]
+        );
+    }
+
+    public static function verify_nonce(): bool {
+        $nonce = $_SERVER['HTTP_X_WP_NONCE'] ?? '';
+        return is_string($nonce) && wp_verify_nonce($nonce, 'wp_rest');
+    }
+
+    /**
+     * Trigger a manual refresh of provider statuses.
+     */
+    public static function handle_refresh(WP_REST_Request $request): WP_REST_Response {
+        $timestamp = gmdate('c');
+        $store     = new Store();
+        $states    = lousy_outages_collect_statuses(true);
+        $errors    = [];
+
+        foreach ($states as $id => $state) {
+            $store->update($id, $state);
+            if (!empty($state['error'])) {
+                $errors[] = [
+                    'id'      => $id,
+                    'provider'=> isset($state['name']) ? (string) $state['name'] : (isset($state['provider']) ? (string) $state['provider'] : $id),
+                    'message' => (string) $state['error'],
+                ];
+            }
+        }
+
+        update_option('lousy_outages_last_poll', $timestamp, false);
+        do_action('lousy_outages_log', 'manual_refresh', [
+            'count' => count($states),
+            'ts'    => $timestamp,
+        ]);
+
+        $providers = [];
+        foreach ($states as $id => $state) {
+            $providers[] = lousy_outages_build_provider_payload($id, $state, $timestamp);
+        }
+
+        $response = [
+            'refreshedAt'   => $timestamp,
+            'providerCount' => count($providers),
+            'errors'        => $errors,
+            'providers'     => $providers,
+        ];
+
+        return rest_ensure_response($response);
+    }
+}

--- a/lousy-outages/includes/Feed.php
+++ b/lousy-outages/includes/Feed.php
@@ -1,0 +1,185 @@
+<?php
+declare(strict_types=1);
+
+namespace LousyOutages;
+
+class Feed {
+    public static function bootstrap(): void {
+        add_action('init', [self::class, 'register']);
+    }
+
+    public static function register(): void {
+        add_feed('lousy-outages', [self::class, 'render']);
+    }
+
+    public static function render(): void {
+        if (function_exists('nocache_headers')) {
+            nocache_headers();
+        }
+
+        header('Content-Type: application/rss+xml; charset=UTF-8');
+
+        $store  = new Store();
+        $states = $store->get_all();
+        if (empty($states)) {
+            $states = lousy_outages_collect_statuses(false);
+        }
+
+        $fetched_at = get_option('lousy_outages_last_poll');
+        if (!$fetched_at) {
+            $fetched_at = gmdate('c');
+        }
+
+        $providers = [];
+        foreach ($states as $id => $state) {
+            $providers[] = lousy_outages_build_provider_payload($id, $state, $fetched_at);
+        }
+
+        $items = self::build_items($providers, $fetched_at);
+
+        echo '<?xml version="1.0" encoding="UTF-8"?>';
+        ?>
+<rss version="2.0">
+  <channel>
+    <title><?php echo esc_html(get_bloginfo('name') . ' – Lousy Outages Alerts'); ?></title>
+    <link><?php echo esc_url(home_url('/lousy-outages/')); ?></link>
+    <description><?php echo esc_html('Live incident alerts from the Lousy Outages dashboard.'); ?></description>
+    <language>en-US</language>
+    <lastBuildDate><?php echo esc_html(self::format_rss_date(gmdate('c'))); ?></lastBuildDate>
+    <?php foreach ($items as $item) : ?>
+      <item>
+        <title><?php echo esc_html($item['title']); ?></title>
+        <link><?php echo esc_url($item['link']); ?></link>
+        <guid isPermaLink="false"><?php echo esc_html($item['guid']); ?></guid>
+        <pubDate><?php echo esc_html($item['pubDate']); ?></pubDate>
+        <description><?php echo esc_html($item['description']); ?></description>
+      </item>
+    <?php endforeach; ?>
+  </channel>
+</rss>
+        <?php
+        exit;
+    }
+
+    private static function build_items(array $providers, string $fallback_time): array {
+        $items      = [];
+        $threshold  = (int) get_option('lousy_outages_prealert_threshold', 60);
+        $threshold  = max(0, min(100, $threshold));
+
+        foreach ($providers as $provider) {
+            $incidents = isset($provider['incidents']) && is_array($provider['incidents']) ? $provider['incidents'] : [];
+            if (!empty($incidents)) {
+                $incident  = $incidents[0];
+                $updated   = $incident['updatedAt'] ?? $incident['startedAt'] ?? $fallback_time;
+                $impact    = $incident['impact'] ?? 'incident';
+                $items[]   = self::make_item(
+                    sprintf('%s: %s (%s)', $provider['name'], $incident['title'], ucfirst((string) $impact)),
+                    $provider['id'],
+                    $updated,
+                    $incident['summary'] ?: $provider['summary'],
+                    $provider['id'] . '-' . $incident['id']
+                );
+                continue;
+            }
+
+            $state = strtolower((string) ($provider['stateCode'] ?? 'unknown'));
+            if ('operational' !== $state) {
+                $items[] = self::make_item(
+                    sprintf('%s: %s', $provider['name'], $provider['state']),
+                    $provider['id'],
+                    $provider['updatedAt'] ?? $fallback_time,
+                    $provider['summary'],
+                    $provider['id'] . '-' . md5($provider['stateCode'] . $provider['summary'])
+                );
+                continue;
+            }
+
+            $prealert = isset($provider['prealert']) && is_array($provider['prealert']) ? $provider['prealert'] : [];
+            $risk     = isset($prealert['risk']) ? (int) $prealert['risk'] : 0;
+            if ($risk >= $threshold && $risk > 0) {
+                $signals     = isset($prealert['signals']) && is_array($prealert['signals']) ? implode(', ', $prealert['signals']) : 'Early warning';
+                $summaryBits = [];
+                if (!empty($prealert['summary'])) {
+                    $summaryBits[] = (string) $prealert['summary'];
+                }
+                if (isset($prealert['measures']) && is_array($prealert['measures'])) {
+                    $measures = [];
+                    if (!empty($prealert['measures']['latency_ms'])) {
+                        $measures[] = 'Latency ' . (int) $prealert['measures']['latency_ms'] . ' ms';
+                    }
+                    if (!empty($prealert['measures']['baseline_ms'])) {
+                        $measures[] = 'Baseline ' . (int) $prealert['measures']['baseline_ms'] . ' ms';
+                    }
+                    if ($measures) {
+                        $summaryBits[] = implode(' • ', $measures);
+                    }
+                }
+                $description = $summaryBits ? implode(' — ', $summaryBits) : $provider['summary'];
+                $items[]     = self::make_item(
+                    sprintf('[EARLY WARNING] %s: %s (Risk %d)', $provider['name'], $signals, $risk),
+                    $provider['id'],
+                    $prealert['updated_at'] ?? $provider['updatedAt'] ?? $fallback_time,
+                    $description,
+                    $provider['id'] . '-early-' . md5($signals . $risk . ($prealert['updated_at'] ?? ''))
+                );
+            }
+        }
+
+        usort($items, static function ($a, $b) {
+            return ($b['timestamp'] ?? 0) <=> ($a['timestamp'] ?? 0);
+        });
+
+        $items = array_slice($items, 0, 25);
+
+        if (empty($items)) {
+            $items[] = self::make_item(
+                'All systems operational',
+                'lousy-outages',
+                $fallback_time,
+                'No active incidents detected across monitored providers.',
+                'lousy-outages-' . gmdate('Ymd')
+            );
+        }
+
+        return array_map(static function ($item) {
+            unset($item['timestamp']);
+            return $item;
+        }, $items);
+    }
+
+    private static function make_item(string $title, string $provider_id, string $time, string $description, string $guid): array {
+        $timestamp = self::parse_time($time);
+        return [
+            'title'     => $title,
+            'link'      => self::provider_link($provider_id),
+            'guid'      => $guid,
+            'pubDate'   => self::format_rss_date($time),
+            'description' => $description,
+            'timestamp' => $timestamp,
+        ];
+    }
+
+    private static function provider_link(string $provider_id): string {
+        $anchor = sanitize_title($provider_id);
+        return home_url('/lousy-outages/#provider-' . $anchor);
+    }
+
+    private static function parse_time(?string $time): int {
+        if (!$time) {
+            return time();
+        }
+        $timestamp = strtotime($time);
+        if (!$timestamp) {
+            return time();
+        }
+        return $timestamp;
+    }
+
+    private static function format_rss_date(string $time): string {
+        $timestamp = strtotime($time);
+        if (!$timestamp) {
+            $timestamp = time();
+        }
+        return gmdate('D, d M Y H:i:s +0000', $timestamp);
+    }
+}

--- a/lousy-outages/includes/Summary.php
+++ b/lousy-outages/includes/Summary.php
@@ -1,0 +1,119 @@
+<?php
+declare(strict_types=1);
+
+namespace LousyOutages;
+
+class Summary {
+    public static function current(): array {
+        $store  = new Store();
+        $states = $store->get_all();
+        $latest = null;
+        $fallback = null;
+
+        foreach ($states as $id => $state) {
+            if (!is_array($state)) {
+                continue;
+            }
+            $status = strtolower((string) ($state['status'] ?? 'unknown'));
+            $provider_name = (string) ($state['name'] ?? $state['provider'] ?? $id);
+            $incidents = isset($state['incidents']) && is_array($state['incidents']) ? $state['incidents'] : [];
+
+            foreach ($incidents as $incident) {
+                if (!is_array($incident)) {
+                    continue;
+                }
+                $updated = self::parse_time($incident['updated_at'] ?? $incident['updatedAt'] ?? $incident['started_at'] ?? $incident['startedAt'] ?? null);
+                if (null === $latest || $updated > $latest['timestamp']) {
+                    $latest = [
+                        'provider_id'   => $id,
+                        'provider_name' => $provider_name,
+                        'title'         => (string) ($incident['title'] ?? 'Incident'),
+                        'summary'       => (string) ($incident['summary'] ?? ''),
+                        'status'        => ucfirst((string) ($incident['impact'] ?? 'incident')),
+                        'started_at'    => (string) ($incident['started_at'] ?? $incident['startedAt'] ?? ''),
+                        'updated_at'    => (string) ($incident['updated_at'] ?? $incident['updatedAt'] ?? ''),
+                        'timestamp'     => $updated,
+                    ];
+                }
+            }
+
+            if ('operational' !== $status && null === $latest) {
+                $updated = self::parse_time($state['updated_at'] ?? $state['updatedAt'] ?? null);
+                if (null === $fallback || $updated > $fallback['timestamp']) {
+                    $fallback = [
+                        'provider_id'   => $id,
+                        'provider_name' => $provider_name,
+                        'title'         => (string) ($state['summary'] ?? Fetcher::status_label($status)),
+                        'status'        => Fetcher::status_label($status),
+                        'started_at'    => (string) ($state['updated_at'] ?? $state['updatedAt'] ?? ''),
+                        'timestamp'     => $updated,
+                    ];
+                }
+            }
+        }
+
+        if ($latest) {
+            return [
+                'hasIncident' => true,
+                'providerId'  => $latest['provider_id'],
+                'provider'    => $latest['provider_name'],
+                'title'       => $latest['title'],
+                'status'      => $latest['status'],
+                'relative'    => self::relative_time($latest['started_at'] ?: $latest['updated_at']),
+                'started_at'  => $latest['started_at'],
+            ];
+        }
+
+        if ($fallback) {
+            return [
+                'hasIncident' => true,
+                'providerId'  => $fallback['provider_id'],
+                'provider'    => $fallback['provider_name'],
+                'title'       => $fallback['title'],
+                'status'      => $fallback['status'],
+                'relative'    => self::relative_time($fallback['started_at']),
+                'started_at'  => $fallback['started_at'],
+            ];
+        }
+
+        return [
+            'hasIncident' => false,
+            'providerId'  => '',
+            'provider'    => '',
+            'title'       => 'All systems operational',
+            'status'      => 'Operational',
+            'relative'    => '',
+            'started_at'  => '',
+        ];
+    }
+
+    private static function parse_time($value): ?int {
+        if (empty($value)) {
+            return null;
+        }
+        $timestamp = strtotime((string) $value);
+        if (false === $timestamp) {
+            return null;
+        }
+        return $timestamp;
+    }
+
+    private static function relative_time(?string $iso): string {
+        if (empty($iso)) {
+            return '';
+        }
+        $timestamp = strtotime($iso);
+        if (false === $timestamp) {
+            return '';
+        }
+        $now = current_time('timestamp', true);
+        if (!is_int($now)) {
+            $now = time();
+        }
+        if ($timestamp > $now) {
+            $timestamp = $now;
+        }
+        $diff = human_time_diff($timestamp, $now);
+        return $diff ? sprintf('%s ago', $diff) : '';
+    }
+}

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -22,6 +22,9 @@ require_once LOUSY_OUTAGES_PATH . 'includes/Detector.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/SMS.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Email.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Precursor.php';
+require_once LOUSY_OUTAGES_PATH . 'includes/Api.php';
+require_once LOUSY_OUTAGES_PATH . 'includes/Feed.php';
+require_once LOUSY_OUTAGES_PATH . 'includes/Summary.php';
 require_once LOUSY_OUTAGES_PATH . 'public/shortcode.php';
 
 use LousyOutages\Providers;
@@ -31,6 +34,11 @@ use LousyOutages\Detector;
 use LousyOutages\SMS;
 use LousyOutages\Email;
 use LousyOutages\Precursor;
+use LousyOutages\Api;
+use LousyOutages\Feed;
+
+Api::bootstrap();
+Feed::bootstrap();
 
 add_action(
     'lousy_outages_log',
@@ -719,14 +727,6 @@ function lousy_outages_build_provider_payload( string $id, array $state, string 
     ];
 }
 
-function lousy_outages_format_rss_date( string $time ): string {
-    $timestamp = strtotime( $time );
-    if ( ! $timestamp ) {
-        $timestamp = time();
-    }
-    return gmdate( 'D, d M Y H:i:s +0000', $timestamp );
-}
-
 /**
  * REST endpoint exposing current status.
  */
@@ -768,186 +768,3 @@ add_action( 'rest_api_init', function () {
     ] );
 } );
 
-add_filter( 'query_vars', function ( $vars ) {
-    $vars[] = 'lousy_outages_api';
-    $vars[] = 'lousy_outages_feed';
-    return $vars;
-} );
-
-add_action( 'init', function () {
-    add_rewrite_rule( '^api/outages/?$', 'index.php?lousy_outages_api=1', 'top' );
-    add_rewrite_rule( '^outages/feed/?$', 'index.php?lousy_outages_feed=1', 'top' );
-} );
-
-add_action( 'template_redirect', function () {
-    $feed_flag = get_query_var( 'lousy_outages_feed' );
-    if ( ! empty( $feed_flag ) ) {
-        $store   = new Store();
-        $refresh = isset( $_GET['refresh'] ) ? filter_var( wp_unslash( $_GET['refresh'] ), FILTER_VALIDATE_BOOLEAN ) : false;
-        $fetched = gmdate( 'c' );
-        $data    = lousy_outages_collect_statuses( (bool) $refresh );
-
-        foreach ( $data as $id => $state ) {
-            $store->update( $id, $state );
-        }
-
-        $providers = [];
-        foreach ( $data as $id => $state ) {
-            $providers[] = lousy_outages_build_provider_payload( $id, $state, $fetched );
-        }
-
-        $items = [];
-        $prealert_threshold = (int) get_option( 'lousy_outages_prealert_threshold', 60 );
-        if ( $prealert_threshold < 0 ) {
-            $prealert_threshold = 0;
-        }
-        if ( $prealert_threshold > 100 ) {
-            $prealert_threshold = 100;
-        }
-        foreach ( $providers as $provider ) {
-            $provider_id      = $provider['id'];
-            $provider_name    = $provider['name'];
-            $provider_summary = $provider['summary'];
-            $provider_url     = $provider['url'] ?: home_url( '/lousy-outages/' );
-            $provider_state   = $provider['stateCode'];
-            $provider_updated = $provider['updatedAt'];
-            $prealert         = ( isset( $provider['prealert'] ) && is_array( $provider['prealert'] ) ) ? $provider['prealert'] : [];
-            $prealert_risk    = isset( $prealert['risk'] ) ? (int) $prealert['risk'] : ( isset( $provider['risk'] ) ? (int) $provider['risk'] : 0 );
-            $prealert_signals = isset( $prealert['signals'] ) && is_array( $prealert['signals'] ) ? $prealert['signals'] : [];
-            $prealert_summary = isset( $prealert['summary'] ) ? (string) $prealert['summary'] : '';
-            $prealert_measures = isset( $prealert['measures'] ) && is_array( $prealert['measures'] ) ? $prealert['measures'] : [];
-
-            if ( ! empty( $provider['incidents'] ) ) {
-                foreach ( $provider['incidents'] as $incident ) {
-                    $title       = sprintf( '%s: %s', $provider_name, $incident['title'] );
-                    $description = $incident['summary'] ?: $provider_summary;
-                    $link        = $incident['url'] ?: $provider_url;
-                    $updated     = $incident['updatedAt'] ?: $incident['startedAt'] ?: $provider_updated;
-
-                    $items[] = [
-                        'title'       => $title,
-                        'description' => $description,
-                        'link'        => $link,
-                        'guid'        => $provider_id . '-' . $incident['id'],
-                        'pubDate'     => lousy_outages_format_rss_date( $updated ?: $fetched ),
-                    ];
-                }
-            } elseif ( 'operational' !== $provider_state ) {
-                $items[] = [
-                    'title'       => sprintf( '%s: %s', $provider_name, $provider['state'] ),
-                    'description' => $provider_summary,
-                    'link'        => $provider_url,
-                    'guid'        => $provider_id . '-' . md5( $provider_state . $provider_summary ),
-                    'pubDate'     => lousy_outages_format_rss_date( $provider_updated ?: $fetched ),
-                ];
-            }
-
-            if ( empty( $provider['incidents'] ) && 'operational' === $provider_state && $prealert_risk >= $prealert_threshold ) {
-                $signals_text = $prealert_signals ? implode( ', ', $prealert_signals ) : 'early-warning';
-                $measure_bits = [];
-                if ( isset( $prealert_measures['latency_ms'] ) && '' !== (string) $prealert_measures['latency_ms'] ) {
-                    $measure_bits[] = 'Latency ' . (int) $prealert_measures['latency_ms'] . ' ms';
-                }
-                if ( isset( $prealert_measures['baseline_ms'] ) && '' !== (string) $prealert_measures['baseline_ms'] ) {
-                    $measure_bits[] = 'Baseline ' . (int) $prealert_measures['baseline_ms'] . ' ms';
-                }
-                $description_bits = [];
-                if ( $prealert_summary ) {
-                    $description_bits[] = $prealert_summary;
-                }
-                if ( ! empty( $measure_bits ) ) {
-                    $description_bits[] = implode( ' • ', $measure_bits );
-                }
-                if ( empty( $description_bits ) ) {
-                    $description_bits[] = $provider_summary;
-                }
-                $items[] = [
-                    'title'       => sprintf( '[EARLY WARNING] %s: %s (RISK %d)', $provider_name, $signals_text, $prealert_risk ),
-                    'description' => implode( ' — ', $description_bits ),
-                    'link'        => $provider_url,
-                    'guid'        => $provider_id . '-early-' . md5( $signals_text . $prealert_risk . $provider_updated ),
-                    'pubDate'     => lousy_outages_format_rss_date( ( isset( $prealert['updated_at'] ) ? $prealert['updated_at'] : $provider_updated ) ?: $fetched ),
-                ];
-            }
-        }
-
-        if ( empty( $items ) ) {
-            $items[] = [
-                'title'       => 'All systems operational',
-                'description' => 'No active incidents detected across monitored providers.',
-                'link'        => home_url( '/lousy-outages/' ),
-                'guid'        => 'lousy-outages-' . gmdate( 'Ymd' ),
-                'pubDate'     => lousy_outages_format_rss_date( $fetched ),
-            ];
-        }
-
-        $items      = array_slice( $items, 0, 30 );
-        $feed_title = get_bloginfo( 'name' ) . ' – Lousy Outages Alerts';
-        $feed_link  = home_url( '/lousy-outages/' );
-        $feed_desc  = 'Live incident alerts from the Lousy Outages dashboard.';
-
-        if ( function_exists( 'nocache_headers' ) ) {
-            nocache_headers();
-        }
-
-        header( 'Content-Type: application/rss+xml; charset=UTF-8' );
-
-        echo '<?xml version="1.0" encoding="UTF-8"?>';
-        ?>
-<rss version="2.0">
-  <channel>
-    <title><?php echo esc_html( $feed_title ); ?></title>
-    <link><?php echo esc_url( $feed_link ); ?></link>
-    <description><?php echo esc_html( $feed_desc ); ?></description>
-    <language>en-US</language>
-    <lastBuildDate><?php echo esc_html( lousy_outages_format_rss_date( gmdate( 'c' ) ) ); ?></lastBuildDate>
-    <?php foreach ( $items as $item ) : ?>
-      <item>
-        <title><?php echo esc_html( $item['title'] ); ?></title>
-        <link><?php echo esc_url( $item['link'] ); ?></link>
-        <guid isPermaLink="false"><?php echo esc_html( $item['guid'] ); ?></guid>
-        <pubDate><?php echo esc_html( $item['pubDate'] ); ?></pubDate>
-        <description><?php echo esc_html( $item['description'] ); ?></description>
-      </item>
-    <?php endforeach; ?>
-  </channel>
-</rss>
-        <?php
-        exit;
-    }
-
-    $flag = get_query_var( 'lousy_outages_api' );
-    if ( empty( $flag ) ) {
-        return;
-    }
-
-    $store   = new Store();
-    $refresh = isset( $_GET['refresh'] ) ? filter_var( wp_unslash( $_GET['refresh'] ), FILTER_VALIDATE_BOOLEAN ) : false;
-    $fetched = gmdate( 'c' );
-    $data    = lousy_outages_collect_statuses( (bool) $refresh );
-
-    foreach ( $data as $id => $state ) {
-        $store->update( $id, $state );
-    }
-
-    $providers = [];
-    foreach ( $data as $id => $state ) {
-        $providers[] = lousy_outages_build_provider_payload( $id, $state, $fetched );
-    }
-
-    if ( function_exists( 'nocache_headers' ) ) {
-        nocache_headers();
-    }
-
-    $payload = [
-        'providers' => $providers,
-        'meta'      => [
-            'fetchedAt'   => $fetched,
-            'generatedAt' => gmdate( 'c' ),
-            'fresh'       => (bool) $refresh,
-        ],
-    ];
-
-    wp_send_json( $payload );
-    exit;
-} );

--- a/parts/lousy-outages-teaser.php
+++ b/parts/lousy-outages-teaser.php
@@ -1,40 +1,73 @@
 <?php
 use LousyOutages\I18n;
+use LousyOutages\Summary;
 
 $teaser_strings = [
     'teaserCaption' => 'Check if your favourite services are up. Insert coin to refresh.',
     'viewDashboard' => 'View Full Dashboard →',
 ];
 
-$feed_url     = esc_url( home_url('/outages/feed') );
-$fallback_url = esc_url( add_query_arg('lousy_outages_feed', '1', home_url('/') ) );
+$feed_url     = esc_url( home_url('/lousy-outages/feed/') );
 
 if ( class_exists( '\\LousyOutages\\I18n' ) ) {
     $locale         = I18n::determine_locale();
     $localized      = I18n::strings( $locale );
     $teaser_strings = array_merge( $teaser_strings, array_intersect_key( $localized, $teaser_strings ) );
 }
+
+$summary_data = [
+    'message'      => 'All systems operational',
+    'href'         => home_url( '/lousy-outages/' ),
+    'incident'     => false,
+    'incidentDate' => '',
+    'relative'     => '',
+];
+
+if ( class_exists( '\\LousyOutages\\Summary' ) ) {
+    $current = Summary::current();
+    if ( ! empty( $current['hasIncident'] ) ) {
+        $provider = $current['provider'] ?? '';
+        $title    = $current['title'] ?? '';
+        $slug     = sanitize_title( (string) ( $current['providerId'] ?? $provider ) );
+        $summary_data['incident']     = true;
+        $summary_data['message']      = trim( sprintf( '⚠️ Outage detected: %s — %s', $provider, $title ) );
+        if ( ! empty( $current['relative'] ) ) {
+            $summary_data['message'] .= sprintf( ' (started %s)', $current['relative'] );
+        }
+        $summary_data['href']         = $slug ? home_url( '/lousy-outages/#provider-' . $slug ) : home_url( '/lousy-outages/' );
+        $summary_data['incidentDate'] = $current['started_at'] ?? '';
+        $summary_data['relative']     = $current['relative'] ?? '';
+    }
+}
+
+$status_classes = $summary_data['incident'] ? 'lo-status-line lo-status-line--alert' : 'lo-status-line lo-status-line--ok';
+$summary_attrs  = '';
+if ( $summary_data['incidentDate'] ) {
+    $summary_attrs .= ' data-incident-start="' . esc_attr( $summary_data['incidentDate'] ) . '"';
+}
+if ( $summary_data['relative'] ) {
+    $summary_attrs .= ' data-relative="' . esc_attr( $summary_data['relative'] ) . '"';
+}
 ?>
 <section id="lousy-outages-teaser" aria-live="polite">
   <div class="lo-teaser">
     <h2 class="pixel-font">Lousy Outages</h2>
-    <div class="lo-teaser-meta">
-      <div class="providers"></div>
-      <p class="caption"><?php echo esc_html( $teaser_strings['teaserCaption'] ); ?></p>
+    <p class="<?php echo esc_attr( $status_classes ); ?>">
+      <a class="lo-status-link" href="<?php echo esc_url( $summary_data['href'] ); ?>" data-lo-summary<?php echo $summary_attrs; ?>>
+        <?php echo esc_html( $summary_data['message'] ); ?>
+      </a>
+    </p>
+    <p class="caption"><?php echo esc_html( $teaser_strings['teaserCaption'] ); ?></p>
+    <div class="lo-actions lo-actions--primary">
+      <a class="view-all pixel-button" href="/lousy-outages/"><?php echo esc_html( $teaser_strings['viewDashboard'] ); ?></a>
     </div>
-    <div class="lo-actions">
+    <div class="lo-actions lo-actions--rss">
       <a class="lo-link" href="<?php echo $feed_url; ?>" target="_blank" rel="noopener">
         <svg class="lo-icon" viewBox="0 0 24 24" aria-hidden="true">
           <path fill="currentColor" d="M6 17a2 2 0 11.001 3.999A2 2 0 016 17zm-2-7v3a8 8 0 018 8h3c0-6.075-4.925-11-11-11zm0-5v3c9.389 0 17 7.611 17 17h3C24 13.85 10.15 0 4 0z"/>
         </svg>
         Subscribe (RSS)
       </a>
-      <noscript>
-        <p><a class="lo-link" href="<?php echo $fallback_url; ?>">RSS (fallback)</a></p>
-      </noscript>
-    </div>
-    <div class="lo-actions">
-      <a class="view-all pixel-button" href="/lousy-outages/"><?php echo esc_html( $teaser_strings['viewDashboard'] ); ?></a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- add a nonce-protected manual refresh REST endpoint and wire it into the dashboard script
- implement a dedicated outages RSS feed renderer and expose it via autodiscovery along with homepage status summary updates
- refresh the homepage teaser styling/logic and document how to subscribe to the new feed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fe746863f4832e8ee4f4b74f956991