### PR TITLE
Improve Lousy Outages subscribe endpoint mail delivery

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -82,6 +82,32 @@ if ( file_exists( $lousy_outages ) ) {
 
 add_filter( 'lousy_outages_voice_enabled', '__return_true' );
 
+add_action( 'phpmailer_init', function( $phpmailer ) {
+    $host = getenv( 'SMTP_HOST' );
+    if ( ! $host ) {
+        return;
+    }
+
+    $phpmailer->isSMTP();
+    $phpmailer->Host = $host;
+
+    $auth_env = getenv( 'SMTP_AUTH' );
+    if ( false === $auth_env || null === $auth_env ) {
+        $phpmailer->SMTPAuth = true;
+    } else {
+        $phpmailer->SMTPAuth = filter_var( $auth_env, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
+        if ( null === $phpmailer->SMTPAuth ) {
+            $phpmailer->SMTPAuth = true;
+        }
+    }
+
+    $phpmailer->Port       = (int) ( getenv( 'SMTP_PORT' ) ?: 587 );
+    $phpmailer->SMTPSecure = getenv( 'SMTP_SECURE' ) ?: 'tls';
+    $phpmailer->Username   = getenv( 'SMTP_USER' ) ?: '';
+    $phpmailer->Password   = getenv( 'SMTP_PASS' ) ?: '';
+    $phpmailer->Timeout    = 10;
+} );
+
 function lousy_outages_feed_autodiscovery() {
     if ( is_front_page() || is_page_template( 'page-lousy-outages.php' ) || is_page( 'lousy-outages' ) ) {
         echo '\n<link rel="alternate" type="application/rss+xml" title="Lousy Outages" href="' . esc_url( home_url( '/lousy-outages/feed/' ) ) . '" />\n';

--- a/lousy-outages/includes/Api.php
+++ b/lousy-outages/includes/Api.php
@@ -39,16 +39,6 @@ class Api {
             ]
         );
 
-        register_rest_route(
-            'lousy-outages/v1',
-            '/subscribe',
-            [
-                'methods'             => 'POST',
-                'permission_callback' => '__return_true',
-                'callback'            => [self::class, 'handle_subscribe'],
-            ]
-        );
-
     }
 
     public static function verify_nonce(): bool {
@@ -165,88 +155,6 @@ class Api {
     }
 
 
-    public static function handle_subscribe(WP_REST_Request $request): WP_REST_Response {
-        $params = self::extract_body_params($request);
-
-        $nonce = $params['_wpnonce'] ?? $params['nonce'] ?? $request->get_header('X-WP-Nonce');
-        if (!is_string($nonce) || !wp_verify_nonce($nonce, 'lousy_outages_subscribe')) {
-            return self::respond_with_message(false, 'Invalid security token.', 403, $request);
-        }
-
-        $honeypot = isset($params['website']) ? trim((string) $params['website']) : '';
-        if ('' !== $honeypot) {
-            return self::respond_with_message(false, 'Something went wrong.', 400, $request);
-        }
-
-        $email = isset($params['email']) ? sanitize_email((string) $params['email']) : '';
-        if (!$email || !is_email($email)) {
-            return self::respond_with_message(false, 'Please provide a valid email address.', 400, $request);
-        }
-
-        $ip      = self::detect_ip($request);
-        $ip_hash = self::hash_ip($ip);
-        $rateKey = self::rate_limit_key($ip_hash);
-        $count   = (int) get_transient($rateKey);
-        if ($count >= 5) {
-            return self::respond_with_message(false, 'Too many requests. Try again soon.', 429, $request);
-        }
-        set_transient($rateKey, $count + 1, 60);
-
-        try {
-            $token = bin2hex(random_bytes(24));
-        } catch (\Throwable $e) {
-            $token = wp_generate_password(32, false, false);
-        }
-
-        Subscriptions::save_pending($email, $token, $ip_hash, 'form');
-
-        \Lousy_Outages_Subscribe::send_confirm_email($email, $token);
-
-        return self::respond_with_message(true, 'Check your email to confirm your subscription.', 200, $request);
-    }
-
-    private static function respond_with_message(bool $success, string $message, int $status, WP_REST_Request $request): WP_REST_Response {
-        if (self::wants_html($request)) {
-            $slug = $success ? 'check-email' : 'invalid';
-            self::store_flash_cookie($slug);
-            status_header(303);
-            header('Location: ' . home_url('/lousy-outages/?sub=' . $slug));
-            exit;
-        }
-
-        return new WP_REST_Response(['message' => $message], $status);
-    }
-
-    private static function wants_html(WP_REST_Request $request): bool {
-        $accept = $request->get_header('accept');
-        if (!is_string($accept)) {
-            return false;
-        }
-
-        return false !== stripos($accept, 'text/html');
-    }
-
-    private static function store_flash_cookie(string $status): void {
-        if (headers_sent()) {
-            return;
-        }
-
-        $value = sanitize_key($status);
-        if ('' === $value) {
-            return;
-        }
-
-        $params = [
-            'expires'  => time() + 300,
-            'path'     => '/',
-            'secure'   => is_ssl(),
-            'httponly' => false,
-            'samesite' => 'Lax',
-        ];
-
-        setcookie('lo_sub_msg', $value, $params);
-    }
-
     private static function sanitize_provider_list(?string $raw): array {
         if (!$raw) {
             return [];
@@ -257,38 +165,6 @@ class Api {
         }, $parts);
 
         return array_values(array_unique($parts));
-    }
-
-    private static function extract_body_params(WP_REST_Request $request): array {
-        $json = $request->get_json_params();
-        if (!is_array($json)) {
-            $json = [];
-        }
-        $body = $request->get_body_params();
-        if (!is_array($body)) {
-            $body = [];
-        }
-        return array_merge($body, $json);
-    }
-
-    private static function detect_ip(WP_REST_Request $request): string {
-        $headers = $request->get_headers();
-        $forwarded = '';
-        if (isset($headers['x-forwarded-for'][0])) {
-            $forwarded = trim(explode(',', $headers['x-forwarded-for'][0])[0]);
-        }
-        if ($forwarded) {
-            return $forwarded;
-        }
-        return $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
-    }
-
-    private static function hash_ip(string $ip): string {
-        return hash('sha256', $ip . wp_salt('nonce'));
-    }
-
-    private static function rate_limit_key(string $ip_hash): string {
-        return 'lousy_outages_subscribe_' . substr($ip_hash, 0, 20);
     }
 
 }


### PR DESCRIPTION
## Summary
- move the `/subscribe` REST route into the Subscribe module and persist unique emails before sending
- send subscriber/admin notifications through `wp_mail`, expose deliverability debug data, and surface transport failures in the API response/logs
- configure PHPMailer via `phpmailer_init` so SMTP environment variables automatically switch the transport

## Testing
- php -l lousy-outages/includes/Subscribe.php
- php -l lousy-outages/includes/Api.php
- php -l functions.php

------
https://chatgpt.com/codex/tasks/task_e_690181326f90832e876be9b814b92b90