### PR TITLE
Refine hero wordmark styling

### DIFF
--- a/assets/brand/hero-wordmark.css
+++ b/assets/brand/hero-wordmark.css
@@ -1,74 +1,84 @@
 @import url("https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap");
 
-/* Container for the hero title wordmark */
-.hero-wordmark {
-  display: inline-block;
-  padding: 10px 14px;
-  border-radius: 14px;
+/* Centered hero container (text + subtle badge) */
+.hero-wordmark-wrap {
+  display: grid;
+  place-items: center;
+  margin: clamp(8px, 2vw, 16px) auto 0;
+}
+
+/* Panel behind the text (replaces green bitmap panel) */
+.hero-badge {
   position: relative;
-  text-decoration: none;
-  line-height: 1.15;
-  /* subtle badge bg so neon reads on dark */
-  background: rgba(10, 12, 16, 0.7);
-}
-
-/* Two-line layout */
-.hero-wordmark .line1 {
-  display: block;
-  font-family: "Press Start 2P", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
-  font-size: clamp(16px, 2.6vw, 22px);
-  letter-spacing: 0.6px;
-  color: #cfffff;
-  text-shadow:
-    0 0 1px #b9ff66,
-    0 0 6px #66fcf1,
-    0 0 12px #66fcf1;
-  text-align: center;
-}
-.hero-wordmark .line1 small { opacity: 0.85; font-size: 0.8em; }
-
-.hero-wordmark .line2 {
-  display: block;
-  margin-top: 6px;
-  font-family: "Press Start 2P", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
-  font-size: clamp(22px, 4.2vw, 34px);
-  letter-spacing: 0.6px;
-  color: #eaffff;
-  text-shadow:
-    0 0 1px #aaffdd,
-    0 0 8px #66fcf1,
-    0 0 16px #66fcf1,
-    0 0 18px #b9ff66;
-  text-align: center;
-}
-
-/* Subtle scanlines (motion-safe fallback below) */
-.hero-wordmark::after {
-  content: "";
-  position: absolute; inset: -6px -8px;
+  max-width: clamp(320px, 78vw, 860px);
+  padding: clamp(12px, 2.2vw, 18px) clamp(14px, 3vw, 24px);
   border-radius: 16px;
+  background: rgba(8, 10, 14, 0.72);
+  box-shadow:
+    0 0 0 1px rgba(185,255,102,.25),
+    0 8px 28px rgba(102,252,241,.10);
+  overflow: hidden;
+}
+
+/* Very light scanlines; we killed the old heavy ones */
+.hero-badge::after {
+  content: "";
+  position: absolute; inset: 0;
   background: repeating-linear-gradient(
     to bottom,
-    rgba(255,255,255,0.025) 0 1px,
+    rgba(255,255,255,0.02) 0 1px,
     transparent 1px 3px
   );
   mix-blend-mode: soft-light;
   pointer-events: none;
 }
+@media (prefers-reduced-motion: reduce) {
+  .hero-badge::after { display: none; }
+}
 
-/* Remove the previous hero logo image, only in hero */
+/* The actual wordmark */
+.hero-wordmark {
+  text-align: center;
+  line-height: 1.12;
+  font-family: "Press Start 2P", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  margin: 0;
+}
+
+/* Top line */
+.hero-wordmark .line1 {
+  display: block;
+  font-size: clamp(16px, 2.4vw, 22px);
+  letter-spacing: .5px;
+  color: #cffefe;
+  text-shadow:
+    0 0 1px #b9ff66,
+    0 0 6px #66fcf1,
+    0 0 12px #66fcf1;
+}
+.hero-wordmark .line1 small { opacity: .9; font-size: .8em; }
+
+/* Bottom line (bigger, but not chunky) */
+.hero-wordmark .line2 {
+  display: block;
+  margin-top: .35em;
+  font-size: clamp(22px, 4vw, 36px);
+  letter-spacing: .5px;
+  color: #eaffff;
+  text-shadow:
+    0 0 1px #aaffdd,
+    0 0 8px #66fcf1,
+    0 0 16px #66fcf1,
+    0 0 20px #b9ff66;
+}
+
+/* Kill the old bitmap/logo in hero only */
 .home .hero img[alt*="EASTON"],
 .home .hero img[src*="east"],
-.home .hero .hero-logo,
+.home .hero .logo,
 .home .hero .site-logo {
   display: none !important;
 }
 
-/* Tighten hero spacing so tagline sits cleanly */
+/* Tighten layout so the tagline follows neatly */
 .home .hero,
-.home .hero .inner { padding-top: clamp(8px, 1.5vw, 16px); min-height: 0; }
-
-/* Motion/contrast safety */
-@media (prefers-reduced-motion: reduce) {
-  .hero-wordmark::after { display: none; }
-}
+.home .hero .inner { padding-top: clamp(6px, 1.2vw, 12px); min-height: 0; }

--- a/functions.php
+++ b/functions.php
@@ -86,23 +86,15 @@ function se_enqueue_brand_assets() {
 }
 add_action( 'wp_enqueue_scripts', 'se_enqueue_brand_assets' );
 
-function se_enqueue_hero_wordmark() {
-    if ( ! is_front_page() ) {
-        return;
-    }
-
+function se_enqueue_hero_wordmark_styles() {
     $dir = get_stylesheet_directory();
     $uri = get_stylesheet_directory_uri();
     $path = '/assets/brand/hero-wordmark.css';
-
-    wp_enqueue_style(
-        'se-hero-wordmark',
-        $uri . $path,
-        array(),
-        file_exists( $dir . $path ) ? filemtime( $dir . $path ) : null
-    );
+    if ( file_exists( $dir . $path ) ) {
+        wp_enqueue_style('se-hero-wordmark', $uri . $path, array(), filemtime($dir . $path));
+    }
 }
-add_action( 'wp_enqueue_scripts', 'se_enqueue_hero_wordmark' );
+add_action('wp_enqueue_scripts', 'se_enqueue_hero_wordmark_styles');
 
 // Load bundled Lousy Outages plugin so shortcode and REST endpoint work
 $lousy_outages = get_template_directory() . '/lousy-outages/lousy-outages.php';

--- a/page-home.php
+++ b/page-home.php
@@ -4,7 +4,7 @@ get_header();
 ?>
 
 <main id="homepage-content">
-    <div class="hero-section folk-crt">
+    <div class="hero hero-section">
         <div class="hero-grid">
             <?php
             $hero_eyebrow = apply_filters('se_home_hero_eyebrow', '');
@@ -21,15 +21,18 @@ get_header();
                 <?php if (!empty($hero_eyebrow)) : ?>
                     <p class="hero-eyebrow pixel-font"><?php echo esc_html($hero_eyebrow); ?></p>
                 <?php endif; ?>
-                <h1 class="retro-title glow-lite hero-title" aria-label="<?php echo esc_attr($hero_logo_label); ?>">
-                    <div class="hero-wordmark" aria-label="<?php echo esc_attr($hero_logo_label); ?>">
-                        <span class="line1">
-                            <?php echo esc_html($hero_logo_top_text); ?>
-                            <small><?php echo esc_html($hero_logo_mid_text); ?></small>
-                        </span>
-                        <span class="line2"><?php echo esc_html($hero_logo_bottom_text); ?></span>
+                <h1 class="screen-reader-text"><?php echo esc_html($hero_logo_label); ?></h1>
+                <div class="hero-wordmark-wrap">
+                    <div class="hero-badge">
+                        <p class="hero-wordmark" aria-label="<?php echo esc_attr($hero_logo_label); ?>">
+                            <span class="line1">
+                                <?php echo esc_html($hero_logo_top_text); ?>
+                                <small><?php echo esc_html($hero_logo_mid_text); ?></small>
+                            </span>
+                            <span class="line2"><?php echo esc_html($hero_logo_bottom_text); ?></span>
+                        </p>
                     </div>
-                </h1>
+                </div>
                 <p class="hero-copy"><?php echo esc_html($hero_copy); ?></p>
             </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -638,7 +638,7 @@ body::before {
 /* ====================== */
 .hero {
   text-align: center;
-  padding: 2rem 1rem;
+  padding: 0 1rem;
 }
 .hero-img,
 .hero-image img {
@@ -894,7 +894,7 @@ footer,
   max-width: 1000px;
   margin: 0 auto;
   text-align: center;
-  padding: 4rem 1rem 2rem;
+  padding: clamp(32px, 6vw, 72px) 1rem clamp(24px, 5vw, 40px);
   position: relative;
   z-index: 2;
 }
@@ -1797,32 +1797,6 @@ body {
     box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
 }
 
-.hero-section.folk-crt {
-  position: relative;
-  padding: 3.25rem 1.25rem 2.25rem;
-  background: linear-gradient(135deg, rgba(20, 26, 32, 0.92) 0%, rgba(24, 38, 34, 0.88) 60%, rgba(36, 28, 24, 0.85) 100%);
-  border: 1px solid rgba(244, 226, 195, 0.28);
-  box-shadow: 0 0 16px rgba(214, 187, 135, 0.16);
-  overflow: hidden;
-}
-
-.hero-section.folk-crt::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background-image: radial-gradient(circle at top left, rgba(255, 214, 153, 0.18), transparent 55%),
-    radial-gradient(circle at bottom right, rgba(118, 224, 255, 0.1), transparent 60%),
-    repeating-linear-gradient(
-      0deg,
-      rgba(248, 240, 220, 0.05) 0,
-      rgba(248, 240, 220, 0.05) 1px,
-      transparent 1px,
-      transparent 4px
-    );
-  opacity: 0.65;
-  pointer-events: none;
-}
-
 .hero-grid {
   position: relative;
   display: grid;
@@ -1840,14 +1814,14 @@ body {
 }
 
 .hero-main {
-  padding: 2.1rem;
-  background: rgba(18, 22, 30, 0.68);
-  border: 1px solid rgba(240, 223, 194, 0.26);
-  box-shadow: inset 0 0 0 1px rgba(137, 212, 255, 0.06);
-  backdrop-filter: blur(3px);
+  padding: clamp(12px, 2vw, 24px) 0;
+  background: none;
+  border: 0;
+  box-shadow: none;
+  backdrop-filter: none;
   width: min(100%, 62ch);
-  text-align: left;
-  justify-self: start;
+  text-align: center;
+  justify-self: center;
 }
 
 .hero-eyebrow {
@@ -1858,17 +1832,11 @@ body {
   font-size: 0.82rem;
 }
 
-.hero-title {
-  font-size: clamp(2.2rem, 3vw + 1.1rem, 3.7rem);
-  margin-bottom: 0.85rem;
-  text-shadow: 0 0 6px rgba(255, 198, 125, 0.36), 0 0 12px rgba(96, 168, 255, 0.28);
-}
-
 .hero-copy {
   font-size: 1.05rem;
   line-height: 1.75;
   color: rgba(243, 235, 223, 0.92);
-  margin-bottom: 1.6rem;
+  margin: clamp(18px, 2.4vw, 28px) auto 1.4rem;
 }
 
 .hero-cta-row {
@@ -2019,7 +1987,7 @@ body {
 @media (max-width: 720px) {
   .hero-main,
   .hero-side {
-    padding: 1.75rem 1.5rem;
+    padding: clamp(12px, 4vw, 24px) 0;
     width: 100%;
   }
 


### PR DESCRIPTION
## Summary
- replace the hero wordmark stylesheet with the new centered neon badge design and hide the legacy bitmap logo
- enqueue the hero wordmark styles through a dedicated helper and update the homepage hero markup to use the new badge structure
- simplify hero spacing by removing the blurred panel styles and tightening padding for a cleaner layout

## Testing
- php -l page-home.php
- php -l functions.php

------
https://chatgpt.com/codex/tasks/task_e_690c24f0d0e0832e9b23bd3df4bf5ed9