### PR TITLE
Fix captcha token usage in Lousy Outages subscription form

### DIFF
--- a/lousy-outages/assets/lousy-outages.js
+++ b/lousy-outages/assets/lousy-outages.js
@@ -504,7 +504,7 @@
     var honeypot = form.querySelector('input[name="website"]');
     var nonceInput = form.querySelector('input[name="_wpnonce"]');
     var challengeInput = form.querySelector('input[name="challenge_response"]');
-    var challengeExpected = form.querySelector('input[name="challenge_expected"]');
+    var challengeTokenInput = form.querySelector('input[name="challenge_token"]');
     var endpoint = form.getAttribute('action') || state.subscribeEndpoint;
     if (!endpoint || !state.fetchImpl) {
       return;
@@ -522,7 +522,7 @@
       setSubscribeStatus(statusEl, 'Please answer the human check.', true);
       return;
     }
-    if (!challengeExpected || !challengeExpected.value) {
+    if (!challengeTokenInput || !challengeTokenInput.value) {
       setSubscribeStatus(statusEl, 'Challenge missing. Reload and try again.', true);
       return;
     }
@@ -535,7 +535,7 @@
       website: honeypot ? honeypot.value : '',
       _wpnonce: nonceInput ? nonceInput.value : '',
       challenge_response: challengeInput ? challengeInput.value.trim() : '',
-      challenge_expected: challengeExpected ? challengeExpected.value : ''
+      challenge_token: challengeTokenInput ? challengeTokenInput.value : ''
     };
 
     state.fetchImpl(endpoint, {


### PR DESCRIPTION
## Summary
- ensure the Lousy Outages subscribe form JavaScript reads the hidden captcha token field
- send the captcha token back to the API when submitting the form so validation succeeds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69027ff745e4832ebc3f6377520cc544