### PR TITLE
Fix brand logo glow and header presentation

### DIFF
--- a/assets/brand/brand-logo.css
+++ b/assets/brand/brand-logo.css
@@ -4,30 +4,38 @@
 .brand-logo { position: relative; display: inline-block; line-height: 0; }
 .brand-logo img { width: clamp(220px, 28vw, 420px); height: auto; }
 
-/* CRT scanlines overlay */
-.brand-logo::after {
-  content: "";
-  position: absolute; inset: 0;
+/* Softer scanlines */
+.brand-logo::after{
+  content:""; position:absolute; inset:0;
   background: repeating-linear-gradient(
     to bottom,
-    rgba(255,255,255,0.05) 0 1px,
+    rgba(255,255,255,0.03) 0 1px,
     transparent 1px 3px
   );
   mix-blend-mode: soft-light;
-  pointer-events: none;
+  pointer-events:none;
 }
 
-/* Tiny flicker */
-@keyframes se-flicker {
-  0%, 100% { opacity: 1; }
-  50%     { opacity: 0.98; }
-}
-.brand-logo { animation: se-flicker 120ms steps(2, end) infinite; }
+/* Tiny flicker -> barely there */
+@keyframes se-flicker{ 0%,100%{opacity:1;} 50%{opacity:.992;} }
+.brand-logo{ animation: se-flicker 160ms steps(2,end) infinite; }
 
-@media (prefers-reduced-motion: reduce) {
-  .brand-logo { animation: none; }
-  .brand-logo::after { display: none; }
+@media (prefers-reduced-motion: reduce){
+  .brand-logo{ animation:none; }
+  .brand-logo::after{ display:none; }
 }
+
+/* TEMP: hide the old hero logo image */
+.hero .old-logo,
+.home .hero img[src*="easton_old"],
+.home .hero img[alt*="EASTON old"]{
+  display: none !important;
+}
+
+/* Make sure the header isn’t clipping the SVG */
+.site-header .brand-logo{ padding-block: 8px; }
+.site-header{ overflow: visible; position: relative; z-index: 2; }
+.buy-coffee{ position: relative; z-index: 3; }
 
 /* Light-surface variant if you ever drop this on a light header */
 .on-light .brand-logo { padding: 6px 10px; border-radius: 12px; background: #111; }

--- a/assets/brand/suzanne-logo.svg
+++ b/assets/brand/suzanne-logo.svg
@@ -1,69 +1,59 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="420" height="150" viewBox="0 0 420 150" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Suzanne (Suzy) Easton logo">
   <defs>
-    <!-- Neon gradient for strokes -->
     <linearGradient id="neon" x1="0" y1="0" x2="420" y2="0" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#B9FF66"/>
       <stop offset="0.5" stop-color="#66FCF1"/>
       <stop offset="1" stop-color="#D36CFF"/>
     </linearGradient>
-    <!-- Outer glow -->
     <filter id="glow" x="-40%" y="-40%" width="180%" height="180%">
-      <feGaussianBlur in="SourceGraphic" stdDeviation="2" result="blur1"/>
-      <feGaussianBlur in="SourceGraphic" stdDeviation="6" result="blur2"/>
+      <!-- lighter glow than before -->
+      <feGaussianBlur in="SourceGraphic" stdDeviation="1.2" result="soft1"/>
+      <feGaussianBlur in="SourceGraphic" stdDeviation="3.2" result="soft2"/>
       <feMerge>
-        <feMergeNode in="blur2"/>
-        <feMergeNode in="blur1"/>
+        <feMergeNode in="soft2"/>
+        <feMergeNode in="soft1"/>
         <feMergeNode in="SourceGraphic"/>
       </feMerge>
     </filter>
-    <!-- Subtle bevel highlight -->
     <linearGradient id="fillGrad" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#0B0C10"/>
       <stop offset="0.55" stop-color="#14161b"/>
       <stop offset="1" stop-color="#0B0C10"/>
     </linearGradient>
-    <!-- Star speckles -->
     <radialGradient id="star" r="1">
       <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.7"/>
       <stop offset="1" stop-color="#FFFFFF" stop-opacity="0"/>
     </radialGradient>
-    <!-- Scanlines (consumed by CSS overlay, left here if you inline the SVG later) -->
-    <pattern id="scan" width="2" height="3" patternUnits="userSpaceOnUse">
-      <rect x="0" y="0" width="2" height="1" fill="#FFFFFF" opacity="0.05"/>
-    </pattern>
   </defs>
 
-  <!-- BG badge (soft edge) -->
-  <rect x="4" y="4" width="412" height="142" rx="14" fill="#030405" stroke="url(#neon)" stroke-width="2" opacity="0.6" filter="url(#glow)"/>
+  <!-- Soft badge -->
+  <rect x="6" y="6" width="408" height="138" rx="14" fill="#030405" stroke="url(#neon)" stroke-width="1.5" opacity="0.75" filter="url(#glow)"/>
 
-  <!-- Sparkles -->
-  <g opacity="0.45">
-    <circle cx="40"  cy="24"  r="1.8" fill="url(#star)"/>
-    <circle cx="365" cy="40"  r="1.2" fill="url(#star)"/>
-    <circle cx="300" cy="20"  r="1.4" fill="url(#star)"/>
-    <circle cx="120" cy="36"  r="1.0" fill="url(#star)"/>
-    <circle cx="210" cy="14"  r="1.3" fill="url(#star)"/>
+  <!-- Subtle sparkles -->
+  <g opacity="0.35">
+    <circle cx="40"  cy="24"  r="1.6" fill="url(#star)"/>
+    <circle cx="365" cy="40"  r="1.0" fill="url(#star)"/>
+    <circle cx="300" cy="22"  r="1.2" fill="url(#star)"/>
+    <circle cx="120" cy="38"  r="0.9" fill="url(#star)"/>
+    <circle cx="210" cy="16"  r="1.1" fill="url(#star)"/>
   </g>
 
   <!-- Wordmark -->
   <g filter="url(#glow)">
-    <!-- SUZANNE -->
-    <text x="210" y="54" text-anchor="middle"
+    <text x="210" y="56" text-anchor="middle"
           font-family="'Press Start 2P', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif"
-          font-size="18" letter-spacing="1"
-          fill="url(#fillGrad)" stroke="url(#neon)" stroke-width="1.6">SUZANNE</text>
+          font-size="18" letter-spacing="0.5"
+          fill="url(#fillGrad)" stroke="url(#neon)" stroke-width="1.2">SUZANNE</text>
 
-    <!-- (SUZY) -->
     <text x="210" y="74" text-anchor="middle"
           font-family="'Press Start 2P', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif"
-          font-size="10" letter-spacing="0.5"
-          fill="url(#fillGrad)" stroke="url(#neon)" stroke-width="1.2">(SUZY)</text>
+          font-size="10" letter-spacing="0.2"
+          fill="url(#fillGrad)" stroke="url(#neon)" stroke-width="1">(SUZY)</text>
 
-    <!-- EASTON -->
     <text x="210" y="112" text-anchor="middle"
           font-family="'Press Start 2P', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif"
-          font-size="34" letter-spacing="1"
-          fill="url(#fillGrad)" stroke="url(#neon)" stroke-width="3">EASTON</text>
+          font-size="32" letter-spacing="0.5"
+          fill="url(#fillGrad)" stroke="url(#neon)" stroke-width="2.2">EASTON</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- replace the brand SVG with the updated neon glow and remove the inline scanline pattern
- soften the CSS scanline overlay and flicker while hiding the legacy hero bitmap logo
- adjust header spacing/overflow and ensure the coffee CTA layers above the glow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690c1211b4f0832e8aa5cf87314c7dba