### PR TITLE
Refresh Lousy Outages emails and update site copy

### DIFF
--- a/lousy-outages/includes/Api.php
+++ b/lousy-outages/includes/Api.php
@@ -200,13 +200,7 @@ class Api {
 
         Subscriptions::save_pending($email, $token, $ip_hash, 'form');
 
-        $confirm_url     = add_query_arg('token', rawurlencode($token), rest_url('lousy-outages/v1/confirm'));
-        $unsubscribe_url = add_query_arg('token', rawurlencode($token), rest_url('lousy-outages/v1/unsubscribe'));
-
-        $subject = 'Confirm your Lousy Outages subscription';
-        $message = "Hi there!\n\nPlease confirm your email to receive Lousy Outages alerts.\n\nConfirm subscription: {$confirm_url}\n\nIf you didn't request this, ignore this email or unsubscribe here: {$unsubscribe_url}\n\n— Lousy Outages";
-
-        wp_mail($email, $subject, $message, ['Content-Type: text/plain; charset=UTF-8']);
+        \Lousy_Outages_Subscribe::send_confirm_email($email, $token);
 
         return self::respond_with_message(true, 'Check your email to confirm your subscription.', 200, $request);
     }

--- a/lousy-outages/includes/Mailer.php
+++ b/lousy-outages/includes/Mailer.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace LousyOutages;
+
+class Mailer {
+    public static function send(string $email, string $subject, string $text_body, string $html_body): void {
+        $email = sanitize_email($email);
+        if (!$email || !is_email($email)) {
+            do_action('lousy_outages_log', 'email_skip', ['reason' => 'invalid_recipient']);
+            return;
+        }
+
+        $boundary = 'lo-' . wp_generate_password(24, false, false);
+        $headers  = [
+            'MIME-Version: 1.0',
+            'Content-Type: multipart/alternative; boundary="' . $boundary . '"; charset=UTF-8',
+        ];
+
+        $parts = [];
+        $parts[] = '--' . $boundary;
+        $parts[] = 'Content-Type: text/plain; charset=UTF-8';
+        $parts[] = 'Content-Transfer-Encoding: 8bit';
+        $parts[] = '';
+        $parts[] = $text_body;
+        $parts[] = '--' . $boundary;
+        $parts[] = 'Content-Type: text/html; charset=UTF-8';
+        $parts[] = 'Content-Transfer-Encoding: 8bit';
+        $parts[] = '';
+        $parts[] = $html_body;
+        $parts[] = '--' . $boundary . '--';
+        $parts[] = '';
+
+        $message = implode("\r\n", $parts);
+
+        wp_mail($email, $subject, $message, $headers);
+    }
+}

--- a/lousy-outages/includes/Subscribe.php
+++ b/lousy-outages/includes/Subscribe.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use LousyOutages\Mailer;
 use LousyOutages\Subscriptions;
 
 class Lousy_Outages_Subscribe {
@@ -34,7 +35,12 @@ class Lousy_Outages_Subscribe {
         }
 
         $status = strtolower((string) ($record['status'] ?? ''));
+        $email  = isset($record['email']) ? sanitize_email((string) $record['email']) : '';
+
         if (Subscriptions::STATUS_SUBSCRIBED === $status) {
+            if ($email && is_email($email)) {
+                self::send_already_subscribed_email($email, $token);
+            }
             return self::redirect_with_status('confirmed');
         }
 
@@ -42,12 +48,8 @@ class Lousy_Outages_Subscribe {
             return self::redirect_with_status('invalid');
         }
 
-        $email = isset($record['email']) ? sanitize_email((string) $record['email']) : '';
         if ($email && is_email($email)) {
-            $unsubscribe_link = home_url('/wp-json/lousy-outages/v1/unsubscribe?token=' . rawurlencode($token));
-            $subject = 'Lousy Outages: subscription confirmed';
-            $body    = "You'll now receive outage alerts. Unsubscribe anytime: {$unsubscribe_link}";
-            wp_mail($email, $subject, $body, ['Content-Type: text/plain; charset=UTF-8']);
+            self::send_welcome_email($email, $token);
         }
 
         return self::redirect_with_status('confirmed');
@@ -55,11 +57,68 @@ class Lousy_Outages_Subscribe {
 
     public static function unsubscribe(\WP_REST_Request $request) {
         $token = sanitize_text_field((string) $request->get_param('token'));
-        if ('' === $token || !self::mark_unsubscribed($token)) {
+        if ('' === $token) {
             return self::redirect_with_status('invalid');
         }
 
+        $record = Subscriptions::find_by_token($token);
+        if (!$record) {
+            return self::redirect_with_status('invalid');
+        }
+
+        if (!self::mark_unsubscribed($token)) {
+            return self::redirect_with_status('invalid');
+        }
+
+        $email = isset($record['email']) ? sanitize_email((string) $record['email']) : '';
+        if ($email && is_email($email)) {
+            self::send_unsubscribed_email($email);
+        }
+
         return self::redirect_with_status('unsubscribed');
+    }
+
+    public static function send_confirm_email(string $email, string $token): void {
+        $email = sanitize_email($email);
+        if (!$email || !is_email($email)) {
+            return;
+        }
+
+        $confirm_url     = add_query_arg('token', rawurlencode($token), rest_url('lousy-outages/v1/confirm'));
+        $unsubscribe_url = add_query_arg('token', rawurlencode($token), rest_url('lousy-outages/v1/unsubscribe'));
+
+        $subject = '👾 jack in to Lousy Outages (confirm your email)';
+
+        $text_body = <<<TEXT
+hey there, console cowboy ⚡
+
+you (or a very stylish bot) asked to receive Lousy Outages alerts.
+click to confirm your human-ness and join the swarm:
+
+CONFIRM ▶ {$confirm_url}
+
+if you didn't request this, chill—no packets were harmed.
+ignore this or nuke it here: {$unsubscribe_url}
+
+— lousy outages • inspired by wrangling third-party providers in IT. built by a bassist-turned-builder
+TEXT;
+
+        $html_body = <<<HTML
+<!doctype html>
+<meta charset="utf-8">
+<body style="font-family: ui-sans-serif,system-ui,Segoe UI,Roboto,Arial; background:#0b0b0b; color:#e6ffe6;">
+  <div style="max-width:560px;margin:24px auto;padding:16px;border:2px solid #39ff14;border-radius:12px;">
+    <h2 style="margin:0 0 8px;font-size:20px;">👾 jack in to Lousy Outages</h2>
+    <p>you (or a very stylish bot) asked to receive outage alerts.</p>
+    <p><a href="{$confirm_url}" style="display:inline-block;padding:10px 14px;border:2px solid #39ff14;border-radius:10px;text-decoration:none;color:#39ff14;">CONFIRM SUBSCRIPTION</a></p>
+    <p style="opacity:.8">not you? <a href="{$unsubscribe_url}" style="color:#39ff14;">unsubscribe</a> or just ignore this.</p>
+    <hr style="border:none;border-top:1px dashed #39ff14;opacity:.4">
+    <p style="font-size:12px;opacity:.75;">lousy outages — inspired by wrangling third-party providers in IT.</p>
+  </div>
+</body>
+HTML;
+
+        Mailer::send($email, $subject, $text_body, $html_body);
     }
 
     private static function mark_confirmed(string $token): bool {
@@ -134,6 +193,106 @@ class Lousy_Outages_Subscribe {
         status_header(302);
         header('Location: ' . home_url($path));
         exit;
+    }
+
+    private static function send_welcome_email(string $email, string $token): void {
+        $unsubscribe_url = add_query_arg('token', rawurlencode($token), rest_url('lousy-outages/v1/unsubscribe'));
+        $dashboard_url   = home_url('/lousy-outages/');
+
+        $subject = '✅ link established: you\'re on the outage radar';
+
+        $text_body = <<<TEXT
+confirmed. welcome to the status underground. 🛰️
+
+you'll get tidy alerts when third-party providers wobble:
+cloudflare • aws • azure • gcp • stripe • pagerduty • zscaler (and friends)
+
+pro tip: bookmark the live dashboard:
+{$dashboard_url}
+
+done with the fun? one-click escape hatch:
+{$unsubscribe_url}
+
+"This is what it feels like to be hunted by something smarter than you."
+— Grimes, Artificial Angels
+TEXT;
+
+        $html_body = <<<HTML
+<!doctype html>
+<meta charset="utf-8">
+<body style="font-family: ui-sans-serif,system-ui,Segoe UI,Roboto,Arial; background:#0b0b0b; color:#e6ffe6;">
+  <div style="max-width:560px;margin:24px auto;padding:16px;border:2px solid #39ff14;border-radius:12px;">
+    <h2 style="margin:0 0 8px;font-size:20px;">✅ link established</h2>
+    <p>welcome to the status underground.</p>
+    <p>you'll get alerts when providers wobble: cloudflare • aws • azure • gcp • stripe • pagerduty • zscaler.</p>
+    <p><a href="{$dashboard_url}" style="display:inline-block;padding:10px 14px;border:2px solid #39ff14;border-radius:10px;text-decoration:none;color:#39ff14;">OPEN LIVE DASHBOARD</a></p>
+    <blockquote style="margin:12px 0;padding:8px 12px;border-left:3px solid #39ff14;opacity:.85;">
+      “This is what it feels like to be hunted by something smarter than you.”<br>
+      — Grimes, <a href="https://www.youtube.com/watch?v=tvGnYM14-1A" style="color:#39ff14;">Artificial Angels</a>
+    </blockquote>
+    <p style="font-size:12px;opacity:.75;">unsubscribe anytime: <a href="{$unsubscribe_url}" style="color:#39ff14;">{$unsubscribe_url}</a></p>
+  </div>
+</body>
+HTML;
+
+        Mailer::send($email, $subject, $text_body, $html_body);
+    }
+
+    private static function send_already_subscribed_email(string $email, string $token): void {
+        $dashboard_url   = home_url('/lousy-outages/');
+        $unsubscribe_url = add_query_arg('token', rawurlencode($token), rest_url('lousy-outages/v1/unsubscribe'));
+
+        $subject = 'you\'re already on the radar (all good)';
+
+        $text_body = <<<TEXT
+no double-hacking needed—your email is already subscribed.
+dashboard: {$dashboard_url}
+unsubscribe: {$unsubscribe_url}
+TEXT;
+
+        $html_body = <<<HTML
+<!doctype html>
+<meta charset="utf-8">
+<body style="font-family: ui-sans-serif,system-ui,Segoe UI,Roboto,Arial; background:#0b0b0b; color:#e6ffe6;">
+  <div style="max-width:560px;margin:24px auto;padding:16px;border:2px solid #39ff14;border-radius:12px;">
+    <h2 style="margin:0 0 8px;font-size:20px;">already connected</h2>
+    <p>no double-hacking needed—your email is already subscribed.</p>
+    <p><a href="{$dashboard_url}" style="color:#39ff14;">open the dashboard</a> • <a href="{$unsubscribe_url}" style="color:#39ff14;">unsubscribe</a></p>
+  </div>
+</body>
+HTML;
+
+        Mailer::send($email, $subject, $text_body, $html_body);
+    }
+
+    private static function send_unsubscribed_email(string $email): void {
+        $resubscribe_url = home_url('/lousy-outages/?sub=check-email');
+
+        $subject = '🧹 wire cut. you\'re unsubscribed.';
+
+        $text_body = <<<TEXT
+you've been cleanly removed from Lousy Outages alerts.
+
+if this was a mistake, jack back in here:
+{$resubscribe_url}  (or just re-enter your email on the site)
+
+until next breach window—stay weird, stay patched.
+TEXT;
+
+        $html_body = <<<HTML
+<!doctype html>
+<meta charset="utf-8">
+<body style="font-family: ui-sans-serif,system-ui,Segoe UI,Roboto,Arial; background:#0b0b0b; color:#e6ffe6;">
+  <div style="max-width:560px;margin:24px auto;padding:16px;border:2px solid #39ff14;border-radius:12px;">
+    <h2 style="margin:0 0 8px;font-size:20px;">🧹 wire cut</h2>
+    <p>you're unsubscribed and off the grid.</p>
+    <p style="opacity:.85">if that was accidental, <a href="{$resubscribe_url}" style="color:#39ff14;">re-subscribe</a> any time.</p>
+    <p style="font-size:12px;opacity:.7;">built in vancouver with coffee, riffs, and command-line confidence.</p>
+  </div>
+</body>
+HTML;
+
+        Mailer::send($email, $subject, $text_body, $html_body);
     }
 }
 

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -24,6 +24,7 @@ require_once LOUSY_OUTAGES_PATH . 'includes/Downdetector.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/I18n.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Detector.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/SMS.php';
+require_once LOUSY_OUTAGES_PATH . 'includes/Mailer.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Email.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Precursor.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Subscriptions.php';

--- a/page-contact.php
+++ b/page-contact.php
@@ -20,10 +20,6 @@ get_header(); ?>
       <a href="https://www.suzyeaston.ca">suzyeaston.ca</a>
     </p>
 
-    <p><strong>LinkedIn:</strong>
-      <a href="https://ca.linkedin.com/in/suzyeaston" target="_blank">ca.linkedin.com/in/suzyeaston</a> <!-- :contentReference[oaicite:0]{index=0} -->
-    </p>
-
     <p><strong>Instagram:</strong>
       <a href="https://www.instagram.com/officialsuzyeaston/" target="_blank">@officialsuzyeaston</a> <!-- :contentReference[oaicite:1]{index=1} -->
     </p>
@@ -55,15 +51,6 @@ get_header(); ?>
           easylivingwithsuzyeaston.podbean.com
         </a>
       </noscript>
-    </p>
-
-    <p><strong>More LinkedIn Posts:</strong><br>
-      • <a href="https://www.linkedin.com/posts/suzyeaston_a-little-louder-activity-7289087085448179712-NjhS" target="_blank">
-        “A Little Louder” reminder on Spotify</a> <!-- :contentReference[oaicite:6]{index=6} --><br>
-      • <a href="https://www.linkedin.com/posts/suzyeaston_suzys-guide-to-vancouvers-april-5th-city-activity-7305153007908790272-P-6s" target="_blank">
-        Podcast launch post</a> <!-- :contentReference[oaicite:7]{index=7} --><br>
-      • <a href="https://www.linkedin.com/posts/suzyeaston_earlyriserchallenge-formerpromusicianturnedqa-activity-7122588141936406528-lQRW" target="_blank">
-        “Early Riser Challenge” QA post</a> <!-- :contentReference[oaicite:8]{index=8} -->
     </p>
 
     <p style="text-align:center;">🎶 <a href="https://suzyeaston.bandcamp.com" target="_blank">Support on Bandcamp</a></p>

--- a/page-home.php
+++ b/page-home.php
@@ -8,13 +8,13 @@ get_header();
         <h1 class="retro-title glow-lite">Suzy Easton &mdash; Vancouver</h1>
         <div class="hero-quote">
             <span class="hero-quote__text">&ldquo;This is what it feels like to be hunted by something smarter than you.&rdquo;</span>
-            <span class="hero-quote__attr">&mdash; <a href="https://www.youtube.com/watch?v=NQr9EcRyIFs" target="_blank" rel="noopener">Grimes, Artificial Angels</a></span>
+            <span class="hero-quote__attr">&mdash; <a href="https://www.youtube.com/watch?v=tvGnYM14-1A" target="_blank" rel="noopener">Grimes, Artificial Angels</a></span>
         </div>
         <div class="lo-home-promo">
             <div class="lo-home-promo__card crt-block">
                 <span class="lo-home-promo__badge" data-lo-home-badge hidden>⚡ Trending now</span>
                 <h3 class="lo-home-promo__title">Lousy Outages — live status radar</h3>
-                <p class="lo-home-promo__subtitle">Cloudflare, AWS, Azure, GCP, Stripe, Okta and more. Auto-refreshing. Built by a bassist-turned-builder.</p>
+                <p class="lo-home-promo__subtitle">Cloudflare, AWS, Azure, GCP, Stripe, Okta and more. Auto-refreshing. Inspired by wrangling third-party providers in IT. Built by a bassist-turned-builder.</p>
                 <a class="pixel-button lo-home-promo__button" href="/lousy-outages/">Open dashboard →</a>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- introduce a shared Mailer helper and wire in Grimes-meets-Hackers HTML/text email templates for confirm, welcome, already-subscribed, and unsubscribe flows
- call the new subscription email helper from the REST subscribe handler and send follow-up notices during confirm/unsubscribe
- refresh homepage promo copy and contact page details to reflect the updated Grimes link and remove LinkedIn

## Testing
- php -l lousy-outages/includes/Mailer.php
- php -l lousy-outages/includes/Subscribe.php
- php -l lousy-outages/includes/Api.php
- php -l page-home.php
- php -l page-contact.php

------
https://chatgpt.com/codex/tasks/task_e_69016d6f9a74832e8487c6620430892e