### PR TITLE
Fix illegal return guard in lousy outages script

### DIFF
--- a/lousy-outages/assets/lousy-outages.js
+++ b/lousy-outages/assets/lousy-outages.js
@@ -418,8 +418,7 @@ if (typeof window === 'undefined') {
     normalizeStatus,
     snarkOutage
   };
-  return;
-}
+} else {
 
 (function (window) {
   'use strict';
@@ -886,3 +885,5 @@ if (typeof window === 'undefined') {
   updateMeta(config.initial ? config.initial.meta : null);
   startCountdown();
 })(window);
+
+}


### PR DESCRIPTION
## Summary
- replace the illegal top-level return in the server guard with a proper `else` branch
- keep the browser IIFE execution scoped to environments where `window` exists

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fe7c77c8ac832ea2c238d50c1ffffa