### PR TITLE
Remove Slack RSS feed from Lousy Outages defaults

### DIFF
--- a/lousy-outages/README.md
+++ b/lousy-outages/README.md
@@ -19,14 +19,13 @@ Monitor third‑party service status and get SMS and email alerts when things br
 | twilio | Twilio | https://status.twilio.com/api/v2/summary.json |
 | linear | Linear | https://status.linear.app/api/v2/summary.json |
 | sentry | Sentry | https://status.sentry.io/api/v2/summary.json |
-| slack | Slack | https://slack-status.com/feed/rss |
 | aws | AWS | https://status.aws.amazon.com/rss/all.rss |
 | azure | Azure | https://azurestatuscdn.azureedge.net/en-us/status/feed/ |
 | gcp | Google Cloud | https://www.google.com/appsstatus/dashboard/en-CA/feed.atom |
 | qubeyond | Qubeyond | https://status.qubeyond.com/state_feed/feed.atom |
 | downdetector-ca | Downdetector (CA Aggregate) | https://downdetector.ca/archive/?format=rss |
 
-Slack is polled from the official RSS feed at `https://slack-status.com/feed/rss`, and Zscaler is queried from `https://trust.zscaler.com` to dodge intermittent DNS failures. New default providers include Slack, Twilio, Linear, Sentry, and Qubeyond—toggle any of them from **Settings → Lousy Outages**.
+Zscaler is queried from `https://trust.zscaler.com` to dodge intermittent DNS failures. New default providers include Twilio, Linear, Sentry, and Qubeyond—toggle any of them from **Settings → Lousy Outages**.
 
 Downdetector is disabled by default because the RSS feed is unofficial and can disappear; enable it from the settings page if it loads for you. When the feed is unreachable, the adapter reports an `unknown` state with an error badge rather than failing the whole poll.
 

--- a/lousy-outages/assets/lousy-outages.js
+++ b/lousy-outages/assets/lousy-outages.js
@@ -37,7 +37,6 @@
       'Somewhere a Lambda forgot to set its alarm.'
     ],
     github: ['Push it real good, but maybe later.'],
-    slack: ['Time to revive the email thread.'],
     default: ['Hold tight—someone’s jiggling the ethernet cable.']
   };
 

--- a/lousy-outages/includes/Downdetector.php
+++ b/lousy-outages/includes/Downdetector.php
@@ -143,7 +143,6 @@ class Downdetector {
             'azure'       => ['microsoft', 'microsoft azure'],
             'gcp'         => ['google cloud', 'google'],
             'github'      => ['github'],
-            'slack'       => ['slack'],
             'zscaler'     => ['zscaler'],
             'cloudflare'  => ['cloudflare'],
             'openai'      => ['openai'],

--- a/lousy-outages/includes/Fetcher.php
+++ b/lousy-outages/includes/Fetcher.php
@@ -696,7 +696,6 @@ class Lousy_Outages_Fetcher {
         'zoom'       => ['kind' => 'statuspage', 'base' => 'https://status.zoom.us'],
 
         // Switch these to RSS/Atom (per Suzy’s feeds)
-        'slack'      => ['kind' => 'rss', 'feed' => 'https://slack-status.com/feed/rss', 'link' => 'https://status.slack.com/'],
         'zscaler'    => ['kind' => 'rss', 'feed' => 'https://trust.zscaler.com/rss-feed', 'link' => 'https://trust.zscaler.com/cloud-status'],
         'gcp'        => ['kind' => 'atom', 'feed' => 'https://www.google.com/appsstatus/dashboard/en-CA/feed.atom', 'link' => 'https://www.google.com/appsstatus/dashboard/'],
         'azure'      => [
@@ -731,7 +730,6 @@ class Lousy_Outages_Fetcher {
     private static $NAMES = [
         'cloudflare' => 'Cloudflare',
         'zoom'       => 'Zoom',
-        'slack'      => 'Slack',
         'zscaler'    => 'Zscaler',
         'gcp'        => 'Google Cloud',
         'azure'      => 'Microsoft Azure',

--- a/lousy-outages/includes/Providers.php
+++ b/lousy-outages/includes/Providers.php
@@ -22,7 +22,6 @@ namespace {
             ['id' => 'sentry', 'name' => 'Sentry', 'type' => 'statuspage', 'url' => 'https://status.sentry.io/api/v2/summary.json'],
 
             // RSS/Atom feeds
-            ['id' => 'slack', 'name' => 'Slack', 'type' => 'rss', 'url' => 'https://slack-status.com/feed/rss'],
             ['id' => 'aws', 'name' => 'AWS', 'type' => 'rss', 'url' => 'https://status.aws.amazon.com/rss/all.rss'],
             ['id' => 'azure', 'name' => 'Azure', 'type' => 'rss', 'url' => 'https://rssfeed.azure.status.microsoft/en-us/status/feed/'],
             ['id' => 'gcp', 'name' => 'Google Cloud', 'type' => 'atom', 'url' => 'https://www.google.com/appsstatus/dashboard/en-CA/feed.atom'],

--- a/lousy-outages/includes/Subscribe.php
+++ b/lousy-outages/includes/Subscribe.php
@@ -198,7 +198,7 @@ class Lousy_Outages_Subscribe {
 confirmed. you're now getting the Lousy Outages briefings. 🛰️
 
 expect:
-- outage and degradation alerts for cloudflare, aws, azure, gcp, slack, pagerduty, zscaler, qubeyond (and their friends)
+- outage and degradation alerts for cloudflare, aws, azure, gcp, pagerduty, zscaler, qubeyond (and their friends)
 - mini postmortems with timelines + impact notes
 - security watch items so you can harden things before the next wobble
 
@@ -221,7 +221,7 @@ TEXT;
   <div style="max-width:560px;margin:24px auto;padding:20px;border:2px solid #ffb81c;border-radius:14px;background:linear-gradient(140deg,#0b0b0b,#1a0b00);box-shadow:0 18px 36px rgba(0,0,0,0.45);">
     <h2 style="margin:0 0 10px;font-size:20px;color:#ffb81c;text-transform:uppercase;letter-spacing:0.05em;">✅ link established</h2>
     <p style="margin:0 0 12px;">welcome to the status underground.</p>
-    <p style="margin:0 0 18px;">you'll get alerts when providers wobble: cloudflare • aws • azure • gcp • slack • pagerduty • zscaler • qubeyond.</p>
+    <p style="margin:0 0 18px;">you'll get alerts when providers wobble: cloudflare • aws • azure • gcp • pagerduty • zscaler • qubeyond.</p>
     <p style="margin:0 0 18px;"><a href="{$dashboard_url}" style="display:inline-block;padding:12px 18px;border-radius:999px;border:2px solid #ffb81c;background:#f04e23;color:#050505;font-weight:700;text-decoration:none;">OPEN LIVE DASHBOARD</a></p>
     <blockquote style="margin:12px 0;padding:10px 14px;border-left:3px solid rgba(255,184,28,0.8);background:rgba(255,184,28,0.08);">
       “This is what it feels like to be hunted by something smarter than you.”<br>


### PR DESCRIPTION
## Summary
- remove the Slack RSS provider from the default Lousy Outages configuration
- update documentation, copy, and UI strings to match the new provider list
- drop Slack-specific Downdetector keywords and feed configuration entries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6903a665d294832e8e73091fc610448e