### PR TITLE
Prioritize outage issues on dashboards

### DIFF
--- a/lousy-outages/includes/Api.php
+++ b/lousy-outages/includes/Api.php
@@ -59,6 +59,8 @@ class Api {
             $providers[] = lousy_outages_build_provider_payload($id, $state, $timestamp);
         }
 
+        $providers = \lousy_outages_sort_providers($providers);
+
         $response = [
             'refreshedAt'   => $timestamp,
             'providerCount' => count($providers),

--- a/lousy-outages/includes/Feed.php
+++ b/lousy-outages/includes/Feed.php
@@ -35,6 +35,8 @@ class Feed {
             $providers[] = lousy_outages_build_provider_payload($id, $state, $fetched_at);
         }
 
+        $providers = \lousy_outages_sort_providers($providers);
+
         $items = self::build_items($providers, $fetched_at);
 
         echo '<?xml version="1.0" encoding="UTF-8"?>';

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -61,6 +61,8 @@ function render_shortcode(): string {
         $provider_payloads[] = $payload;
     }
 
+    $provider_payloads = \lousy_outages_sort_providers( $provider_payloads );
+
     $refresh_nonce = wp_create_nonce( 'wp_rest' );
 
     $config = [


### PR DESCRIPTION
## Summary
- add a shared helper that orders providers by incidents, state, errors, and risk
- reuse the helper across the shortcode, REST API, and RSS feed so issues appear first everywhere

## Testing
- npm test *(fails: polls at configured interval without stacking timers)*

------
https://chatgpt.com/codex/tasks/task_e_68fed501e468832ebe7b210dfb1e162d