### PR TITLE
Add neon arcade logo with branded header styling

### DIFF
--- a/assets/brand/README.md
+++ b/assets/brand/README.md
@@ -1,0 +1,9 @@
+# Brand Assets
+
+These files power the arcade-inspired site logo:
+
+- `suzanne-logo.svg` – the primary neon badge used in the header.
+- `brand-logo.css` – scanline/flicker effects and responsive sizing. Loaded globally via `functions.php`.
+- `scripts/export-logo.mjs` – optional helper script (run locally) for exporting PNG variants.
+
+To swap logos in templates, wrap the SVG (or an `<img>` referencing it) in an element with the `brand-logo` class so the effects apply. Reduced-motion users automatically get a static version without animation.

--- a/assets/brand/brand-logo.css
+++ b/assets/brand/brand-logo.css
@@ -1,0 +1,33 @@
+/* Load arcade-ish font for fallbacks without shipping a binary */
+@import url("https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap");
+
+.brand-logo { position: relative; display: inline-block; line-height: 0; }
+.brand-logo img { width: clamp(220px, 28vw, 420px); height: auto; }
+
+/* CRT scanlines overlay */
+.brand-logo::after {
+  content: "";
+  position: absolute; inset: 0;
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(255,255,255,0.05) 0 1px,
+    transparent 1px 3px
+  );
+  mix-blend-mode: soft-light;
+  pointer-events: none;
+}
+
+/* Tiny flicker */
+@keyframes se-flicker {
+  0%, 100% { opacity: 1; }
+  50%     { opacity: 0.98; }
+}
+.brand-logo { animation: se-flicker 120ms steps(2, end) infinite; }
+
+@media (prefers-reduced-motion: reduce) {
+  .brand-logo { animation: none; }
+  .brand-logo::after { display: none; }
+}
+
+/* Light-surface variant if you ever drop this on a light header */
+.on-light .brand-logo { padding: 6px 10px; border-radius: 12px; background: #111; }

--- a/assets/brand/suzanne-logo.svg
+++ b/assets/brand/suzanne-logo.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="420" height="150" viewBox="0 0 420 150" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Suzanne (Suzy) Easton logo">
+  <defs>
+    <!-- Neon gradient for strokes -->
+    <linearGradient id="neon" x1="0" y1="0" x2="420" y2="0" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#B9FF66"/>
+      <stop offset="0.5" stop-color="#66FCF1"/>
+      <stop offset="1" stop-color="#D36CFF"/>
+    </linearGradient>
+    <!-- Outer glow -->
+    <filter id="glow" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="2" result="blur1"/>
+      <feGaussianBlur in="SourceGraphic" stdDeviation="6" result="blur2"/>
+      <feMerge>
+        <feMergeNode in="blur2"/>
+        <feMergeNode in="blur1"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <!-- Subtle bevel highlight -->
+    <linearGradient id="fillGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0B0C10"/>
+      <stop offset="0.55" stop-color="#14161b"/>
+      <stop offset="1" stop-color="#0B0C10"/>
+    </linearGradient>
+    <!-- Star speckles -->
+    <radialGradient id="star" r="1">
+      <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.7"/>
+      <stop offset="1" stop-color="#FFFFFF" stop-opacity="0"/>
+    </radialGradient>
+    <!-- Scanlines (consumed by CSS overlay, left here if you inline the SVG later) -->
+    <pattern id="scan" width="2" height="3" patternUnits="userSpaceOnUse">
+      <rect x="0" y="0" width="2" height="1" fill="#FFFFFF" opacity="0.05"/>
+    </pattern>
+  </defs>
+
+  <!-- BG badge (soft edge) -->
+  <rect x="4" y="4" width="412" height="142" rx="14" fill="#030405" stroke="url(#neon)" stroke-width="2" opacity="0.6" filter="url(#glow)"/>
+
+  <!-- Sparkles -->
+  <g opacity="0.45">
+    <circle cx="40"  cy="24"  r="1.8" fill="url(#star)"/>
+    <circle cx="365" cy="40"  r="1.2" fill="url(#star)"/>
+    <circle cx="300" cy="20"  r="1.4" fill="url(#star)"/>
+    <circle cx="120" cy="36"  r="1.0" fill="url(#star)"/>
+    <circle cx="210" cy="14"  r="1.3" fill="url(#star)"/>
+  </g>
+
+  <!-- Wordmark -->
+  <g filter="url(#glow)">
+    <!-- SUZANNE -->
+    <text x="210" y="54" text-anchor="middle"
+          font-family="'Press Start 2P', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif"
+          font-size="18" letter-spacing="1"
+          fill="url(#fillGrad)" stroke="url(#neon)" stroke-width="1.6">SUZANNE</text>
+
+    <!-- (SUZY) -->
+    <text x="210" y="74" text-anchor="middle"
+          font-family="'Press Start 2P', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif"
+          font-size="10" letter-spacing="0.5"
+          fill="url(#fillGrad)" stroke="url(#neon)" stroke-width="1.2">(SUZY)</text>
+
+    <!-- EASTON -->
+    <text x="210" y="112" text-anchor="middle"
+          font-family="'Press Start 2P', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif"
+          font-size="34" letter-spacing="1"
+          fill="url(#fillGrad)" stroke="url(#neon)" stroke-width="3">EASTON</text>
+  </g>
+</svg>

--- a/functions.php
+++ b/functions.php
@@ -74,6 +74,18 @@ function suzy_enqueue_scripts() {
 }
 add_action( 'wp_enqueue_scripts', 'suzy_enqueue_scripts' );
 
+function se_enqueue_brand_assets() {
+    $dir = get_stylesheet_directory();
+    $uri = get_stylesheet_directory_uri();
+    wp_enqueue_style(
+        'se-brand-logo',
+        $uri . '/assets/brand/brand-logo.css',
+        array(),
+        file_exists( $dir . '/assets/brand/brand-logo.css' ) ? filemtime( $dir . '/assets/brand/brand-logo.css' ) : null
+    );
+}
+add_action( 'wp_enqueue_scripts', 'se_enqueue_brand_assets' );
+
 // Load bundled Lousy Outages plugin so shortcode and REST endpoint work
 $lousy_outages = get_template_directory() . '/lousy-outages/lousy-outages.php';
 if ( file_exists( $lousy_outages ) ) {

--- a/header.php
+++ b/header.php
@@ -112,7 +112,13 @@
 ?>
 
 <header class="main-header">
-  <a href="/" class="logo">Suzy Easton</a>
+  <a class="brand-logo" href="<?php echo esc_url( home_url( '/' ) ); ?>" aria-label="Home">
+    <img
+      src="<?php echo esc_url( get_stylesheet_directory_uri() . '/assets/brand/suzanne-logo.svg' ); ?>"
+      alt="Suzanne (Suzy) Easton"
+      width="420" height="150"
+      decoding="async" loading="eager" />
+  </a>
   <?php get_template_part( 'parts/bmc-button' ); ?>
 </header>
 

--- a/scripts/export-logo.mjs
+++ b/scripts/export-logo.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * Simple helper to export the SVG logo to PNG using Puppeteer.
+ * Run locally: `node scripts/export-logo.mjs ./assets/brand/suzanne-logo.svg out.png`
+ */
+
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const [,, inputPath, outputPath = 'suzanne-logo.png', scaleArg = '2'] = process.argv;
+
+if (!inputPath) {
+  console.error('Usage: node scripts/export-logo.mjs <input-svg> [output-png] [scale]');
+  process.exit(1);
+}
+
+const scale = Number.parseFloat(scaleArg) || 2;
+
+const puppeteer = await import('puppeteer');
+const browser = await puppeteer.launch();
+const page = await browser.newPage();
+
+const svg = await readFile(inputPath, 'utf8');
+await page.setContent(svg, { waitUntil: 'load' });
+const element = await page.$('svg');
+
+if (!element) {
+  console.error('Could not find <svg> in the provided file.');
+  await browser.close();
+  process.exit(1);
+}
+
+const { width, height } = await element.boundingBox();
+await page.setViewport({ width: Math.ceil(width * scale), height: Math.ceil(height * scale), deviceScaleFactor: scale });
+
+const png = await element.screenshot({ omitBackground: true });
+await writeFile(outputPath, png);
+
+console.log(`Exported ${path.basename(outputPath)} at ${scale}x scale.`);
+await browser.close();


### PR DESCRIPTION
## Summary
- add the supplied neon arcade SVG logo and supporting brand assets
- enqueue the new logo styling and replace the header markup to use the SVG
- document the brand files and include an optional export helper script

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690c0fdb6368832e80b49dbf6a9e0e98