### PR TITLE
Replace homepage hero logo with neon text wordmark

### DIFF
--- a/assets/brand/hero-wordmark.css
+++ b/assets/brand/hero-wordmark.css
@@ -1,0 +1,74 @@
+@import url("https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap");
+
+/* Container for the hero title wordmark */
+.hero-wordmark {
+  display: inline-block;
+  padding: 10px 14px;
+  border-radius: 14px;
+  position: relative;
+  text-decoration: none;
+  line-height: 1.15;
+  /* subtle badge bg so neon reads on dark */
+  background: rgba(10, 12, 16, 0.7);
+}
+
+/* Two-line layout */
+.hero-wordmark .line1 {
+  display: block;
+  font-family: "Press Start 2P", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  font-size: clamp(16px, 2.6vw, 22px);
+  letter-spacing: 0.6px;
+  color: #cfffff;
+  text-shadow:
+    0 0 1px #b9ff66,
+    0 0 6px #66fcf1,
+    0 0 12px #66fcf1;
+  text-align: center;
+}
+.hero-wordmark .line1 small { opacity: 0.85; font-size: 0.8em; }
+
+.hero-wordmark .line2 {
+  display: block;
+  margin-top: 6px;
+  font-family: "Press Start 2P", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  font-size: clamp(22px, 4.2vw, 34px);
+  letter-spacing: 0.6px;
+  color: #eaffff;
+  text-shadow:
+    0 0 1px #aaffdd,
+    0 0 8px #66fcf1,
+    0 0 16px #66fcf1,
+    0 0 18px #b9ff66;
+  text-align: center;
+}
+
+/* Subtle scanlines (motion-safe fallback below) */
+.hero-wordmark::after {
+  content: "";
+  position: absolute; inset: -6px -8px;
+  border-radius: 16px;
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(255,255,255,0.025) 0 1px,
+    transparent 1px 3px
+  );
+  mix-blend-mode: soft-light;
+  pointer-events: none;
+}
+
+/* Remove the previous hero logo image, only in hero */
+.home .hero img[alt*="EASTON"],
+.home .hero img[src*="east"],
+.home .hero .hero-logo,
+.home .hero .site-logo {
+  display: none !important;
+}
+
+/* Tighten hero spacing so tagline sits cleanly */
+.home .hero,
+.home .hero .inner { padding-top: clamp(8px, 1.5vw, 16px); min-height: 0; }
+
+/* Motion/contrast safety */
+@media (prefers-reduced-motion: reduce) {
+  .hero-wordmark::after { display: none; }
+}

--- a/functions.php
+++ b/functions.php
@@ -86,6 +86,24 @@ function se_enqueue_brand_assets() {
 }
 add_action( 'wp_enqueue_scripts', 'se_enqueue_brand_assets' );
 
+function se_enqueue_hero_wordmark() {
+    if ( ! is_front_page() ) {
+        return;
+    }
+
+    $dir = get_stylesheet_directory();
+    $uri = get_stylesheet_directory_uri();
+    $path = '/assets/brand/hero-wordmark.css';
+
+    wp_enqueue_style(
+        'se-hero-wordmark',
+        $uri . $path,
+        array(),
+        file_exists( $dir . $path ) ? filemtime( $dir . $path ) : null
+    );
+}
+add_action( 'wp_enqueue_scripts', 'se_enqueue_hero_wordmark' );
+
 // Load bundled Lousy Outages plugin so shortcode and REST endpoint work
 $lousy_outages = get_template_directory() . '/lousy-outages/lousy-outages.php';
 if ( file_exists( $lousy_outages ) ) {

--- a/page-home.php
+++ b/page-home.php
@@ -12,16 +12,23 @@ get_header();
             $hero_logo_top = apply_filters('se_home_hero_logo_top', 'Suzanne');
             $hero_logo_mid = apply_filters('se_home_hero_logo_mid', '(Suzy)');
             $hero_logo_bottom = apply_filters('se_home_hero_logo_bottom', 'Easton');
+            $hero_logo_top_text = function_exists('mb_strtoupper') ? mb_strtoupper($hero_logo_top, 'UTF-8') : strtoupper($hero_logo_top);
+            $hero_logo_mid_text = function_exists('mb_strtoupper') ? mb_strtoupper($hero_logo_mid, 'UTF-8') : strtoupper($hero_logo_mid);
+            $hero_logo_bottom_text = function_exists('mb_strtoupper') ? mb_strtoupper($hero_logo_bottom, 'UTF-8') : strtoupper($hero_logo_bottom);
             $hero_copy    = apply_filters('se_home_hero_copy', 'Independent music, infrastructure nerdiness, and creative experiments direct from Vancouver.');
             ?>
             <div class="hero-main">
                 <?php if (!empty($hero_eyebrow)) : ?>
                     <p class="hero-eyebrow pixel-font"><?php echo esc_html($hero_eyebrow); ?></p>
                 <?php endif; ?>
-                <h1 class="retro-title glow-lite hero-title galaga-logo" aria-label="<?php echo esc_attr($hero_logo_label); ?>">
-                    <span class="galaga-logo__top"><?php echo esc_html($hero_logo_top); ?></span>
-                    <span class="galaga-logo__mid"><?php echo esc_html($hero_logo_mid); ?></span>
-                    <span class="galaga-logo__bottom"><?php echo esc_html($hero_logo_bottom); ?></span>
+                <h1 class="retro-title glow-lite hero-title" aria-label="<?php echo esc_attr($hero_logo_label); ?>">
+                    <div class="hero-wordmark" aria-label="<?php echo esc_attr($hero_logo_label); ?>">
+                        <span class="line1">
+                            <?php echo esc_html($hero_logo_top_text); ?>
+                            <small><?php echo esc_html($hero_logo_mid_text); ?></small>
+                        </span>
+                        <span class="line2"><?php echo esc_html($hero_logo_bottom_text); ?></span>
+                    </div>
                 </h1>
                 <p class="hero-copy"><?php echo esc_html($hero_copy); ?></p>
             </div>


### PR DESCRIPTION
## Summary
- add dedicated hero wordmark stylesheet with neon arcade styling and hero spacing tweaks
- enqueue the hero wordmark CSS only on the front page
- swap the homepage hero logo markup for the two-line text wordmark using existing filter defaults

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690c22bac654832e9c1d40d26b0b904b