### PR TITLE
Refresh homepage hero and SEO metadata

### DIFF
--- a/header.php
+++ b/header.php
@@ -18,27 +18,68 @@
     $site_name   = 'Suzy Easton';
     $default_img = 'https://suzyeaston.ca/arcade/og-image.png';
 
+    $meta_keywords = 'Suzy Easton, musician, creative technologist';
+
     if ( is_front_page() ) {
       $meta_title = 'Suzy Easton – Vancouver Musician & Creative Technologist';
-      $meta_desc  = 'Home base for Vancouver, BC, Canada musician Suzy Easton. Explore music reviews, rock demos, retro games and AI-powered tools.';
+      $meta_desc  = 'Suzanne (Suzy) Easton shares indie music spotlights, outage stories, retro-inspired tools, and Vancouver-based creative tech experiments.';
+      $meta_keywords = 'Suzy Easton, Suzanne Easton, Vancouver musician, creative technologist, Lousy Outages, indie music, retro arcade website, outage analysis';
       $meta_img   = $default_img;
     } elseif ( is_page_template( 'page-track-analyzer.php' ) ) {
       $meta_title = "Suzy's Track Analyzer – AI Vibe Checker for Musicians";
       $meta_desc  = 'Upload an MP3 and get a quick vibe check powered by AI—perfect for indie producers and music tech fans.';
+      $meta_keywords = 'track analyzer, music AI tool, Suzy Easton, mix feedback';
       $meta_img   = $default_img;
     } elseif ( is_page_template( 'page-arcade.php' ) ) {
       $meta_title = 'Canucks Puck Bash - Retro Hockey Arcade';
       $meta_desc  = "Shoot, score, and hear 'Don't You Forget About Me' in this 80s-style hockey arcade game.";
+      $meta_keywords = 'Canucks arcade game, retro hockey game, Suzy Easton arcade';
       $meta_img   = $default_img;
     } else {
       $meta_title = wp_title( '|', false, 'right' ) . $site_name;
       $meta_desc  = get_bloginfo( 'description' );
+      $meta_keywords = 'Suzy Easton, musician, creative technologist, Vancouver artist';
       $meta_img   = $default_img;
     }
     $meta_url = home_url( add_query_arg( [], $wp->request ) );
+    $structured_data = [
+      '@context' => 'https://schema.org',
+      '@graph'   => [
+        [
+          '@type' => 'WebSite',
+          'name' => $site_name,
+          'url'  => home_url( '/' ),
+          'description' => $meta_desc,
+          'inLanguage'  => get_bloginfo( 'language' ),
+          'potentialAction' => [
+            '@type' => 'SearchAction',
+            'target' => home_url( '/?s={search_term_string}' ),
+            'query-input' => 'required name=search_term_string',
+          ],
+        ],
+        [
+          '@type' => 'Person',
+          'name' => 'Suzy Easton',
+          'url'  => 'https://www.suzyeaston.ca',
+          'jobTitle' => 'Musician and Creative Technologist',
+          'address' => [
+            '@type' => 'PostalAddress',
+            'addressLocality' => 'Vancouver',
+            'addressCountry'  => 'CA',
+          ],
+          'sameAs' => [
+            'https://suzyeaston.bandcamp.com',
+            'https://soundcloud.com/suzyeaston',
+            'https://instagram.com/suzyeaston',
+            'https://youtube.com/@suzyeaston',
+          ],
+        ],
+      ],
+    ];
   ?>
   <title><?php echo esc_html( $meta_title ); ?></title>
   <meta name="description" content="<?php echo esc_attr( $meta_desc ); ?>">
+  <meta name="keywords" content="<?php echo esc_attr( $meta_keywords ); ?>">
   <meta property="og:type" content="website">
   <meta property="og:title" content="<?php echo esc_attr( $meta_title ); ?>">
   <meta property="og:description" content="<?php echo esc_attr( $meta_desc ); ?>">
@@ -49,24 +90,7 @@
   <meta name="twitter:description" content="<?php echo esc_attr( $meta_desc ); ?>">
   <meta name="twitter:image" content="<?php echo esc_url( $meta_img ); ?>">
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "Person",
-    "name": "Suzy Easton",
-    "url": "https://www.suzyeaston.ca",
-    "jobTitle": "Musician and Creative Technologist",
-    "address": {
-      "@type": "PostalAddress",
-      "addressLocality": "Vancouver",
-      "addressCountry": "CA"
-    },
-    "sameAs": [
-      "https://suzyeaston.bandcamp.com",
-      "https://soundcloud.com/suzyeaston",
-      "https://instagram.com/suzyeaston",
-      "https://youtube.com/@suzyeaston"
-    ]
-  }
+  <?php echo wp_json_encode( $structured_data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT ); ?>
   </script>
 
   <!-- Main stylesheet -->

--- a/page-home.php
+++ b/page-home.php
@@ -7,19 +7,28 @@ get_header();
     <div class="hero-section folk-crt">
         <div class="hero-grid">
             <?php
-            $hero_eyebrow = apply_filters('se_home_hero_eyebrow', 'Now headlining the trail');
-            $hero_title   = apply_filters('se_home_hero_title', 'Creative signals from Suzy Easton');
-            $hero_copy    = apply_filters('se_home_hero_copy', 'Independent music, advocacy, and experimental tools live from Vancouver.');
+            $hero_eyebrow = apply_filters('se_home_hero_eyebrow', '');
+            $hero_logo_label = apply_filters('se_home_hero_title', 'Suzanne (Suzy) Easton');
+            $hero_logo_top = apply_filters('se_home_hero_logo_top', 'Suzanne');
+            $hero_logo_mid = apply_filters('se_home_hero_logo_mid', '(Suzy)');
+            $hero_logo_bottom = apply_filters('se_home_hero_logo_bottom', 'Easton');
+            $hero_copy    = apply_filters('se_home_hero_copy', 'Independent music, infrastructure nerdiness, and creative experiments direct from Vancouver.');
             ?>
             <div class="hero-main">
-                <p class="hero-eyebrow pixel-font"><?php echo esc_html($hero_eyebrow); ?></p>
-                <h1 class="retro-title glow-lite hero-title"><?php echo esc_html($hero_title); ?></h1>
+                <?php if (!empty($hero_eyebrow)) : ?>
+                    <p class="hero-eyebrow pixel-font"><?php echo esc_html($hero_eyebrow); ?></p>
+                <?php endif; ?>
+                <h1 class="retro-title glow-lite hero-title galaga-logo" aria-label="<?php echo esc_attr($hero_logo_label); ?>">
+                    <span class="galaga-logo__top"><?php echo esc_html($hero_logo_top); ?></span>
+                    <span class="galaga-logo__mid"><?php echo esc_html($hero_logo_mid); ?></span>
+                    <span class="galaga-logo__bottom"><?php echo esc_html($hero_logo_bottom); ?></span>
+                </h1>
                 <p class="hero-copy"><?php echo esc_html($hero_copy); ?></p>
             </div>
         </div>
         <section class="lo-callout lo-8bit">
           <h2>Weekly Show: <span>Lousy Outages</span></h2>
-          <p>New weekly YouTube chaos — status meltdowns, longer riffs, and plenty of fun with real third-party wobbles.</p>
+          <p>New episodes drop every week on YouTube where Suzanne unpacks outage chaos, security quirks, and her sharp tech riffs.</p>
           <a class="btn-8bit" href="/lousy-outages/">OPEN THE LIVE DASHBOARD →</a>
         </section>
         <h2 class="retro-title glow-lite">Musician &amp; Creative Technologist</h2>
@@ -107,19 +116,25 @@ get_header();
 
     <section class="now-listening">
         <h2 class="pixel-font">Now Listening</h2>
-        <iframe width="100%" height="360" src="https://www.youtube.com/embed/GwetNnBkgQM?autoplay=0" title="Metric – Full Performance (Live on KEXP)" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        <p class="pixel-font now-listening-caption">🎶 Metric — Live on KEXP. stripped-down, all-acoustic set. no AI-weapons funding here.</p>
-        <div class="info-callout pixel-font">
-            <p>Spotify CEO Daniel Ek used his investment firm Prima Materia to lead a <strong>€600M (~US $694M)</strong> Series D funding round in June 2025 for Helsing, a German defense‑AI startup now valued at $12&nbsp;billion.</p>
-            <p>Helsing develops AI‑enabled drones, aircraft and submarines for defense, and Ek also sits on its board as chairman.</p>
-            <p>At least one indie band – Deerhoof – pulled their music from Spotify in protest, citing ethical concerns over music &ldquo;killing people&rdquo; due to this connection.</p>
+        <div class="now-listening-item">
+            <iframe width="100%" height="360" src="https://www.youtube.com/embed/GwetNnBkgQM?autoplay=0" title="Metric – Full Performance (Live on KEXP)" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+            <p class="pixel-font now-listening-caption">🎶 Metric — Live on KEXP. stripped-down, all-acoustic set. no AI-weapons funding here.</p>
+        </div>
+        <?php
+        $willie_heading = apply_filters('se_home_willie_heading', 'Now Playing: Willie Nelson — “Hands on the Wheel”');
+        $willie_body    = apply_filters('se_home_willie_body', 'At a moment when the world feels off-kilter, “Hands on the Wheel” brings it back to center. Minimal production, maximum heart. Love steadies the hands.');
+        ?>
+        <div class="now-listening-item">
+            <h3 class="pixel-font now-listening-subhead"><?php echo esc_html($willie_heading); ?></h3>
+            <p class="pixel-font now-listening-caption"><?php echo esc_html($willie_body); ?></p>
+            <iframe width="100%" height="360" src="https://www.youtube.com/embed/71cIYDnDZUk?autoplay=0" title="Willie Nelson — Hands on the Wheel" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
     </section>
 
     <?php
     $grimes_note = apply_filters(
         'se_home_grimes_note',
-        'Streaming ethics are hotly debated. In 2025, Spotify founder Daniel Ek’s fund Prima Materia led a €600M round into defense-AI company Helsing; some indie artists responded by pulling music from Spotify. Suzy’s site highlights artists directly via embeds and Bandcamp whenever possible.'
+        'Spotify founder Daniel Ek’s fund Prima Materia poured €600M into defense-AI company Helsing in 2025. Indie mainstays like Deerhoof yanked catalogues in protest, calling out the weapons tie-in. Sharing Grimes here keeps the conversation loud: artists deserve platforms that aren’t bankrolled by war tech.'
     );
     $grimes_heading = apply_filters('se_home_grimes_heading', 'Spotlight: Grimes — “Artificial Angels”');
     ?>
@@ -129,20 +144,6 @@ get_header();
         </div>
         <h2 class="pixel-font"><?php echo esc_html($grimes_heading); ?></h2>
         <iframe width="100%" height="360" src="https://www.youtube.com/embed/tvGnYM14-1A?autoplay=0" title="Grimes — Artificial Angels (Official Video)" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-    </section>
-
-    <?php
-    $willie_heading = apply_filters('se_home_willie_heading', 'Now Playing: Willie Nelson — “Hands on the Wheel”');
-    $willie_body    = apply_filters('se_home_willie_body', 'At a moment when the world feels off-kilter, “Hands on the Wheel” brings it back to center. Minimal production, maximum heart. Love steadies the hands.');
-    ?>
-    <section class="hero-section folk-crt willie-feature">
-        <div class="hero-grid">
-            <div class="hero-main">
-                <h2 class="retro-title glow-lite"><?php echo esc_html($willie_heading); ?></h2>
-                <p class="hero-copy"><?php echo esc_html($willie_body); ?></p>
-                <iframe width="100%" height="360" src="https://www.youtube.com/embed/71cIYDnDZUk?autoplay=0" title="Willie Nelson — Hands on the Wheel" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-            </div>
-        </div>
     </section>
 
     <section class="track-analyzer-feature">

--- a/style.css
+++ b/style.css
@@ -906,6 +906,44 @@ footer,
 .hero-section h2 {
   font-size: 1.25rem;
 }
+
+.galaga-logo {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 1rem 1.5rem;
+  border: 3px solid rgba(255, 255, 255, 0.35);
+  box-shadow: 0 0 12px rgba(0, 255, 170, 0.45);
+  background: radial-gradient(circle at top, rgba(0, 255, 128, 0.4), rgba(0, 0, 0, 0.85));
+  text-transform: uppercase;
+  letter-spacing: 0.25rem;
+}
+
+.galaga-logo span {
+  display: block;
+  width: 100%;
+}
+
+.galaga-logo__top {
+  font-size: 1.1rem;
+  color: #ffdd57;
+  text-shadow: 0 0 6px rgba(255, 221, 87, 0.9);
+}
+
+.galaga-logo__mid {
+  font-size: 0.85rem;
+  color: #00e5ff;
+  text-shadow: 0 0 6px rgba(0, 229, 255, 0.8);
+}
+
+.galaga-logo__bottom {
+  font-size: 1.6rem;
+  color: #ff3bf0;
+  text-shadow:
+    0 0 6px rgba(255, 59, 240, 0.7),
+    0 0 14px rgba(0, 255, 170, 0.4);
+}
 .tagline {
   margin: 20px auto;
   max-width: 800px;
@@ -1250,6 +1288,21 @@ body {
   text-align: center;
   position: relative;
   overflow: hidden;
+}
+
+.now-listening-item {
+  margin-bottom: 30px;
+}
+
+.now-listening-item:last-of-type {
+  margin-bottom: 0;
+}
+
+.now-listening-subhead {
+  margin-bottom: 12px;
+  font-size: 0.85rem;
+  letter-spacing: 2px;
+  text-transform: uppercase;
 }
 
 #now-listening-widget img {


### PR DESCRIPTION
## Summary
- restyle the homepage hero with a Galaga-inspired Suzy Easton logo and refreshed weekly show description
- reorganize the Now Listening section, move the Willie Nelson feature, and update the Grimes commentary around Spotify and Helsing
- expand SEO signals with revised meta description, keywords, and structured data graph

## Testing
- php -l page-home.php
- php -l header.php

------
https://chatgpt.com/codex/tasks/task_e_690c080e18b8832eb798679cc4a51629