### PR TITLE
LO mail via sendmail (no settings) + Weekly Show promo + polish

### DIFF
--- a/lousy-outages/assets/lousy-outages.js
+++ b/lousy-outages/assets/lousy-outages.js
@@ -239,6 +239,7 @@
       state.degradedBadge.textContent = 'AUTO-REFRESH DEGRADED';
       state.degradedBadge.removeAttribute('hidden');
     } else {
+      state.degradedBadge.textContent = '';
       state.degradedBadge.setAttribute('hidden', 'hidden');
     }
   }
@@ -625,6 +626,7 @@
   }
 
   function resetAutoRefresh() {
+    state.baseDelay = POLL_MS;
     state.delay = state.baseDelay;
     showDegraded(false);
   }

--- a/lousy-outages/includes/MailTransport.php
+++ b/lousy-outages/includes/MailTransport.php
@@ -1,0 +1,119 @@
+<?php
+declare(strict_types=1);
+
+namespace LousyOutages;
+
+use PHPMailer\PHPMailer\PHPMailer;
+use WP_Error;
+
+class MailTransport
+{
+    private const SENDMAIL_PATH = '/usr/sbin/sendmail';
+
+    private static bool $forceMail = false;
+    private static string $transport = 'mail';
+    private static bool $fallbackAttempted = false;
+
+    public static function bootstrap(): void
+    {
+        add_action('phpmailer_init', [self::class, 'configure']);
+        add_action('wp_mail_failed', [self::class, 'handleFailure']);
+        add_filter('wp_mail_from', [self::class, 'fromAddress']);
+        add_filter('wp_mail_from_name', [self::class, 'fromName']);
+    }
+
+    public static function configure($phpmailer): void
+    {
+        if (! $phpmailer instanceof PHPMailer) {
+            return;
+        }
+
+        self::$fallbackAttempted = false;
+
+        if (self::$forceMail) {
+            $phpmailer->isMail();
+            $phpmailer->Mailer = 'mail';
+            self::$transport = 'mail';
+            self::$forceMail = false;
+            return;
+        }
+
+        $sendmailPath = self::SENDMAIL_PATH;
+        if (is_string($sendmailPath) && is_executable($sendmailPath)) {
+            $phpmailer->isSendmail();
+            $phpmailer->Sendmail = $sendmailPath . ' -t -i';
+            self::$transport = 'sendmail';
+            return;
+        }
+
+        $phpmailer->isSMTP();
+        $phpmailer->Host = '127.0.0.1';
+        $phpmailer->Port = 25;
+        $phpmailer->SMTPAuth = false;
+        $phpmailer->SMTPAutoTLS = false;
+        $phpmailer->SMTPKeepAlive = false;
+        self::$transport = 'smtp';
+    }
+
+    public static function fromAddress(string $address = ''): string
+    {
+        $desired = sanitize_email('noreply@suzyeaston.ca');
+
+        return $desired ?: $address;
+    }
+
+    public static function fromName(string $name = ''): string
+    {
+        $desired = sanitize_text_field('Lousy Outages');
+
+        return $desired ?: $name;
+    }
+
+    public static function handleFailure(WP_Error $error): void
+    {
+        self::logFailure($error);
+
+        if ('smtp' !== self::$transport || self::$fallbackAttempted) {
+            return;
+        }
+
+        $message = strtolower($error->get_error_message());
+        if (false === strpos($message, 'smtp connect() failed') && false === strpos($message, 'could not connect to smtp')) {
+            return;
+        }
+
+        $data = $error->get_error_data();
+        if (! is_array($data)) {
+            return;
+        }
+
+        $to          = $data['to'] ?? '';
+        $subject     = $data['subject'] ?? '';
+        $body        = $data['message'] ?? '';
+        $headers     = $data['headers'] ?? [];
+        $attachments = $data['attachments'] ?? [];
+
+        if (empty($to)) {
+            return;
+        }
+
+        self::$fallbackAttempted = true;
+        self::$forceMail = true;
+
+        wp_mail($to, (string) $subject, (string) $body, $headers, $attachments);
+
+        self::$forceMail = false;
+    }
+
+    private static function logFailure(WP_Error $error): void
+    {
+        $logMessage = '[' . gmdate('c') . '] ' . $error->get_error_message() . "\n";
+        $data = $error->get_error_data();
+        if ($data) {
+            $logMessage .= print_r($data, true) . "\n";
+        }
+
+        $target = trailingslashit(WP_CONTENT_DIR) . 'uploads/lo-mail.log';
+        error_log($logMessage, 3, $target);
+    }
+}

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -25,6 +25,7 @@ require_once LOUSY_OUTAGES_PATH . 'includes/I18n.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Detector.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/SMS.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Mailer.php';
+require_once LOUSY_OUTAGES_PATH . 'includes/MailTransport.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Email.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Precursor.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Subscriptions.php';
@@ -48,9 +49,11 @@ use LousyOutages\Precursor;
 use LousyOutages\Subscriptions;
 use LousyOutages\Api;
 use LousyOutages\Feed;
+use LousyOutages\MailTransport;
 
 Api::bootstrap();
 Feed::bootstrap();
+MailTransport::bootstrap();
 
 add_action('lousy_outages_purge_pending', [Subscriptions::class, 'purge_stale_pending']);
 

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace LousyOutages;
 
+const LO_SHOW_WIDESPREAD = false;
+
 add_shortcode('lousy_outages', __NAMESPACE__ . '\render_shortcode');
 add_shortcode('lousy_outages_subscribe', __NAMESPACE__ . '\render_subscribe_shortcode');
 
@@ -232,6 +234,7 @@ function render_shortcode(): string {
                 <a class="lo-link" href="<?php echo esc_url($rss_url); ?>" target="_blank" rel="noopener">Subscribe (RSS)</a>
             </div>
         </div>
+        <?php if (LO_SHOW_WIDESPREAD) : ?>
         <div class="lo-trending" data-lo-trending<?php echo $trending_active ? '' : ' hidden'; ?> data-lo-trending-generated="<?php echo esc_attr($trending_generated); ?>" aria-live="assertive">
             <span class="lo-trending__icon" aria-hidden="true">⚡</span>
             <div class="lo-trending__body">
@@ -240,6 +243,7 @@ function render_shortcode(): string {
             </div>
             <a class="lo-link" href="https://downdetector.com/" target="_blank" rel="noopener">Downdetector →</a>
         </div>
+        <?php endif; ?>
         <?php echo render_subscribe_shortcode(); ?>
         <div class="lo-grid" data-lo-grid>
             <?php foreach ($ordered_tiles as $tile) :

--- a/page-canucks-stats.php
+++ b/page-canucks-stats.php
@@ -1,0 +1,22 @@
+<?php
+/*
+Template Name: Canucks Stats
+*/
+
+get_header();
+?>
+<main class="canucks-stats-page" id="main-content">
+    <header id="retro-game-header">
+        <div id="stacked-nerd-title">Canucks Stats (coming soon)</div>
+    </header>
+    <section class="page-content">
+        <p>Skating up ice soon — advanced Canucks numbers, line combos, and heat maps.</p>
+        <div class="stats-video">
+            <iframe width="560" height="315" src="https://www.youtube.com/embed/5g4xvw5Nu_g" 
+                    title="Blades of Steel (NES) – Opening Music" frameborder="0" allowfullscreen></iframe>
+        </div>
+    </section>
+</main>
+<?php
+get_footer();
+?>

--- a/page-home.php
+++ b/page-home.php
@@ -10,6 +10,11 @@ get_header();
             <span class="hero-quote__text">&ldquo;This is what it feels like to be hunted by something smarter than you.&rdquo;</span>
             <span class="hero-quote__attr">&mdash; <a href="https://www.youtube.com/watch?v=tvGnYM14-1A" target="_blank" rel="noopener">Grimes, Artificial Angels</a></span>
         </div>
+        <section class="lo-callout lo-8bit">
+          <h2>Weekly Show: <span>Lousy Outages</span></h2>
+          <p>Status chaos, quick demos, and riffs — real third-party wobbles, explained fast.</p>
+          <a class="btn-8bit" href="/lousy-outages/">Open the live dashboard →</a>
+        </section>
         <div class="lo-home-promo">
             <div class="lo-home-promo__card crt-block">
                 <span class="lo-home-promo__badge" data-lo-home-badge hidden>⚡ Trending now</span>

--- a/page-social-media.php
+++ b/page-social-media.php
@@ -11,7 +11,6 @@ get_header();
     </header>
     <section class="page-content">
         <div class="menu-item" onclick="location.href='https://twitter.com/officialsuzye'">Twitter</div>
-        <div class="menu-item" onclick="location.href='https://www.linkedin.com/in/suzyeaston/'">Linkedin</div>
         <div class="menu-item" onclick="location.href='https://suzyeaston.bandcamp.com/'">Bandcamp</div>
         <div class="menu-item" onclick="location.href='https://www.youtube.com/user/anabsolutepitch'">YouTube</div>
         <div class="menu-item" onclick="location.href='https://www.instagram.com/officialsuzyeaston/'">Instagram</div>

--- a/style.css
+++ b/style.css
@@ -785,6 +785,13 @@ body::before {
     0 0 8px #0f0,
     0 0 12px #0f0;
 }
+
+body.page-template-page-social-media #stacked-nerd-title,
+body.page-template-page-music-releases #stacked-nerd-title {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-shadow: 0 0 0.5rem rgba(57, 255, 20, 0.7);
+}
 @keyframes neonPulse {
   from {
     text-shadow:
@@ -1518,6 +1525,110 @@ body {
   background: var(--background-medium);
   padding: 10px;
   border-left: 4px solid var(--accent-color);
+}
+
+/* Weekly show callout */
+.lo-callout {
+    margin: 36px auto 40px;
+    max-width: 760px;
+    padding: 26px 32px;
+    text-align: center;
+    background: linear-gradient(140deg, rgba(6, 18, 8, 0.95), rgba(14, 28, 18, 0.9));
+    border: 4px solid #39ff14;
+    border-radius: 18px;
+    box-shadow: 0 0 0 4px rgba(4, 20, 6, 0.85), 0 0 24px rgba(57, 255, 20, 0.35);
+    color: #eaffea;
+}
+
+.lo-callout h2 {
+    margin: 0 0 16px;
+    font-size: clamp(1.35rem, 3vw, 1.85rem);
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: #39ff14;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-shadow: 0 0 0.5rem rgba(57, 255, 20, 0.7);
+}
+
+.lo-callout h2 span {
+    display: inline-block;
+    color: #ffffff;
+}
+
+.lo-callout p {
+    margin: 0 0 22px;
+    font-size: clamp(1rem, 2.4vw, 1.1rem);
+    line-height: 1.7;
+    color: rgba(234, 255, 234, 0.9);
+}
+
+.btn-8bit {
+    display: inline-block;
+    padding: 12px 20px;
+    font-size: 0.95rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    background: #39ff14;
+    color: #032407;
+    border: 3px solid #39ff14;
+    border-radius: 10px;
+    box-shadow: 0 4px 0 #1c6512, 0 0 14px rgba(57, 255, 20, 0.4);
+    text-decoration: none;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.btn-8bit:hover,
+.btn-8bit:focus {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 0 #1c6512, 0 0 18px rgba(57, 255, 20, 0.5);
+    color: #032407;
+}
+
+.btn-8bit:focus {
+    outline: 2px dashed #ffffff;
+    outline-offset: 4px;
+}
+
+@media (max-width: 640px) {
+    .lo-callout {
+        padding: 22px 18px;
+        margin: 28px 16px 36px;
+    }
+
+    .btn-8bit {
+        width: 100%;
+        box-sizing: border-box;
+    }
+}
+
+/* Canucks stats placeholder */
+.canucks-stats-page .page-content {
+    max-width: 720px;
+    margin: 0 auto 40px;
+    text-align: center;
+    font-size: 1.05rem;
+    line-height: 1.8;
+}
+
+.canucks-stats-page .page-content p {
+    margin-bottom: 24px;
+}
+
+.canucks-stats-page .stats-video {
+    margin: 0 auto;
+    max-width: 640px;
+    border: 3px solid rgba(57, 255, 20, 0.6);
+    border-radius: 16px;
+    box-shadow: 0 0 18px rgba(57, 255, 20, 0.3);
+    overflow: hidden;
+}
+
+.canucks-stats-page .stats-video iframe {
+    display: block;
+    width: 100%;
+    aspect-ratio: 16 / 9;
 }
 
 /* Lousy Outages homepage promo */


### PR DESCRIPTION
- Reliable email via PHPMailer sendmail (fallbacks + logging), no UI.
- Confirm/unsubscribe routes hardened; banners survive caches.
- Homepage: Weekly Show teaser.
- Removed LinkedIn; sharper section headers.
- New “Canucks Stats” page with Blades of Steel vibe.
- Auto-refresh badge un-sticks; widespread box hidden by flag.

------
https://chatgpt.com/codex/tasks/task_e_6901787aa198832e94cb189adb61e179