### PR TITLE
Restore legacy aliases for outage summary

### DIFF
--- a/lousy-outages/includes/compat.php
+++ b/lousy-outages/includes/compat.php
@@ -72,3 +72,13 @@ if ( ! class_exists('LousyOutages\\Fetcher') && class_exists('SuzyEaston\\LousyO
     // LO: keep legacy namespace compatibility for tests and old hooks.
     class_alias('SuzyEaston\\LousyOutages\\Fetcher', 'LousyOutages\\Fetcher');
 }
+
+if ( ! class_exists('LousyOutages\\Summary') && class_exists('SuzyEaston\\LousyOutages\\Summary') ) {
+    // LO: surface incident summary data to legacy templates.
+    class_alias('SuzyEaston\\LousyOutages\\Summary', 'LousyOutages\\Summary');
+}
+
+if ( ! class_exists('LousyOutages\\I18n') && class_exists('SuzyEaston\\LousyOutages\\I18n') ) {
+    // LO: allow legacy front-end strings lookup.
+    class_alias('SuzyEaston\\LousyOutages\\I18n', 'LousyOutages\\I18n');
+}


### PR DESCRIPTION
## Summary
- alias the namespaced Summary and I18n classes back to the legacy LousyOutages namespace so existing templates read incident data

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69110f388aa4832eb9e0305d67e4e0e8)