### PR TITLE
Clarify outage refresh timestamp label

### DIFF
--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -333,7 +333,9 @@ function render_shortcode(): string {
         return wp_date($format, $timestamp);
     };
 
-    $fetched_label = ('snapshot' === strtolower((string) $source)) ? 'Last fetched:' : 'Fetched:';
+    $fetched_label = ('snapshot' === strtolower((string) $source))
+        ? 'Outage info last refreshed:'
+        : 'Outage info fetched:';
 
     ob_start();
     ?>


### PR DESCRIPTION
## Summary
- update the lousy outages header label to say when outage info was last refreshed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690283499e34832e8d19df80e9b2b6de