### PR TITLE
fix(outages): ensure enabled providers are retained

### DIFF
--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -101,13 +101,12 @@ function render_shortcode(): string {
 
     $providers_config = Providers::enabled();
     if (is_array($provider_map) && $provider_map) {
-        $providers_config = array_intersect_key($providers_config, $provider_map);
-        if (empty($providers_config)) {
-            foreach ($provider_map as $slug => $provider_info) {
+        foreach ($provider_map as $slug => $info) {
+            if (!isset($providers_config[$slug]) && is_array($info)) {
                 $providers_config[$slug] = [
                     'id'         => $slug,
-                    'name'       => $provider_info['name'],
-                    'status_url' => $provider_info['status_url'],
+                    'name'       => isset($info['name']) ? (string) $info['name'] : ucfirst((string) $slug),
+                    'status_url' => isset($info['status_url']) ? (string) $info['status_url'] : '',
                 ];
             }
         }


### PR DESCRIPTION
## Summary
- keep the Providers::enabled() list as the source of truth and append any extra providers from the fetcher map

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690bfb616358832e834002109f0d7646