### PR TITLE
Add status fallback for blocked Statuspage providers

### DIFF
--- a/lousy-outages/includes/Adapters.php
+++ b/lousy-outages/includes/Adapters.php
@@ -47,6 +47,35 @@ function from_statuspage_summary(string $json): array {
     ];
 }
 
+function from_statuspage_status(string $json): array {
+    $data = json_decode($json, true);
+    if (! is_array($data)) {
+        return ['state' => 'unknown', 'incidents' => [], 'raw' => null];
+    }
+
+    $indicator = strtolower((string) ($data['status']['indicator'] ?? 'unknown'));
+    $map       = [
+        'none'        => 'operational',
+        'minor'       => 'degraded',
+        'minor_outage'=> 'degraded',
+        'partial'     => 'degraded',
+        'degraded'    => 'degraded',
+        'major'       => 'major',
+        'critical'    => 'major',
+        'maintenance' => 'maintenance',
+    ];
+
+    $state = $map[$indicator] ?? 'unknown';
+
+    return [
+        'state'      => $state,
+        'incidents'  => [],
+        'updated_at' => $data['page']['updated_at'] ?? null,
+        'summary'    => $data['status']['description'] ?? '',
+        'raw'        => $data,
+    ];
+}
+
 function from_slack_current(string $json): array {
     $data = json_decode($json, true);
     if (!is_array($data)) {

--- a/lousy-outages/includes/Providers.php
+++ b/lousy-outages/includes/Providers.php
@@ -10,20 +10,20 @@ namespace {
             ['id' => 'openai', 'name' => 'OpenAI', 'type' => 'statuspage', 'url' => 'https://status.openai.com/api/v2/summary.json'],
             ['id' => 'atlassian', 'name' => 'Atlassian', 'type' => 'statuspage', 'url' => 'https://status.atlassian.com/api/v2/summary.json'],
             ['id' => 'digitalocean', 'name' => 'DigitalOcean', 'type' => 'statuspage', 'url' => 'https://status.digitalocean.com/api/v2/summary.json'],
-            ['id' => 'gitlab', 'name' => 'GitLab', 'type' => 'statuspage', 'url' => 'https://status.gitlab.com/api/v2/summary.json'],
+            ['id' => 'gitlab', 'name' => 'GitLab', 'type' => 'statuspage', 'url' => 'https://status.gitlab.com/api/v2/summary.json', 'status_endpoint' => 'https://status.gitlab.com/api/v2/status.json'],
             ['id' => 'netlify', 'name' => 'Netlify', 'type' => 'statuspage', 'url' => 'https://www.netlifystatus.com/api/v2/summary.json'],
             ['id' => 'vercel', 'name' => 'Vercel', 'type' => 'statuspage', 'url' => 'https://www.vercel-status.com/api/v2/summary.json'],
-            ['id' => 'okta', 'name' => 'Okta', 'type' => 'statuspage', 'url' => 'https://status.okta.com/api/v2/summary.json'],
+            ['id' => 'okta', 'name' => 'Okta', 'type' => 'statuspage', 'url' => 'https://status.okta.com/api/v2/summary.json', 'status_endpoint' => 'https://status.okta.com/api/v2/status.json'],
             ['id' => 'pagerduty', 'name' => 'PagerDuty', 'type' => 'statuspage', 'url' => 'https://status.pagerduty.com/api/v2/summary.json'],
             ['id' => 'zoom', 'name' => 'Zoom', 'type' => 'statuspage', 'url' => 'https://status.zoom.us/api/v2/summary.json'],
-            ['id' => 'zscaler', 'name' => 'Zscaler', 'type' => 'statuspage', 'url' => 'https://trust.zscaler.com/api/v2/summary.json'],
+            ['id' => 'zscaler', 'name' => 'Zscaler', 'type' => 'statuspage', 'url' => 'https://trust.zscaler.com/api/v2/summary.json', 'status_endpoint' => 'https://trust.zscaler.com/api/v2/status.json'],
 
             // High-value adds (Statuspage JSON)
-            ['id' => 'stripe', 'name' => 'Stripe', 'type' => 'statuspage', 'url' => 'https://status.stripe.com/api/v2/summary.json'],
+            ['id' => 'stripe', 'name' => 'Stripe', 'type' => 'statuspage', 'url' => 'https://status.stripe.com/api/v2/summary.json', 'status_endpoint' => 'https://status.stripe.com/api/v2/status.json'],
             ['id' => 'twilio', 'name' => 'Twilio', 'type' => 'statuspage', 'url' => 'https://status.twilio.com/api/v2/summary.json'],
-            ['id' => 'fastly', 'name' => 'Fastly', 'type' => 'statuspage', 'url' => 'https://status.fastly.com/api/v2/summary.json'],
+            ['id' => 'fastly', 'name' => 'Fastly', 'type' => 'statuspage', 'url' => 'https://status.fastly.com/api/v2/summary.json', 'status_endpoint' => 'https://status.fastly.com/api/v2/status.json'],
             ['id' => 'datadog', 'name' => 'Datadog', 'type' => 'statuspage', 'url' => 'https://status.datadoghq.com/api/v2/summary.json'],
-            ['id' => 'notion', 'name' => 'Notion', 'type' => 'statuspage', 'url' => 'https://www.notionstatus.com/api/v2/summary.json'],
+            ['id' => 'notion', 'name' => 'Notion', 'type' => 'statuspage', 'url' => 'https://status.notion.so/api/v2/summary.json', 'status_endpoint' => 'https://status.notion.so/api/v2/status.json'],
             ['id' => 'linear', 'name' => 'Linear', 'type' => 'statuspage', 'url' => 'https://status.linear.app/api/v2/summary.json'],
             ['id' => 'sentry', 'name' => 'Sentry', 'type' => 'statuspage', 'url' => 'https://status.sentry.io/api/v2/summary.json'],
 
@@ -159,7 +159,7 @@ namespace LousyOutages {
                 'zscaler' => 'https://trust.zscaler.com/',
                 'stripe'  => 'https://status.stripe.com/',
                 'gitlab'  => 'https://status.gitlab.com/',
-                'notion'  => 'https://www.notionstatus.com/',
+                'notion'  => 'https://status.notion.so/',
             ];
 
             if ( ! empty( $provider['id'] ) && isset( $wellKnown[ $provider['id'] ] ) ) {


### PR DESCRIPTION
## Summary
- add a Statuspage status.json adapter and fallback so blocked summary APIs still report overall health
- update default provider list with status endpoint hints and Notion's new domain
- adjust fetcher messaging for status-only results and extend tests to cover the new fallback path

## Testing
- php tests/FetcherTest.php
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_690113d51af4832eae73146d09a0bd82