### PR TITLE
LO: solid confirm/unsubscribe + cleaner sources + smarter refresh

### DIFF
--- a/lousy-outages/README.md
+++ b/lousy-outages/README.md
@@ -11,27 +11,24 @@ Monitor third‑party service status and get SMS and email alerts when things br
 | openai | OpenAI | https://status.openai.com/api/v2/summary.json |
 | atlassian | Atlassian | https://status.atlassian.com/api/v2/summary.json |
 | digitalocean | DigitalOcean | https://status.digitalocean.com/api/v2/summary.json |
-| gitlab | GitLab | https://status.gitlab.com/api/v2/summary.json |
+| gitlab | GitLab | https://status.gitlab.com/pages/5b36dc6502d06804c08349f7/rss |
 | netlify | Netlify | https://www.netlifystatus.com/api/v2/summary.json |
 | vercel | Vercel | https://www.vercel-status.com/api/v2/summary.json |
-| okta | Okta | https://status.okta.com/api/v2/summary.json |
 | pagerduty | PagerDuty | https://status.pagerduty.com/api/v2/summary.json |
 | zoom | Zoom | https://status.zoom.us/api/v2/summary.json |
-| zscaler | Zscaler | https://trust.zscaler.com/api/v2/summary.json |
-| stripe | Stripe | https://status.stripe.com/api/v2/summary.json |
+| zscaler | Zscaler | https://trust.zscaler.com/rss-feed |
+| stripe | Stripe | https://www.stripestatus.com/history.rss |
 | twilio | Twilio | https://status.twilio.com/api/v2/summary.json |
-| fastly | Fastly | https://status.fastly.com/api/v2/summary.json |
 | datadog | Datadog | https://status.datadoghq.com/api/v2/summary.json |
-| notion | Notion | https://www.notionstatus.com/api/v2/summary.json |
 | linear | Linear | https://status.linear.app/api/v2/summary.json |
 | sentry | Sentry | https://status.sentry.io/api/v2/summary.json |
 | slack | Slack | https://slack-status.com/api/v2.0.0/current |
 | aws | AWS | https://status.aws.amazon.com/rss/all.rss |
 | azure | Azure | https://azurestatuscdn.azureedge.net/en-us/status/feed/ |
-| gcp | Google Cloud | https://status.cloud.google.com/feed.atom |
+| gcp | Google Cloud | https://www.google.com/appsstatus/dashboard/en-CA/feed.atom |
 | downdetector-ca | Downdetector (CA Aggregate) | https://downdetector.ca/archive/?format=rss |
 
-Slack now uses the official `slack-status.com/api/v2.0.0/current` endpoint so green states render the "All systems operational" headline, and Zscaler is polled from `https://trust.zscaler.com` to dodge intermittent DNS failures. New default providers include Stripe, Twilio, Fastly, Datadog, Notion, Linear, and Sentry—toggle any of them from **Settings → Lousy Outages**.
+Slack now uses the official `slack-status.com/api/v2.0.0/current` endpoint so green states render the "All systems operational" headline, and Zscaler is polled from `https://trust.zscaler.com` to dodge intermittent DNS failures. New default providers include Stripe, Twilio, Datadog, Linear, and Sentry—toggle any of them from **Settings → Lousy Outages**.
 
 Downdetector is disabled by default because the RSS feed is unofficial and can disappear; enable it from the settings page if it loads for you. When the feed is unreachable, the adapter reports an `unknown` state with an error badge rather than failing the whole poll.
 

--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -322,6 +322,13 @@
   color: #c9ffc4;
 }
 
+.lo-subscribe__title {
+  margin: 0 0 6px;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #f4fff0;
+}
+
 .lo-subscribe__intro {
   margin: 0 0 12px;
   font-size: 0.95rem;

--- a/lousy-outages/includes/Downdetector.php
+++ b/lousy-outages/includes/Downdetector.php
@@ -153,7 +153,6 @@ class Downdetector {
             'vercel'      => ['vercel'],
             'atlassian'   => ['atlassian', 'jira', 'confluence', 'bitbucket'],
             'pagerduty'   => ['pagerduty', 'pager duty'],
-            'okta'        => ['okta'],
             'zoom'        => ['zoom'],
         ];
 

--- a/lousy-outages/includes/Providers.php
+++ b/lousy-outages/includes/Providers.php
@@ -10,20 +10,17 @@ namespace {
             ['id' => 'openai', 'name' => 'OpenAI', 'type' => 'statuspage', 'url' => 'https://status.openai.com/api/v2/summary.json'],
             ['id' => 'atlassian', 'name' => 'Atlassian', 'type' => 'statuspage', 'url' => 'https://status.atlassian.com/api/v2/summary.json'],
             ['id' => 'digitalocean', 'name' => 'DigitalOcean', 'type' => 'statuspage', 'url' => 'https://status.digitalocean.com/api/v2/summary.json'],
-            ['id' => 'gitlab', 'name' => 'GitLab', 'type' => 'statuspage', 'url' => 'https://status.gitlab.com/api/v2/summary.json', 'status_endpoint' => 'https://status.gitlab.com/api/v2/status.json'],
+            ['id' => 'gitlab', 'name' => 'GitLab', 'type' => 'rss', 'url' => 'https://status.gitlab.com/pages/5b36dc6502d06804c08349f7/rss'],
             ['id' => 'netlify', 'name' => 'Netlify', 'type' => 'statuspage', 'url' => 'https://www.netlifystatus.com/api/v2/summary.json'],
             ['id' => 'vercel', 'name' => 'Vercel', 'type' => 'statuspage', 'url' => 'https://www.vercel-status.com/api/v2/summary.json'],
-            ['id' => 'okta', 'name' => 'Okta', 'type' => 'statuspage', 'url' => 'https://status.okta.com/api/v2/summary.json', 'status_endpoint' => 'https://status.okta.com/api/v2/status.json'],
             ['id' => 'pagerduty', 'name' => 'PagerDuty', 'type' => 'statuspage', 'url' => 'https://status.pagerduty.com/api/v2/summary.json'],
             ['id' => 'zoom', 'name' => 'Zoom', 'type' => 'statuspage', 'url' => 'https://status.zoom.us/api/v2/summary.json'],
-            ['id' => 'zscaler', 'name' => 'Zscaler', 'type' => 'statuspage', 'url' => 'https://trust.zscaler.com/api/v2/summary.json', 'status_endpoint' => 'https://trust.zscaler.com/api/v2/status.json'],
+            ['id' => 'zscaler', 'name' => 'Zscaler', 'type' => 'rss', 'url' => 'https://trust.zscaler.com/rss-feed'],
 
             // High-value adds (Statuspage JSON)
-            ['id' => 'stripe', 'name' => 'Stripe', 'type' => 'statuspage', 'url' => 'https://status.stripe.com/api/v2/summary.json', 'status_endpoint' => 'https://status.stripe.com/api/v2/status.json'],
+            ['id' => 'stripe', 'name' => 'Stripe', 'type' => 'rss', 'url' => 'https://www.stripestatus.com/history.rss'],
             ['id' => 'twilio', 'name' => 'Twilio', 'type' => 'statuspage', 'url' => 'https://status.twilio.com/api/v2/summary.json'],
-            ['id' => 'fastly', 'name' => 'Fastly', 'type' => 'statuspage', 'url' => 'https://status.fastly.com/api/v2/summary.json', 'status_endpoint' => 'https://status.fastly.com/api/v2/status.json'],
             ['id' => 'datadog', 'name' => 'Datadog', 'type' => 'statuspage', 'url' => 'https://status.datadoghq.com/api/v2/summary.json'],
-            ['id' => 'notion', 'name' => 'Notion', 'type' => 'statuspage', 'url' => 'https://www.notionstatus.com/api/v2/summary.json', 'status_endpoint' => 'https://www.notionstatus.com/api/v2/status.json'],
             ['id' => 'linear', 'name' => 'Linear', 'type' => 'statuspage', 'url' => 'https://status.linear.app/api/v2/summary.json'],
             ['id' => 'sentry', 'name' => 'Sentry', 'type' => 'statuspage', 'url' => 'https://status.sentry.io/api/v2/summary.json'],
 
@@ -33,7 +30,7 @@ namespace {
             // RSS/Atom feeds
             ['id' => 'aws', 'name' => 'AWS', 'type' => 'rss', 'url' => 'https://status.aws.amazon.com/rss/all.rss'],
             ['id' => 'azure', 'name' => 'Azure', 'type' => 'rss', 'url' => 'https://azurestatuscdn.azureedge.net/en-us/status/feed/'],
-            ['id' => 'gcp', 'name' => 'Google Cloud', 'type' => 'atom', 'url' => 'https://status.cloud.google.com/feed.atom'],
+            ['id' => 'gcp', 'name' => 'Google Cloud', 'type' => 'atom', 'url' => 'https://www.google.com/appsstatus/dashboard/en-CA/feed.atom'],
 
             // Optional aggregate (disabled by default in settings)
             ['id' => 'downdetector-ca', 'name' => 'Downdetector (CA Aggregate)', 'type' => 'rss', 'url' => 'https://downdetector.ca/archive/?format=rss', 'disabled' => true, 'optional' => true],
@@ -155,11 +152,9 @@ namespace LousyOutages {
 
         private static function derive_status_url( array $provider ): string {
             $wellKnown = [
-                'fastly'  => 'https://www.fastlystatus.com/',
                 'zscaler' => 'https://trust.zscaler.com/',
                 'stripe'  => 'https://status.stripe.com/',
                 'gitlab'  => 'https://status.gitlab.com/',
-                'notion'  => 'https://www.notionstatus.com/',
             ];
 
             if ( ! empty( $provider['id'] ) && isset( $wellKnown[ $provider['id'] ] ) ) {

--- a/lousy-outages/includes/Subscribe.php
+++ b/lousy-outages/includes/Subscribe.php
@@ -24,20 +24,42 @@ class Lousy_Outages_Subscribe {
 
     public static function confirm(\WP_REST_Request $request) {
         $token = sanitize_text_field((string) $request->get_param('token'));
-        if ('' === $token || !self::mark_confirmed($token)) {
-            return self::redirect('/lousy-outages/?sub=invalid');
+        if ('' === $token) {
+            return self::redirect_with_status('invalid');
         }
 
-        return self::redirect('/lousy-outages/?sub=confirmed');
+        $record = Subscriptions::find_by_token($token);
+        if (!$record) {
+            return self::redirect_with_status('invalid');
+        }
+
+        $status = strtolower((string) ($record['status'] ?? ''));
+        if (Subscriptions::STATUS_SUBSCRIBED === $status) {
+            return self::redirect_with_status('confirmed');
+        }
+
+        if (!self::mark_confirmed($token)) {
+            return self::redirect_with_status('invalid');
+        }
+
+        $email = isset($record['email']) ? sanitize_email((string) $record['email']) : '';
+        if ($email && is_email($email)) {
+            $unsubscribe_link = home_url('/wp-json/lousy-outages/v1/unsubscribe?token=' . rawurlencode($token));
+            $subject = 'Lousy Outages: subscription confirmed';
+            $body    = "You'll now receive outage alerts. Unsubscribe anytime: {$unsubscribe_link}";
+            wp_mail($email, $subject, $body, ['Content-Type: text/plain; charset=UTF-8']);
+        }
+
+        return self::redirect_with_status('confirmed');
     }
 
     public static function unsubscribe(\WP_REST_Request $request) {
         $token = sanitize_text_field((string) $request->get_param('token'));
         if ('' === $token || !self::mark_unsubscribed($token)) {
-            return self::redirect('/lousy-outages/?sub=invalid');
+            return self::redirect_with_status('invalid');
         }
 
-        return self::redirect('/lousy-outages/?sub=unsubscribed');
+        return self::redirect_with_status('unsubscribed');
     }
 
     private static function mark_confirmed(string $token): bool {
@@ -77,6 +99,35 @@ class Lousy_Outages_Subscribe {
         }
 
         return Subscriptions::update_status_by_token($token, Subscriptions::STATUS_UNSUBSCRIBED);
+    }
+
+    private static function redirect_with_status(string $status) {
+        $status = sanitize_key($status);
+        if ($status) {
+            self::store_flash_cookie($status);
+        }
+        return self::redirect('/lousy-outages/?sub=' . rawurlencode($status ?: '')); 
+    }
+
+    private static function store_flash_cookie(string $status): void {
+        if (headers_sent()) {
+            return;
+        }
+
+        $value = sanitize_key($status);
+        if ('' === $value) {
+            return;
+        }
+
+        $params = [
+            'expires'  => time() + 300,
+            'path'     => '/',
+            'secure'   => is_ssl(),
+            'httponly' => false,
+            'samesite' => 'Lax',
+        ];
+
+        setcookie('lo_sub_msg', $value, $params);
     }
 
     private static function redirect(string $path) {

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -332,7 +332,8 @@ function render_subscribe_shortcode(): string {
     ob_start();
     ?>
     <div class="lo-subscribe" data-lo-subscribe>
-        <p class="lo-subscribe__intro">Subscribe by email or <a href="<?php echo $rss_url; ?>" target="_blank" rel="noopener">RSS</a>.</p>
+        <h2 class="lo-subscribe__title">Subscribe by email or RSS</h2>
+        <p class="lo-subscribe__intro">Get outage alerts in your inbox or follow the <a href="<?php echo $rss_url; ?>" target="_blank" rel="noopener">RSS feed</a>.</p>
         <form class="lo-subscribe__form" method="post" action="<?php echo esc_url($endpoint); ?>" data-lo-subscribe-form>
             <label class="lo-subscribe__label">
                 <span>Email</span>

--- a/page-lousy-outages.php
+++ b/page-lousy-outages.php
@@ -3,6 +3,16 @@
 get_header();
 
 $sub_status = isset($_GET['sub']) ? sanitize_key(wp_unslash($_GET['sub'])) : '';
+$cookie_status = '';
+if (isset($_COOKIE['lo_sub_msg'])) {
+    $cookie_status = sanitize_key(wp_unslash($_COOKIE['lo_sub_msg']));
+    if ('' === $sub_status && '' !== $cookie_status) {
+        $sub_status = $cookie_status;
+    }
+    if (!headers_sent()) {
+        setcookie('lo_sub_msg', '', time() - HOUR_IN_SECONDS, '/', '', is_ssl(), false);
+    }
+}
 $banner     = '';
 $tone       = 'info';
 


### PR DESCRIPTION
## Summary
- ensure confirm/unsubscribe routes send confirmation email, reuse tokens idempotently, and set flash cookies so banners survive caches
- improve subscribe UX and auto-refresh handling with Accept-aware responses, inline success messaging, and adaptive degraded/backoff logic
- retire noisy providers, update cloud/source feeds, enforce severity-based sorting, and tighten widespread issue detection

## Testing
- `php -l lousy-outages/includes/Subscribe.php`
- `php -l lousy-outages/includes/Api.php`
- `php -l lousy-outages/includes/Fetcher.php`
- `php -l lousy-outages/includes/Trending.php`
- `php -l page-lousy-outages.php`
- `php -l lousy-outages/includes/Providers.php`
- `php -l lousy-outages/includes/Downdetector.php`


------
https://chatgpt.com/codex/tasks/task_e_6901650ecf3c832ebe440595abf6e907