### PR TITLE
Add daily digest email flow and update homepage music embeds

### DIFF
--- a/lousy-outages/includes/Cron/Refresh.php
+++ b/lousy-outages/includes/Cron/Refresh.php
@@ -12,6 +12,7 @@ class Refresh
         add_filter('cron_schedules', [self::class, 'registerSchedule']);
         add_action('init', [self::class, 'ensureScheduled']);
         add_action('lousy_outages_refresh', [IncidentAlerts::class, 'run']);
+        add_action('lo_send_daily_digest', [IncidentAlerts::class, 'send_daily_digest']);
     }
 
     public static function registerSchedule(array $schedules): array
@@ -23,6 +24,13 @@ class Refresh
             ];
         }
 
+        if (! isset($schedules['lo_daily'])) {
+            $schedules['lo_daily'] = [
+                'interval' => DAY_IN_SECONDS,
+                'display'  => __('Every 24 Hours', 'lousy-outages'),
+            ];
+        }
+
         return $schedules;
     }
 
@@ -30,6 +38,10 @@ class Refresh
     {
         if (! wp_next_scheduled('lousy_outages_refresh')) {
             wp_schedule_event(time() + MINUTE_IN_SECONDS, 'five_minutes', 'lousy_outages_refresh');
+        }
+
+        if (! wp_next_scheduled('lo_send_daily_digest')) {
+            wp_schedule_event(time() + HOUR_IN_SECONDS, 'lo_daily', 'lo_send_daily_digest');
         }
     }
 }

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -266,20 +266,49 @@ function render_shortcode(): string {
         $ordered_tiles[] = $tile;
     }
 
+    $operational_placeholders = apply_filters('lo_operational_placeholder_providers', ['openai', 'twilio']);
+    if (!is_array($operational_placeholders)) {
+        $operational_placeholders = ['openai', 'twilio'];
+    }
+    $operational_placeholders = array_map('sanitize_key', $operational_placeholders);
+
+    $placeholder_label = apply_filters('lo_operational_placeholder_label', 'OPERATIONAL');
+    if (!is_string($placeholder_label) || '' === trim($placeholder_label)) {
+        $placeholder_label = 'OPERATIONAL';
+    }
+
+    $placeholder_summary = apply_filters('lo_operational_placeholder_summary', 'Assuming operational — awaiting the next live sync.');
+    if (!is_string($placeholder_summary) || '' === trim($placeholder_summary)) {
+        $placeholder_summary = 'Assuming operational — awaiting the next live sync.';
+    }
+
+    $placeholder_message = apply_filters('lo_operational_placeholder_message', 'Live status feed quiet; placeholder set to operational.');
+    if (!is_string($placeholder_message) || '' === trim($placeholder_message)) {
+        $placeholder_message = 'Live status feed quiet; placeholder set to operational.';
+    }
+
     foreach ($providers_config as $slug => $provider_config) {
         if (isset($tiles_by_slug[$slug])) {
             continue;
         }
+        $provider_key = sanitize_key($slug);
+        $is_operational_placeholder = in_array($provider_key, $operational_placeholders, true);
+        $status_slug = $is_operational_placeholder ? 'operational' : 'unknown';
+        $status_label = $is_operational_placeholder ? $placeholder_label : 'UNKNOWN';
+        $status_class = $is_operational_placeholder ? 'status--operational' : 'status--unknown';
+        $summary_text = $is_operational_placeholder ? $placeholder_summary : 'Status unavailable';
+        $message_text = $is_operational_placeholder ? $placeholder_message : 'Status unavailable';
+
         $ordered_tiles[] = [
             'id'           => $slug,
             'provider'     => $slug,
             'name'         => $provider_config['name'] ?? ucfirst($slug),
-            'status'       => 'unknown',
-            'status_label' => 'UNKNOWN',
-            'status_class' => 'status--unknown',
-            'overall'      => 'unknown',
-            'message'      => 'Status unavailable',
-            'summary'      => 'Status unavailable',
+            'status'       => $status_slug,
+            'status_label' => $status_label,
+            'status_class' => $status_class,
+            'overall'      => $status_slug,
+            'message'      => $message_text,
+            'summary'      => $summary_text,
             'components'   => [],
             'incidents'    => [],
             'fetched_at'   => $fetched_at,
@@ -293,15 +322,23 @@ function render_shortcode(): string {
 
     if (!$ordered_tiles && $provider_map) {
         foreach ($provider_map as $slug => $provider_info) {
+            $provider_key = sanitize_key($slug);
+            $is_operational_placeholder = in_array($provider_key, $operational_placeholders, true);
+            $status_slug = $is_operational_placeholder ? 'operational' : 'unknown';
+            $status_label = $is_operational_placeholder ? $placeholder_label : 'UNKNOWN';
+            $status_class = $is_operational_placeholder ? 'status--operational' : 'status--unknown';
+            $summary_text = $is_operational_placeholder ? $placeholder_summary : 'Status unavailable';
+            $message_text = $is_operational_placeholder ? $placeholder_message : 'Status unavailable';
+
             $ordered_tiles[] = [
                 'provider'     => $slug,
                 'name'         => $provider_info['name'],
-                'status'       => 'unknown',
-                'status_label' => 'UNKNOWN',
-                'status_class' => 'status--unknown',
-                'overall'      => 'unknown',
-                'message'      => 'Status unavailable',
-                'summary'      => 'Status unavailable',
+                'status'       => $status_slug,
+                'status_label' => $status_label,
+                'status_class' => $status_class,
+                'overall'      => $status_slug,
+                'message'      => $message_text,
+                'summary'      => $summary_text,
                 'components'   => [],
                 'incidents'    => [],
                 'fetched_at'   => $fetched_at,

--- a/page-home.php
+++ b/page-home.php
@@ -6,13 +6,15 @@ get_header();
 <main id="homepage-content">
     <div class="hero-section folk-crt">
         <div class="hero-grid">
+            <?php
+            $hero_eyebrow = apply_filters('se_home_hero_eyebrow', 'Now headlining the trail');
+            $hero_title   = apply_filters('se_home_hero_title', 'Creative signals from Suzy Easton');
+            $hero_copy    = apply_filters('se_home_hero_copy', 'Independent music, advocacy, and experimental tools live from Vancouver.');
+            ?>
             <div class="hero-main">
-                <p class="hero-eyebrow pixel-font">Now headlining the trail</p>
-                <h1 class="retro-title glow-lite hero-title">Willie on the Wheel</h1>
-                <p class="hero-copy">Now Playing: Willie Nelson — “Hands on the Wheel”<br><br>At a moment when the world feels off-kilter, “Hands on the Wheel” brings it back to center. The closer from Red Headed Stranger is all soft steel and steady time—minimal production, maximum heart. It’s a simple truth you can hum: love steadies the hands.</p>
-                <div class="hero-cta-row">
-                    <a class="btn-8bit hero-cta" href="https://www.youtube.com/watch?v=71cIYDnDZUk" target="_blank" rel="noopener">Ride with “Hands on the Wheel” →</a>
-                </div>
+                <p class="hero-eyebrow pixel-font"><?php echo esc_html($hero_eyebrow); ?></p>
+                <h1 class="retro-title glow-lite hero-title"><?php echo esc_html($hero_title); ?></h1>
+                <p class="hero-copy"><?php echo esc_html($hero_copy); ?></p>
             </div>
         </div>
         <section class="lo-callout lo-8bit">
@@ -111,6 +113,35 @@ get_header();
             <p>Spotify CEO Daniel Ek used his investment firm Prima Materia to lead a <strong>€600M (~US $694M)</strong> Series D funding round in June 2025 for Helsing, a German defense‑AI startup now valued at $12&nbsp;billion.</p>
             <p>Helsing develops AI‑enabled drones, aircraft and submarines for defense, and Ek also sits on its board as chairman.</p>
             <p>At least one indie band – Deerhoof – pulled their music from Spotify in protest, citing ethical concerns over music &ldquo;killing people&rdquo; due to this connection.</p>
+        </div>
+    </section>
+
+    <?php
+    $grimes_note = apply_filters(
+        'se_home_grimes_note',
+        'Streaming ethics are hotly debated. In 2025, Spotify founder Daniel Ek’s fund Prima Materia led a €600M round into defense-AI company Helsing; some indie artists responded by pulling music from Spotify. Suzy’s site highlights artists directly via embeds and Bandcamp whenever possible.'
+    );
+    $grimes_heading = apply_filters('se_home_grimes_heading', 'Spotlight: Grimes — “Artificial Angels”');
+    ?>
+    <section class="now-listening grimes-feature">
+        <div class="info-callout pixel-font">
+            <p><?php echo wp_kses_post($grimes_note); ?></p>
+        </div>
+        <h2 class="pixel-font"><?php echo esc_html($grimes_heading); ?></h2>
+        <iframe width="100%" height="360" src="https://www.youtube.com/embed/tvGnYM14-1A?autoplay=0" title="Grimes — Artificial Angels (Official Video)" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    </section>
+
+    <?php
+    $willie_heading = apply_filters('se_home_willie_heading', 'Now Playing: Willie Nelson — “Hands on the Wheel”');
+    $willie_body    = apply_filters('se_home_willie_body', 'At a moment when the world feels off-kilter, “Hands on the Wheel” brings it back to center. Minimal production, maximum heart. Love steadies the hands.');
+    ?>
+    <section class="hero-section folk-crt willie-feature">
+        <div class="hero-grid">
+            <div class="hero-main">
+                <h2 class="retro-title glow-lite"><?php echo esc_html($willie_heading); ?></h2>
+                <p class="hero-copy"><?php echo esc_html($willie_body); ?></p>
+                <iframe width="100%" height="360" src="https://www.youtube.com/embed/71cIYDnDZUk?autoplay=0" title="Willie Nelson — Hands on the Wheel" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+            </div>
         </div>
     </section>
 


### PR DESCRIPTION
## Summary
- enforce first-alert-only logic and schedule daily digest emails with new composer copy
- add operational placeholders for OpenAI and Twilio cards when live data is missing
- refresh the homepage hero, move the Willie feature below Metric with an embed, and add a Grimes spotlight note

## Testing
- php -l lousy-outages/includes/Storage/IncidentStore.php
- php -l lousy-outages/includes/IncidentAlerts.php
- php -l lousy-outages/includes/Cron/Refresh.php
- php -l lousy-outages/includes/email-templates.php
- php -l lousy-outages/public/shortcode.php
- php -l page-home.php

------
https://chatgpt.com/codex/tasks/task_e_690c013ec6b8832e99cce04141b4a73c