### PR TITLE
Refresh homepage hero with Willie on the Wheel spotlight

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -4,17 +4,28 @@ get_header();
 ?>
 
 <main id="homepage-content">
-    <div class="hero-section">
-        <h1 class="retro-title glow-lite">Suzy Easton &mdash; Vancouver</h1>
-        <div id="quote-rotator" aria-live="polite" aria-atomic="true" data-quote-rotator>
-            <figure class="quote q-grimes">
-                <blockquote>&ldquo;This is what it feels like to be hunted by something smarter than you.&rdquo;</blockquote>
-                <figcaption>&mdash; Grimes, <em>Artificial Angels</em></figcaption>
-            </figure>
-            <figure class="quote q-willie" hidden aria-hidden="true">
-                <blockquote>&ldquo;Hands on the Wheel&rdquo; &mdash; Willie Nelson. tender, road-worn, and steady at the helm.</blockquote>
-                <figcaption><a href="https://www.youtube.com/watch?v=71cIYDnDZUk" target="_blank" rel="noopener">Watch on YouTube</a></figcaption>
-            </figure>
+    <div class="hero-section folk-crt">
+        <div class="hero-grid">
+            <div class="hero-main">
+                <p class="hero-eyebrow pixel-font">Now headlining the trail</p>
+                <h1 class="retro-title glow-lite hero-title">Willie on the Wheel</h1>
+                <p class="hero-copy">Willie Nelson is steering this week&rsquo;s vibes &mdash; old steel strings, tender harmonies, a steady hand on the reins. It&rsquo;s Oregon Trail heartland folk running on arcade power: love-forward, hopeful, and still wired for hard rock, soul, and future electronics.</p>
+                <div class="hero-cta-row">
+                    <a class="btn-8bit hero-cta" href="https://www.youtube.com/watch?v=71cIYDnDZUk" target="_blank" rel="noopener">Ride with Willie &rarr;</a>
+                    <a class="pixel-button hero-cta-alt" href="/music-releases/">Read the tour journal</a>
+                </div>
+                <div class="influence-ticker" aria-live="polite" aria-atomic="true">
+                    <span class="influence-label pixel-font">Traveling companions:</span>
+                    <span class="influence-current" data-influence-rotator data-influences='["Metric","Cat Stevens","Neil Young","Grateful Dead"]'>Metric</span>
+                </div>
+            </div>
+            <aside class="hero-side">
+                <div class="prairie-lantern" aria-hidden="true"></div>
+                <figure class="grimes-sidequest">
+                    <figcaption class="pixel-font">Side quest signal</figcaption>
+                    <p>Grimes is still transmitting neon coordinates. <a href="https://www.youtube.com/watch?v=b6pomaq30G0" target="_blank" rel="noopener">Catch the artificial angels &rarr;</a></p>
+                </figure>
+            </aside>
         </div>
         <section class="lo-callout lo-8bit">
           <h2>Weekly Show: <span>Lousy Outages</span></h2>
@@ -139,56 +150,33 @@ get_header();
 
     <script>
       (function () {
-        var rotator = document.querySelector('[data-quote-rotator]');
-        if (!rotator) {
+        var ticker = document.querySelector('[data-influence-rotator]');
+        if (!ticker) {
           return;
         }
-        var grimes = rotator.querySelector('.q-grimes');
-        var willie = rotator.querySelector('.q-willie');
-        if (!grimes || !willie) {
+        var influences;
+        try {
+          influences = JSON.parse(ticker.getAttribute('data-influences') || '[]');
+        } catch (err) {
+          influences = [];
+        }
+        if (!Array.isArray(influences) || influences.length === 0) {
           return;
         }
-        grimes.removeAttribute('aria-hidden');
-        if (willie.hasAttribute('hidden')) {
-          willie.setAttribute('aria-hidden', 'true');
-        } else {
-          willie.removeAttribute('aria-hidden');
-        }
+        var index = 0;
         var mq = typeof window.matchMedia === 'function' ? window.matchMedia('(prefers-reduced-motion: reduce)') : null;
-        if (mq && mq.matches) {
-          return;
-        }
-        var showingGrimes = true;
-        var toggleQuotes = function () {
-          if (showingGrimes) {
-            grimes.setAttribute('hidden', '');
-            grimes.setAttribute('aria-hidden', 'true');
-            willie.removeAttribute('hidden');
-            willie.removeAttribute('aria-hidden');
-          } else {
-            willie.setAttribute('hidden', '');
-            willie.setAttribute('aria-hidden', 'true');
-            grimes.removeAttribute('hidden');
-            grimes.removeAttribute('aria-hidden');
-          }
-          showingGrimes = !showingGrimes;
+        var update = function () {
+          ticker.classList.remove('influence-swap');
+          void ticker.offsetWidth;
+          ticker.textContent = influences[index];
+          ticker.classList.add('influence-swap');
+          index = (index + 1) % influences.length;
         };
-        var intervalId = window.setInterval(toggleQuotes, 12000);
-        if (mq) {
-          var handleChange = function (event) {
-            if (event.matches) {
-              window.clearInterval(intervalId);
-              willie.setAttribute('hidden', '');
-              willie.setAttribute('aria-hidden', 'true');
-              grimes.removeAttribute('hidden');
-              grimes.removeAttribute('aria-hidden');
-            }
-          };
-          if (typeof mq.addEventListener === 'function') {
-            mq.addEventListener('change', handleChange);
-          } else if (typeof mq.addListener === 'function') {
-            mq.addListener(handleChange);
-          }
+        if (!mq || !mq.matches) {
+          update();
+          window.setInterval(update, 7000);
+        } else {
+          ticker.textContent = influences[0];
         }
       }());
     </script>

--- a/style.css
+++ b/style.css
@@ -1743,3 +1743,231 @@ body {
     border-radius: 999px;
     box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
 }
+
+.hero-section.folk-crt {
+  position: relative;
+  padding: 3.5rem 1.25rem 2rem;
+  background: linear-gradient(135deg, rgba(18, 26, 38, 0.95) 0%, rgba(25, 40, 32, 0.92) 55%, rgba(45, 30, 15, 0.9) 100%);
+  border: 2px solid rgba(255, 232, 200, 0.35);
+  box-shadow: 0 0 28px rgba(255, 199, 120, 0.18);
+  overflow: hidden;
+}
+
+.hero-section.folk-crt::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(circle at top left, rgba(255, 214, 153, 0.25), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(118, 224, 255, 0.15), transparent 60%);
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+.hero-grid {
+  position: relative;
+  display: grid;
+  gap: 2.5rem;
+  margin: 0 auto 2.5rem;
+  max-width: 1060px;
+  z-index: 1;
+}
+
+@media (min-width: 860px) {
+  .hero-grid {
+    grid-template-columns: minmax(0, 2.4fr) minmax(0, 1fr);
+    align-items: stretch;
+  }
+}
+
+.hero-main {
+  padding: 2.25rem;
+  background: rgba(14, 18, 24, 0.72);
+  border: 1px solid rgba(255, 231, 204, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(137, 212, 255, 0.08);
+  backdrop-filter: blur(4px);
+}
+
+.hero-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: #ffd9a6;
+  margin-bottom: 0.75rem;
+  font-size: 0.82rem;
+}
+
+.hero-title {
+  font-size: clamp(2.75rem, 4vw + 1rem, 4.8rem);
+  margin-bottom: 1rem;
+  text-shadow: 0 0 8px rgba(255, 198, 125, 0.45), 0 0 18px rgba(96, 168, 255, 0.35);
+}
+
+.hero-copy {
+  font-size: 1.1rem;
+  line-height: 1.8;
+  color: #f7f0e3;
+  margin-bottom: 1.75rem;
+}
+
+.hero-cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  margin-bottom: 1.5rem;
+}
+
+.hero-cta {
+  font-size: 1.05rem;
+  padding: 0.85rem 1.6rem;
+  background: linear-gradient(90deg, #ffb45b, #ff8663);
+  color: #1a0d06;
+  border-color: rgba(26, 12, 5, 0.35);
+  box-shadow: 0 0 12px rgba(255, 162, 74, 0.4);
+}
+
+.hero-cta:hover,
+.hero-cta:focus {
+  box-shadow: 0 0 18px rgba(255, 198, 125, 0.65);
+  transform: translateY(-1px);
+}
+
+.hero-cta-alt {
+  background: rgba(19, 32, 27, 0.7);
+  border: 1px solid rgba(145, 219, 255, 0.35);
+  color: #d9f2ff;
+  transition: background-color 220ms ease, transform 220ms ease;
+}
+
+.hero-cta-alt:hover,
+.hero-cta-alt:focus {
+  background: rgba(30, 55, 47, 0.85);
+  transform: translateY(-1px);
+}
+
+.influence-ticker {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 0.9rem;
+  border-radius: 6px;
+  background: rgba(10, 18, 12, 0.7);
+  border: 1px solid rgba(162, 241, 202, 0.4);
+  box-shadow: 0 0 12px rgba(91, 208, 160, 0.25);
+  color: #e9ffe9;
+}
+
+.influence-label {
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+  color: rgba(233, 255, 233, 0.8);
+  text-transform: uppercase;
+}
+
+.influence-current {
+  font-weight: 700;
+  font-size: 1.05rem;
+  min-width: 8ch;
+  display: inline-block;
+}
+
+.influence-current.influence-swap {
+  animation: influenceFade 6.4s ease-in-out 1;
+}
+
+@keyframes influenceFade {
+  0% {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  10% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  90% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
+
+.hero-side {
+  position: relative;
+  padding: 2.5rem 2rem;
+  background: rgba(17, 15, 24, 0.75);
+  border: 1px solid rgba(205, 179, 255, 0.3);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 1.5rem;
+  overflow: hidden;
+}
+
+.prairie-lantern {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  margin: 0 auto 0.5rem;
+  background: radial-gradient(circle at 40% 30%, rgba(255, 194, 125, 0.9), rgba(250, 157, 66, 0.4) 55%, rgba(20, 11, 6, 0) 75%);
+  box-shadow: 0 0 28px rgba(255, 186, 110, 0.55);
+  animation: lanternPulse 8s ease-in-out infinite;
+}
+
+@keyframes lanternPulse {
+  0%,
+  100% {
+    transform: translateY(0);
+    box-shadow: 0 0 24px rgba(255, 186, 110, 0.45);
+  }
+  50% {
+    transform: translateY(-4px);
+    box-shadow: 0 0 34px rgba(255, 204, 143, 0.65);
+  }
+}
+
+.grimes-sidequest {
+  background: rgba(20, 28, 46, 0.78);
+  border: 1px solid rgba(142, 221, 255, 0.35);
+  padding: 1.5rem;
+  color: #e2f3ff;
+  font-size: 0.95rem;
+  line-height: 1.7;
+  box-shadow: inset 0 0 0 1px rgba(138, 190, 255, 0.12);
+}
+
+.grimes-sidequest a {
+  color: #9de6ff;
+  text-decoration: underline;
+}
+
+.grimes-sidequest a:hover,
+.grimes-sidequest a:focus {
+  color: #c7f3ff;
+}
+
+.grimes-sidequest .pixel-font {
+  display: inline-block;
+  margin-bottom: 0.6rem;
+  color: rgba(198, 234, 255, 0.8);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 720px) {
+  .hero-main,
+  .hero-side {
+    padding: 1.75rem 1.5rem;
+  }
+
+  .hero-cta {
+    width: 100%;
+    text-align: center;
+  }
+
+  .hero-cta-alt {
+    width: 100%;
+    text-align: center;
+  }
+}
+


### PR DESCRIPTION
## Summary
- spotlight Willie Nelson on the homepage with a refreshed hero layout, main CTA, and supporting Grimes signal
- add a lightweight influence ticker that rotates Metric, Cat Stevens, Neil Young, and Grateful Dead
- extend the theme styling for a folk-trail CRT vibe with gentle animations and accessible contrast

## Testing
- php -l page-home.php

------
https://chatgpt.com/codex/tasks/task_e_690821d8409c832ea820f2dd9bd5770b