### PR TITLE
Adjust header layout and center hero wordmark

### DIFF
--- a/assets/brand/header-tweak.css
+++ b/assets/brand/header-tweak.css
@@ -1,0 +1,31 @@
+/* Header: more left/right, less top/bottom */
+.site-header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;   /* logo | spacer | CTA */
+  align-items: center;
+  padding: 6px 22px;                      /* ↓ top/bottom, ↑ left/right */
+  gap: 12px;
+  min-height: 56px;
+  overflow: visible;
+}
+
+/* Keep logo snug on the left */
+.site-header .brand-logo,
+.site-header .brand-wordmark {
+  margin-inline: 0;                        /* no random side margins */
+}
+
+/* Make sure the middle column actually flexes */
+.site-header::before { content: ""; }
+
+/* Right-side CTA stays tight */
+.buy-coffee, .header-cta {
+  white-space: nowrap;
+  margin-left: 8px;
+  font-size: clamp(12px, 1.7vw, 16px);
+}
+
+/* If your theme wraps content inside an inner container: ensure it fills */
+.site-header .wrap, .site-header .container {
+  display: contents;                       /* let grid above control layout */
+}

--- a/assets/brand/hero-wordmark.css
+++ b/assets/brand/hero-wordmark.css
@@ -2,15 +2,19 @@
 
 /* Centered hero container (text + subtle badge) */
 .hero-wordmark-wrap {
-  display: grid;
-  place-items: center;
+  display: flex;
+  justify-content: center;           /* hard center */
+  align-items: center;
   margin: clamp(8px, 2vw, 16px) auto 0;
+  width: 100%;
 }
 
 /* Panel behind the text (replaces green bitmap panel) */
 .hero-badge {
   position: relative;
-  max-width: clamp(320px, 78vw, 860px);
+  margin: 0 auto;
+  width: fit-content;
+  max-width: min(92vw, 860px);
   padding: clamp(12px, 2.2vw, 18px) clamp(14px, 3vw, 24px);
   border-radius: 16px;
   background: rgba(8, 10, 14, 0.72);
@@ -43,6 +47,9 @@
   font-family: "Press Start 2P", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
   margin: 0;
 }
+
+/* If a parent section has text-align:left, override here */
+.home .hero { text-align: initial; }
 
 /* Top line */
 .hero-wordmark .line1 {
@@ -79,6 +86,6 @@
   display: none !important;
 }
 
-/* Tighten layout so the tagline follows neatly */
+/* Trim hero top padding only if needed */
 .home .hero,
-.home .hero .inner { padding-top: clamp(6px, 1.2vw, 12px); min-height: 0; }
+.home .hero .inner { padding-top: clamp(4px, 1vw, 10px); min-height: 0; }

--- a/functions.php
+++ b/functions.php
@@ -372,3 +372,14 @@ add_action('wp_head', function () {
         echo "<link rel=\"alternate\" type=\"application/rss+xml\" title=\"Lousy Outages Alerts\" href=\"{$href}\" />\n";
     }
 });
+
+function se_enqueue_header_tweak_css() {
+    $dir = get_stylesheet_directory();
+    $uri = get_stylesheet_directory_uri();
+    $path = '/assets/brand/header-tweak.css';
+    if ( file_exists( $dir . $path ) ) {
+        wp_enqueue_style('se-header-tweak', $uri . $path, array(), filemtime($dir . $path));
+    }
+}
+add_action('wp_enqueue_scripts', 'se_enqueue_header_tweak_css');
+


### PR DESCRIPTION
## Summary
- add a header tweak stylesheet to grid-align the header and adjust spacing
- enqueue the header tweak stylesheet from the theme
- center the hero wordmark and badge while reducing extra top padding

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690c2b35ae40832ea45d2dd419f0a9cb