### PR TITLE
Normalize Lousy Outages namespaces

### DIFF
--- a/lousy-outages/includes/Adapters.php
+++ b/lousy-outages/includes/Adapters.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Lousy\Adapters;
+namespace SuzyEaston\LousyOutages\Adapters;
 
 function from_statuspage_summary(string $json): array {
     $data = json_decode($json, true);

--- a/lousy-outages/includes/Adapters/Statuspage.php
+++ b/lousy-outages/includes/Adapters/Statuspage.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Lousy\Adapters\Statuspage;
+namespace SuzyEaston\LousyOutages\Adapters\Statuspage;
 
 /**
  * Attempt to infer a service state from a Statuspage error payload or body.

--- a/lousy-outages/includes/Api.php
+++ b/lousy-outages/includes/Api.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace LousyOutages;
+namespace SuzyEaston\LousyOutages;
 
 use WP_REST_Request;
 use WP_REST_Response;

--- a/lousy-outages/includes/Cron/Refresh.php
+++ b/lousy-outages/includes/Cron/Refresh.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace LousyOutages\Cron;
+namespace SuzyEaston\LousyOutages\Cron;
 
-use LousyOutages\IncidentAlerts;
+use SuzyEaston\LousyOutages\IncidentAlerts;
 
 class Refresh
 {

--- a/lousy-outages/includes/Detector.php
+++ b/lousy-outages/includes/Detector.php
@@ -1,5 +1,5 @@
 <?php
-namespace LousyOutages;
+namespace SuzyEaston\LousyOutages;
 
 class Detector {
     private Store $store;

--- a/lousy-outages/includes/Downdetector.php
+++ b/lousy-outages/includes/Downdetector.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace LousyOutages;
+namespace SuzyEaston\LousyOutages;
 
 class Downdetector {
     private const CACHE_KEY = 'lousy_outages_downdetector_trends';

--- a/lousy-outages/includes/Email.php
+++ b/lousy-outages/includes/Email.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace LousyOutages;
+namespace SuzyEaston\LousyOutages;
 
-use LousyOutages\Email\Composer;
+use SuzyEaston\LousyOutages\Email\Composer;
 
 class Email {
     private const STATUS_LABELS = [

--- a/lousy-outages/includes/Email/Composer.php
+++ b/lousy-outages/includes/Email/Composer.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace LousyOutages\Email;
+namespace SuzyEaston\LousyOutages\Email;
 
-use LousyOutages\Model\Incident;
+use SuzyEaston\LousyOutages\Model\Incident;
 
 class Composer
 {

--- a/lousy-outages/includes/Feed.php
+++ b/lousy-outages/includes/Feed.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace LousyOutages;
+namespace SuzyEaston\LousyOutages;
 
 class Feed {
     public static function bootstrap(): void {

--- a/lousy-outages/includes/Fetch.php
+++ b/lousy-outages/includes/Fetch.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Lousy;
+namespace SuzyEaston\LousyOutages;
 
 /**
  * Perform an HTTP GET request with sane defaults and graceful error handling.

--- a/lousy-outages/includes/Fetcher.php
+++ b/lousy-outages/includes/Fetcher.php
@@ -1,17 +1,17 @@
 <?php
 declare(strict_types=1);
 
-namespace LousyOutages;
+namespace SuzyEaston\LousyOutages;
 
 // Changelog:
 // - 2024-06-05: Improve HTTP resilience, add history fallbacks, enhance error reporting.
 
-use function Lousy\http_get;
-use function Lousy\Adapters\from_rss_atom;
-use function Lousy\Adapters\from_slack_current;
-use function Lousy\Adapters\from_statuspage_status;
-use function Lousy\Adapters\from_statuspage_summary;
-use function Lousy\Adapters\Statuspage\detect_state_from_error;
+use function SuzyEaston\LousyOutages\http_get;
+use function SuzyEaston\LousyOutages\Adapters\from_rss_atom;
+use function SuzyEaston\LousyOutages\Adapters\from_slack_current;
+use function SuzyEaston\LousyOutages\Adapters\from_statuspage_status;
+use function SuzyEaston\LousyOutages\Adapters\from_statuspage_summary;
+use function SuzyEaston\LousyOutages\Adapters\Statuspage\detect_state_from_error;
 
 class Fetcher {
     private const STATUS_LABELS = [

--- a/lousy-outages/includes/I18n.php
+++ b/lousy-outages/includes/I18n.php
@@ -1,5 +1,5 @@
 <?php
-namespace LousyOutages;
+namespace SuzyEaston\LousyOutages;
 
 class I18n {
     private const STRINGS = [

--- a/lousy-outages/includes/IncidentAlerts.php
+++ b/lousy-outages/includes/IncidentAlerts.php
@@ -1,28 +1,15 @@
 <?php
 declare(strict_types=1);
 
-namespace {
-    if (! function_exists('lo_is_scheduled_maintenance')) {
-        /**
-         * Detects scheduled or planned maintenance announcements.
-         */
-        function lo_is_scheduled_maintenance(string $title, string $description): bool
-        {
-            $haystack = $title . ' ' . $description;
-            return 1 === preg_match('/\b(scheduled|planned).{0,40}maintenance\b/i', $haystack);
-        }
-    }
-}
+namespace SuzyEaston\LousyOutages;
 
-namespace LousyOutages;
-
-use LousyOutages\Email\Composer;
-use LousyOutages\Model\Incident;
-use LousyOutages\Mailer;
-use LousyOutages\Providers;
-use LousyOutages\Sources\Sources;
-use LousyOutages\Sources\StatuspageSource;
-use LousyOutages\Storage\IncidentStore;
+use SuzyEaston\LousyOutages\Email\Composer;
+use SuzyEaston\LousyOutages\Mailer;
+use SuzyEaston\LousyOutages\Model\Incident;
+use SuzyEaston\LousyOutages\Providers;
+use SuzyEaston\LousyOutages\Sources\Sources;
+use SuzyEaston\LousyOutages\Sources\StatuspageSource;
+use SuzyEaston\LousyOutages\Storage\IncidentStore;
 use WP_REST_Request;
 
 class IncidentAlerts {
@@ -479,7 +466,7 @@ class IncidentAlerts {
         }
 
         $status = self::normalize_status_code($statusRaw, $impactRaw);
-        if (lo_is_scheduled_maintenance($title, $bodyText)) {
+        if (self::isScheduledMaintenance($title, $bodyText)) {
             $status = 'maintenance';
         }
         $impact = self::normalize_impact($impactRaw ?: self::impact_from_status($status));
@@ -1260,6 +1247,13 @@ class IncidentAlerts {
         }
 
         return true;
+    }
+
+    private static function isScheduledMaintenance(string $title, string $description): bool
+    {
+        $haystack = $title . ' ' . $description;
+
+        return 1 === preg_match('/\\b(scheduled|planned).{0,40}maintenance\\b/i', $haystack);
     }
 
     private static function log_error(string $provider, string $message): void {

--- a/lousy-outages/includes/MailTransport.php
+++ b/lousy-outages/includes/MailTransport.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace LousyOutages;
+namespace SuzyEaston\LousyOutages;
 
 use PHPMailer\PHPMailer\PHPMailer;
 use WP_Error;

--- a/lousy-outages/includes/Mailer.php
+++ b/lousy-outages/includes/Mailer.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace LousyOutages;
+namespace SuzyEaston\LousyOutages;
 
 class Mailer {
     /**

--- a/lousy-outages/includes/Model/Incident.php
+++ b/lousy-outages/includes/Model/Incident.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace LousyOutages\Model;
+namespace SuzyEaston\LousyOutages\Model;
 
 class Incident
 {

--- a/lousy-outages/includes/Precursor.php
+++ b/lousy-outages/includes/Precursor.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace LousyOutages;
+namespace SuzyEaston\LousyOutages;
 
 class Precursor {
     private $timeout;

--- a/lousy-outages/includes/Providers.php
+++ b/lousy-outages/includes/Providers.php
@@ -1,8 +1,12 @@
 <?php
 declare(strict_types=1);
 
-namespace {
-    function lousy_outages_default_providers(): array {
+namespace SuzyEaston\LousyOutages;
+
+class Providers {
+    private const OPTION_DEFAULT_ENABLED = 'lousy_outages_default_enabled_providers';
+
+    private static function defaultProviders(): array {
         return [
             // Statuspage JSON
             [
@@ -109,252 +113,245 @@ namespace {
             ['id' => 'downdetector-ca', 'name' => 'Downdetector (CA Aggregate)', 'type' => 'rss', 'url' => 'https://downdetector.ca/archive/?format=rss', 'disabled' => true, 'optional' => true],
         ];
     }
-}
 
-namespace LousyOutages {
+    /**
+     * Return the provider configuration map.
+     */
+    public static function list(): array {
+        $defaults  = self::defaultProviders();
+        $providers = [];
 
-    class Providers {
-        private const OPTION_DEFAULT_ENABLED = 'lousy_outages_default_enabled_providers';
+        foreach ( $defaults as $provider ) {
+            if ( ! is_array( $provider ) ) {
+                continue;
+            }
 
-        /**
-         * Return the provider configuration map.
-         */
-        public static function list(): array {
-            $defaults  = \lousy_outages_default_providers();
+            $id = isset( $provider['id'] ) ? (string) $provider['id'] : '';
+            if ( '' === $id ) {
+                continue;
+            }
+
+            $providers[ $id ] = $provider;
+        }
+
+        $providers = apply_filters( 'lousy_outages_providers', $providers );
+        if ( ! is_array( $providers ) ) {
             $providers = [];
+        }
 
-            foreach ( $defaults as $provider ) {
-                if ( ! is_array( $provider ) ) {
+        foreach ( $providers as $id => &$provider ) {
+            if ( ! is_array( $provider ) ) {
+                unset( $providers[ $id ] );
+                continue;
+            }
+
+            $provider = self::prepare_provider( (string) $id, $provider );
+        }
+        unset( $provider );
+
+        return $providers;
+    }
+
+    /**
+     * Return enabled providers from options or defaults.
+     */
+    public static function enabled(): array {
+        $all             = self::list();
+        $default_enabled = array_keys(
+            array_filter(
+                $all,
+                static fn( array $prov ): bool => ! empty( $prov['enabled'] )
+            )
+        );
+        $saved               = get_option( 'lousy_outages_providers', false );
+        $stored_default_list = get_option( self::OPTION_DEFAULT_ENABLED, null );
+        $previous_defaults   = is_array( $stored_default_list )
+            ? array_values(
+                array_filter(
+                    array_map( 'strval', $stored_default_list ),
+                    static fn( $value ): bool => '' !== (string) $value
+                )
+            )
+            : [];
+
+        if ( is_array( $saved ) ) {
+            $enabled_ids = [];
+            foreach ( $saved as $id ) {
+                if ( ! is_scalar( $id ) ) {
                     continue;
                 }
-
-                $id = isset( $provider['id'] ) ? (string) $provider['id'] : '';
+                $id = (string) $id;
                 if ( '' === $id ) {
                     continue;
                 }
-
-                $providers[ $id ] = $provider;
+                $enabled_ids[] = $id;
             }
 
-            $providers = apply_filters( 'lousy_outages_providers', $providers );
-            if ( ! is_array( $providers ) ) {
-                $providers = [];
-            }
+            $new_defaults = array_diff( $default_enabled, $previous_defaults );
+            $updated      = false;
 
-            foreach ( $providers as $id => &$provider ) {
-                if ( ! is_array( $provider ) ) {
-                    unset( $providers[ $id ] );
-                    continue;
-                }
-
-                $provider = self::prepare_provider( (string) $id, $provider );
-            }
-            unset( $provider );
-
-            return $providers;
-        }
-
-        /**
-         * Return enabled providers from options or defaults.
-         */
-        public static function enabled(): array {
-            $all             = self::list();
-            $default_enabled = array_keys(
-                array_filter(
-                    $all,
-                    static fn( array $prov ): bool => ! empty( $prov['enabled'] )
-                )
-            );
-            $saved               = get_option( 'lousy_outages_providers', false );
-            $stored_default_list = get_option( self::OPTION_DEFAULT_ENABLED, null );
-            $previous_defaults   = is_array( $stored_default_list )
-                ? array_values(
-                    array_filter(
-                        array_map( 'strval', $stored_default_list ),
-                        static fn( $value ): bool => '' !== (string) $value
-                    )
-                )
-                : [];
-
-            if ( is_array( $saved ) ) {
-                $enabled_ids = [];
-                foreach ( $saved as $id ) {
-                    if ( ! is_scalar( $id ) ) {
-                        continue;
-                    }
-                    $id = (string) $id;
-                    if ( '' === $id ) {
-                        continue;
-                    }
-                    $enabled_ids[] = $id;
-                }
-
-                $new_defaults = array_diff( $default_enabled, $previous_defaults );
-                $updated      = false;
-
-                if ( ! empty( $new_defaults ) ) {
-                    foreach ( $new_defaults as $id ) {
-                        if ( ! in_array( $id, $enabled_ids, true ) ) {
-                            $enabled_ids[] = $id;
-                            $updated       = true;
-                        }
+            if ( ! empty( $new_defaults ) ) {
+                foreach ( $new_defaults as $id ) {
+                    if ( ! in_array( $id, $enabled_ids, true ) ) {
+                        $enabled_ids[] = $id;
+                        $updated       = true;
                     }
                 }
-
-                if ( $updated ) {
-                    $enabled_ids = array_values( array_unique( $enabled_ids ) );
-                    update_option( 'lousy_outages_providers', $enabled_ids, false );
-                }
-
-                if ( $previous_defaults !== $default_enabled ) {
-                    update_option( self::OPTION_DEFAULT_ENABLED, $default_enabled, false );
-                }
-            } else {
-                $enabled_ids = $default_enabled;
-
-                if ( $previous_defaults !== $default_enabled ) {
-                    update_option( self::OPTION_DEFAULT_ENABLED, $default_enabled, false );
-                }
             }
 
-            $enabled = [];
-            foreach ( $enabled_ids as $id ) {
-                if ( isset( $all[ $id ] ) ) {
-                    $enabled[ $id ] = $all[ $id ];
-                }
+            if ( $updated ) {
+                $enabled_ids = array_values( array_unique( $enabled_ids ) );
+                update_option( 'lousy_outages_providers', $enabled_ids, false );
             }
 
-            return $enabled;
+            if ( $previous_defaults !== $default_enabled ) {
+                update_option( self::OPTION_DEFAULT_ENABLED, $default_enabled, false );
+            }
+        } else {
+            $enabled_ids = $default_enabled;
+
+            if ( $previous_defaults !== $default_enabled ) {
+                update_option( self::OPTION_DEFAULT_ENABLED, $default_enabled, false );
+            }
         }
 
-        private static function prepare_provider( string $id, array $provider ): array {
-            $provider['id']   = $id;
-            $provider['name'] = (string) ( $provider['name'] ?? $id );
-            $provider['type'] = strtolower( (string) ( $provider['type'] ?? 'statuspage' ) );
-
-            if ( ! isset( $provider['url'] ) ) {
-                $endpoint = self::coalesce_endpoint( $provider );
-                if ( null !== $endpoint ) {
-                    $provider['url'] = $endpoint;
-                }
+        $enabled = [];
+        foreach ( $enabled_ids as $id ) {
+            if ( isset( $all[ $id ] ) ) {
+                $enabled[ $id ] = $all[ $id ];
             }
-
-            $provider['enabled'] = array_key_exists( 'enabled', $provider )
-                ? (bool) $provider['enabled']
-                : ! ( isset( $provider['disabled'] ) && $provider['disabled'] );
-            unset( $provider['disabled'] );
-
-            $provider['optional'] = ! empty( $provider['optional'] );
-
-            if ( empty( $provider['status_url'] ) || ! is_string( $provider['status_url'] ) ) {
-                $provider['status_url'] = self::derive_status_url( $provider );
-            }
-
-            // Maintain legacy endpoint keys for backwards compatibility with filters.
-            if ( 'statuspage' === $provider['type'] && empty( $provider['summary'] ) && ! empty( $provider['url'] ) ) {
-                $provider['summary'] = $provider['url'];
-            }
-            if ( 'rss' === $provider['type'] && empty( $provider['rss'] ) && ! empty( $provider['url'] ) ) {
-                $provider['rss'] = $provider['url'];
-            }
-            if ( 'atom' === $provider['type'] && empty( $provider['atom'] ) && ! empty( $provider['url'] ) ) {
-                $provider['atom'] = $provider['url'];
-            }
-            if ( in_array( $provider['type'], [ 'slack', 'slack_current' ], true ) && empty( $provider['current'] ) && ! empty( $provider['url'] ) ) {
-                $provider['current'] = $provider['url'];
-            }
-
-            return $provider;
         }
 
-        private static function coalesce_endpoint( array $provider ): ?string {
-            foreach ( [ 'summary', 'url', 'rss', 'atom', 'current', 'endpoint' ] as $key ) {
-                if ( empty( $provider[ $key ] ) || ! is_string( $provider[ $key ] ) ) {
-                    continue;
-                }
+        return $enabled;
+    }
 
-                return $provider[ $key ];
+    private static function prepare_provider( string $id, array $provider ): array {
+        $provider['id']   = $id;
+        $provider['name'] = (string) ( $provider['name'] ?? $id );
+        $provider['type'] = strtolower( (string) ( $provider['type'] ?? 'statuspage' ) );
+
+        if ( ! isset( $provider['url'] ) ) {
+            $endpoint = self::coalesce_endpoint( $provider );
+            if ( null !== $endpoint ) {
+                $provider['url'] = $endpoint;
             }
-
-            return null;
         }
 
-        private static function derive_status_url( array $provider ): string {
-            $wellKnown = [
-                'zscaler'  => 'https://trust.zscaler.com/',
-                'slack'    => 'https://status.slack.com/',
-                'qubeyond' => 'https://status.qubeyond.com/',
-            ];
+        $provider['enabled'] = array_key_exists( 'enabled', $provider )
+            ? (bool) $provider['enabled']
+            : ! ( isset( $provider['disabled'] ) && $provider['disabled'] );
+        unset( $provider['disabled'] );
 
-            if ( ! empty( $provider['id'] ) && isset( $wellKnown[ $provider['id'] ] ) ) {
-                return trailingslashit( $wellKnown[ $provider['id'] ] );
+        $provider['optional'] = ! empty( $provider['optional'] );
+
+        if ( empty( $provider['status_url'] ) || ! is_string( $provider['status_url'] ) ) {
+            $provider['status_url'] = self::derive_status_url( $provider );
+        }
+
+        // Maintain legacy endpoint keys for backwards compatibility with filters.
+        if ( 'statuspage' === $provider['type'] && empty( $provider['summary'] ) && ! empty( $provider['url'] ) ) {
+            $provider['summary'] = $provider['url'];
+        }
+        if ( 'rss' === $provider['type'] && empty( $provider['rss'] ) && ! empty( $provider['url'] ) ) {
+            $provider['rss'] = $provider['url'];
+        }
+        if ( 'atom' === $provider['type'] && empty( $provider['atom'] ) && ! empty( $provider['url'] ) ) {
+            $provider['atom'] = $provider['url'];
+        }
+        if ( in_array( $provider['type'], [ 'slack', 'slack_current' ], true ) && empty( $provider['current'] ) && ! empty( $provider['url'] ) ) {
+            $provider['current'] = $provider['url'];
+        }
+
+        return $provider;
+    }
+
+    private static function coalesce_endpoint( array $provider ): ?string {
+        foreach ( [ 'summary', 'url', 'rss', 'atom', 'current', 'endpoint' ] as $key ) {
+            if ( empty( $provider[ $key ] ) || ! is_string( $provider[ $key ] ) ) {
+                continue;
             }
 
-            $type           = strtolower( (string) ( $provider['type'] ?? 'statuspage' ) );
-            $candidates     = [];
-            $candidate_keys = [ 'status_url', 'url', 'summary', 'rss', 'atom', 'current', 'endpoint' ];
+            return $provider[ $key ];
+        }
 
-            foreach ( $candidate_keys as $key ) {
-                if ( empty( $provider[ $key ] ) || ! is_string( $provider[ $key ] ) ) {
-                    continue;
-                }
-                $candidates[] = $provider[ $key ];
+        return null;
+    }
+
+    private static function derive_status_url( array $provider ): string {
+        $wellKnown = [
+            'zscaler'  => 'https://trust.zscaler.com/',
+            'slack'    => 'https://status.slack.com/',
+            'qubeyond' => 'https://status.qubeyond.com/',
+        ];
+
+        if ( ! empty( $provider['id'] ) && isset( $wellKnown[ $provider['id'] ] ) ) {
+            return trailingslashit( $wellKnown[ $provider['id'] ] );
+        }
+
+        $type           = strtolower( (string) ( $provider['type'] ?? 'statuspage' ) );
+        $candidates     = [];
+        $candidate_keys = [ 'status_url', 'url', 'summary', 'rss', 'atom', 'current', 'endpoint' ];
+
+        foreach ( $candidate_keys as $key ) {
+            if ( empty( $provider[ $key ] ) || ! is_string( $provider[ $key ] ) ) {
+                continue;
+            }
+            $candidates[] = $provider[ $key ];
+        }
+
+        foreach ( $candidates as $candidate ) {
+            $candidate = trim( $candidate );
+            if ( '' === $candidate ) {
+                continue;
             }
 
-            foreach ( $candidates as $candidate ) {
-                $candidate = trim( $candidate );
-                if ( '' === $candidate ) {
-                    continue;
-                }
+            $adjusted = $candidate;
+            if ( in_array( $type, [ 'statuspage', 'slack', 'slack_current' ], true ) ) {
+                $adjusted = preg_replace( '#/api/v\d+(?:\.\d+)*?/(summary\.json|current|status\.json)$#', '/', $adjusted );
+                $adjusted = preg_replace( '#/api/v\d+(?:\.\d+)*?/history\.(?:rss|atom)$#', '/', (string) $adjusted );
+            }
 
-                $adjusted = $candidate;
-                if ( in_array( $type, [ 'statuspage', 'slack', 'slack_current' ], true ) ) {
-                    $adjusted = preg_replace( '#/api/v\d+(?:\.\d+)*?/(summary\.json|current|status\.json)$#', '/', $adjusted );
-                    $adjusted = preg_replace( '#/api/v\d+(?:\.\d+)*?/history\.(?:rss|atom)$#', '/', (string) $adjusted );
-                }
+            if ( in_array( $type, [ 'rss', 'atom', 'rss-optional' ], true ) ) {
+                $adjusted = preg_replace( '#/(?:feed(?:s)?/?)?(?:[^/]*\.(?:rss|atom|xml))/?$#i', '/', (string) $adjusted );
+            }
 
-                if ( in_array( $type, [ 'rss', 'atom', 'rss-optional' ], true ) ) {
-                    $adjusted = preg_replace( '#/(?:feed(?:s)?/?)?(?:[^/]*\.(?:rss|atom|xml))/?$#i', '/', (string) $adjusted );
-                }
+            $parts = wp_parse_url( $adjusted ?: $candidate );
+            if ( empty( $parts['scheme'] ) || empty( $parts['host'] ) ) {
+                continue;
+            }
 
-                $parts = wp_parse_url( $adjusted ?: $candidate );
-                if ( empty( $parts['scheme'] ) || empty( $parts['host'] ) ) {
-                    continue;
-                }
-
-                $base = $parts['scheme'] . '://' . $parts['host'];
-                if ( ! empty( $parts['path'] ) ) {
-                    $path = trim( (string) $parts['path'], '/' );
-                    if ( '' !== $path ) {
-                        if ( in_array( $type, [ 'statuspage', 'slack', 'slack_current' ], true ) ) {
-                            $path = preg_replace( '#^api/.*$#', '', $path );
-                        } elseif ( in_array( $type, [ 'rss', 'atom', 'rss-optional' ], true ) ) {
-                            $segments = array_filter( explode( '/', $path ), static fn( $seg ) => '' !== $seg );
-                            while ( $segments ) {
-                                $last = strtolower( (string) end( $segments ) );
-                                if ( '' === $last ) {
-                                    array_pop( $segments );
-                                    continue;
-                                }
-                                if ( preg_match( '#\.(?:rss|atom|xml)$#', $last ) || in_array( $last, [ 'feed', 'feeds', 'rss', 'atom' ], true ) ) {
-                                    array_pop( $segments );
-                                    continue;
-                                }
-                                break;
+            $base = $parts['scheme'] . '://' . $parts['host'];
+            if ( ! empty( $parts['path'] ) ) {
+                $path = trim( (string) $parts['path'], '/' );
+                if ( '' !== $path ) {
+                    if ( in_array( $type, [ 'statuspage', 'slack', 'slack_current' ], true ) ) {
+                        $path = preg_replace( '#^api/.*$#', '', $path );
+                    } elseif ( in_array( $type, [ 'rss', 'atom', 'rss-optional' ], true ) ) {
+                        $segments = array_filter( explode( '/', $path ), static fn( $seg ) => '' !== $seg );
+                        while ( $segments ) {
+                            $last = strtolower( (string) end( $segments ) );
+                            if ( '' === $last ) {
+                                array_pop( $segments );
+                                continue;
                             }
-                            $path = implode( '/', $segments );
+                            if ( preg_match( '#\.(?:rss|atom|xml)$#', $last ) || in_array( $last, [ 'feed', 'feeds', 'rss', 'atom' ], true ) ) {
+                                array_pop( $segments );
+                                continue;
+                            }
+                            break;
                         }
-                        $path = trim( (string) $path, '/' );
-                        if ( '' !== $path ) {
-                            $base .= '/' . $path;
-                        }
+                        $path = implode( '/', $segments );
+                    }
+                    $path = trim( (string) $path, '/' );
+                    if ( '' !== $path ) {
+                        $base .= '/' . $path;
                     }
                 }
-
-                return trailingslashit( $base );
             }
 
-            return trailingslashit( home_url( '/' ) );
+            return trailingslashit( $base );
         }
+
+        return trailingslashit( home_url( '/' ) );
     }
 }

--- a/lousy-outages/includes/SMS.php
+++ b/lousy-outages/includes/SMS.php
@@ -1,5 +1,5 @@
 <?php
-namespace LousyOutages;
+namespace SuzyEaston\LousyOutages;
 
 class SMS {
     private function send( string $body ): void {

--- a/lousy-outages/includes/Sources/Sources.php
+++ b/lousy-outages/includes/Sources/Sources.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace LousyOutages\Sources;
+namespace SuzyEaston\LousyOutages\Sources;
 
 /**
  * Registry for incident sources.

--- a/lousy-outages/includes/Sources/StatuspageSource.php
+++ b/lousy-outages/includes/Sources/StatuspageSource.php
@@ -109,6 +109,10 @@ if ( ! class_exists('LO_StatuspageSource') ) {
 }
 
 // Bridge the namespaced calls to this compat class.
+if ( ! class_exists('SuzyEaston\\LousyOutages\\Sources\\StatuspageSource') ) {
+  class_alias('LO_StatuspageSource', 'SuzyEaston\\LousyOutages\\Sources\\StatuspageSource');
+}
+
 if ( ! class_exists('LousyOutages\\Sources\\StatuspageSource') ) {
   class_alias('LO_StatuspageSource', 'LousyOutages\\Sources\\StatuspageSource');
 }

--- a/lousy-outages/includes/Sources/index.php
+++ b/lousy-outages/includes/Sources/index.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace LousyOutages\Sources;
+namespace SuzyEaston\LousyOutages\Sources;
 
 Sources::register('openai', new StatuspageSource('OpenAI', 'https://status.openai.com/api/v2/summary.json', 'https://status.openai.com'));
 Sources::register('twilio', new StatuspageSource('Twilio', 'https://status.twilio.com/api/v2/summary.json', 'https://status.twilio.com'));

--- a/lousy-outages/includes/Storage/IncidentStore.php
+++ b/lousy-outages/includes/Storage/IncidentStore.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace LousyOutages\Storage;
+namespace SuzyEaston\LousyOutages\Storage;
 
-use LousyOutages\Model\Incident;
+use SuzyEaston\LousyOutages\Model\Incident;
 
 class IncidentStore
 {

--- a/lousy-outages/includes/Store.php
+++ b/lousy-outages/includes/Store.php
@@ -1,5 +1,5 @@
 <?php
-namespace LousyOutages;
+namespace SuzyEaston\LousyOutages;
 
 class Store {
     private string $option = 'lousy_outages_states';

--- a/lousy-outages/includes/Subscribe.php
+++ b/lousy-outages/includes/Subscribe.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-use LousyOutages\IncidentAlerts;
-use LousyOutages\Mailer;
-use LousyOutages\Subscriptions;
+use SuzyEaston\LousyOutages\IncidentAlerts;
+use SuzyEaston\LousyOutages\Mailer;
+use SuzyEaston\LousyOutages\Subscriptions;
 
 class Lousy_Outages_Subscribe {
     public static function bootstrap(): void {
@@ -359,7 +359,7 @@ function lo_handle_subscribe(\WP_REST_Request $request) {
         return rest_ensure_response([
             'transport'     => $transport,
             'headers'       => $headers,
-            'mailer'        => 'LousyOutages\\Mailer',
+            'mailer'        => 'SuzyEaston\\LousyOutages\\Mailer',
             'domain'        => $domain,
             'sendmail_path' => $sendmailPath,
         ]);

--- a/lousy-outages/includes/Subscriptions.php
+++ b/lousy-outages/includes/Subscriptions.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace LousyOutages;
+namespace SuzyEaston\LousyOutages;
 
 class Subscriptions {
     public const TABLE = 'lousy_outages_subs';

--- a/lousy-outages/includes/Summary.php
+++ b/lousy-outages/includes/Summary.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace LousyOutages;
+namespace SuzyEaston\LousyOutages;
 
 class Summary {
     public static function current(): array {

--- a/lousy-outages/includes/Trending.php
+++ b/lousy-outages/includes/Trending.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace LousyOutages;
+namespace SuzyEaston\LousyOutages;
 
 class Trending
 {

--- a/lousy-outages/includes/compat.php
+++ b/lousy-outages/includes/compat.php
@@ -1,11 +1,15 @@
 <?php
 // Legacy incident shim so older integrations keep working alongside the namespaced classes.
 if ( ! class_exists('LO_Incident') ) {
-    if ( ! class_exists('LousyOutages\\Model\\Incident') ) {
+    if ( ! class_exists('SuzyEaston\\LousyOutages\\Model\\Incident') ) {
         require_once __DIR__ . '/Model/Incident.php';
     }
 
-    class LO_Incident extends \LousyOutages\Model\Incident {
+    if ( ! class_exists('LousyOutages\\Model\\Incident') && class_exists('SuzyEaston\\LousyOutages\\Model\\Incident') ) {
+        class_alias('SuzyEaston\\LousyOutages\\Model\\Incident', 'LousyOutages\\Model\\Incident');
+    }
+
+    class LO_Incident extends \SuzyEaston\LousyOutages\Model\Incident {
         public function __construct($provider, $id, $title, $status, $url, $component = null, $impact = null, $detected_at = null, $resolved_at = null) {
             $detected = (null === $detected_at || '' === $detected_at) ? time() : (int) $detected_at;
             $resolved = (null === $resolved_at || '' === $resolved_at) ? null : (int) $resolved_at;
@@ -56,6 +60,10 @@ if ( ! class_exists('LO_Incident') ) {
 }
 
 // Allow legacy code referencing the old namespaced alias to continue working if needed.
+if ( ! class_exists('SuzyEaston\\LousyOutages\\Model\\LegacyIncident') ) {
+    class_alias('LO_Incident', 'SuzyEaston\\LousyOutages\\Model\\LegacyIncident');
+}
+
 if ( ! class_exists('LousyOutages\\Model\\LegacyIncident') ) {
     class_alias('LO_Incident', 'LousyOutages\\Model\\LegacyIncident');
 }

--- a/lousy-outages/includes/email-templates.php
+++ b/lousy-outages/includes/email-templates.php
@@ -12,11 +12,11 @@ if (!function_exists('lo_unsubscribe_url_for')) {
             return home_url('/lousy-outages/');
         }
 
-        if (!class_exists('LousyOutages\\IncidentAlerts')) {
+        if (!class_exists('SuzyEaston\\LousyOutages\\IncidentAlerts')) {
             return home_url('/lousy-outages/');
         }
 
-        $token = \LousyOutages\IncidentAlerts::build_unsubscribe_token($email);
+        $token = \SuzyEaston\LousyOutages\IncidentAlerts::build_unsubscribe_token($email);
 
         return add_query_arg(
             [
@@ -122,7 +122,7 @@ if (!function_exists('send_lo_confirmation_email')) {
             'List-Unsubscribe-Post: List-Unsubscribe=One-Click',
         ];
 
-        $sent = \LousyOutages\Mailer::send($email, $subject, $text_body, $html_body, $headers);
+        $sent = \SuzyEaston\LousyOutages\Mailer::send($email, $subject, $text_body, $html_body, $headers);
 
         if (!$sent) {
             error_log('[lousy_outages] confirmation_email send failed for ' . $email);
@@ -167,7 +167,7 @@ if (!function_exists('LO_compose_daily_digest')) {
 
             $items[] = [
                 'provider' => $provider,
-                'title'    => \LousyOutages\Email\Composer::shortTitle($title),
+                'title'    => \SuzyEaston\LousyOutages\Email\Composer::shortTitle($title),
                 'status'   => $status ?: 'Status update',
                 'url'      => $url,
             ];
@@ -322,7 +322,7 @@ if (!function_exists('send_lo_outage_alert_email')) {
         $detected_epoch = strtotime($timestamp_raw) ?: time();
         $resolved_epoch = ('resolved' === $status_slug) ? $detected_epoch : null;
 
-        $incident_object = new \LousyOutages\Model\Incident(
+        $incident_object = new \SuzyEaston\LousyOutages\Model\Incident(
             $service_label,
             md5($service_label . '|' . $clean_summary . '|' . $status_slug . '|' . $timestamp_display),
             $clean_summary,
@@ -334,7 +334,7 @@ if (!function_exists('send_lo_outage_alert_email')) {
             $resolved_epoch
         );
 
-        $subject = \LousyOutages\Email\Composer::subjectForIncident($incident_object, $status_slug);
+        $subject = \SuzyEaston\LousyOutages\Email\Composer::subjectForIncident($incident_object, $status_slug);
 
         $text_body_lines = [
             sprintf('%s outage alert', strtoupper($service_label)),
@@ -427,7 +427,7 @@ if (!function_exists('send_lo_outage_alert_email')) {
             }
         }
 
-        $sent = \LousyOutages\Mailer::send($email, $subject, $text_body, $html_body, $headers);
+        $sent = \SuzyEaston\LousyOutages\Mailer::send($email, $subject, $text_body, $html_body, $headers);
 
         if (!$sent) {
             error_log('[lousy_outages] outage_email send failed for ' . $email . ' subject=' . $subject);

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -51,19 +51,19 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
     require_once LOUSY_OUTAGES_PATH . 'wp-cli/class-wp-cli-lousy.php';
 }
 
-use LousyOutages\Providers;
-use LousyOutages\Store;
-use LousyOutages\Fetcher;
-use LousyOutages\Detector;
-use LousyOutages\SMS;
-use LousyOutages\Email;
-use LousyOutages\Precursor;
-use LousyOutages\Subscriptions;
-use LousyOutages\Api;
-use LousyOutages\Feed;
-use LousyOutages\MailTransport;
-use LousyOutages\IncidentAlerts;
-use LousyOutages\Cron\Refresh as RefreshCron;
+use SuzyEaston\LousyOutages\Providers;
+use SuzyEaston\LousyOutages\Store;
+use SuzyEaston\LousyOutages\Fetcher;
+use SuzyEaston\LousyOutages\Detector;
+use SuzyEaston\LousyOutages\SMS;
+use SuzyEaston\LousyOutages\Email;
+use SuzyEaston\LousyOutages\Precursor;
+use SuzyEaston\LousyOutages\Subscriptions;
+use SuzyEaston\LousyOutages\Api;
+use SuzyEaston\LousyOutages\Feed;
+use SuzyEaston\LousyOutages\MailTransport;
+use SuzyEaston\LousyOutages\IncidentAlerts;
+use SuzyEaston\LousyOutages\Cron\Refresh as RefreshCron;
 
 Api::bootstrap();
 Feed::bootstrap();
@@ -299,14 +299,14 @@ function lousy_outages_filter_snapshot( array $snapshot ): array {
 
     if ( empty( $providers ) ) {
         $snapshot['providers'] = [];
-        $snapshot['trending']  = ( new \LousyOutages\Trending() )->evaluate( [] );
+        $snapshot['trending']  = ( new \SuzyEaston\LousyOutages\Trending() )->evaluate( [] );
         return $snapshot;
     }
 
     $enabled = Providers::enabled();
     if ( ! is_array( $enabled ) || empty( $enabled ) ) {
         $snapshot['providers'] = [];
-        $snapshot['trending']  = ( new \LousyOutages\Trending() )->evaluate( [] );
+        $snapshot['trending']  = ( new \SuzyEaston\LousyOutages\Trending() )->evaluate( [] );
         return $snapshot;
     }
 
@@ -331,7 +331,7 @@ function lousy_outages_filter_snapshot( array $snapshot ): array {
         )
     );
 
-    $snapshot['trending'] = ( new \LousyOutages\Trending() )->evaluate( $snapshot['providers'] );
+    $snapshot['trending'] = ( new \SuzyEaston\LousyOutages\Trending() )->evaluate( $snapshot['providers'] );
 
     return $snapshot;
 }
@@ -360,7 +360,7 @@ function lousy_outages_build_snapshot( array $states, string $timestamp, string 
     }
 
     $providers = lousy_outages_sort_providers( $providers );
-    $trending  = ( new \LousyOutages\Trending() )->evaluate( $providers );
+    $trending  = ( new \SuzyEaston\LousyOutages\Trending() )->evaluate( $providers );
 
     return lousy_outages_filter_snapshot( [
         'providers'  => $providers,

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace LousyOutages;
+namespace SuzyEaston\LousyOutages;
 
 const LO_SHOW_WIDESPREAD = false;
 

--- a/lousy-outages/wp-cli/class-wp-cli-lousy.php
+++ b/lousy-outages/wp-cli/class-wp-cli-lousy.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
 
-namespace LousyOutages\CLI;
+namespace SuzyEaston\LousyOutages\CLI;
 
-use LousyOutages\Fetcher;
-use LousyOutages\Providers;
+use SuzyEaston\LousyOutages\Fetcher;
+use SuzyEaston\LousyOutages\Providers;
 use WP_CLI;
 use function WP_CLI\Utils\format_items;
 


### PR DESCRIPTION
## Summary
- migrate all Lousy Outages PHP files to the SuzyEaston\LousyOutages namespace and update the loader imports accordingly
- convert IncidentAlerts to use an internal maintenance helper instead of a global function so the file stays in a single namespace
- fold the provider defaults into the Providers class and extend compat shims to alias the new namespaces for legacy consumers

## Testing
- find lousy-outages -name '*.php' -print0 | xargs -0 -n1 php -l
- php -l functions.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910f7c9ebfc832e825e637a933e9551)