### PR TITLE
Add cached snapshot HUD and lyric captcha protections

### DIFF
--- a/lousy-outages/assets/captcha.js
+++ b/lousy-outages/assets/captcha.js
@@ -1,0 +1,201 @@
+(function (root) {
+  'use strict';
+
+  if (!root || !root.document) {
+    return;
+  }
+
+  var doc = root.document;
+  var apiConfig = root.LoLyricCaptcha || {};
+
+  function toMsSeconds(value) {
+    var ttl = parseInt(value, 10);
+    if (!Number.isFinite(ttl) || ttl <= 0) {
+      ttl = 120;
+    }
+    return ttl * 1000;
+  }
+
+  function parseExpiry(value) {
+    if (typeof value !== 'string' || value === '') {
+      return null;
+    }
+    var time = Date.parse(value);
+    if (Number.isNaN(time)) {
+      return null;
+    }
+    return time;
+  }
+
+  function formatRemaining(ms) {
+    if (ms <= 0) {
+      return 'expired';
+    }
+    var totalSeconds = Math.floor(ms / 1000);
+    var minutes = Math.floor(totalSeconds / 60);
+    var seconds = totalSeconds % 60;
+    var sec = seconds < 10 ? '0' + seconds : '' + seconds;
+    return minutes + ':' + sec + ' remaining';
+  }
+
+  function initCaptcha(form) {
+    if (!form) {
+      return;
+    }
+    var container = form.querySelector('[data-lo-captcha]');
+    if (!container) {
+      return;
+    }
+
+    var promptEl = container.querySelector('[data-lo-captcha-prompt]');
+    var fragmentEl = container.querySelector('[data-lo-captcha-fragment]');
+    var refreshBtn = container.querySelector('[data-lo-captcha-refresh]');
+    var inputEl = container.querySelector('[data-lo-captcha-input]');
+    var tokenInput = form.querySelector('[data-lo-captcha-token]');
+    var noteEl = container.querySelector('.lo-subscribe__note');
+    var baseNote = noteEl ? noteEl.textContent : '';
+    var countdownTimer = null;
+    var currentExpiry = parseExpiry(container.getAttribute('data-expires'));
+    var requestInFlight = false;
+
+    function clearCountdown() {
+      if (countdownTimer) {
+        root.clearInterval(countdownTimer);
+        countdownTimer = null;
+      }
+    }
+
+    function updateCountdown() {
+      if (!noteEl) {
+        return;
+      }
+      if (!currentExpiry) {
+        noteEl.textContent = baseNote;
+        return;
+      }
+      var remaining = currentExpiry - Date.now();
+      if (remaining <= 0) {
+        noteEl.textContent = baseNote + ' (expired)';
+        return;
+      }
+      noteEl.textContent = baseNote + ' (' + formatRemaining(remaining) + ')';
+    }
+
+    function startCountdown() {
+      clearCountdown();
+      updateCountdown();
+      if (!currentExpiry) {
+        return;
+      }
+      countdownTimer = root.setInterval(function () {
+        if (doc.hidden) {
+          return;
+        }
+        updateCountdown();
+        if (currentExpiry && currentExpiry <= Date.now()) {
+          clearCountdown();
+          updateCountdown();
+        }
+      }, 1000);
+    }
+
+    function applyChallenge(challenge) {
+      if (!challenge || typeof challenge !== 'object') {
+        return;
+      }
+      var fragment = String(challenge.fragment || '');
+      var prompt = String(challenge.prompt || (promptEl ? promptEl.textContent : ''));
+      var token = String(challenge.token || '');
+      var expiresAt = parseExpiry(challenge.expires_at);
+      if (!expiresAt) {
+        expiresAt = Date.now() + toMsSeconds(challenge.ttl || apiConfig.ttl);
+      }
+      currentExpiry = expiresAt;
+
+      container.setAttribute('data-token', token);
+      container.setAttribute('data-expires', new Date(expiresAt).toISOString());
+
+      if (promptEl) {
+        promptEl.textContent = prompt;
+      }
+      if (fragmentEl) {
+        fragmentEl.textContent = '“' + fragment + '” …';
+      }
+      if (tokenInput) {
+        tokenInput.value = token;
+      }
+      if (inputEl) {
+        inputEl.value = '';
+        try {
+          inputEl.focus();
+        } catch (err) {
+          // ignore focus errors
+        }
+      }
+
+      startCountdown();
+    }
+
+    function toggleRefresh(disabled) {
+      if (!refreshBtn) {
+        return;
+      }
+      refreshBtn.disabled = !!disabled;
+      refreshBtn.setAttribute('aria-busy', disabled ? 'true' : 'false');
+    }
+
+    function fetchChallenge() {
+      if (!apiConfig.endpoint || requestInFlight) {
+        return;
+      }
+      requestInFlight = true;
+      toggleRefresh(true);
+
+      var headers = {};
+      if (apiConfig.nonce) {
+        headers['X-WP-Nonce'] = apiConfig.nonce;
+      }
+
+      root.fetch(apiConfig.endpoint, {
+        method: 'GET',
+        credentials: 'same-origin',
+        headers: headers
+      }).then(function (response) {
+        if (!response || typeof response.json !== 'function') {
+          throw new Error('invalid response');
+        }
+        return response.json();
+      }).then(function (payload) {
+        applyChallenge(payload);
+      }).catch(function () {
+        // keep existing challenge on failure
+      }).finally(function () {
+        requestInFlight = false;
+        toggleRefresh(false);
+      });
+    }
+
+    if (refreshBtn) {
+      refreshBtn.addEventListener('click', function (event) {
+        event.preventDefault();
+        fetchChallenge();
+      });
+    }
+
+    doc.addEventListener('visibilitychange', function () {
+      if (!doc.hidden) {
+        startCountdown();
+      }
+    });
+
+    updateCountdown();
+    startCountdown();
+  }
+
+  var forms = doc.querySelectorAll('[data-lo-subscribe-form]');
+  if (!forms || !forms.length) {
+    return;
+  }
+
+  Array.prototype.forEach.call(forms, initCaptcha);
+})(typeof window !== 'undefined' ? window : this);

--- a/lousy-outages/assets/hud.css
+++ b/lousy-outages/assets/hud.css
@@ -1,0 +1,42 @@
+.lo-hud {
+  position: relative;
+}
+
+.lo-hud-spinner {
+  display: none;
+  margin-left: 0.75rem;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: #8f80ff;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.lo-hud-spinner::before {
+  content: '';
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  animation: lo-hud-spin 0.9s linear infinite;
+}
+
+.lo-hud--dialing .lo-hud-spinner {
+  display: inline-flex;
+}
+
+@keyframes lo-hud-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.lo-hud [data-lo-degraded] {
+  transition: opacity 0.25s ease;
+}

--- a/lousy-outages/assets/hud.js
+++ b/lousy-outages/assets/hud.js
@@ -1,0 +1,376 @@
+(function (root) {
+  'use strict';
+
+  if (!root || !root.document) {
+    return;
+  }
+
+  var doc = root.document;
+
+  var STATUS_CLASS_MAP = {
+    operational: 'status--operational',
+    degraded: 'status--degraded',
+    outage: 'status--outage',
+    maintenance: 'status--maintenance',
+    unknown: 'status--unknown'
+  };
+
+  function normalizeService(service) {
+    if (!service || typeof service !== 'object') {
+      return null;
+    }
+    var status = String(service.status || service.stateCode || service.state || 'unknown').toLowerCase();
+    if (status === 'major_outage' || status === 'critical') {
+      status = 'outage';
+    } else if (status === 'minor_outage' || status === 'degraded_performance' || status === 'partial_outage') {
+      status = 'degraded';
+    }
+    var statusText = String(service.status_text || service.state || service.status_label || '').trim();
+    if (!statusText) {
+      statusText = status.replace(/_/g, ' ');
+      statusText = statusText.charAt(0).toUpperCase() + statusText.slice(1);
+    }
+    return {
+      id: String(service.id || service.provider || ''),
+      name: String(service.name || service.provider || ''),
+      status: status || 'unknown',
+      status_text: statusText,
+      summary: String(service.summary || service.message || ''),
+      url: String(service.url || ''),
+      updated_at: String(service.updated_at || service.updatedAt || ''),
+      risk: parseInt(service.risk, 10) || 0
+    };
+  }
+
+  function normalizeSnapshot(payload, fallbackTtl) {
+    var ttl = parseInt(payload && payload.ttl_seconds, 10);
+    if (!Number.isFinite(ttl) || ttl <= 0) {
+      ttl = Math.max(30, Math.round((fallbackTtl || 60000) / 1000));
+    }
+    var services = Array.isArray(payload && payload.services) ? payload.services.map(normalizeService).filter(Boolean) : [];
+    return {
+      updated_at: (payload && payload.updated_at) ? String(payload.updated_at) : new Date().toISOString(),
+      ttl_seconds: ttl,
+      services: services,
+      stale: !!(payload && payload.stale)
+    };
+  }
+
+  function formatDate(value) {
+    if (!value) {
+      return '';
+    }
+    var parsed = Date.parse(value);
+    if (Number.isNaN(parsed)) {
+      return value;
+    }
+    try {
+      return new Intl.DateTimeFormat(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit'
+      }).format(new Date(parsed));
+    } catch (err) {
+      return new Date(parsed).toISOString();
+    }
+  }
+
+  function escapeId(value) {
+    if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+      return CSS.escape(value);
+    }
+    return String(value).replace(/[^a-zA-Z0-9_-]/g, '\\$&');
+  }
+
+  function applyStatusClass(el, status) {
+    if (!el || !el.classList) {
+      return;
+    }
+    var classes = Object.values(STATUS_CLASS_MAP);
+    classes.forEach(function (cls) { el.classList.remove(cls); });
+    var mapped = STATUS_CLASS_MAP[status] || STATUS_CLASS_MAP.unknown;
+    el.classList.add(mapped);
+  }
+
+  function setupHud(container, config) {
+    if (!container) {
+      return;
+    }
+    container.classList.add('lo-hud');
+
+    var refreshBtn = container.querySelector('[data-lo-refresh]');
+    var countdownEl = container.querySelector('[data-lo-countdown]');
+    var fetchedEl = container.querySelector('[data-lo-fetched]');
+    var fetchedLabelEl = container.querySelector('[data-lo-fetched-label]');
+    var degradedEl = container.querySelector('[data-lo-degraded]');
+    var gridEl = container.querySelector('[data-lo-grid]');
+    var baseCountdown = countdownEl ? countdownEl.textContent : 'Auto-refresh ready';
+    var snapshotEndpoint = container.getAttribute('data-lo-snapshot') || config.snapshotEndpoint || '';
+    var refreshInterval = parseInt(container.getAttribute('data-lo-refresh-interval'), 10);
+    if (!Number.isFinite(refreshInterval) || refreshInterval <= 0) {
+      refreshInterval = parseInt(config.pollInterval, 10);
+    }
+    if (!Number.isFinite(refreshInterval) || refreshInterval <= 0) {
+      refreshInterval = 60000;
+    }
+
+    var spinnerEl = doc.createElement('span');
+    spinnerEl.className = 'lo-hud-spinner';
+    spinnerEl.setAttribute('aria-hidden', 'true');
+    spinnerEl.textContent = 'Dialing…';
+    if (refreshBtn && refreshBtn.parentNode) {
+      refreshBtn.parentNode.insertBefore(spinnerEl, refreshBtn.nextSibling);
+    } else {
+      container.appendChild(spinnerEl);
+    }
+
+    var state = {
+      fetchInFlight: false,
+      refreshTimer: null,
+      countdownTimer: null,
+      nextRefreshAt: null,
+      lastSnapshot: null
+    };
+
+    function setSpinner(active) {
+      if (active) {
+        container.classList.add('lo-hud--dialing');
+      } else {
+        container.classList.remove('lo-hud--dialing');
+      }
+    }
+
+    function setRefreshing(active) {
+      if (!refreshBtn) {
+        return;
+      }
+      refreshBtn.disabled = !!active;
+      refreshBtn.setAttribute('aria-busy', active ? 'true' : 'false');
+      refreshBtn.textContent = active ? 'Refreshing…' : 'Refresh now';
+    }
+
+    function setDegraded(active, message) {
+      if (!degradedEl) {
+        return;
+      }
+      if (active) {
+        degradedEl.textContent = message || 'Auto-refresh degraded';
+        degradedEl.removeAttribute('hidden');
+      } else {
+        degradedEl.textContent = '';
+        degradedEl.setAttribute('hidden', 'hidden');
+      }
+    }
+
+    function clearTimers() {
+      if (state.refreshTimer) {
+        root.clearTimeout(state.refreshTimer);
+        state.refreshTimer = null;
+      }
+      if (state.countdownTimer) {
+        root.clearInterval(state.countdownTimer);
+        state.countdownTimer = null;
+      }
+      state.nextRefreshAt = null;
+    }
+
+    function updateCountdown() {
+      if (!countdownEl) {
+        return;
+      }
+      if (!state.nextRefreshAt) {
+        countdownEl.textContent = doc.hidden ? 'Auto-refresh paused' : baseCountdown;
+        return;
+      }
+      var diff = state.nextRefreshAt - Date.now();
+      if (diff <= 0) {
+        countdownEl.textContent = 'Refreshing…';
+        return;
+      }
+      var seconds = Math.round(diff / 1000);
+      if (seconds < 60) {
+        countdownEl.textContent = 'Next refresh in ' + seconds + 's';
+        return;
+      }
+      var minutes = Math.floor(seconds / 60);
+      var remaining = seconds % 60;
+      countdownEl.textContent = 'Next refresh in ' + minutes + 'm ' + (remaining < 10 ? '0' : '') + remaining + 's';
+    }
+
+    function startCountdown() {
+      if (state.countdownTimer) {
+        root.clearInterval(state.countdownTimer);
+      }
+      updateCountdown();
+      state.countdownTimer = root.setInterval(updateCountdown, 1000);
+    }
+
+    function scheduleRefresh(delay) {
+      if (doc.hidden) {
+        clearTimers();
+        updateCountdown();
+        return;
+      }
+      if (!Number.isFinite(delay) || delay <= 0) {
+        delay = refreshInterval;
+      }
+      if (state.refreshTimer) {
+        root.clearTimeout(state.refreshTimer);
+      }
+      state.nextRefreshAt = Date.now() + delay;
+      startCountdown();
+      state.refreshTimer = root.setTimeout(function () {
+        state.refreshTimer = null;
+        fetchSnapshot(false);
+      }, delay);
+    }
+
+    function updateFetchedLabel() {
+      if (!fetchedEl || !state.lastSnapshot) {
+        return;
+      }
+      fetchedEl.textContent = formatDate(state.lastSnapshot.updated_at);
+      if (fetchedLabelEl) {
+        fetchedLabelEl.textContent = state.lastSnapshot.stale ? 'Last fetched (stale)' : 'Last fetched';
+      }
+    }
+
+    function updateCards(services) {
+      if (!Array.isArray(services)) {
+        return;
+      }
+      services.forEach(function (service) {
+        if (!service || !service.id) {
+          return;
+        }
+        var selector = '[data-provider-id="' + escapeId(service.id) + '"]';
+        var card = gridEl ? gridEl.querySelector(selector) : null;
+        if (!card) {
+          card = container.querySelector(selector);
+        }
+        if (!card) {
+          return;
+        }
+        var badge = card.querySelector('[data-lo-badge]') || card.querySelector('.status-badge');
+        if (badge) {
+          badge.textContent = service.status_text;
+          applyStatusClass(badge, service.status);
+          badge.setAttribute('data-status', service.status);
+        }
+        var summary = card.querySelector('[data-lo-summary]') || card.querySelector('.provider-card__summary');
+        if (summary) {
+          summary.textContent = service.summary || '';
+        }
+        var link = card.querySelector('[data-lo-status-url]') || card.querySelector('.provider-link');
+        if (link && service.url) {
+          link.setAttribute('href', service.url);
+        }
+      });
+    }
+
+    function applySnapshot(snapshot) {
+      state.lastSnapshot = snapshot;
+      updateFetchedLabel();
+      updateCards(snapshot.services);
+      if (snapshot.stale) {
+        setDegraded(true, 'Showing cached data – refreshing soon');
+      } else {
+        setDegraded(false);
+      }
+    }
+
+    function fetchSnapshot(manual) {
+      if (!snapshotEndpoint || state.fetchInFlight) {
+        return;
+      }
+      state.fetchInFlight = true;
+      setRefreshing(true);
+      setSpinner(true);
+
+      root.fetch(snapshotEndpoint, {
+        method: 'GET',
+        credentials: 'same-origin',
+        headers: { Accept: 'application/json' }
+      }).then(function (response) {
+        if (!response || typeof response.json !== 'function') {
+          throw new Error('invalid response');
+        }
+        return response.json();
+      }).then(function (payload) {
+        var snapshot = normalizeSnapshot(payload, refreshInterval);
+        applySnapshot(snapshot);
+        scheduleRefresh(refreshInterval);
+      }).catch(function () {
+        setDegraded(true, 'Auto-refresh unavailable – retrying');
+        scheduleRefresh(Math.min(refreshInterval, 30000));
+      }).finally(function () {
+        state.fetchInFlight = false;
+        setRefreshing(false);
+        setSpinner(false);
+      });
+    }
+
+    if (refreshBtn) {
+      refreshBtn.addEventListener('click', function (event) {
+        event.preventDefault();
+        if (state.fetchInFlight) {
+          return;
+        }
+        fetchSnapshot(true);
+      });
+    }
+
+    doc.addEventListener('visibilitychange', function () {
+      if (doc.hidden) {
+        clearTimers();
+        updateCountdown();
+      } else {
+        if (state.fetchInFlight) {
+          return;
+        }
+        if (state.lastSnapshot && state.lastSnapshot.stale) {
+          fetchSnapshot(false);
+        } else {
+          scheduleRefresh(Math.min(5000, refreshInterval));
+        }
+      }
+    });
+
+    var initialSnapshot = null;
+    var configInitial = config && config.initial ? config.initial : null;
+    if (configInitial && Array.isArray(configInitial.providers)) {
+      initialSnapshot = normalizeSnapshot({
+        updated_at: configInitial.fetched_at || configInitial.fetchedAt,
+        services: configInitial.providers,
+        stale: false,
+        ttl_seconds: Math.round(refreshInterval / 1000)
+      }, refreshInterval);
+    }
+
+    if (initialSnapshot) {
+      applySnapshot(initialSnapshot);
+    }
+
+    scheduleRefresh(refreshInterval);
+  }
+
+  function init() {
+    var config = root.LousyOutagesConfig || {};
+    var containers = doc.querySelectorAll('.lousy-outages');
+    if (!containers || !containers.length) {
+      return;
+    }
+    Array.prototype.forEach.call(containers, function (container) {
+      setupHud(container, config);
+    });
+  }
+
+  if (doc.readyState === 'loading') {
+    doc.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})(typeof window !== 'undefined' ? window : this);

--- a/lousy-outages/includes/Cron.php
+++ b/lousy-outages/includes/Cron.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Cron helpers for refreshing the cached snapshot.
+ */
+
+declare(strict_types=1);
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+if (! function_exists('lo_cron_bootstrap')) {
+    function lo_cron_bootstrap(): void
+    {
+        add_filter('cron_schedules', 'lo_register_snapshot_schedule');
+        add_action('init', 'lo_ensure_snapshot_schedule');
+        add_action('lo_refresh_snapshot', 'lo_run_snapshot_refresh');
+    }
+}
+
+if (! function_exists('lo_cron_activate')) {
+    function lo_cron_activate(): void
+    {
+        lo_ensure_snapshot_schedule();
+    }
+}
+
+if (! function_exists('lo_cron_deactivate')) {
+    function lo_cron_deactivate(): void
+    {
+        wp_clear_scheduled_hook('lo_refresh_snapshot');
+    }
+}
+
+if (! function_exists('lo_register_snapshot_schedule')) {
+    function lo_register_snapshot_schedule(array $schedules): array
+    {
+        $interval = lo_snapshot_interval_seconds();
+        $schedules['lo_snapshot_interval'] = [
+            'interval' => $interval,
+            'display'  => __('Lousy Outages Snapshot Interval', 'lousy-outages'),
+        ];
+
+        return $schedules;
+    }
+}
+
+if (! function_exists('lo_snapshot_interval_seconds')) {
+    function lo_snapshot_interval_seconds(): int
+    {
+        $minutes = (int) get_option('lo_snapshot_interval_minutes', 3);
+        $minutes = (int) apply_filters('lo_snapshot_interval_minutes', $minutes);
+        if ($minutes < 2) {
+            $minutes = 2;
+        }
+        if ($minutes > 5) {
+            $minutes = 5;
+        }
+
+        return max(120, $minutes * MINUTE_IN_SECONDS);
+    }
+}
+
+if (! function_exists('lo_ensure_snapshot_schedule')) {
+    function lo_ensure_snapshot_schedule(): void
+    {
+        if (! wp_next_scheduled('lo_refresh_snapshot')) {
+            wp_schedule_event(time() + 30, 'lo_snapshot_interval', 'lo_refresh_snapshot');
+        }
+    }
+}
+
+if (! function_exists('lo_run_snapshot_refresh')) {
+    function lo_run_snapshot_refresh(): void
+    {
+        if (! function_exists('lo_snapshot_refresh')) {
+            return;
+        }
+
+        $snapshot = lo_snapshot_refresh(true);
+        do_action('lousy_outages_log', 'snapshot_refresh', [
+            'services' => is_array($snapshot['services'] ?? null) ? count($snapshot['services']) : 0,
+            'stale'    => ! empty($snapshot['stale']),
+            'updated'  => $snapshot['updated_at'] ?? gmdate('c'),
+        ]);
+    }
+}

--- a/lousy-outages/includes/Mailer.php
+++ b/lousy-outages/includes/Mailer.php
@@ -82,6 +82,12 @@ class Mailer {
 
         $message = implode("\r\n", $parts);
 
-        return wp_mail($email, $subject, $message, $headers);
+        $sent = wp_mail($email, $subject, $message, $headers);
+
+        if (! $sent && defined('WP_DEBUG') && WP_DEBUG) {
+            error_log(sprintf('[lousy_outages] mail_send_failed recipient=%s subject=%s', $email, $subject));
+        }
+
+        return (bool) $sent;
     }
 }

--- a/lousy-outages/includes/Snapshot.php
+++ b/lousy-outages/includes/Snapshot.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Snapshot caching and REST exposure for Lousy Outages.
+ */
+
+declare(strict_types=1);
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+if (! function_exists('lo_snapshot_bootstrap')) {
+    function lo_snapshot_bootstrap(): void
+    {
+        add_action('rest_api_init', 'lo_snapshot_register_route');
+    }
+}
+
+if (! function_exists('lo_snapshot_register_route')) {
+    function lo_snapshot_register_route(): void
+    {
+        register_rest_route(
+            'lousy/v1',
+            '/snapshot',
+            [
+                'methods'             => \WP_REST_Server::READABLE,
+                'permission_callback' => '__return_true',
+                'callback'            => 'lo_snapshot_rest_callback',
+            ]
+        );
+    }
+}
+
+if (! function_exists('lo_snapshot_rest_callback')) {
+    function lo_snapshot_rest_callback(\WP_REST_Request $request)
+    {
+        return rest_ensure_response(lo_snapshot_get_cached());
+    }
+}
+
+if (! function_exists('lo_snapshot_transient_key')) {
+    function lo_snapshot_transient_key(): string
+    {
+        return 'lo_snapshot_payload_v1';
+    }
+}
+
+if (! function_exists('lo_snapshot_last_good_key')) {
+    function lo_snapshot_last_good_key(): string
+    {
+        return 'lo_snapshot_last_good_v1';
+    }
+}
+
+if (! function_exists('lo_snapshot_default_ttl')) {
+    function lo_snapshot_default_ttl(): int
+    {
+        $ttl = (int) apply_filters('lo_snapshot_ttl', 300);
+        if ($ttl < 120) {
+            $ttl = 120;
+        }
+        if ($ttl > 900) {
+            $ttl = 900;
+        }
+
+        return $ttl;
+    }
+}
+
+if (! function_exists('lo_snapshot_refresh')) {
+    function lo_snapshot_refresh(bool $force_refresh = true): array
+    {
+        if (! function_exists('lousy_outages_get_snapshot')) {
+            return lo_snapshot_get_cached();
+        }
+
+        $raw = lousy_outages_get_snapshot($force_refresh);
+        $updated_at = isset($raw['fetched_at']) ? (string) $raw['fetched_at'] : gmdate('c');
+        $services = [];
+        if (! empty($raw['providers']) && is_array($raw['providers'])) {
+            foreach ($raw['providers'] as $provider) {
+                if (! is_array($provider)) {
+                    continue;
+                }
+                $services[] = lo_snapshot_normalize_service($provider, $updated_at);
+            }
+        }
+
+        $payload = [
+            'updated_at' => $updated_at,
+            'services'   => $services,
+        ];
+
+        return lo_snapshot_store($payload);
+    }
+}
+
+if (! function_exists('lo_snapshot_store')) {
+    function lo_snapshot_store(array $payload): array
+    {
+        $ttl = lo_snapshot_default_ttl();
+        $expires_at = time() + $ttl;
+
+        $stored = [
+            'updated_at' => (string) ($payload['updated_at'] ?? gmdate('c')),
+            'services'   => is_array($payload['services'] ?? null) ? array_values($payload['services']) : [],
+            'expires_at' => $expires_at,
+        ];
+
+        set_transient(lo_snapshot_transient_key(), $stored, $ttl);
+        update_option(lo_snapshot_last_good_key(), $stored, false);
+
+        return lo_snapshot_prepare_response($stored, false);
+    }
+}
+
+if (! function_exists('lo_snapshot_get_cached')) {
+    function lo_snapshot_get_cached(): array
+    {
+        $cached = get_transient(lo_snapshot_transient_key());
+        if (is_array($cached) && ! empty($cached['services'])) {
+            $stale = isset($cached['expires_at']) ? (int) $cached['expires_at'] < time() : false;
+            return lo_snapshot_prepare_response($cached, $stale);
+        }
+
+        $stored = get_option(lo_snapshot_last_good_key(), []);
+        if (is_array($stored) && ! empty($stored['services'])) {
+            return lo_snapshot_prepare_response($stored, true);
+        }
+
+        return [
+            'updated_at'  => gmdate('c'),
+            'ttl_seconds' => lo_snapshot_default_ttl(),
+            'services'    => [],
+            'stale'       => true,
+        ];
+    }
+}
+
+if (! function_exists('lo_snapshot_prepare_response')) {
+    function lo_snapshot_prepare_response(array $stored, bool $stale): array
+    {
+        $ttl = lo_snapshot_default_ttl();
+        $response = [
+            'updated_at'  => isset($stored['updated_at']) ? (string) $stored['updated_at'] : gmdate('c'),
+            'ttl_seconds' => $ttl,
+            'services'    => [],
+            'stale'       => $stale,
+        ];
+
+        if (! empty($stored['services']) && is_array($stored['services'])) {
+            foreach ($stored['services'] as $service) {
+                if (! is_array($service)) {
+                    continue;
+                }
+                $response['services'][] = lo_snapshot_normalize_service($service, $response['updated_at']);
+            }
+        }
+
+        return $response;
+    }
+}
+
+if (! function_exists('lo_snapshot_normalize_service')) {
+    function lo_snapshot_normalize_service(array $service, string $fetched_at): array
+    {
+        $status_code = strtolower((string) ($service['stateCode'] ?? $service['status'] ?? 'unknown'));
+        $status_label = (string) ($service['state'] ?? $service['status_label'] ?? ucfirst($status_code));
+        $updated_at = (string) ($service['updatedAt'] ?? $service['updated_at'] ?? $fetched_at);
+        $risk = 0;
+        if (isset($service['risk'])) {
+            $risk = (int) $service['risk'];
+        } elseif (isset($service['prealert']['risk'])) {
+            $risk = (int) $service['prealert']['risk'];
+        }
+
+        return [
+            'id'          => (string) ($service['id'] ?? $service['provider'] ?? ''),
+            'name'        => (string) ($service['name'] ?? $service['provider'] ?? ''),
+            'status'      => $status_code ?: 'unknown',
+            'status_text' => $status_label ?: 'Unknown',
+            'summary'     => (string) ($service['summary'] ?? $service['message'] ?? ''),
+            'updated_at'  => $updated_at ?: $fetched_at,
+            'url'         => (string) ($service['url'] ?? ''),
+            'risk'        => max(0, $risk),
+        ];
+    }
+}

--- a/lousy-outages/includes/email-templates.php
+++ b/lousy-outages/includes/email-templates.php
@@ -72,18 +72,18 @@ if (!function_exists('send_lo_confirmation_email')) {
         $confirm_raw  = esc_url_raw($confirm_url);
         $confirm_html = esc_url($confirm_url);
 
-        $subject = '🕹️ Confirm Access: Lousy Outages Command Console';
+        $subject = '🔔 You’re subscribed to Lousy Outages';
 
         $text_body_lines = [
-            'Rogue signal detected. Ready to jack in?',
+            'Welcome to the Lousy Outages alert list!',
             '',
-            'Confirm your access to the Lousy Outages command bunker:',
+            'Tap the link below to confirm and start receiving outage intel:',
             $confirm_raw,
             '',
-            'If this wasn\'t you, cut the wire instantly:',
-            $unsubscribe_raw,
+            'Dashboard anytime: ' . home_url('/lousy-outages/'),
             '',
-            'Stay sharp – Lousy Outages',
+            'Unsubscribe instantly if this wasn’t you:',
+            $unsubscribe_raw,
         ];
         $text_body = implode("\n", $text_body_lines);
 
@@ -95,21 +95,21 @@ if (!function_exists('send_lo_confirmation_email')) {
             <meta charset="utf-8">
             <title>Lousy Outages Confirmation</title>
         </head>
-        <body style="margin:0;background:#000;color:#FFD700;font-family:'Courier New','Lucida Console',monospace;">
-            <div style="max-width:640px;margin:0 auto;padding:36px 18px;">
-                <div style="border:3px solid #00FF00;background:linear-gradient(155deg,rgba(0,0,0,0.95),rgba(12,20,0,0.92));border-radius:20px;padding:30px 26px;box-shadow:0 0 32px rgba(0,255,0,0.3);">
-                    <p style="margin:0 0 12px;font-size:13px;letter-spacing:0.18em;text-transform:uppercase;color:#00FF00;">rogue signal detected</p>
-                    <h1 style="margin:0 0 16px;font-size:28px;color:#FFD700;letter-spacing:0.08em;text-transform:uppercase;">Confirm bunker access</h1>
-                    <p style="margin:0 0 18px;font-size:16px;line-height:1.6;color:#FDF5A6;">One tap locks your feed into outage intel and neon-lit play-by-play. No confirmation, no transmissions.</p>
+        <body style="margin:0;background:#05050a;color:#f7f4ff;font-family:Segoe UI,Roboto,system-ui,-apple-system,sans-serif;">
+            <div style="max-width:640px;margin:0 auto;padding:32px 20px;">
+                <div style="border-radius:18px;border:1px solid rgba(119,85,255,0.4);background:linear-gradient(145deg,#0d0c1f,#1b1540);box-shadow:0 22px 46px rgba(26,17,68,0.45);padding:32px 30px;">
+                    <p style="margin:0 0 12px;font-size:14px;letter-spacing:0.12em;text-transform:uppercase;color:#8f80ff;">Welcome aboard</p>
+                    <h1 style="margin:0 0 16px;font-size:30px;color:#f9f7ff;letter-spacing:0.04em;">You’re subscribed to Lousy Outages</h1>
+                    <p style="margin:0 0 18px;font-size:16px;line-height:1.6;color:rgba(255,255,255,0.82);">Confirm your email to receive outage alerts, post-mortems, and status intel. One click keeps you in the loop.</p>
                     <p style="margin:0 0 22px;">
-                        <a href="<?php echo esc_url($confirm_html); ?>" style="display:inline-block;padding:16px 26px;border-radius:999px;border:2px solid #00FF00;background:#111;color:#00FF00;font-weight:700;text-decoration:none;text-transform:uppercase;letter-spacing:0.12em;">Confirm &amp; Jack In</a>
+                        <a href="<?php echo esc_url($confirm_html); ?>" style="display:inline-block;padding:16px 28px;border-radius:999px;border:2px solid rgba(170,144,255,0.9);background:#6c5ce7;color:#fff;font-weight:700;text-decoration:none;letter-spacing:0.08em;">Confirm subscription</a>
                     </p>
-                    <p style="margin:0 0 18px;font-size:13px;color:#FDF5A6;">If the button stalls, copy this access link:<br><span style="color:#00FF00;"><?php echo esc_html($confirm_raw); ?></span></p>
-                    <div style="margin:24px 0;padding:16px 18px;border:1px dashed rgba(0,255,0,0.6);border-radius:14px;background:rgba(4,25,4,0.7);color:#BFFFBF;font-size:13px;">
-                        <strong style="display:block;font-size:11px;letter-spacing:0.18em;color:#7BFF7B;margin-bottom:6px;text-transform:uppercase;">Unsubscribe</strong>
-                        Back out anytime: <a style="color:#7BFF7B;text-decoration:none;" href="<?php echo esc_url($unsubscribe_html); ?>"><?php echo esc_html($unsubscribe_raw); ?></a>
+                    <p style="margin:0 0 18px;font-size:14px;color:rgba(255,255,255,0.75);">Button sleepy? Copy this link instead:<br><span style="word-break:break-all;color:#b6a9ff;"><?php echo esc_html($confirm_raw); ?></span></p>
+                    <p style="margin:0 0 18px;font-size:14px;color:rgba(255,255,255,0.75);">Visit the live dashboard any time:<br><a href="<?php echo esc_url(home_url('/lousy-outages/')); ?>" style="color:#8f80ff;"><?php echo esc_html(home_url('/lousy-outages/')); ?></a></p>
+                    <div style="margin:24px 0 0;padding:16px 18px;border:1px dashed rgba(143,128,255,0.6);border-radius:14px;background:rgba(24,20,58,0.7);color:rgba(255,255,255,0.8);font-size:13px;">
+                        <strong style="display:block;font-size:11px;letter-spacing:0.16em;color:#d0c6ff;margin-bottom:6px;text-transform:uppercase;">Unsubscribe</strong>
+                        Leave immediately if this wasn’t you:<br><a style="color:#d0c6ff;text-decoration:none;" href="<?php echo esc_url($unsubscribe_html); ?>"><?php echo esc_html($unsubscribe_raw); ?></a>
                     </div>
-                    <p style="margin:0;font-size:12px;color:rgba(255,215,0,0.75);">Console tip: whitelist suzyeaston.ca so the alerts don&rsquo;t get ghosted.</p>
                 </div>
             </div>
         </body>


### PR DESCRIPTION
## Summary
- add snapshot transient management, REST endpoint, and cron wiring so the dashboard reads cached data
- update the public shortcode to enqueue the new HUD/lyric captcha assets and avoid live provider fetches on render
- refresh confirmation/alert email templates and improve mailer logging

## Testing
- php -l lousy-outages/includes/Snapshot.php
- php -l lousy-outages/includes/Subscribe.php
- php -l lousy-outages/public/shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_69027641b19c832e9b38309f59e4096a