### PR TITLE
Fix serialization error in RSS adapter

### DIFF
--- a/lousy-outages/includes/Adapters.php
+++ b/lousy-outages/includes/Adapters.php
@@ -134,6 +134,6 @@ function from_rss_atom(string $xml): array {
         'state'      => $state,
         'incidents'  => $items,
         'updated_at' => $items[0]['updated_at'] ?? null,
-        'raw'        => $feed,
+        'raw'        => $xml,
     ];
 }


### PR DESCRIPTION
## Summary
- prevent RSS adapter from storing SimpleXMLElement instances in cached results
- ensure transient caching can serialize outage data without fatal errors

## Testing
- php -l lousy-outages/includes/Adapters.php

------
https://chatgpt.com/codex/tasks/task_e_68fed10eda30832eb9447f6334a3e87e