### PR TITLE
Implement server-side caching and subscriptions for Lousy Outages

### DIFF
--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -237,3 +237,124 @@
     text-align: center;
   }
 }
+
+.lo-pill--degraded {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #ffd400;
+  border-color: #ffd400;
+  background: rgba(255, 212, 0, 0.15);
+}
+
+.lo-components {
+  margin-top: 8px;
+}
+
+.lo-components__title {
+  margin: 0 0 4px;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #ffecc7;
+}
+
+.lo-components__list {
+  list-style: disc;
+  margin: 0;
+  padding-left: 18px;
+  color: #fff1d8;
+  font-size: 0.85rem;
+}
+
+.lo-component-name {
+  font-weight: 600;
+}
+
+.lo-component-status {
+  margin-left: 6px;
+  color: #ffd400;
+}
+
+.lo-inc-summary {
+  margin: 4px 0 0;
+  font-size: 0.85rem;
+  color: #c9ffc4;
+}
+
+.lo-subscribe {
+  margin: 24px auto;
+  padding: 16px;
+  max-width: 480px;
+  border: 2px solid #2af200;
+  border-radius: 14px;
+  background: rgba(42, 242, 0, 0.08);
+  color: #c9ffc4;
+}
+
+.lo-subscribe__intro {
+  margin: 0 0 12px;
+  font-size: 0.95rem;
+  color: #e0ffe0;
+}
+
+.lo-subscribe__form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-end;
+}
+
+.lo-subscribe__label {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 220px;
+  font-size: 0.9rem;
+}
+
+.lo-subscribe__label input[type="email"] {
+  margin-top: 6px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(42, 242, 0, 0.6);
+  background: rgba(0, 0, 0, 0.6);
+  color: #f4fff0;
+}
+
+.lo-subscribe__button {
+  background: #2af200;
+  color: #000;
+  border: none;
+  border-radius: 10px;
+  padding: 10px 18px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.lo-subscribe__button:hover,
+.lo-subscribe__button:focus {
+  background: #51ff2a;
+}
+
+.lo-subscribe__status {
+  flex-basis: 100%;
+  margin: 0;
+  min-height: 1.2em;
+  font-size: 0.85rem;
+  color: #a7ff9a;
+}
+
+.lo-subscribe__status--error {
+  color: #ff8484;
+}
+
+@media (max-width: 600px) {
+  .lo-subscribe__form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .lo-subscribe__button {
+    width: 100%;
+  }
+}

--- a/lousy-outages/includes/Api.php
+++ b/lousy-outages/includes/Api.php
@@ -21,6 +21,53 @@ class Api {
                 'callback'            => [self::class, 'handle_refresh'],
             ]
         );
+
+        register_rest_route(
+            'lousy-outages/v1',
+            '/summary',
+            [
+                'methods'             => 'GET',
+                'permission_callback' => '__return_true',
+                'callback'            => [self::class, 'handle_summary'],
+                'args'                => [
+                    'provider' => [
+                        'description'       => 'Optional provider filter (comma-separated)',
+                        'type'              => 'string',
+                        'sanitize_callback' => 'sanitize_text_field',
+                    ],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            'lousy-outages/v1',
+            '/subscribe',
+            [
+                'methods'             => 'POST',
+                'permission_callback' => '__return_true',
+                'callback'            => [self::class, 'handle_subscribe'],
+            ]
+        );
+
+        register_rest_route(
+            'lousy-outages/v1',
+            '/confirm',
+            [
+                'methods'             => 'GET',
+                'permission_callback' => '__return_true',
+                'callback'            => [self::class, 'handle_confirm'],
+            ]
+        );
+
+        register_rest_route(
+            'lousy-outages/v1',
+            '/unsubscribe',
+            [
+                'methods'             => 'GET',
+                'permission_callback' => '__return_true',
+                'callback'            => [self::class, 'handle_unsubscribe'],
+            ]
+        );
     }
 
     public static function verify_nonce(): bool {
@@ -69,5 +116,196 @@ class Api {
         ];
 
         return rest_ensure_response($response);
+    }
+
+    public static function handle_summary(WP_REST_Request $request): WP_REST_Response {
+        $providerParam = $request->get_param('provider');
+        $filters       = self::sanitize_provider_list(is_string($providerParam) ? $providerParam : null);
+
+        $fetcher  = new Lousy_Outages_Fetcher();
+        $result   = $fetcher->get_all($filters ?: null);
+        $providers = array_values($result['providers']);
+
+        $payload = [
+            'providers'  => $providers,
+            'fetched_at' => $result['fetched_at'],
+        ];
+        if (!empty($result['errors'])) {
+            $payload['errors'] = $result['errors'];
+        }
+
+        $etag       = '"' . md5(wp_json_encode($payload)) . '"';
+        $ifNoneMatch = trim((string) $request->get_header('if-none-match'));
+
+        if ('' !== $ifNoneMatch && $ifNoneMatch === $etag) {
+            $response = new WP_REST_Response(null, 304);
+            $response->header('ETag', $etag);
+            $response->header('Cache-Control', 'no-cache, must-revalidate');
+            return $response;
+        }
+
+        $response = new WP_REST_Response($payload, 200);
+        $response->header('ETag', $etag);
+        $response->header('Cache-Control', 'no-cache, must-revalidate');
+
+        return $response;
+    }
+
+    public static function handle_subscribe(WP_REST_Request $request): WP_REST_Response {
+        $params = self::extract_body_params($request);
+
+        $nonce = $params['_wpnonce'] ?? $params['nonce'] ?? $request->get_header('X-WP-Nonce');
+        if (!is_string($nonce) || !wp_verify_nonce($nonce, 'lousy_outages_subscribe')) {
+            return new WP_REST_Response(['message' => 'Invalid security token.'], 403);
+        }
+
+        $honeypot = isset($params['website']) ? trim((string) $params['website']) : '';
+        if ('' !== $honeypot) {
+            return new WP_REST_Response(['message' => 'Something went wrong.'], 400);
+        }
+
+        $email = isset($params['email']) ? sanitize_email((string) $params['email']) : '';
+        if (!$email || !is_email($email)) {
+            return new WP_REST_Response(['message' => 'Please provide a valid email address.'], 400);
+        }
+
+        $ip      = self::detect_ip($request);
+        $ip_hash = self::hash_ip($ip);
+        $rateKey = self::rate_limit_key($ip_hash);
+        $count   = (int) get_transient($rateKey);
+        if ($count >= 5) {
+            return new WP_REST_Response(['message' => 'Too many requests. Try again soon.'], 429);
+        }
+        set_transient($rateKey, $count + 1, 60);
+
+        try {
+            $token = bin2hex(random_bytes(24));
+        } catch (\Throwable $e) {
+            $token = wp_generate_password(32, false, false);
+        }
+
+        Subscriptions::save_pending($email, $token, $ip_hash, 'form');
+
+        $confirm_url     = add_query_arg('token', rawurlencode($token), rest_url('lousy-outages/v1/confirm'));
+        $unsubscribe_url = add_query_arg('token', rawurlencode($token), rest_url('lousy-outages/v1/unsubscribe'));
+
+        $subject = 'Confirm your Lousy Outages subscription';
+        $message = "Hi there!\n\nPlease confirm your email to receive Lousy Outages alerts.\n\nConfirm subscription: {$confirm_url}\n\nIf you didn\'t request this, ignore this email or unsubscribe here: {$unsubscribe_url}\n\n— Lousy Outages";
+
+        wp_mail($email, $subject, $message, ['Content-Type: text/plain; charset=UTF-8']);
+
+        $response = new WP_REST_Response([
+            'message' => 'Check your email to confirm your subscription.',
+            'status'  => 'pending',
+        ], 200);
+        $response->header('Cache-Control', 'no-store, max-age=0');
+
+        return $response;
+    }
+
+    public static function handle_confirm(WP_REST_Request $request): WP_REST_Response {
+        $token = sanitize_text_field((string) $request->get_param('token'));
+        if ('' === $token) {
+            return self::html_response('Missing token', 'This confirmation link is missing a token.', 400);
+        }
+
+        $record = Subscriptions::find_by_token($token);
+        if (!$record) {
+            return self::html_response('Link expired', 'This confirmation link is invalid or has expired.', 404);
+        }
+
+        $status  = strtolower((string) ($record['status'] ?? ''));
+        $created = isset($record['created_at']) ? strtotime((string) $record['created_at']) : false;
+        $cutoff  = time() - 14 * DAY_IN_SECONDS;
+
+        if (Subscriptions::STATUS_PENDING === $status) {
+            if (!$created || $created < $cutoff) {
+                Subscriptions::update_status_by_token($token, Subscriptions::STATUS_UNSUBSCRIBED);
+                return self::html_response('Link expired', 'This confirmation link has expired. Please subscribe again.', 410);
+            }
+
+            Subscriptions::update_status_by_token($token, Subscriptions::STATUS_SUBSCRIBED);
+            return self::html_response('Subscription confirmed', 'Thanks! You will now receive outage alerts by email.');
+        }
+
+        if (Subscriptions::STATUS_SUBSCRIBED === $status) {
+            return self::html_response('Already confirmed', 'This email address is already confirmed.');
+        }
+
+        return self::html_response('Unsubscribed', 'This subscription has been unsubscribed.');
+    }
+
+    public static function handle_unsubscribe(WP_REST_Request $request): WP_REST_Response {
+        $token = sanitize_text_field((string) $request->get_param('token'));
+        if ('' === $token) {
+            return self::html_response('Missing token', 'No unsubscribe token was provided.', 400);
+        }
+
+        $record = Subscriptions::find_by_token($token);
+        if (!$record) {
+            return self::html_response('Link invalid', 'This unsubscribe link is invalid or has already been used.', 404);
+        }
+
+        if (Subscriptions::STATUS_UNSUBSCRIBED !== strtolower((string) $record['status'] ?? '')) {
+            Subscriptions::update_status_by_token($token, Subscriptions::STATUS_UNSUBSCRIBED);
+        }
+
+        return self::html_response('You have been unsubscribed', 'You will no longer receive outage alerts.');
+    }
+
+    private static function sanitize_provider_list(?string $raw): array {
+        if (!$raw) {
+            return [];
+        }
+        $parts = array_filter(array_map('trim', explode(',', $raw)));
+        return array_values(array_unique($parts));
+    }
+
+    private static function extract_body_params(WP_REST_Request $request): array {
+        $json = $request->get_json_params();
+        if (!is_array($json)) {
+            $json = [];
+        }
+        $body = $request->get_body_params();
+        if (!is_array($body)) {
+            $body = [];
+        }
+        return array_merge($body, $json);
+    }
+
+    private static function detect_ip(WP_REST_Request $request): string {
+        $headers = $request->get_headers();
+        $forwarded = '';
+        if (isset($headers['x-forwarded-for'][0])) {
+            $forwarded = trim(explode(',', $headers['x-forwarded-for'][0])[0]);
+        }
+        if ($forwarded) {
+            return $forwarded;
+        }
+        return $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
+    }
+
+    private static function hash_ip(string $ip): string {
+        return hash('sha256', $ip . wp_salt('nonce'));
+    }
+
+    private static function rate_limit_key(string $ip_hash): string {
+        return 'lousy_outages_subscribe_' . substr($ip_hash, 0, 20);
+    }
+
+    private static function html_response(string $title, string $message, int $status = 200): WP_REST_Response {
+        $title   = esc_html($title);
+        $message = esc_html($message);
+        $body    = '<!DOCTYPE html><html lang="en"><head><meta charset="utf-8" /><title>' . $title . '</title>'
+            . '<style>body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;background:#101410;color:#f4fff0;padding:48px;display:flex;justify-content:center;}'
+            . '.lo-card{max-width:520px;background:#1a261a;border-radius:16px;padding:32px;box-shadow:0 12px 32px rgba(0,0,0,0.35);}'
+            . '.lo-card h1{margin-top:0;font-size:1.6rem;} .lo-card p{margin:12px 0 0;font-size:1rem;line-height:1.5;}</style>'
+            . '</head><body><main class="lo-card"><h1>' . $title . '</h1><p>' . $message . '</p></main></body></html>';
+
+        $response = new WP_REST_Response($body, $status);
+        $response->header('Content-Type', 'text/html; charset=utf-8');
+        $response->header('Cache-Control', 'no-store, max-age=0');
+
+        return $response;
     }
 }

--- a/lousy-outages/includes/Providers.php
+++ b/lousy-outages/includes/Providers.php
@@ -23,7 +23,7 @@ namespace {
             ['id' => 'twilio', 'name' => 'Twilio', 'type' => 'statuspage', 'url' => 'https://status.twilio.com/api/v2/summary.json'],
             ['id' => 'fastly', 'name' => 'Fastly', 'type' => 'statuspage', 'url' => 'https://status.fastly.com/api/v2/summary.json', 'status_endpoint' => 'https://status.fastly.com/api/v2/status.json'],
             ['id' => 'datadog', 'name' => 'Datadog', 'type' => 'statuspage', 'url' => 'https://status.datadoghq.com/api/v2/summary.json'],
-            ['id' => 'notion', 'name' => 'Notion', 'type' => 'statuspage', 'url' => 'https://status.notion.so/api/v2/summary.json', 'status_endpoint' => 'https://status.notion.so/api/v2/status.json'],
+            ['id' => 'notion', 'name' => 'Notion', 'type' => 'statuspage', 'url' => 'https://www.notionstatus.com/api/v2/summary.json', 'status_endpoint' => 'https://www.notionstatus.com/api/v2/status.json'],
             ['id' => 'linear', 'name' => 'Linear', 'type' => 'statuspage', 'url' => 'https://status.linear.app/api/v2/summary.json'],
             ['id' => 'sentry', 'name' => 'Sentry', 'type' => 'statuspage', 'url' => 'https://status.sentry.io/api/v2/summary.json'],
 
@@ -159,7 +159,7 @@ namespace LousyOutages {
                 'zscaler' => 'https://trust.zscaler.com/',
                 'stripe'  => 'https://status.stripe.com/',
                 'gitlab'  => 'https://status.gitlab.com/',
-                'notion'  => 'https://status.notion.so/',
+                'notion'  => 'https://www.notionstatus.com/',
             ];
 
             if ( ! empty( $provider['id'] ) && isset( $wellKnown[ $provider['id'] ] ) ) {

--- a/lousy-outages/includes/Subscriptions.php
+++ b/lousy-outages/includes/Subscriptions.php
@@ -1,0 +1,136 @@
+<?php
+declare(strict_types=1);
+
+namespace LousyOutages;
+
+class Subscriptions {
+    public const TABLE = 'lousy_outages_subs';
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_SUBSCRIBED = 'subscribed';
+    public const STATUS_UNSUBSCRIBED = 'unsubscribed';
+
+    public static function table_name(): string {
+        global $wpdb;
+        return $wpdb->prefix . self::TABLE;
+    }
+
+    public static function create_table(): void {
+        global $wpdb;
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+        $charset = $wpdb->get_charset_collate();
+        $table   = self::table_name();
+
+        $sql = "CREATE TABLE {$table} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            email VARCHAR(190) NOT NULL,
+            status VARCHAR(20) NOT NULL DEFAULT 'pending',
+            token CHAR(64) NOT NULL,
+            created_at DATETIME NOT NULL,
+            updated_at DATETIME NOT NULL,
+            ip_hash CHAR(64) NOT NULL,
+            consent_source VARCHAR(50) NOT NULL DEFAULT '',
+            PRIMARY KEY  (id),
+            UNIQUE KEY email (email),
+            UNIQUE KEY token (token)
+        ) {$charset};";
+
+        dbDelta($sql);
+    }
+
+    public static function schedule_purge(): void {
+        if (!wp_next_scheduled('lousy_outages_purge_pending')) {
+            wp_schedule_event(time() + DAY_IN_SECONDS, 'daily', 'lousy_outages_purge_pending');
+        }
+    }
+
+    public static function clear_schedule(): void {
+        wp_clear_scheduled_hook('lousy_outages_purge_pending');
+    }
+
+    public static function purge_stale_pending(): int {
+        global $wpdb;
+        $table = self::table_name();
+        $cutoff = gmdate('Y-m-d H:i:s', time() - 14 * DAY_IN_SECONDS);
+        return (int) $wpdb->query($wpdb->prepare("DELETE FROM {$table} WHERE status = %s AND created_at < %s", self::STATUS_PENDING, $cutoff));
+    }
+
+    public static function save_pending(string $email, string $token, string $ip_hash, string $source = 'form'): void {
+        global $wpdb;
+        $table  = self::table_name();
+        $now    = gmdate('Y-m-d H:i:s');
+
+        $existing = $wpdb->get_row($wpdb->prepare("SELECT id, status FROM {$table} WHERE email = %s", $email));
+
+        if ($existing) {
+            $wpdb->update(
+                $table,
+                [
+                    'status'         => self::STATUS_PENDING,
+                    'token'          => $token,
+                    'updated_at'     => $now,
+                    'ip_hash'        => $ip_hash,
+                    'consent_source' => $source,
+                ],
+                ['id' => (int) $existing->id],
+                ['%s', '%s', '%s', '%s', '%s'],
+                ['%d']
+            );
+        } else {
+            $wpdb->insert(
+                $table,
+                [
+                    'email'          => $email,
+                    'status'         => self::STATUS_PENDING,
+                    'token'          => $token,
+                    'created_at'     => $now,
+                    'updated_at'     => $now,
+                    'ip_hash'        => $ip_hash,
+                    'consent_source' => $source,
+                ],
+                ['%s', '%s', '%s', '%s', '%s', '%s', '%s']
+            );
+        }
+    }
+
+    public static function find_by_token(string $token): ?array {
+        global $wpdb;
+        $table = self::table_name();
+        $row   = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$table} WHERE token = %s", $token), ARRAY_A);
+        return $row ?: null;
+    }
+
+    public static function update_status_by_token(string $token, string $status): bool {
+        global $wpdb;
+        $table = self::table_name();
+        $updated = $wpdb->update(
+            $table,
+            [
+                'status'     => $status,
+                'updated_at' => gmdate('Y-m-d H:i:s'),
+            ],
+            ['token' => $token],
+            ['%s', '%s'],
+            ['%s']
+        );
+
+        return false !== $updated && $updated > 0;
+    }
+
+    public static function update_token_for_email(string $email, string $token): bool {
+        global $wpdb;
+        $table = self::table_name();
+        $updated = $wpdb->update(
+            $table,
+            [
+                'token'      => $token,
+                'updated_at' => gmdate('Y-m-d H:i:s'),
+            ],
+            ['email' => $email],
+            ['%s', '%s'],
+            ['%s']
+        );
+
+        return false !== $updated && $updated > 0;
+    }
+}

--- a/page-home.php
+++ b/page-home.php
@@ -12,7 +12,7 @@ get_header();
 
     <p>Toured nationally as a bassist, recorded with Steve Albini in Chicago, and appeared on MuchMusic. Today, I keep creating, playing around with programming/coding and releasing new music at night while shipping infrastructure code by day hah!</p>
 
-    <p>After navigating tenancy issues in my own building and helping neighbours do the same, I’ve started to get involved in civic life, and exploring a possible run for Vancouver City Council in 2026.</p>
+    <p>After digging into local housing issues, I’m focusing my energy on building and shipping tech—more prototypes, fewer arguments.</p>
 </section>
 
         <p class="arcade-subtext">Insert coin to explore</p>


### PR DESCRIPTION
## Summary
- add a WordPress fetcher with transient caching, ETag handling, and corrected provider status endpoints
- introduce subscription data model, REST routes, and shortcodes for summary, subscribe, confirm, and unsubscribe flows
- refresh the front-end widget with ETag-aware polling/backoff, subscribe form enhancements, and updated homepage copy

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_69011a115414832e91ce7d40c76ef742