### PR TITLE
Refresh provider list with new Slack and Qubeyond feeds

### DIFF
--- a/lousy-outages/README.md
+++ b/lousy-outages/README.md
@@ -11,24 +11,22 @@ Monitor third‑party service status and get SMS and email alerts when things br
 | openai | OpenAI | https://status.openai.com/api/v2/summary.json |
 | atlassian | Atlassian | https://status.atlassian.com/api/v2/summary.json |
 | digitalocean | DigitalOcean | https://status.digitalocean.com/api/v2/summary.json |
-| gitlab | GitLab | https://status.gitlab.com/pages/5b36dc6502d06804c08349f7/rss |
 | netlify | Netlify | https://www.netlifystatus.com/api/v2/summary.json |
 | vercel | Vercel | https://www.vercel-status.com/api/v2/summary.json |
 | pagerduty | PagerDuty | https://status.pagerduty.com/api/v2/summary.json |
 | zoom | Zoom | https://status.zoom.us/api/v2/summary.json |
 | zscaler | Zscaler | https://trust.zscaler.com/rss-feed |
-| stripe | Stripe | https://www.stripestatus.com/history.rss |
 | twilio | Twilio | https://status.twilio.com/api/v2/summary.json |
-| datadog | Datadog | https://status.datadoghq.com/api/v2/summary.json |
 | linear | Linear | https://status.linear.app/api/v2/summary.json |
 | sentry | Sentry | https://status.sentry.io/api/v2/summary.json |
-| slack | Slack | https://slack-status.com/api/v2.0.0/current |
+| slack | Slack | https://slack-status.com/feed/rss |
 | aws | AWS | https://status.aws.amazon.com/rss/all.rss |
 | azure | Azure | https://azurestatuscdn.azureedge.net/en-us/status/feed/ |
 | gcp | Google Cloud | https://www.google.com/appsstatus/dashboard/en-CA/feed.atom |
+| qubeyond | Qubeyond | https://status.qubeyond.com/state_feed/feed.atom |
 | downdetector-ca | Downdetector (CA Aggregate) | https://downdetector.ca/archive/?format=rss |
 
-Slack now uses the official `slack-status.com/api/v2.0.0/current` endpoint so green states render the "All systems operational" headline, and Zscaler is polled from `https://trust.zscaler.com` to dodge intermittent DNS failures. New default providers include Stripe, Twilio, Datadog, Linear, and Sentry—toggle any of them from **Settings → Lousy Outages**.
+Slack is polled from the official RSS feed at `https://slack-status.com/feed/rss`, and Zscaler is queried from `https://trust.zscaler.com` to dodge intermittent DNS failures. New default providers include Slack, Twilio, Linear, Sentry, and Qubeyond—toggle any of them from **Settings → Lousy Outages**.
 
 Downdetector is disabled by default because the RSS feed is unofficial and can disappear; enable it from the settings page if it loads for you. When the feed is unreachable, the adapter reports an `unknown` state with an error badge rather than failing the whole poll.
 

--- a/lousy-outages/includes/Downdetector.php
+++ b/lousy-outages/includes/Downdetector.php
@@ -143,7 +143,6 @@ class Downdetector {
             'azure'       => ['microsoft', 'microsoft azure'],
             'gcp'         => ['google cloud', 'google'],
             'github'      => ['github'],
-            'gitlab'      => ['gitlab'],
             'slack'       => ['slack'],
             'zscaler'     => ['zscaler'],
             'cloudflare'  => ['cloudflare'],
@@ -154,6 +153,7 @@ class Downdetector {
             'atlassian'   => ['atlassian', 'jira', 'confluence', 'bitbucket'],
             'pagerduty'   => ['pagerduty', 'pager duty'],
             'zoom'        => ['zoom'],
+            'qubeyond'    => ['qubeyond'],
         ];
 
         $keywords = [];

--- a/lousy-outages/includes/Fetcher.php
+++ b/lousy-outages/includes/Fetcher.php
@@ -693,12 +693,10 @@ class Lousy_Outages_Fetcher {
     private static $PROVIDERS = [
         // Statuspage JSON (keep as JSON)
         'cloudflare' => ['kind' => 'statuspage', 'base' => 'https://www.cloudflarestatus.com'],
-        'datadog'    => ['kind' => 'statuspage', 'base' => 'https://status.datadoghq.com'],
         'zoom'       => ['kind' => 'statuspage', 'base' => 'https://status.zoom.us'],
 
         // Switch these to RSS/Atom (per Suzy’s feeds)
-        'stripe'     => ['kind' => 'rss', 'feed' => 'https://www.stripestatus.com/history.rss', 'link' => 'https://www.stripestatus.com/'],
-        'gitlab'     => ['kind' => 'rss', 'feed' => 'https://status.gitlab.com/pages/5b36dc6502d06804c08349f7/rss', 'link' => 'https://status.gitlab.com/'],
+        'slack'      => ['kind' => 'rss', 'feed' => 'https://slack-status.com/feed/rss', 'link' => 'https://status.slack.com/'],
         'zscaler'    => ['kind' => 'rss', 'feed' => 'https://trust.zscaler.com/rss-feed', 'link' => 'https://trust.zscaler.com/cloud-status'],
         'gcp'        => ['kind' => 'atom', 'feed' => 'https://www.google.com/appsstatus/dashboard/en-CA/feed.atom', 'link' => 'https://www.google.com/appsstatus/dashboard/'],
         'azure'      => [
@@ -709,6 +707,7 @@ class Lousy_Outages_Fetcher {
             ],
             'link' => 'https://status.azure.com/en-us/status',
         ],
+        'qubeyond'   => ['kind' => 'atom', 'feed' => 'https://status.qubeyond.com/state_feed/feed.atom', 'link' => 'https://status.qubeyond.com/'],
 
         // PagerDuty (HTML scrape of dashboard headline)
         'pagerduty'  => ['kind' => 'scrape', 'url' => 'https://status.pagerduty.com/posts/dashboard'],
@@ -731,13 +730,12 @@ class Lousy_Outages_Fetcher {
 
     private static $NAMES = [
         'cloudflare' => 'Cloudflare',
-        'datadog'    => 'Datadog',
         'zoom'       => 'Zoom',
-        'stripe'     => 'Stripe',
-        'gitlab'     => 'GitLab',
+        'slack'      => 'Slack',
         'zscaler'    => 'Zscaler',
         'gcp'        => 'Google Cloud',
         'azure'      => 'Microsoft Azure',
+        'qubeyond'   => 'Qubeyond',
         'pagerduty'  => 'PagerDuty',
         'aws'        => 'Amazon Web Services',
         'crowdstrike'=> 'CrowdStrike',

--- a/lousy-outages/includes/Providers.php
+++ b/lousy-outages/includes/Providers.php
@@ -10,7 +10,6 @@ namespace {
             ['id' => 'openai', 'name' => 'OpenAI', 'type' => 'statuspage', 'url' => 'https://status.openai.com/api/v2/summary.json'],
             ['id' => 'atlassian', 'name' => 'Atlassian', 'type' => 'statuspage', 'url' => 'https://status.atlassian.com/api/v2/summary.json'],
             ['id' => 'digitalocean', 'name' => 'DigitalOcean', 'type' => 'statuspage', 'url' => 'https://status.digitalocean.com/api/v2/summary.json'],
-            ['id' => 'gitlab', 'name' => 'GitLab', 'type' => 'rss', 'url' => 'https://status.gitlab.com/pages/5b36dc6502d06804c08349f7/rss'],
             ['id' => 'netlify', 'name' => 'Netlify', 'type' => 'statuspage', 'url' => 'https://www.netlifystatus.com/api/v2/summary.json'],
             ['id' => 'vercel', 'name' => 'Vercel', 'type' => 'statuspage', 'url' => 'https://www.vercel-status.com/api/v2/summary.json'],
             ['id' => 'pagerduty', 'name' => 'PagerDuty', 'type' => 'statuspage', 'url' => 'https://status.pagerduty.com/api/v2/summary.json'],
@@ -18,19 +17,16 @@ namespace {
             ['id' => 'zscaler', 'name' => 'Zscaler', 'type' => 'rss', 'url' => 'https://trust.zscaler.com/rss-feed'],
 
             // High-value adds (Statuspage JSON)
-            ['id' => 'stripe', 'name' => 'Stripe', 'type' => 'rss', 'url' => 'https://www.stripestatus.com/history.rss'],
             ['id' => 'twilio', 'name' => 'Twilio', 'type' => 'statuspage', 'url' => 'https://status.twilio.com/api/v2/summary.json'],
-            ['id' => 'datadog', 'name' => 'Datadog', 'type' => 'statuspage', 'url' => 'https://status.datadoghq.com/api/v2/summary.json'],
             ['id' => 'linear', 'name' => 'Linear', 'type' => 'statuspage', 'url' => 'https://status.linear.app/api/v2/summary.json'],
             ['id' => 'sentry', 'name' => 'Sentry', 'type' => 'statuspage', 'url' => 'https://status.sentry.io/api/v2/summary.json'],
 
-            // Vendor APIs
-            ['id' => 'slack', 'name' => 'Slack', 'type' => 'slack_current', 'url' => 'https://slack-status.com/api/v2.0.0/current'],
-
             // RSS/Atom feeds
+            ['id' => 'slack', 'name' => 'Slack', 'type' => 'rss', 'url' => 'https://slack-status.com/feed/rss'],
             ['id' => 'aws', 'name' => 'AWS', 'type' => 'rss', 'url' => 'https://status.aws.amazon.com/rss/all.rss'],
             ['id' => 'azure', 'name' => 'Azure', 'type' => 'rss', 'url' => 'https://rssfeed.azure.status.microsoft/en-us/status/feed/'],
             ['id' => 'gcp', 'name' => 'Google Cloud', 'type' => 'atom', 'url' => 'https://www.google.com/appsstatus/dashboard/en-CA/feed.atom'],
+            ['id' => 'qubeyond', 'name' => 'Qubeyond', 'type' => 'atom', 'url' => 'https://status.qubeyond.com/state_feed/feed.atom'],
 
             // Optional aggregate (disabled by default in settings)
             ['id' => 'downdetector-ca', 'name' => 'Downdetector (CA Aggregate)', 'type' => 'rss', 'url' => 'https://downdetector.ca/archive/?format=rss', 'disabled' => true, 'optional' => true],
@@ -152,9 +148,9 @@ namespace LousyOutages {
 
         private static function derive_status_url( array $provider ): string {
             $wellKnown = [
-                'zscaler' => 'https://trust.zscaler.com/',
-                'stripe'  => 'https://status.stripe.com/',
-                'gitlab'  => 'https://status.gitlab.com/',
+                'zscaler'  => 'https://trust.zscaler.com/',
+                'slack'    => 'https://status.slack.com/',
+                'qubeyond' => 'https://status.qubeyond.com/',
             ];
 
             if ( ! empty( $provider['id'] ) && isset( $wellKnown[ $provider['id'] ] ) ) {

--- a/lousy-outages/includes/Subscribe.php
+++ b/lousy-outages/includes/Subscribe.php
@@ -198,7 +198,7 @@ class Lousy_Outages_Subscribe {
 confirmed. you're now getting the Lousy Outages briefings. 🛰️
 
 expect:
-- outage and degradation alerts for cloudflare, aws, azure, gcp, stripe, pagerduty, zscaler (and their friends)
+- outage and degradation alerts for cloudflare, aws, azure, gcp, slack, pagerduty, zscaler, qubeyond (and their friends)
 - mini postmortems with timelines + impact notes
 - security watch items so you can harden things before the next wobble
 
@@ -221,7 +221,7 @@ TEXT;
   <div style="max-width:560px;margin:24px auto;padding:20px;border:2px solid #ffb81c;border-radius:14px;background:linear-gradient(140deg,#0b0b0b,#1a0b00);box-shadow:0 18px 36px rgba(0,0,0,0.45);">
     <h2 style="margin:0 0 10px;font-size:20px;color:#ffb81c;text-transform:uppercase;letter-spacing:0.05em;">✅ link established</h2>
     <p style="margin:0 0 12px;">welcome to the status underground.</p>
-    <p style="margin:0 0 18px;">you'll get alerts when providers wobble: cloudflare • aws • azure • gcp • stripe • pagerduty • zscaler.</p>
+    <p style="margin:0 0 18px;">you'll get alerts when providers wobble: cloudflare • aws • azure • gcp • slack • pagerduty • zscaler • qubeyond.</p>
     <p style="margin:0 0 18px;"><a href="{$dashboard_url}" style="display:inline-block;padding:12px 18px;border-radius:999px;border:2px solid #ffb81c;background:#f04e23;color:#050505;font-weight:700;text-decoration:none;">OPEN LIVE DASHBOARD</a></p>
     <blockquote style="margin:12px 0;padding:10px 14px;border-left:3px solid rgba(255,184,28,0.8);background:rgba(255,184,28,0.08);">
       “This is what it feels like to be hunted by something smarter than you.”<br>


### PR DESCRIPTION
## Summary
- remove Stripe, Datadog, and GitLab from the default provider roster
- add Slack's RSS feed and the Qubeyond Atom feed to the provider defaults and fetcher map
- update supporting docs, downdetector keywords, and subscription copy to reflect the new provider mix

## Testing
- php -l lousy-outages/includes/Providers.php
- php -l lousy-outages/includes/Fetcher.php
- php -l lousy-outages/includes/Downdetector.php
- php -l lousy-outages/includes/Subscribe.php

------
https://chatgpt.com/codex/tasks/task_e_6903a30fb1f0832eb6668ae76b7c11d6