### PR TITLE
Replace PHP 8 match expressions with switches for PHP 7 compatibility

### DIFF
--- a/lousy-outages/includes/Fetcher.php
+++ b/lousy-outages/includes/Fetcher.php
@@ -1184,22 +1184,52 @@ class Lousy_Outages_Fetcher {
 
     private function map_indicator(string $indicator): string {
         $indicator = strtolower($indicator);
-        return match ($indicator) {
-            'none', 'operational', 'ok', 'green' => 'operational',
-            'maintenance', 'maintainance' => 'maintenance',
-            'minor', 'minor_outage', 'degraded', 'partial_outage', 'warning' => 'degraded',
-            'major', 'major_outage', 'critical', 'outage' => 'outage',
-            default => 'unknown',
-        };
+
+        switch ($indicator) {
+            case 'none':
+            case 'operational':
+            case 'ok':
+            case 'green':
+                return 'operational';
+
+            case 'maintenance':
+            case 'maintainance':
+                return 'maintenance';
+
+            case 'minor':
+            case 'minor_outage':
+            case 'degraded':
+            case 'partial_outage':
+            case 'warning':
+                return 'degraded';
+
+            case 'major':
+            case 'major_outage':
+            case 'critical':
+            case 'outage':
+                return 'outage';
+
+            default:
+                return 'unknown';
+        }
     }
 
     private function status_label(string $status): string {
-        return match (strtolower($status)) {
-            'operational' => 'Operational',
-            'degraded'    => 'Degraded',
-            'outage'      => 'Outage',
-            'maintenance' => 'Maintenance',
-            default       => 'Unknown',
-        };
+        switch (strtolower($status)) {
+            case 'operational':
+                return 'Operational';
+
+            case 'degraded':
+                return 'Degraded';
+
+            case 'outage':
+                return 'Outage';
+
+            case 'maintenance':
+                return 'Maintenance';
+
+            default:
+                return 'Unknown';
+        }
     }
 }


### PR DESCRIPTION
## Summary
- replace Fetcher::map_indicator and ::status_label match expressions with PHP 7 compatible switch statements

## Testing
- php -l lousy-outages/includes/Fetcher.php

------
https://chatgpt.com/codex/tasks/task_e_6901235422e4832eab01dd65a9c54f86