### PR TITLE
Improve Lousy Outages emails and homepage messaging

### DIFF
--- a/lousy-outages/includes/Mailer.php
+++ b/lousy-outages/includes/Mailer.php
@@ -12,10 +12,41 @@ class Mailer {
         }
 
         $boundary = 'lo-' . wp_generate_password(24, false, false);
+
+        $from_email = get_option('admin_email');
+        if (!is_email($from_email)) {
+            $host = wp_parse_url(home_url(), PHP_URL_HOST);
+            if (!is_string($host) || '' === $host) {
+                $host = 'example.com';
+            }
+            $from_email = 'no-reply@' . ltrim($host, '@');
+        }
+        $from_email = (string) apply_filters('lousy_outages_mail_from_email', $from_email, $email);
+        if (!is_email($from_email)) {
+            $from_email = $email;
+        }
+
+        $from_name = wp_specialchars_decode(get_bloginfo('name', 'display'), ENT_QUOTES);
+        if ('' === trim((string) $from_name)) {
+            $from_name = 'Lousy Outages';
+        }
+        $from_name = (string) apply_filters('lousy_outages_mail_from_name', $from_name, $email);
+        $from_name = trim(preg_replace('/[\r\n]+/', ' ', $from_name));
+
+        $reply_to = apply_filters('lousy_outages_mail_reply_to', $from_email, $email);
+
         $headers  = [
             'MIME-Version: 1.0',
             'Content-Type: multipart/alternative; boundary="' . $boundary . '"; charset=UTF-8',
         ];
+
+        if (is_email($from_email)) {
+            $headers[] = 'From: ' . trim($from_name ? sprintf('%s <%s>', $from_name, $from_email) : $from_email);
+        }
+
+        if (is_string($reply_to) && is_email($reply_to)) {
+            $headers[] = 'Reply-To: ' . $reply_to;
+        }
 
         $parts = [];
         $parts[] = '--' . $boundary;

--- a/page-home.php
+++ b/page-home.php
@@ -12,17 +12,9 @@ get_header();
         </div>
         <section class="lo-callout lo-8bit">
           <h2>Weekly Show: <span>Lousy Outages</span></h2>
-          <p>Status chaos, quick demos, and riffs — real third-party wobbles, explained fast.</p>
+          <p>New weekly YouTube chaos — status meltdowns, longer riffs, and plenty of fun with real third-party wobbles.</p>
           <a class="btn-8bit" href="/lousy-outages/">Open the live dashboard →</a>
         </section>
-        <div class="lo-home-promo">
-            <div class="lo-home-promo__card crt-block">
-                <span class="lo-home-promo__badge" data-lo-home-badge hidden>⚡ Trending now</span>
-                <h3 class="lo-home-promo__title">Lousy Outages — live status radar</h3>
-                <p class="lo-home-promo__subtitle">Cloudflare, AWS, Azure, GCP, Stripe, Okta and more. Auto-refreshing. Inspired by wrangling third-party providers in IT. Built by a bassist-turned-builder.</p>
-                <a class="pixel-button lo-home-promo__button" href="/lousy-outages/">Open dashboard →</a>
-            </div>
-        </div>
         <h2 class="retro-title glow-lite">Musician &amp; Creative Technologist</h2>
         <section class="pixel-intro" style="max-width: 720px; margin: 0 auto; line-height: 1.8; font-size: 1.05rem;">
     <p>I&rsquo;m a musician, technologist, and creative builder based in Vancouver.</p>
@@ -81,6 +73,7 @@ get_header();
                 <div class="group-buttons">
                     <a href="/riff-generator" class="pixel-button">Riff Generator</a>
                     <a href="/arcade" class="pixel-button">Canucks Game</a>
+                    <a href="/canucks-stats" class="pixel-button">Canucks Stats</a>
                     <a href="/albini-qa" class="pixel-button">Albini Q&amp;A</a>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- ensure subscription emails provide predictable From and Reply-To headers for better deliverability
- update the homepage hero copy to spotlight the new YouTube weekly show and remove the redundant promo block
- add a Canucks Stats shortcut to the Games & Tools section on the homepage

## Testing
- php -l lousy-outages/includes/Mailer.php
- php -l page-home.php

------
https://chatgpt.com/codex/tasks/task_e_69017d794f08832e8260acec2c5bad21