### PR TITLE
Improve subscribe form readability and add anti-bot challenge

### DIFF
--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -318,58 +318,94 @@
 
 .lo-subscribe {
   margin: 24px auto;
-  padding: 18px;
-  max-width: 520px;
+  padding: 24px 26px;
+  max-width: 540px;
   border: 2px solid rgba(255, 184, 28, 0.9);
-  border-radius: 14px;
-  background: rgba(240, 78, 35, 0.15);
-  color: rgba(255, 233, 196, 0.92);
-  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.35);
+  border-radius: 18px;
+  background: linear-gradient(140deg, rgba(240, 78, 35, 0.16), rgba(10, 10, 10, 0.92));
+  color: rgba(255, 233, 196, 0.95);
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.4);
 }
 
 .lo-subscribe__title {
-  margin: 0 0 6px;
-  font-size: 1.15rem;
-  font-weight: 700;
+  margin: 0 0 8px;
+  font-size: 1.25rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
   color: #ffb81c;
 }
 
 .lo-subscribe__intro {
-  margin: 0 0 12px;
-  font-size: 0.95rem;
-  color: rgba(255, 233, 196, 0.85);
+  margin: 0 0 16px;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: rgba(255, 233, 196, 0.88);
 }
 
 .lo-subscribe__form {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
-  align-items: flex-end;
+  gap: 16px;
+  align-items: stretch;
 }
 
 .lo-subscribe__label {
   display: flex;
   flex-direction: column;
-  flex: 1 1 220px;
-  font-size: 0.9rem;
+  flex: 1 1 240px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: rgba(255, 233, 196, 0.88);
 }
 
-.lo-subscribe__label input[type="email"] {
-  margin-top: 6px;
-  padding: 10px 12px;
-  border-radius: 10px;
-  border: 1px solid rgba(255, 184, 28, 0.6);
-  background: rgba(8, 8, 8, 0.75);
-  color: #ffe9c4;
+.lo-subscribe__label span {
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.lo-subscribe__input {
+  margin-top: 8px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 2px solid rgba(255, 184, 28, 0.85);
+  background: #ffe9c4;
+  color: #050505;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.15);
+  transition: box-shadow 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+}
+
+.lo-subscribe__input:focus {
+  outline: none;
+  border-color: #ffcf5c;
+  box-shadow: 0 0 0 3px rgba(255, 184, 28, 0.35);
+}
+
+.lo-subscribe__input::placeholder {
+  color: rgba(5, 5, 5, 0.55);
+}
+
+.lo-subscribe__challenge {
+  flex-basis: 100%;
+}
+
+.lo-subscribe__note {
+  margin: 6px 0 0;
+  font-size: 0.85rem;
+  color: rgba(255, 233, 196, 0.85);
 }
 
 .lo-subscribe__button {
   background: #f04e23;
   color: #050505;
   border: 2px solid #ffb81c;
-  border-radius: 10px;
-  padding: 10px 22px;
-  font-weight: 700;
+  border-radius: 999px;
+  padding: 12px 28px;
+  font-weight: 800;
+  font-size: 1rem;
   cursor: pointer;
   transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
@@ -383,10 +419,11 @@
 
 .lo-subscribe__status {
   flex-basis: 100%;
-  margin: 0;
-  min-height: 1.2em;
-  font-size: 0.85rem;
-  color: rgba(255, 233, 196, 0.85);
+  margin: 4px 0 0;
+  min-height: 1.4em;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: rgba(255, 233, 196, 0.92);
 }
 
 .lo-subscribe__status--error {
@@ -394,9 +431,10 @@
 }
 
 .lo-subscribe__help {
-  margin: 12px 0 0;
-  font-size: 0.85rem;
-  color: rgba(255, 233, 196, 0.75);
+  margin: 16px 0 0;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: rgba(255, 233, 196, 0.8);
 }
 
 .lo-banner {
@@ -436,7 +474,10 @@
 @media (max-width: 600px) {
   .lo-subscribe__form {
     flex-direction: column;
-    align-items: stretch;
+  }
+
+  .lo-subscribe__challenge {
+    flex-basis: auto;
   }
 
   .lo-subscribe__button {

--- a/lousy-outages/assets/lousy-outages.js
+++ b/lousy-outages/assets/lousy-outages.js
@@ -475,6 +475,8 @@
     var emailInput = form.querySelector('input[name="email"]');
     var honeypot = form.querySelector('input[name="website"]');
     var nonceInput = form.querySelector('input[name="_wpnonce"]');
+    var challengeInput = form.querySelector('input[name="challenge_response"]');
+    var challengeExpected = form.querySelector('input[name="challenge_expected"]');
     var endpoint = form.getAttribute('action') || state.subscribeEndpoint;
     if (!endpoint || !state.fetchImpl) {
       return;
@@ -488,6 +490,14 @@
       setSubscribeStatus(statusEl, 'Submission blocked.', true);
       return;
     }
+    if (!challengeInput || !challengeInput.value.trim()) {
+      setSubscribeStatus(statusEl, 'Please answer the human check.', true);
+      return;
+    }
+    if (!challengeExpected || !challengeExpected.value) {
+      setSubscribeStatus(statusEl, 'Challenge missing. Reload and try again.', true);
+      return;
+    }
     setSubscribeStatus(statusEl, 'Sending…');
     form.querySelectorAll('button, input[type="submit"]').forEach(function (btn) {
       btn.disabled = true;
@@ -495,7 +505,9 @@
     var payload = {
       email: email,
       website: honeypot ? honeypot.value : '',
-      _wpnonce: nonceInput ? nonceInput.value : ''
+      _wpnonce: nonceInput ? nonceInput.value : '',
+      challenge_response: challengeInput ? challengeInput.value.trim() : '',
+      challenge_expected: challengeExpected ? challengeExpected.value : ''
     };
 
     state.fetchImpl(endpoint, {


### PR DESCRIPTION
## Summary
- restyle the Lousy Outages subscribe form to improve contrast and readability
- add a lightweight secret word challenge and server-side validation to deter bots
- update the subscribe JavaScript to require the challenge response before submitting

## Testing
- php -l lousy-outages/public/shortcode.php
- php -l lousy-outages/includes/Subscribe.php

------
https://chatgpt.com/codex/tasks/task_e_69024208daf4832ea4f1b36fab4368ac