### PR TITLE
Fix missing DNS helper in fetcher error handling

### DIFF
--- a/lousy-outages/includes/Fetcher.php
+++ b/lousy-outages/includes/Fetcher.php
@@ -592,6 +592,14 @@ class Fetcher {
         return false;
     }
 
+    private function is_dns_error(string $message): bool {
+        if ('' === trim($message)) {
+            return false;
+        }
+
+        return 'dns' === $this->classify_network_error($message);
+    }
+
     private function sanitize(?string $text): string {
         if (! $text) {
             return '';


### PR DESCRIPTION
## Summary
- add the missing DNS error helper used by the fetcher suppression logic
- reuse the existing network error classifier to determine DNS failures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690290252ea4832eb7d97f13bd59c3be