### PR TITLE
Fix Lousy Outages loader visibility

### DIFF
--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -97,6 +97,10 @@
   display: inline-block;
 }
 
+.lousy-outages [hidden] {
+  display: none !important;
+}
+
 .lo-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));


### PR DESCRIPTION
## Summary
- ensure elements inside the Lousy Outages widget respect the hidden attribute so the loading spinner disappears once data is loaded

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_69028187142c832e8fa14aa4732816a4