### PR TITLE
Implement Lousy Outages v3 feed and frontend upgrades

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -10,6 +10,14 @@ get_header();
             <span class="hero-quote__text">&ldquo;This is what it feels like to be hunted by something smarter than you.&rdquo;</span>
             <span class="hero-quote__attr">&mdash; <a href="https://www.youtube.com/watch?v=NQr9EcRyIFs" target="_blank" rel="noopener">Grimes, Artificial Angels</a></span>
         </div>
+        <div class="lo-home-promo">
+            <div class="lo-home-promo__card crt-block">
+                <span class="lo-home-promo__badge" data-lo-home-badge hidden>⚡ Trending now</span>
+                <h3 class="lo-home-promo__title">Lousy Outages — live status radar</h3>
+                <p class="lo-home-promo__subtitle">Cloudflare, AWS, Azure, GCP, Stripe, Okta and more. Auto-refreshing. Built by a bassist-turned-builder.</p>
+                <a class="pixel-button lo-home-promo__button" href="/lousy-outages/">Open dashboard →</a>
+            </div>
+        </div>
         <h2 class="retro-title glow-lite">Musician &amp; Creative Technologist</h2>
         <section class="pixel-intro" style="max-width: 720px; margin: 0 auto; line-height: 1.8; font-size: 1.05rem;">
     <p>I&rsquo;m a musician, technologist, and creative builder based in Vancouver.</p>
@@ -125,4 +133,38 @@ get_header();
     </section>
 </main>
 
+    <script>
+      (function () {
+        var badge = document.querySelector('[data-lo-home-badge]');
+        if (!badge || typeof window.fetch !== 'function') {
+          return;
+        }
+        var endpoint = '<?php echo esc_url_raw(rest_url('lousy-outages/v1/summary')); ?>?lite=1';
+        fetch(endpoint, {
+          headers: { 'Accept': 'application/json' },
+          credentials: 'same-origin',
+          cache: 'no-store'
+        })
+          .then(function (res) {
+            if (!res) {
+              return null;
+            }
+            if (res.status === 204) {
+              return null;
+            }
+            if (res.status >= 200 && res.status < 300) {
+              return res.json().catch(function () { return null; });
+            }
+            return null;
+          })
+          .then(function (data) {
+            if (data && data.trending) {
+              badge.removeAttribute('hidden');
+            }
+          })
+          .catch(function () {
+            // ignore errors on homepage badge
+          });
+      }());
+    </script>
 <?php get_footer(); ?>

--- a/page-subscribe-thanks.php
+++ b/page-subscribe-thanks.php
@@ -1,0 +1,16 @@
+<?php
+/* Template Name: Lousy Outages Subscribe Thanks */
+get_header();
+?>
+<main class="subscribe-thanks">
+  <section class="lo-thanks-card crt-block" style="max-width:600px;margin:80px auto;padding:48px;border-radius:18px;background:#0d130d;color:#e8ffee;box-shadow:0 16px 48px rgba(0,0,0,0.35);text-align:center;">
+    <h1 class="retro-title glow-lite" style="font-size:2rem;margin-bottom:24px;">Subscribed to Lousy Outages</h1>
+    <?php if (!empty($_GET['error'])) : ?>
+      <p style="font-size:1.1rem;margin-bottom:16px;">We couldn’t add that email address. Please head back and try again.</p>
+    <?php else : ?>
+      <p style="font-size:1.1rem;margin-bottom:16px;">Check your inbox for a confirmation email. Once you click the link you’ll start receiving outage alerts.</p>
+    <?php endif; ?>
+    <a class="pixel-button" href="<?php echo esc_url(home_url('/lousy-outages/')); ?>">Return to dashboard →</a>
+  </section>
+</main>
+<?php get_footer(); ?>

--- a/style.css
+++ b/style.css
@@ -1519,3 +1519,60 @@ body {
   padding: 10px;
   border-left: 4px solid var(--accent-color);
 }
+
+/* Lousy Outages homepage promo */
+.lo-home-promo {
+    margin: 32px auto 48px;
+    max-width: 720px;
+}
+.lo-home-promo__card {
+    position: relative;
+    border: 2px solid rgba(113, 255, 206, 0.7);
+    border-radius: 20px;
+    padding: 28px 32px 32px;
+    background: linear-gradient(135deg, rgba(8, 18, 12, 0.95), rgba(18, 28, 20, 0.92));
+    color: #e4ffee;
+    box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
+    overflow: hidden;
+}
+.lo-home-promo__card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image: repeating-linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.05) 0,
+        rgba(255, 255, 255, 0.05) 1px,
+        transparent 1px,
+        transparent 4px
+    );
+    mix-blend-mode: overlay;
+    pointer-events: none;
+}
+.lo-home-promo__title {
+    font-size: 1.6rem;
+    margin: 0 0 12px;
+}
+.lo-home-promo__subtitle {
+    font-size: 1.05rem;
+    margin: 0 0 20px;
+    line-height: 1.6;
+}
+.lo-home-promo__button {
+    margin-top: 8px;
+}
+.lo-home-promo__badge {
+    position: absolute;
+    top: 16px;
+    right: 20px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 12px;
+    font-size: 0.75rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    background: rgba(255, 255, 255, 0.12);
+    border-radius: 999px;
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
+}


### PR DESCRIPTION
## Summary
- overhaul the Lousy Outages fetcher with the new provider registry, caching/ETag handling, and RSS/Atom/PagerDuty strategies
- refresh the REST endpoints and dashboard assets to use ETags, severity sorting, improved polling/backoff, and AJAX subscribe responses
- add the homepage promo badge flow, neon styling, and a subscribe confirmation template

## Testing
- php -l lousy-outages/includes/Fetcher.php
- php -l lousy-outages/includes/Api.php
- php -l page-home.php
- php -l page-subscribe-thanks.php

------
https://chatgpt.com/codex/tasks/task_e_69013f0e3710832e8eb43ee7ff1e61f7