### PR TITLE
Filter disabled providers from outage cache

### DIFF
--- a/lousy-outages/includes/Store.php
+++ b/lousy-outages/includes/Store.php
@@ -6,7 +6,20 @@ class Store {
     private string $log_option = 'lousy_outages_log';
 
     public function get_all(): array {
-        return get_option( $this->option, [] );
+        $stored = get_option( $this->option, [] );
+
+        if ( ! is_array( $stored ) || empty( $stored ) ) {
+            return [];
+        }
+
+        $enabled = Providers::enabled();
+        if ( ! is_array( $enabled ) || empty( $enabled ) ) {
+            return [];
+        }
+
+        $allowed = array_fill_keys( array_keys( $enabled ), true );
+
+        return array_intersect_key( $stored, $allowed );
     }
 
     public function get( string $id ): ?array {


### PR DESCRIPTION
## Summary
- ignore cached outage records for providers that are no longer enabled
- strip disabled providers from stored snapshots and recompute the trending badge payload

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6903aee99a30832e8ef4a9c7b2db29a2