### PR TITLE
Remove next refresh countdown messaging

### DIFF
--- a/lousy-outages/assets/hud.js
+++ b/lousy-outages/assets/hud.js
@@ -190,14 +190,7 @@
         countdownEl.textContent = 'Refreshing…';
         return;
       }
-      var seconds = Math.round(diff / 1000);
-      if (seconds < 60) {
-        countdownEl.textContent = 'Next refresh in ' + seconds + 's';
-        return;
-      }
-      var minutes = Math.floor(seconds / 60);
-      var remaining = seconds % 60;
-      countdownEl.textContent = 'Next refresh in ' + minutes + 'm ' + (remaining < 10 ? '0' : '') + remaining + 's';
+      countdownEl.textContent = '';
     }
 
     function startCountdown() {

--- a/lousy-outages/assets/lousy-outages.js
+++ b/lousy-outages/assets/lousy-outages.js
@@ -202,14 +202,7 @@
       state.countdownEl.textContent = 'Refreshing…';
       return;
     }
-    var seconds = Math.round(diff / 1000);
-    if (seconds < 60) {
-      state.countdownEl.textContent = 'Next refresh in ' + seconds + 's';
-      return;
-    }
-    var minutes = Math.floor(seconds / 60);
-    var rem = seconds % 60;
-    state.countdownEl.textContent = 'Next refresh in ' + minutes + 'm ' + rem + 's';
+    state.countdownEl.textContent = '';
   }
 
   function updateFetched() {


### PR DESCRIPTION
## Summary
- stop rendering the countdown text that announced the next automatic refresh in the outages UI
- keep the paused and refreshing states readable while otherwise leaving the area blank

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6902b0e2e7e8832e95d31c57e5ab97c7