### PR TITLE
Soften Willie hero and remove orb

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -20,7 +20,7 @@ get_header();
                 </div>
             </div>
             <aside class="hero-side">
-                <div class="prairie-lantern" aria-hidden="true"></div>
+                <header class="hero-side-header pixel-font">Signal log</header>
                 <figure class="grimes-sidequest">
                     <figcaption class="pixel-font">Side quest signal</figcaption>
                     <p>Grimes is still transmitting neon coordinates. <a href="https://www.youtube.com/watch?v=b6pomaq30G0" target="_blank" rel="noopener">Catch the artificial angels &rarr;</a></p>

--- a/style.css
+++ b/style.css
@@ -1746,10 +1746,10 @@ body {
 
 .hero-section.folk-crt {
   position: relative;
-  padding: 3.5rem 1.25rem 2rem;
-  background: linear-gradient(135deg, rgba(18, 26, 38, 0.95) 0%, rgba(25, 40, 32, 0.92) 55%, rgba(45, 30, 15, 0.9) 100%);
-  border: 2px solid rgba(255, 232, 200, 0.35);
-  box-shadow: 0 0 28px rgba(255, 199, 120, 0.18);
+  padding: 3.25rem 1.25rem 2.25rem;
+  background: linear-gradient(135deg, rgba(20, 26, 32, 0.92) 0%, rgba(24, 38, 34, 0.88) 60%, rgba(36, 28, 24, 0.85) 100%);
+  border: 1px solid rgba(244, 226, 195, 0.28);
+  box-shadow: 0 0 16px rgba(214, 187, 135, 0.16);
   overflow: hidden;
 }
 
@@ -1757,18 +1757,25 @@ body {
   content: "";
   position: absolute;
   inset: 0;
-  background-image: radial-gradient(circle at top left, rgba(255, 214, 153, 0.25), transparent 55%),
-    radial-gradient(circle at bottom right, rgba(118, 224, 255, 0.15), transparent 60%);
-  mix-blend-mode: screen;
+  background-image: radial-gradient(circle at top left, rgba(255, 214, 153, 0.18), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(118, 224, 255, 0.1), transparent 60%),
+    repeating-linear-gradient(
+      0deg,
+      rgba(248, 240, 220, 0.05) 0,
+      rgba(248, 240, 220, 0.05) 1px,
+      transparent 1px,
+      transparent 4px
+    );
+  opacity: 0.65;
   pointer-events: none;
 }
 
 .hero-grid {
   position: relative;
   display: grid;
-  gap: 2.5rem;
+  gap: 2.25rem;
   margin: 0 auto 2.5rem;
-  max-width: 1060px;
+  max-width: 1040px;
   z-index: 1;
 }
 
@@ -1780,11 +1787,14 @@ body {
 }
 
 .hero-main {
-  padding: 2.25rem;
-  background: rgba(14, 18, 24, 0.72);
-  border: 1px solid rgba(255, 231, 204, 0.35);
-  box-shadow: inset 0 0 0 1px rgba(137, 212, 255, 0.08);
-  backdrop-filter: blur(4px);
+  padding: 2.1rem;
+  background: rgba(18, 22, 30, 0.68);
+  border: 1px solid rgba(240, 223, 194, 0.26);
+  box-shadow: inset 0 0 0 1px rgba(137, 212, 255, 0.06);
+  backdrop-filter: blur(3px);
+  width: min(100%, 62ch);
+  text-align: left;
+  justify-self: start;
 }
 
 .hero-eyebrow {
@@ -1796,16 +1806,16 @@ body {
 }
 
 .hero-title {
-  font-size: clamp(2.75rem, 4vw + 1rem, 4.8rem);
-  margin-bottom: 1rem;
-  text-shadow: 0 0 8px rgba(255, 198, 125, 0.45), 0 0 18px rgba(96, 168, 255, 0.35);
+  font-size: clamp(2.2rem, 3vw + 1.1rem, 3.7rem);
+  margin-bottom: 0.85rem;
+  text-shadow: 0 0 6px rgba(255, 198, 125, 0.36), 0 0 12px rgba(96, 168, 255, 0.28);
 }
 
 .hero-copy {
-  font-size: 1.1rem;
-  line-height: 1.8;
-  color: #f7f0e3;
-  margin-bottom: 1.75rem;
+  font-size: 1.05rem;
+  line-height: 1.75;
+  color: rgba(243, 235, 223, 0.92);
+  margin-bottom: 1.6rem;
 }
 
 .hero-cta-row {
@@ -1820,26 +1830,26 @@ body {
   padding: 0.85rem 1.6rem;
   background: linear-gradient(90deg, #ffb45b, #ff8663);
   color: #1a0d06;
-  border-color: rgba(26, 12, 5, 0.35);
-  box-shadow: 0 0 12px rgba(255, 162, 74, 0.4);
+  border-color: rgba(26, 12, 5, 0.22);
+  box-shadow: 0 0 8px rgba(255, 162, 74, 0.32);
 }
 
 .hero-cta:hover,
 .hero-cta:focus {
-  box-shadow: 0 0 18px rgba(255, 198, 125, 0.65);
+  box-shadow: 0 0 12px rgba(255, 198, 125, 0.5);
   transform: translateY(-1px);
 }
 
 .hero-cta-alt {
-  background: rgba(19, 32, 27, 0.7);
-  border: 1px solid rgba(145, 219, 255, 0.35);
+  background: rgba(19, 32, 27, 0.62);
+  border: 1px solid rgba(145, 219, 255, 0.28);
   color: #d9f2ff;
   transition: background-color 220ms ease, transform 220ms ease;
 }
 
 .hero-cta-alt:hover,
 .hero-cta-alt:focus {
-  background: rgba(30, 55, 47, 0.85);
+  background: rgba(30, 55, 47, 0.78);
   transform: translateY(-1px);
 }
 
@@ -1849,10 +1859,10 @@ body {
   gap: 0.5rem;
   padding: 0.65rem 0.9rem;
   border-radius: 6px;
-  background: rgba(10, 18, 12, 0.7);
-  border: 1px solid rgba(162, 241, 202, 0.4);
-  box-shadow: 0 0 12px rgba(91, 208, 160, 0.25);
-  color: #e9ffe9;
+  background: rgba(10, 18, 12, 0.6);
+  border: 1px solid rgba(162, 241, 202, 0.28);
+  box-shadow: 0 0 10px rgba(91, 208, 160, 0.18);
+  color: rgba(233, 255, 233, 0.92);
 }
 
 .influence-label {
@@ -1894,46 +1904,45 @@ body {
 
 .hero-side {
   position: relative;
-  padding: 2.5rem 2rem;
-  background: rgba(17, 15, 24, 0.75);
-  border: 1px solid rgba(205, 179, 255, 0.3);
+  padding: 2.25rem 2rem;
+  background: rgba(18, 18, 26, 0.72);
+  border: 1px solid rgba(196, 208, 255, 0.25);
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  gap: 1.5rem;
+  gap: 1.4rem;
   overflow: hidden;
+  align-self: start;
 }
 
-.prairie-lantern {
-  width: 120px;
-  height: 120px;
-  border-radius: 50%;
-  margin: 0 auto 0.5rem;
-  background: radial-gradient(circle at 40% 30%, rgba(255, 194, 125, 0.9), rgba(250, 157, 66, 0.4) 55%, rgba(20, 11, 6, 0) 75%);
-  box-shadow: 0 0 28px rgba(255, 186, 110, 0.55);
-  animation: lanternPulse 8s ease-in-out infinite;
+.hero-side::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(150, 205, 255, 0.12), transparent 65%);
+  opacity: 0.7;
+  pointer-events: none;
 }
 
-@keyframes lanternPulse {
-  0%,
-  100% {
-    transform: translateY(0);
-    box-shadow: 0 0 24px rgba(255, 186, 110, 0.45);
-  }
-  50% {
-    transform: translateY(-4px);
-    box-shadow: 0 0 34px rgba(255, 204, 143, 0.65);
-  }
+.hero-side-header {
+  font-size: 0.78rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(201, 220, 255, 0.7);
+  position: relative;
+  z-index: 1;
+  margin-bottom: 0.25rem;
 }
 
 .grimes-sidequest {
-  background: rgba(20, 28, 46, 0.78);
-  border: 1px solid rgba(142, 221, 255, 0.35);
-  padding: 1.5rem;
-  color: #e2f3ff;
-  font-size: 0.95rem;
-  line-height: 1.7;
-  box-shadow: inset 0 0 0 1px rgba(138, 190, 255, 0.12);
+  background: rgba(24, 32, 48, 0.72);
+  border: 1px solid rgba(142, 221, 255, 0.28);
+  padding: 1.6rem;
+  color: #deecff;
+  font-size: 0.93rem;
+  line-height: 1.6;
+  box-shadow: inset 0 0 0 1px rgba(138, 190, 255, 0.08);
+  position: relative;
+  z-index: 1;
 }
 
 .grimes-sidequest a {
@@ -1958,6 +1967,7 @@ body {
   .hero-main,
   .hero-side {
     padding: 1.75rem 1.5rem;
+    width: 100%;
   }
 
   .hero-cta {


### PR DESCRIPTION
## Summary
- remove the prairie lantern orb from the home page hero and add a subtle "Signal log" header for the sidebar note
- rebalance the hero layout with a narrower copy column, softened glow effects, and a calmer color treatment while preserving retro cues
- tweak call-to-action and ticker styling for a less intense presentation across desktop and mobile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69086edb1de0832ea8c767353c58708e