### PR TITLE
Add cloud provider feeds, caching tweaks, and trending banner

### DIFF
--- a/__tests__/normalizer.test.js
+++ b/__tests__/normalizer.test.js
@@ -15,11 +15,11 @@ test('normalizeStatus returns normalized code and label for operational', () => 
   });
 });
 
-test('normalizeStatus falls back to unknown for unexpected values', () => {
+test('normalizeStatus maps critical to major outage', () => {
   const normalized = app.normalizeStatus('critical');
-  assert.equal(normalized.code, 'unknown');
-  assert.equal(normalized.label, 'Unknown');
-  assert.equal(normalized.className, 'status--unknown');
+  assert.equal(normalized.code, 'major');
+  assert.equal(normalized.label, 'Major Outage');
+  assert.equal(normalized.className, 'status--outage');
 });
 test('snarkOutage uses provider-specific quip when available', () => {
   const originalRandom = Math.random;

--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -37,6 +37,36 @@
   margin: 10px 0 16px;
 }
 
+.lo-trending {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: rgba(255, 212, 0, 0.12);
+  border: 2px solid #ffd400;
+  border-radius: 14px;
+  padding: 10px 14px;
+  margin-bottom: 18px;
+  color: #ffd400;
+  font-weight: 600;
+}
+
+.lo-trending__icon {
+  font-size: 1.4rem;
+  line-height: 1;
+}
+
+.lo-trending__body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.lo-trending__reasons {
+  font-size: 0.85rem;
+  color: #fff8c7;
+}
+
 .lo-link {
   display: inline-flex;
   align-items: center;

--- a/lousy-outages/includes/Api.php
+++ b/lousy-outages/includes/Api.php
@@ -126,9 +126,14 @@ class Api {
         $result   = $fetcher->get_all($filters ?: null);
         $providers = array_values($result['providers']);
 
+        $trending = isset($result['trending']) && is_array($result['trending'])
+            ? $result['trending']
+            : ['trending' => false, 'signals' => [], 'generated_at' => gmdate('c')];
+
         $payload = [
             'providers'  => $providers,
             'fetched_at' => $result['fetched_at'],
+            'trending'   => $trending,
         ];
         if (!empty($result['errors'])) {
             $payload['errors'] = $result['errors'];

--- a/lousy-outages/includes/Trending.php
+++ b/lousy-outages/includes/Trending.php
@@ -1,0 +1,180 @@
+<?php
+declare(strict_types=1);
+
+namespace LousyOutages;
+
+/**
+ * Lightweight trending detector that looks for correlated outage signals.
+ */
+class Trending
+{
+    private const OPTION_KEY     = 'lousy_outages_trending_buffer';
+    private const BUFFER_WINDOW  = 3600; // seconds to retain historical signals (60 minutes)
+    private const SIGNAL_WINDOW  = 900;  // seconds for co-occurring signals (15 minutes)
+    private const MAX_SIGNAL_LOG = 24;
+
+    /**
+     * Evaluate the latest provider states and return a trending summary.
+     */
+    public function evaluate(array $providers, array $map): array
+    {
+        $timestamp = time();
+        $signals   = $this->collect_signals($providers, $timestamp);
+
+        $buffer   = $this->load_buffer();
+        $buffer[] = [
+            'ts'      => $timestamp,
+            'signals' => $signals,
+        ];
+        $buffer = $this->prune_buffer($buffer, $timestamp);
+        $this->store_buffer($buffer);
+
+        $recentSignals = $this->recent_signals($buffer, $timestamp);
+        $unique        = array_values(array_unique($recentSignals));
+        $active        = count($unique) >= 2;
+
+        return [
+            'trending'     => $active,
+            'signals'      => array_slice($unique, 0, self::MAX_SIGNAL_LOG),
+            'generated_at' => gmdate('c', $timestamp),
+        ];
+    }
+
+    /**
+     * Convert provider payloads into normalized signal identifiers.
+     */
+    private function collect_signals(array $providers, int $timestamp): array
+    {
+        $signals = [];
+
+        foreach ($providers as $provider) {
+            if (!is_array($provider)) {
+                continue;
+            }
+
+            $slug = strtolower((string) ($provider['id'] ?? $provider['provider'] ?? ''));
+            if ('' === $slug) {
+                continue;
+            }
+
+            $overall = strtolower((string) ($provider['overall'] ?? $provider['status'] ?? ''));
+            if (in_array($overall, ['degraded', 'major', 'outage'], true)) {
+                $signals[] = $slug . ':status=' . $overall;
+            }
+
+            if (!empty($provider['error'])) {
+                $signals[] = $slug . ':fetch_error';
+            }
+
+            if (!empty($provider['probe']) && is_array($provider['probe'])) {
+                $probe = $provider['probe'];
+                $rate  = isset($probe['window_error_rate']) ? (float) $probe['window_error_rate'] : 0.0;
+                if ($rate >= 0.3) {
+                    $signals[] = $slug . ':probe=' . round($rate * 100) . '%';
+                } elseif (!empty($probe['recent_failure'])) {
+                    $signals[] = $slug . ':probe';
+                }
+            }
+
+            $incidents = is_array($provider['incidents'] ?? null) ? $provider['incidents'] : [];
+            foreach ($incidents as $incident) {
+                if (!is_array($incident)) {
+                    continue;
+                }
+                $reference = $this->latest_timestamp($incident);
+                if ($reference && ($timestamp - $reference) <= self::SIGNAL_WINDOW) {
+                    switch ($slug) {
+                        case 'aws':
+                            $signals[] = 'aws:rss+new_item';
+                            break;
+                        case 'azure':
+                            $signals[] = 'azure:rss+new_item';
+                            break;
+                        case 'gcp':
+                            $signals[] = 'gcp:json+new_item';
+                            break;
+                        default:
+                            $signals[] = $slug . ':incident';
+                            break;
+                    }
+                    break;
+                }
+            }
+
+            if ('cloudflare' === $slug && in_array($overall, ['degraded', 'major', 'outage'], true)) {
+                $signals[] = 'cloudflare:indicator=' . $overall;
+            }
+        }
+
+        return $signals;
+    }
+
+    private function latest_timestamp(array $incident): int
+    {
+        foreach (['updated_at', 'updatedAt', 'started_at', 'startedAt'] as $key) {
+            if (empty($incident[$key])) {
+                continue;
+            }
+            $time = strtotime((string) $incident[$key]);
+            if ($time) {
+                return $time;
+            }
+        }
+
+        return 0;
+    }
+
+    private function recent_signals(array $buffer, int $timestamp): array
+    {
+        $signals = [];
+
+        foreach ($buffer as $entry) {
+            if (!is_array($entry) || empty($entry['signals']) || empty($entry['ts'])) {
+                continue;
+            }
+
+            $ts = (int) $entry['ts'];
+            if (($timestamp - $ts) > self::SIGNAL_WINDOW) {
+                continue;
+            }
+
+            if (is_array($entry['signals'])) {
+                $signals = array_merge($signals, $entry['signals']);
+            }
+        }
+
+        return $signals;
+    }
+
+    private function prune_buffer(array $buffer, int $timestamp): array
+    {
+        $cutoff = $timestamp - self::BUFFER_WINDOW;
+
+        $buffer = array_filter(
+            $buffer,
+            static function ($entry) use ($cutoff) {
+                if (!is_array($entry) || empty($entry['ts'])) {
+                    return false;
+                }
+                return ((int) $entry['ts']) >= $cutoff;
+            }
+        );
+
+        if (count($buffer) > self::MAX_SIGNAL_LOG) {
+            $buffer = array_slice(array_values($buffer), -1 * self::MAX_SIGNAL_LOG);
+        }
+
+        return array_values($buffer);
+    }
+
+    private function load_buffer(): array
+    {
+        $buffer = get_option(self::OPTION_KEY, []);
+        return is_array($buffer) ? $buffer : [];
+    }
+
+    private function store_buffer(array $buffer): void
+    {
+        update_option(self::OPTION_KEY, $buffer, false);
+    }
+}

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -18,6 +18,7 @@ require_once LOUSY_OUTAGES_PATH . 'includes/Fetch.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Adapters.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Adapters/Statuspage.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Store.php';
+require_once LOUSY_OUTAGES_PATH . 'includes/Trending.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Fetcher.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Downdetector.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/I18n.php';


### PR DESCRIPTION
## Summary
- expand the summary fetcher with a typed provider registry covering Statuspage vendors plus AWS, Azure, GCP, Zscaler, and CrowdStrike
- add response caching with conditional requests, RSS/JSON adapters, and a trending detector shared by the REST API and dashboard
- surface the new data on the front-end with visibility-aware auto-refresh, If-None-Match support, and a neon "trending" banner with Downdetector link

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_69013152a940832ebda1902af6edcdcf