### PR TITLE
Add rotating hero quote and refresh homepage music copy

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -6,14 +6,20 @@ get_header();
 <main id="homepage-content">
     <div class="hero-section">
         <h1 class="retro-title glow-lite">Suzy Easton &mdash; Vancouver</h1>
-        <div class="hero-quote">
-            <span class="hero-quote__text">&ldquo;This is what it feels like to be hunted by something smarter than you.&rdquo;</span>
-            <span class="hero-quote__attr">&mdash; <a href="https://www.youtube.com/watch?v=tvGnYM14-1A" target="_blank" rel="noopener">Grimes, Artificial Angels</a></span>
+        <div id="quote-rotator" aria-live="polite">
+            <figure class="quote q-grimes">
+                <blockquote>&ldquo;This is what it feels like to be hunted by something smarter than you.&rdquo;</blockquote>
+                <figcaption>&mdash; Grimes, <em>Artificial Angels</em></figcaption>
+            </figure>
+            <figure class="quote q-willie" hidden>
+                <blockquote>&ldquo;Hands on the Wheel&rdquo; &mdash; Willie Nelson. tender, road-worn, and steady at the helm.</blockquote>
+                <figcaption><a href="https://www.youtube.com/watch?v=71cIYDnDZUk" target="_blank" rel="noopener">Watch on YouTube</a></figcaption>
+            </figure>
         </div>
         <section class="lo-callout lo-8bit">
           <h2>Weekly Show: <span>Lousy Outages</span></h2>
           <p>New weekly YouTube chaos — status meltdowns, longer riffs, and plenty of fun with real third-party wobbles.</p>
-          <a class="btn-8bit" href="/lousy-outages/">Open the live dashboard →</a>
+          <a class="btn-8bit" href="/lousy-outages/">OPEN THE LIVE DASHBOARD →</a>
         </section>
         <h2 class="retro-title glow-lite">Musician &amp; Creative Technologist</h2>
         <section class="pixel-intro" style="max-width: 720px; margin: 0 auto; line-height: 1.8; font-size: 1.05rem;">
@@ -101,7 +107,7 @@ get_header();
     <section class="now-listening">
         <h2 class="pixel-font">Now Listening</h2>
         <iframe width="100%" height="360" src="https://www.youtube.com/embed/GwetNnBkgQM?autoplay=0" title="Metric – Full Performance (Live on KEXP)" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        <p class="pixel-font now-listening-caption">🎶 Metric — Live on KEXP. Raw energy, shimmering synths, no AI weapons funding here.</p>
+        <p class="pixel-font now-listening-caption">🎶 Metric — Live on KEXP. stripped-down, all-acoustic set. no AI-weapons funding here.</p>
         <div class="info-callout pixel-font">
             <p>Spotify CEO Daniel Ek used his investment firm Prima Materia to lead a <strong>€600M (~US $694M)</strong> Series D funding round in June 2025 for Helsing, a German defense‑AI startup now valued at $12&nbsp;billion.</p>
             <p>Helsing develops AI‑enabled drones, aircraft and submarines for defense, and Ek also sits on its board as chairman.</p>
@@ -130,6 +136,50 @@ get_header();
         <p style="text-align:center;">New demo drops this weekend. Stay noisy.</p>
     </section>
 </main>
+
+    <script>
+      (function () {
+        var rotator = document.getElementById('quote-rotator');
+        if (!rotator) {
+          return;
+        }
+        var grimes = rotator.querySelector('.q-grimes');
+        var willie = rotator.querySelector('.q-willie');
+        if (!grimes || !willie) {
+          return;
+        }
+        var mq = typeof window.matchMedia === 'function' ? window.matchMedia('(prefers-reduced-motion: reduce)') : null;
+        if (mq && mq.matches) {
+          return;
+        }
+        var showingGrimes = true;
+        var toggleQuotes = function () {
+          if (showingGrimes) {
+            grimes.setAttribute('hidden', '');
+            willie.removeAttribute('hidden');
+          } else {
+            willie.setAttribute('hidden', '');
+            grimes.removeAttribute('hidden');
+          }
+          showingGrimes = !showingGrimes;
+        };
+        var intervalId = window.setInterval(toggleQuotes, 12000);
+        if (mq) {
+          var handleChange = function (event) {
+            if (event.matches) {
+              window.clearInterval(intervalId);
+              willie.setAttribute('hidden', '');
+              grimes.removeAttribute('hidden');
+            }
+          };
+          if (typeof mq.addEventListener === 'function') {
+            mq.addEventListener('change', handleChange);
+          } else if (typeof mq.addListener === 'function') {
+            mq.addListener(handleChange);
+          }
+        }
+      }());
+    </script>
 
     <script>
       (function () {

--- a/style.css
+++ b/style.css
@@ -949,20 +949,16 @@ footer,
   100% { background-position: 0% 50%; }
 }
 
-.hero-section .hero-quote {
-  font-family: "Press Start 2P", cursive;
-  font-size: 0.8rem;
-  color: rgba(244, 255, 240, 0.85);
-  text-align: center;
+#quote-rotator {
   margin: 0.75rem auto 1.5rem;
   max-width: 32em;
+  text-align: center;
   position: relative;
   padding: 0.75rem 0;
-  opacity: 0.85;
 }
 
-.hero-section .hero-quote::before,
-.hero-section .hero-quote::after {
+#quote-rotator::before,
+#quote-rotator::after {
   content: "";
   position: absolute;
   left: 50%;
@@ -974,35 +970,53 @@ footer,
   opacity: 0.6;
 }
 
-.hero-section .hero-quote::before {
+#quote-rotator::before {
   top: 0;
 }
 
-.hero-section .hero-quote::after {
+#quote-rotator::after {
   bottom: 0;
 }
 
-.hero-section .hero-quote__text {
-  display: block;
-  margin-bottom: 0.35rem;
+#quote-rotator .quote {
+  font-family: "Press Start 2P", cursive;
+  font-size: 0.8rem;
+  color: rgba(244, 255, 240, 0.85);
+  margin: 0;
+  opacity: 1;
+  transition: opacity 500ms ease-in-out;
 }
 
-.hero-section .hero-quote__attr {
-  display: block;
+#quote-rotator .quote blockquote {
+  margin: 0 0 0.35rem;
+}
+
+#quote-rotator .quote figcaption {
   font-size: 0.75rem;
   opacity: 0.75;
 }
 
-.hero-section .hero-quote a {
+#quote-rotator .quote a {
   color: inherit;
   text-decoration: none;
   border-bottom: 1px dotted rgba(0, 255, 170, 0.5);
 }
 
-.hero-section .hero-quote a:hover,
-.hero-section .hero-quote a:focus {
+#quote-rotator .quote a:hover,
+#quote-rotator .quote a:focus {
   color: var(--accent-color);
   border-bottom-color: var(--accent-color);
+}
+
+#quote-rotator .quote[hidden] {
+  display: block !important;
+  opacity: 0;
+  height: 0;
+  overflow: hidden;
+}
+
+#quote-rotator .quote:not([hidden]) {
+  opacity: 1;
 }
 
 .hero-section .pixel-intro {


### PR DESCRIPTION
## Summary
- replace the static hero quote with a rotator that alternates between Grimes and Willie Nelson highlights while respecting reduced-motion preferences
- update styling to support the new quote rotator and keep the hero spacing tight under the headline
- refresh the Metric blurb copy and ensure the Lousy Outages CTA button keeps its intended text treatment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6907e93c3b2c832eafb48f60f6b5c2d1