### PR TITLE
Add retro email templates and cron fallback

### DIFF
--- a/lousy-outages/includes/IncidentAlerts.php
+++ b/lousy-outages/includes/IncidentAlerts.php
@@ -33,10 +33,10 @@ class IncidentAlerts {
     private const OPTION_SEEN             = 'lo_seen_incidents';
     private const OPTION_LAST_CHECK       = 'lo_last_status_check';
     private const TRANSIENT_PREFIX   = 'lo_cooldown_';
-    private static $altBody = '';
 
     public static function bootstrap(): void {
         add_action('init', [self::class, 'ensure_schedule']);
+        add_action('init', [self::class, 'maybe_trigger_fallback'], 20);
         add_action('admin_notices', [self::class, 'render_admin_notice']);
         add_action('rest_api_init', [self::class, 'register_routes']);
     }
@@ -44,7 +44,33 @@ class IncidentAlerts {
     public static function ensure_schedule(): void {
         if (!wp_next_scheduled('lo_check_statuses')) {
             wp_schedule_event(time() + 60, 'lo_five_minutes', 'lo_check_statuses');
+            do_action('lousy_outages_log', 'cron_scheduled', ['hook' => 'lo_check_statuses']);
         }
+    }
+
+    public static function maybe_trigger_fallback(): void {
+        if (wp_doing_cron()) {
+            return;
+        }
+
+        $next = wp_next_scheduled('lo_check_statuses');
+        if ($next) {
+            return;
+        }
+
+        $last = get_option(self::OPTION_LAST_CHECK);
+        $last_ts = $last ? strtotime((string) $last) : 0;
+        if ($last_ts && (time() - $last_ts) < 15 * MINUTE_IN_SECONDS) {
+            return;
+        }
+
+        if (defined('DISABLE_WP_CRON') && DISABLE_WP_CRON) {
+            do_action('lousy_outages_log', 'cron_disabled', ['hook' => 'lo_check_statuses']);
+            return;
+        }
+
+        wp_schedule_single_event(time() + 60, 'lo_check_statuses');
+        do_action('lousy_outages_log', 'cron_fallback_scheduled', ['hook' => 'lo_check_statuses']);
     }
 
     public static function register_routes(): void {
@@ -100,6 +126,8 @@ class IncidentAlerts {
     }
 
     public static function run(): void {
+        do_action('lousy_outages_log', 'lo_check_statuses_run', ['ts' => gmdate('c')]);
+
         $incidents = self::collect_incidents();
         update_option(self::OPTION_LAST_CHECK, gmdate('c'), false);
 
@@ -511,16 +539,16 @@ class IncidentAlerts {
         }
 
         $provider = ucfirst((string) ($incident['provider'] ?? 'Provider'));
-        $subject  = sprintf('major incident — %s: %s', $provider, (string) ($incident['name'] ?? 'unknown'));
-
-        $impact      = strtoupper((string) ($incident['impact'] ?? 'major'));
+        $impact    = (string) ($incident['impact'] ?? 'major incident');
+        $status    = isset($incident['status']) ? (string) $incident['status'] : '';
+        $statusLabel = $status ? $status : ucwords(strtolower($impact));
         $components  = isset($incident['components']) && is_array($incident['components']) ? $incident['components'] : [];
         $componentLine = $components ? implode(' • ', $components) : 'All tracked components';
         $started_at  = (string) ($incident['started_at'] ?? '');
         $url         = (string) ($incident['url'] ?? '');
+        $summary     = isset($incident['name']) ? (string) $incident['name'] : '';
+        $notes       = isset($incident['body']) ? (string) $incident['body'] : '';
 
-        $headers = [];
-        $headers[] = 'Content-Type: text/html; charset=UTF-8';
         foreach ($subscribers as $email) {
             $token = self::build_unsubscribe_token($email);
             $unsubscribe = add_query_arg(
@@ -532,38 +560,20 @@ class IncidentAlerts {
                 home_url('/lousy-outages/')
             );
 
-            $html_body = self::build_html_email(
-                $provider,
-                $incident['name'] ?? '',
-                $impact,
-                $componentLine,
-                $started_at,
-                $url,
-                $unsubscribe
-            );
-            $text_body = self::build_text_email(
-                $provider,
-                $incident['name'] ?? '',
-                $impact,
-                $components,
-                $started_at,
-                $url,
-                $unsubscribe
-            );
+            $incident_payload = [
+                'service'         => $provider,
+                'status'          => $statusLabel,
+                'impact'          => $impact,
+                'summary'         => $summary,
+                'notes'           => $notes,
+                'timestamp'       => $started_at,
+                'components'      => $componentLine,
+                'components_list' => $components,
+                'url'             => $url,
+                'unsubscribe_url' => $unsubscribe,
+            ];
 
-            $headersWithList = $headers;
-            $headersWithList[] = 'List-Unsubscribe: <' . esc_url_raw($unsubscribe) . '>';
-            $headersWithList[] = 'List-Unsubscribe-Post: List-Unsubscribe=One-Click';
-
-            add_filter('wp_mail_content_type', [self::class, 'force_html_content']);
-            self::$altBody = $text_body;
-            add_action('phpmailer_init', [self::class, 'inject_alt_body']);
-
-            $sent = wp_mail($email, $subject, $html_body, $headersWithList);
-
-            remove_filter('wp_mail_content_type', [self::class, 'force_html_content']);
-            remove_action('phpmailer_init', [self::class, 'inject_alt_body']);
-            self::$altBody = '';
+            $sent = send_lo_outage_alert_email($email, $incident_payload);
 
             if (!$sent) {
                 self::log_error((string) ($incident['provider'] ?? 'incident'), 'mail send failed for ' . $email);
@@ -572,84 +582,6 @@ class IncidentAlerts {
         }
 
         return true;
-    }
-
-    public static function force_html_content(): string {
-        return 'text/html';
-    }
-
-    public static function inject_alt_body($phpmailer): void {
-        if ($phpmailer instanceof \PHPMailer\PHPMailer\PHPMailer && '' !== self::$altBody) {
-            $phpmailer->AltBody = self::$altBody;
-        }
-    }
-
-    private static function build_html_email(string $provider, string $name, string $impact, string $components, string $started_at, string $url, string $unsubscribe): string {
-        $title = esc_html($name ?: 'Major incident');
-        $impactLabel = esc_html($impact);
-        $componentsLabel = esc_html($components ?: 'components unknown');
-        $startedLabel = esc_html($started_at ?: 'time TBD');
-        $cta = $url ? sprintf('<a href="%s" style="color:#f04e23;">open incident log</a>', esc_url($url)) : '';
-        $unsubscribeLink = esc_url($unsubscribe);
-
-        return <<<HTML
-<!doctype html>
-<meta charset="utf-8">
-<body style="margin:0;background:#050505;color:#ffe9c4;font-family:'Space Grotesk',system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
-  <div style="max-width:640px;margin:0 auto;padding:32px 24px;">
-    <div style="background:linear-gradient(140deg,#160800 0%,#2d1300 100%);border:2px solid #ffb81c;box-shadow:0 0 28px rgba(240,78,35,0.4);border-radius:18px;padding:28px;">
-      <header style="display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:18px;">
-        <span style="font-size:18px;letter-spacing:0.08em;text-transform:uppercase;color:#ffb81c;">lousy outages</span>
-        <span style="font-size:14px;color:rgba(255,233,196,0.85);">old-school outage intel</span>
-      </header>
-      <h1 style="margin:0 0 12px;font-size:26px;color:#ffe9c4;">{$impactLabel} — {$provider}</h1>
-      <p style="margin:0 0 18px;font-size:20px;color:#ffb81c;">{$title}</p>
-      <div style="display:grid;gap:12px;margin:20px 0;">
-        <div style="background:rgba(20,10,0,0.65);border-radius:14px;padding:14px 16px;color:#ffe3b5;font-size:15px;">
-          <strong style="display:block;font-size:12px;letter-spacing:0.1em;color:#ffb81c;margin-bottom:4px;">components</strong>
-          {$componentsLabel}
-        </div>
-        <div style="background:rgba(20,10,0,0.65);border-radius:14px;padding:14px 16px;color:#ffe3b5;font-size:15px;">
-          <strong style="display:block;font-size:12px;letter-spacing:0.1em;color:#ffb81c;margin-bottom:4px;">started</strong>
-          {$startedLabel}
-        </div>
-      </div>
-      <p style="font-size:15px;color:rgba(255,233,196,0.85);line-height:1.6;">massive systems turbulence detected. stay frosty, reroute workloads if you can, and keep the synthwave looping.</p>
-      <p style="margin:20px 0;">{$cta}</p>
-      <footer style="margin-top:24px;border-top:1px dashed rgba(255,184,28,0.4);padding-top:16px;color:rgba(255,233,196,0.75);font-size:12px;">
-        broadcasting for <em>console cowboys</em> &amp; dream logic engineers.<br>
-        <a href="{$unsubscribeLink}" style="color:#ffb81c;">unsubscribe instantly</a> • keep hacking the planet.
-      </footer>
-    </div>
-  </div>
-</body>
-HTML;
-    }
-
-    private static function build_text_email(string $provider, string $name, string $impact, array $components, string $started_at, string $url, string $unsubscribe): string {
-        $componentsLine = $components ? implode(', ', $components) : 'All tracked components';
-        $unsubscribeText = esc_url_raw($unsubscribe);
-        $lines = [
-            sprintf('Major incident — %s', $provider),
-            $name ?: 'Unnamed incident',
-            'Impact: ' . $impact,
-            'Components: ' . $componentsLine,
-        ];
-
-        if ('' !== $started_at) {
-            $lines[] = 'Started: ' . $started_at;
-        }
-
-        if ('' !== $url) {
-            $lines[] = 'Details: ' . $url;
-        }
-
-        $lines[] = '';
-        $lines[] = 'Unsubscribe: ' . $unsubscribeText;
-        $lines[] = '';
-        $lines[] = 'Stay sharp. – Lousy Outages';
-
-        return implode("\n", $lines);
     }
 
     private static function is_on_cooldown(string $provider): bool {
@@ -680,14 +612,23 @@ HTML;
             return;
         }
 
+        $messages = [];
+
         $last = get_option(self::OPTION_LAST_CHECK);
         if ($last) {
-            $message = sprintf('Last provider check ran at %s (UTC)', $last);
+            $messages[] = sprintf('Last provider check ran at %s (UTC)', $last);
         } else {
-            $message = 'Lousy Outages incident checker has not run yet.';
+            $messages[] = 'Lousy Outages incident checker has not run yet.';
         }
 
-        echo '<div class="notice notice-info"><p>' . esc_html($message) . '</p></div>';
+        if (defined('DISABLE_WP_CRON') && DISABLE_WP_CRON) {
+            $messages[] = 'WordPress cron is disabled. Configure a real server cron to hit wp-cron.php or run "wp cron event run lo_check_statuses" regularly.';
+        } elseif (!wp_next_scheduled('lo_check_statuses')) {
+            $messages[] = 'No upcoming outage scans are scheduled. A fallback run was queued, but setting up a server cron is recommended for reliability.';
+        }
+
+        $safe_messages = array_map('esc_html', $messages);
+        echo '<div class="notice notice-info"><p>' . implode('</p><p>', $safe_messages) . '</p></div>';
     }
 }
 

--- a/lousy-outages/includes/Subscribe.php
+++ b/lousy-outages/includes/Subscribe.php
@@ -112,38 +112,12 @@ class Lousy_Outages_Subscribe {
             home_url('/lousy-outages/')
         );
 
-        $subject = '👾 jack in to Lousy Outages (confirm your email)';
+        $sent = send_lo_confirmation_email($email, $unsubscribe_url, $confirm_url);
 
-        $text_body = <<<TEXT
-hey there, console cowboy ⚡
-
-you (or a very stylish bot) asked to receive Lousy Outages alerts.
-click to confirm your human-ness and join the swarm:
-
-CONFIRM ▶ {$confirm_url}
-
-if you didn't request this, chill—no packets were harmed.
-ignore this or nuke it here: <{$unsubscribe_url}>
-
-— lousy outages • inspired by wrangling third-party providers in IT. built by a bassist-turned-builder
-TEXT;
-
-        $html_body = <<<HTML
-<!doctype html>
-<meta charset="utf-8">
-<body style="font-family: ui-sans-serif,system-ui,Segoe UI,Roboto,Arial; background:#050505; color:#ffe9c4;">
-  <div style="max-width:560px;margin:24px auto;padding:20px;border:2px solid #ffb81c;border-radius:14px;background:linear-gradient(140deg,#0b0b0b,#1a0b00);box-shadow:0 18px 36px rgba(0,0,0,0.45);">
-    <h2 style="margin:0 0 8px;font-size:20px;color:#ffb81c;letter-spacing:0.05em;text-transform:uppercase;">👾 jack in to Lousy Outages</h2>
-    <p style="margin:0 0 16px;">you (or a very stylish bot) asked to receive outage alerts.</p>
-    <p style="margin:0 0 18px;"><a href="{$confirm_url}" style="display:inline-block;padding:12px 18px;border-radius:999px;border:2px solid #ffb81c;background:#f04e23;color:#050505;font-weight:700;text-decoration:none;">CONFIRM SUBSCRIPTION</a></p>
-    <p style="margin:0 0 12px;opacity:.85;">not you? <a href="{$unsubscribe_url}" style="color:#ffb81c;">unsubscribe here</a> or just ignore this.</p>
-    <hr style="border:none;border-top:1px dashed rgba(255,184,28,0.5);margin:18px 0;">
-    <p style="margin:0;font-size:12px;opacity:.75;">lousy outages — inspired by wrangling third-party providers in IT.</p>
-  </div>
-</body>
-HTML;
-
-        Mailer::send($email, $subject, $text_body, $html_body);
+        do_action('lousy_outages_log', 'confirmation_email_dispatched', [
+            'email' => $email,
+            'sent'  => $sent,
+        ]);
     }
 
     private static function mark_confirmed(string $token): bool {
@@ -232,7 +206,7 @@ HTML;
         );
         $dashboard_url = home_url('/lousy-outages/');
 
-        $subject = '✅ link established: you\'re on the outage radar';
+        $subject = '🔔 Subscribed to Lousy Outages';
 
         $text_body = <<<TEXT
 confirmed. you're now getting the Lousy Outages briefings. 🛰️

--- a/lousy-outages/includes/email-templates.php
+++ b/lousy-outages/includes/email-templates.php
@@ -1,0 +1,283 @@
+<?php
+/**
+ * Email template helpers for Lousy Outages.
+ */
+
+declare(strict_types=1);
+
+if (!class_exists('Lousy_Outages_Email_Helper')) {
+    class Lousy_Outages_Email_Helper {
+        /** @var string */
+        private static $alt_body = '';
+
+        public static function set_alt_body(string $body): void {
+            self::$alt_body = $body;
+        }
+
+        public static function get_alt_body(): string {
+            return self::$alt_body;
+        }
+
+        public static function reset(): void {
+            self::$alt_body = '';
+        }
+
+        public static function html_content_type(): string {
+            return 'text/html; charset=UTF-8';
+        }
+
+        public static function inject_alt_body($phpmailer): void {
+            if ($phpmailer instanceof \PHPMailer\PHPMailer\PHPMailer) {
+                $alt = self::get_alt_body();
+                if ('' !== $alt) {
+                    $phpmailer->AltBody = $alt;
+                }
+            }
+        }
+    }
+}
+
+if (!function_exists('send_lo_confirmation_email')) {
+    /**
+     * Sends the Lousy Outages confirmation email.
+     */
+    function send_lo_confirmation_email(string $email, string $unsubscribe_url, ?string $confirm_url = null): bool {
+        $email = sanitize_email($email);
+        if (!$email || !is_email($email)) {
+            error_log('[lousy_outages] confirmation_email invalid recipient');
+            return false;
+        }
+
+        $unsubscribe_url = $unsubscribe_url ?: home_url('/lousy-outages/');
+        $unsubscribe_raw = esc_url_raw($unsubscribe_url);
+        $unsubscribe_html = esc_url($unsubscribe_url);
+
+        if (null === $confirm_url || '' === trim((string) $confirm_url)) {
+            $confirm_url = apply_filters('lo_confirmation_cta_url', '', $email, $unsubscribe_url);
+        }
+        if (null === $confirm_url || '' === trim((string) $confirm_url)) {
+            $confirm_url = add_query_arg(
+                'email',
+                rawurlencode($email),
+                home_url('/lousy-outages/')
+            );
+        }
+        $confirm_raw  = esc_url_raw($confirm_url);
+        $confirm_html = esc_url($confirm_url);
+
+        $subject = '🕹️ Confirm Access: Lousy Outages Command Console';
+
+        $text_body_lines = [
+            'Rogue signal detected. Ready to jack in?',
+            '',
+            'Confirm your access to the Lousy Outages command bunker:',
+            $confirm_raw,
+            '',
+            'If this wasn\'t you, cut the wire instantly:',
+            $unsubscribe_raw,
+            '',
+            'Stay sharp – Lousy Outages',
+        ];
+        $text_body = implode("\n", $text_body_lines);
+
+        $html_body = '<!doctype html>' .
+            '<meta charset="utf-8">' .
+            '<body style="margin:0;background:#000;color:#FFD700;font-family:\'Courier New\',\'Lucida Console\',monospace;">' .
+            '  <div style="max-width:640px;margin:0 auto;padding:36px 18px;">' .
+            '    <div style="border:3px solid #00FF00;background:linear-gradient(155deg,rgba(0,0,0,0.95),rgba(12,20,0,0.92));border-radius:20px;padding:30px 26px;box-shadow:0 0 32px rgba(0,255,0,0.3);">' .
+            '      <p style="margin:0 0 12px;font-size:13px;letter-spacing:0.18em;text-transform:uppercase;color:#00FF00;">rogue signal detected</p>' .
+            '      <h1 style="margin:0 0 16px;font-size:28px;color:#FFD700;letter-spacing:0.08em;text-transform:uppercase;">Confirm bunker access</h1>' .
+            '      <p style="margin:0 0 18px;font-size:16px;line-height:1.6;color:#FDF5A6;">One tap locks your feed into outage intel and neon-lit play-by-play. No confirmation, no transmissions.</p>' .
+            '      <p style="margin:0 0 22px;">' .
+            '        <a href="' . $confirm_html . '" style="display:inline-block;padding:16px 26px;border-radius:999px;border:2px solid #00FF00;background:#111;color:#00FF00;font-weight:700;text-decoration:none;text-transform:uppercase;letter-spacing:0.12em;">Confirm &amp; Jack In</a>' .
+            '      </p>' .
+            '      <p style="margin:0 0 18px;font-size:13px;color:#FDF5A6;">If the button stalls, copy this access link:<br><span style="color:#00FF00;">' . esc_html($confirm_raw) . '</span></p>' .
+            '      <div style="margin:24px 0;padding:16px 18px;border:1px dashed rgba(0,255,0,0.6);border-radius:14px;background:rgba(4,25,4,0.7);color:#BFFFBF;font-size:13px;">' .
+            '        <strong style="display:block;font-size:11px;letter-spacing:0.18em;color:#7BFF7B;margin-bottom:6px;text-transform:uppercase;">Unsubscribe</strong>' .
+            '        Back out anytime: <a style="color:#7BFF7B;text-decoration:none;" href="' . $unsubscribe_html . '">' . esc_html($unsubscribe_raw) . '</a>' .
+            '      </div>' .
+            '      <p style="margin:0;font-size:12px;color:rgba(255,215,0,0.75);">Console tip: whitelist suzyeaston.ca so the alerts don\'t get ghosted.</p>' .
+            '    </div>' .
+            '  </div>' .
+            '</body>';
+
+        $headers = [
+            'MIME-Version: 1.0',
+            'Content-Type: text/html; charset=UTF-8',
+            'List-Unsubscribe: <' . $unsubscribe_raw . '>',
+            'List-Unsubscribe-Post: List-Unsubscribe=One-Click',
+        ];
+
+        Lousy_Outages_Email_Helper::set_alt_body($text_body);
+        add_filter('wp_mail_content_type', ['Lousy_Outages_Email_Helper', 'html_content_type']);
+        add_action('phpmailer_init', ['Lousy_Outages_Email_Helper', 'inject_alt_body']);
+
+        $sent = wp_mail($email, $subject, $html_body, $headers);
+
+        remove_filter('wp_mail_content_type', ['Lousy_Outages_Email_Helper', 'html_content_type']);
+        remove_action('phpmailer_init', ['Lousy_Outages_Email_Helper', 'inject_alt_body']);
+        Lousy_Outages_Email_Helper::reset();
+
+        if (!$sent) {
+            error_log('[lousy_outages] confirmation_email send failed for ' . $email);
+        } elseif (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log('Sent Lousy Outages confirmation to ' . $email . ' at ' . current_time('mysql'));
+        }
+
+        return (bool) $sent;
+    }
+}
+
+if (!function_exists('send_lo_outage_alert_email')) {
+    /**
+     * Sends a themed outage alert email.
+     *
+     * @param array<string,mixed> $incident_data
+     */
+    function send_lo_outage_alert_email(string $email, array $incident_data): bool {
+        $email = sanitize_email($email);
+        if (!$email || !is_email($email)) {
+            error_log('[lousy_outages] outage_email invalid recipient');
+            return false;
+        }
+
+        $service = isset($incident_data['service']) ? (string) $incident_data['service'] : 'Service';
+        $status  = isset($incident_data['status']) ? (string) $incident_data['status'] : 'Status Change';
+        $summary = isset($incident_data['summary']) ? (string) $incident_data['summary'] : '';
+        $impact  = isset($incident_data['impact']) ? (string) $incident_data['impact'] : $status;
+        $timestamp_raw = isset($incident_data['timestamp']) ? (string) $incident_data['timestamp'] : '';
+        $components = isset($incident_data['components']) ? (string) $incident_data['components'] : '';
+        $status_url = isset($incident_data['url']) ? (string) $incident_data['url'] : '';
+        $extra_notes = isset($incident_data['notes']) ? (string) $incident_data['notes'] : '';
+
+        $service_label = trim($service) ?: 'Service';
+        $status_label  = trim($status) ?: (trim($impact) ?: 'Status Change');
+        $summary_text  = trim($summary) ?: trim($extra_notes);
+        $status_url    = $status_url ?: home_url('/lousy-outages/');
+        $status_url_raw  = esc_url_raw($status_url);
+        $status_url_html = esc_url($status_url);
+
+        $timestamp_display = $timestamp_raw;
+        if ('' !== $timestamp_raw) {
+            $time = strtotime($timestamp_raw);
+            if (false !== $time) {
+                $timestamp_display = wp_date('M j, Y g:i A T', $time);
+            }
+        }
+        $timestamp_display = $timestamp_display ?: wp_date('M j, Y g:i A T');
+
+        $component_line = trim($components);
+        if ('' === $component_line && isset($incident_data['components_list']) && is_array($incident_data['components_list'])) {
+            $component_line = implode(' • ', array_map('strval', $incident_data['components_list']));
+        }
+        if ('' === $component_line) {
+            $component_line = 'All monitored components';
+        }
+
+        $unsubscribe_url = '';
+        if (isset($incident_data['unsubscribe_url']) && '' !== trim((string) $incident_data['unsubscribe_url'])) {
+            $unsubscribe_url = (string) $incident_data['unsubscribe_url'];
+        } elseif (class_exists('LousyOutages\\IncidentAlerts')) {
+            $token = \LousyOutages\IncidentAlerts::build_unsubscribe_token($email);
+            $unsubscribe_url = add_query_arg(
+                [
+                    'lo_unsub' => 1,
+                    'email'    => rawurlencode($email),
+                    'token'    => $token,
+                ],
+                home_url('/lousy-outages/')
+            );
+        } else {
+            $unsubscribe_url = home_url('/lousy-outages/');
+        }
+        $unsubscribe_raw  = esc_url_raw($unsubscribe_url);
+        $unsubscribe_html = esc_url($unsubscribe_url);
+
+        $clean_summary = $summary_text ?: sprintf('%s status changed to %s.', $service_label, $status_label);
+
+        $subject = sprintf('🚨 Outage Alert: %s – %s', $service_label, $status_label);
+
+        $text_body_lines = [
+            sprintf('%s outage alert', strtoupper($service_label)),
+            sprintf('Status: %s', $status_label),
+            sprintf('Detected: %s', $timestamp_display),
+            '',
+            $clean_summary,
+            '',
+            'Impacted components: ' . $component_line,
+            '',
+            'Track live status: ' . $status_url_raw,
+            '',
+            'Unsubscribe: ' . $unsubscribe_raw,
+            '',
+            'Hold the line — Lousy Outages',
+        ];
+        $text_body = implode("\n", $text_body_lines);
+
+        $service_html = esc_html($service_label);
+        $status_html  = esc_html($status_label);
+        $timestamp_html = esc_html($timestamp_display);
+        $summary_html = nl2br(esc_html($clean_summary));
+        $components_html = esc_html($component_line);
+
+        $html_body = '<!doctype html>' .
+            '<meta charset="utf-8">' .
+            '<body style="margin:0;background:#000;color:#FFD700;font-family:\'Courier New\',\'Lucida Console\',monospace;">' .
+            '  <div style="max-width:680px;margin:0 auto;padding:36px 18px;">' .
+            '    <div style="border:3px solid #FF3131;background:linear-gradient(155deg,rgba(24,0,0,0.95),rgba(6,0,12,0.92));border-radius:22px;padding:32px 28px;box-shadow:0 0 36px rgba(255,49,49,0.4);">' .
+            '      <header style="display:flex;justify-content:space-between;align-items:center;margin-bottom:20px;text-transform:uppercase;">' .
+            '        <span style="font-size:14px;letter-spacing:0.16em;color:#FF3131;">lousy outages alert</span>' .
+            '        <span style="font-size:12px;color:rgba(255,215,0,0.75);">command bunker feed</span>' .
+            '      </header>' .
+            '      <h1 style="margin:0 0 10px;font-size:30px;color:#FF3131;letter-spacing:0.1em;">' . $service_html . '</h1>' .
+            '      <p style="margin:0 0 18px;font-size:20px;color:#FFD700;text-transform:uppercase;letter-spacing:0.08em;">' . $status_html . '</p>' .
+            '      <div style="display:grid;gap:14px;margin:0 0 22px;">' .
+            '        <div style="background:rgba(255,49,49,0.12);border:1px dashed rgba(255,49,49,0.6);border-radius:14px;padding:14px 18px;color:#FDF5A6;font-size:13px;">' .
+            '          <strong style="display:block;font-size:11px;letter-spacing:0.18em;color:#FF9797;margin-bottom:4px;text-transform:uppercase;">detected</strong>' .
+            '          ' . $timestamp_html .
+            '        </div>' .
+            '        <div style="background:rgba(0,255,0,0.08);border:1px dashed rgba(0,255,0,0.35);border-radius:14px;padding:14px 18px;color:#D6FFD6;font-size:13px;">' .
+            '          <strong style="display:block;font-size:11px;letter-spacing:0.18em;color:#7BFF7B;margin-bottom:4px;text-transform:uppercase;">components</strong>' .
+            '          ' . $components_html .
+            '        </div>' .
+            '      </div>' .
+            '      <p style="margin:0 0 18px;font-size:15px;line-height:1.7;color:#FDF5A6;">' . $summary_html . '</p>' .
+            '      <p style="margin:0 0 24px;">' .
+            '        <a href="' . $status_url_html . '" style="display:inline-block;padding:16px 28px;border-radius:999px;border:2px solid #FF3131;background:#000;color:#FF3131;font-weight:700;text-decoration:none;text-transform:uppercase;letter-spacing:0.12em;">View live status</a>' .
+            '      </p>' .
+            '      <p style="margin:0 0 18px;font-size:12px;color:rgba(255,215,0,0.7);">Manual override URL: <a style="color:#FF9797;" href="' . $status_url_html . '">' . esc_html($status_url_raw) . '</a></p>' .
+            '      <footer style="margin-top:26px;padding-top:18px;border-top:1px dashed rgba(255,49,49,0.4);font-size:12px;color:rgba(255,215,0,0.7);">' .
+            '        Want out? <a style="color:#7BFF7B;" href="' . $unsubscribe_html . '">Unsubscribe instantly</a><br>' .
+            '        Raw link: <span style="color:#7BFF7B;">' . esc_html($unsubscribe_raw) . '</span>' .
+            '      </footer>' .
+            '    </div>' .
+            '  </div>' .
+            '</body>';
+
+        $headers = [
+            'MIME-Version: 1.0',
+            'Content-Type: text/html; charset=UTF-8',
+            'List-Unsubscribe: <' . $unsubscribe_raw . '>',
+            'List-Unsubscribe-Post: List-Unsubscribe=One-Click',
+        ];
+
+        Lousy_Outages_Email_Helper::set_alt_body($text_body);
+        add_filter('wp_mail_content_type', ['Lousy_Outages_Email_Helper', 'html_content_type']);
+        add_action('phpmailer_init', ['Lousy_Outages_Email_Helper', 'inject_alt_body']);
+
+        $sent = wp_mail($email, $subject, $html_body, $headers);
+
+        remove_filter('wp_mail_content_type', ['Lousy_Outages_Email_Helper', 'html_content_type']);
+        remove_action('phpmailer_init', ['Lousy_Outages_Email_Helper', 'inject_alt_body']);
+        Lousy_Outages_Email_Helper::reset();
+
+        if (!$sent) {
+            error_log('[lousy_outages] outage_email send failed for ' . $email . ' subject=' . $subject);
+        } elseif (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log('Sent Lousy Outages alert to ' . $email . ' at ' . current_time('mysql'));
+        }
+
+        return (bool) $sent;
+    }
+}
+

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -26,6 +26,7 @@ require_once LOUSY_OUTAGES_PATH . 'includes/Detector.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/SMS.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Mailer.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/MailTransport.php';
+require_once LOUSY_OUTAGES_PATH . 'includes/email-templates.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Email.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Precursor.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Subscriptions.php';


### PR DESCRIPTION
## Summary
- add retro-styled HTML templates for confirmation and outage alerts with alt-body handling and logging
- connect subscription confirmation and incident mailers to the new templates and refresh welcome subject line
- add cron fallback scheduling plus admin notice guidance when WordPress cron is disabled or missing

## Testing
- php -l lousy-outages/includes/email-templates.php
- php -l lousy-outages/includes/IncidentAlerts.php

------
https://chatgpt.com/codex/tasks/task_e_69024c427494832ea7180364fec489a1