### PR TITLE
Improve status fetch fallbacks and add WP-CLI probe

### DIFF
--- a/lousy-outages/includes/Adapters/Statuspage.php
+++ b/lousy-outages/includes/Adapters/Statuspage.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+namespace Lousy\Adapters\Statuspage;
+
+/**
+ * Attempt to infer a service state from a Statuspage error payload or body.
+ */
+function detect_state_from_error(string $body): ?string {
+    $body = trim($body);
+    if ('' === $body) {
+        return null;
+    }
+
+    $mapping = [
+        'none'                => 'operational',
+        'minor'               => 'degraded',
+        'minor_outage'        => 'degraded',
+        'degraded_performance'=> 'degraded',
+        'partial'             => 'degraded',
+        'partial_outage'      => 'degraded',
+        'investigating'       => 'degraded',
+        'identified'          => 'degraded',
+        'monitoring'          => 'degraded',
+        'major'               => 'outage',
+        'major_outage'        => 'outage',
+        'critical'            => 'outage',
+        'maintenance'         => 'maintenance',
+    ];
+
+    $state = null;
+    $decoded = json_decode($body, true);
+    if (is_array($decoded)) {
+        $indicator = strtolower((string) ($decoded['status']['indicator'] ?? $decoded['status'] ?? ''));
+        if ($indicator && isset($mapping[$indicator])) {
+            $state = $mapping[$indicator];
+        }
+
+        if (! $state && isset($decoded['page']['status_indicator'])) {
+            $hint = strtolower((string) $decoded['page']['status_indicator']);
+            if (isset($mapping[$hint])) {
+                $state = $mapping[$hint];
+            }
+        }
+    }
+
+    if (! $state) {
+        $haystack = strtolower($body);
+        foreach (['major_outage', 'partial_outage', 'investigating', 'identified', 'monitoring'] as $needle) {
+            if (false !== strpos($haystack, $needle)) {
+                $state = $mapping[$needle] ?? 'degraded';
+                break;
+            }
+        }
+        if (! $state && false !== strpos($haystack, 'critical')) {
+            $state = 'outage';
+        }
+    }
+
+    if (! $state || 'operational' === $state) {
+        return null;
+    }
+
+    return $state;
+}

--- a/lousy-outages/includes/Providers.php
+++ b/lousy-outages/includes/Providers.php
@@ -154,6 +154,18 @@ namespace LousyOutages {
         }
 
         private static function derive_status_url( array $provider ): string {
+            $wellKnown = [
+                'fastly'  => 'https://www.fastlystatus.com/',
+                'zscaler' => 'https://trust.zscaler.com/',
+                'stripe'  => 'https://status.stripe.com/',
+                'gitlab'  => 'https://status.gitlab.com/',
+                'notion'  => 'https://www.notionstatus.com/',
+            ];
+
+            if ( ! empty( $provider['id'] ) && isset( $wellKnown[ $provider['id'] ] ) ) {
+                return trailingslashit( $wellKnown[ $provider['id'] ] );
+            }
+
             $type           = strtolower( (string) ( $provider['type'] ?? 'statuspage' ) );
             $candidates     = [];
             $candidate_keys = [ 'status_url', 'url', 'summary', 'rss', 'atom', 'current', 'endpoint' ];

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -16,6 +16,7 @@ define( 'LOUSY_OUTAGES_PATH', plugin_dir_path( __FILE__ ) );
 require_once LOUSY_OUTAGES_PATH . 'includes/Providers.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Fetch.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Adapters.php';
+require_once LOUSY_OUTAGES_PATH . 'includes/Adapters/Statuspage.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Store.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Fetcher.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Downdetector.php';
@@ -28,6 +29,10 @@ require_once LOUSY_OUTAGES_PATH . 'includes/Api.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Feed.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Summary.php';
 require_once LOUSY_OUTAGES_PATH . 'public/shortcode.php';
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+    require_once LOUSY_OUTAGES_PATH . 'wp-cli/class-wp-cli-lousy.php';
+}
 
 use LousyOutages\Providers;
 use LousyOutages\Store;

--- a/lousy-outages/wp-cli/class-wp-cli-lousy.php
+++ b/lousy-outages/wp-cli/class-wp-cli-lousy.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace LousyOutages\CLI;
+
+use LousyOutages\Fetcher;
+use LousyOutages\Providers;
+use WP_CLI;
+use function WP_CLI\Utils\format_items;
+
+if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+    return;
+}
+
+class ProbeCommand {
+    public function __invoke( array $args, array $assoc_args ): void {
+        $id       = isset( $assoc_args['id'] ) ? (string) $assoc_args['id'] : '';
+        $timeout  = (int) apply_filters( 'lousy_outages_fetch_timeout', 10 );
+        $fetcher  = new Fetcher( $timeout );
+
+        if ( '' !== $id ) {
+            $providers = Providers::list();
+            if ( ! isset( $providers[ $id ] ) ) {
+                WP_CLI::error( sprintf( 'Provider "%s" not found.', $id ) );
+            }
+
+            $provider = $providers[ $id ];
+            $state    = $fetcher->fetch( $provider );
+            $line     = sprintf(
+                '%s | %s | %s | updated:%s | error:%s',
+                $state['name'] ?? $id,
+                $state['status_label'] ?? $state['status'] ?? 'Unknown',
+                preg_replace('/\s+/', ' ', (string) ( $state['summary'] ?? '' )),
+                $state['updated_at'] ?? '-',
+                $state['error'] ?? '-'
+            );
+            WP_CLI::line( $line );
+            return;
+        }
+
+        $rows      = [];
+        $providers = Providers::enabled();
+        foreach ( $providers as $provider ) {
+            $state      = $fetcher->fetch( $provider );
+            $rows[] = [
+                'id'      => $state['id'] ?? ( $provider['id'] ?? '' ),
+                'name'    => $state['name'] ?? ( $provider['name'] ?? '' ),
+                'status'  => $state['status_label'] ?? $state['status'] ?? 'Unknown',
+                'summary' => preg_replace('/\s+/', ' ', (string) ( $state['summary'] ?? '' )),
+                'updated' => $state['updated_at'] ?? '-',
+                'error'   => $state['error'] ?? '-',
+            ];
+        }
+
+        if ( empty( $rows ) ) {
+            WP_CLI::warning( 'No enabled providers were found.' );
+            return;
+        }
+
+        format_items( 'table', $rows, [ 'id', 'name', 'status', 'summary', 'updated', 'error' ] );
+    }
+}
+
+WP_CLI::add_command( 'lousy:probe', ProbeCommand::class );

--- a/tests/FetcherTest.php
+++ b/tests/FetcherTest.php
@@ -1,0 +1,163 @@
+<?php
+declare(strict_types=1);
+
+namespace {
+    function trailingslashit( $value ) {
+        $value = (string) $value;
+        return '' === $value ? '/' : rtrim( $value, "/\\" ) . '/';
+    }
+
+    function wp_strip_all_tags( $text ) {
+        return trim( strip_tags( (string) $text ) );
+    }
+
+    function wp_json_encode( $value ) {
+        return json_encode( $value );
+    }
+
+    function wp_parse_url( $url ) {
+        return parse_url( $url );
+    }
+
+    function home_url( $path = '/' ) {
+        return 'https://example.com' . (string) $path;
+    }
+}
+
+namespace Lousy {
+    class HttpMock {
+        /** @var array<int, mixed> */
+        public static array $queue = [];
+
+        public static function queue( array $responses ): void {
+            self::$queue = $responses;
+        }
+
+        public static function pop(string $url): array {
+            if ( empty( self::$queue ) ) {
+                return [
+                    'ok'      => false,
+                    'status'  => 0,
+                    'error'   => 'request_failed',
+                    'message' => 'No mock response queued for ' . $url,
+                    'body'    => null,
+                ];
+            }
+
+            $current = array_shift( self::$queue );
+            if ( is_callable( $current ) ) {
+                return (array) $current( $url );
+            }
+
+            return (array) $current;
+        }
+    }
+
+    function http_get( string $url, array $args = [] ): array {
+        return HttpMock::pop( $url );
+    }
+}
+
+namespace LousyOutages\Tests {
+    use Lousy\HttpMock;
+    use LousyOutages\Fetcher;
+
+    require_once __DIR__ . '/../lousy-outages/includes/Adapters.php';
+    require_once __DIR__ . '/../lousy-outages/includes/Adapters/Statuspage.php';
+    require_once __DIR__ . '/../lousy-outages/includes/Fetcher.php';
+
+    $tests = [];
+
+    $tests['statuspage_rss_fallback_after_404'] = static function (): void {
+        $rss = sprintf(
+            '<?xml version="1.0"?><rss><channel><item><title>Outage</title><pubDate>%s</pubDate></item></channel></rss>',
+            gmdate( 'D, d M Y H:i:s \G\M\T' )
+        );
+
+        HttpMock::queue([
+            [ 'ok' => false, 'status' => 404, 'error' => 'http_error', 'message' => 'HTTP 404 response', 'body' => '' ],
+            [ 'ok' => true, 'status' => 200, 'error' => null, 'message' => null, 'body' => $rss ],
+        ]);
+
+        $fetcher  = new Fetcher( 4 );
+        $result   = $fetcher->fetch([
+            'id'         => 'example',
+            'name'       => 'Example',
+            'type'       => 'statuspage',
+            'url'        => 'https://status.example.com/api/v2/summary.json',
+            'status_url' => 'https://status.example.com/',
+        ]);
+
+        if ( ! in_array( $result['status'], [ 'operational', 'degraded', 'outage' ], true ) ) {
+            throw new \RuntimeException( 'Expected RSS fallback to produce a known status.' );
+        }
+        if ( null !== $result['error'] ) {
+            throw new \RuntimeException( 'Expected error to be cleared after fallback.' );
+        }
+    };
+
+    $tests['statuspage_atom_fallback_after_401'] = static function (): void {
+        $atom = sprintf(
+            '<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"><entry><title>Degraded</title><updated>%s</updated></entry></feed>',
+            gmdate( 'c' )
+        );
+
+        HttpMock::queue([
+            [ 'ok' => false, 'status' => 401, 'error' => 'http_error', 'message' => 'HTTP 401 response', 'body' => '' ],
+            [ 'ok' => false, 'status' => 404, 'error' => 'http_error', 'message' => 'HTTP 404 response', 'body' => '' ],
+            [ 'ok' => true, 'status' => 200, 'error' => null, 'message' => null, 'body' => $atom ],
+        ]);
+
+        $fetcher = new Fetcher( 4 );
+        $result  = $fetcher->fetch([
+            'id'   => 'atom-example',
+            'name' => 'Atom Example',
+            'type' => 'statuspage',
+            'url'  => 'https://status.example.net/api/v2/summary.json',
+        ]);
+
+        if ( ! in_array( $result['status'], [ 'operational', 'degraded', 'outage' ], true ) ) {
+            throw new \RuntimeException( 'Expected Atom fallback to produce a known status.' );
+        }
+        if ( null !== $result['error'] ) {
+            throw new \RuntimeException( 'Expected no error after Atom fallback.' );
+        }
+    };
+
+    $tests['optional_empty_body'] = static function (): void {
+        HttpMock::queue([
+            [ 'ok' => true, 'status' => 200, 'error' => null, 'message' => null, 'body' => '   ' ],
+        ]);
+
+        $fetcher = new Fetcher( 4 );
+        $result  = $fetcher->fetch([
+            'id'       => 'optional',
+            'name'     => 'Optional',
+            'type'     => 'rss-optional',
+            'url'      => 'https://status.optional.example/history.rss',
+            'optional' => true,
+        ]);
+
+        if ( false === strpos( (string) $result['error'], 'optional_unavailable' ) ) {
+            throw new \RuntimeException( 'Expected optional_unavailable error string.' );
+        }
+    };
+
+    $failed = false;
+
+    foreach ( $tests as $name => $callback ) {
+        try {
+            $callback();
+            echo "ok - {$name}\n";
+        } catch ( \Throwable $throwable ) {
+            $failed = true;
+            echo "not ok - {$name}: " . $throwable->getMessage() . "\n";
+        }
+    }
+
+    if ( $failed ) {
+        exit( 1 );
+    }
+
+    echo "All tests passed\n";
+}


### PR DESCRIPTION
## Summary
- harden the fetcher with IPv4 retries, clearer errors, and history feed fallbacks
- add Statuspage error detection helpers and provider host overrides for common vendors
- expose a `wp lousy:probe` command and add lightweight fetcher regression tests

## Testing
- php tests/FetcherTest.php

------
https://chatgpt.com/codex/tasks/task_e_68fed736d6c0832eb810591dd7fd916f