### PR TITLE
Treat Zscaler IP range advisories as maintenance

### DIFF
--- a/lousy-outages/includes/IncidentAlerts.php
+++ b/lousy-outages/includes/IncidentAlerts.php
@@ -472,8 +472,15 @@ class IncidentAlerts {
 
         $status = self::normalize_status_code($statusRaw, $impactRaw);
         if (self::isScheduledMaintenance($title, $bodyText)) {
-            $status = 'maintenance';
+            $status    = 'maintenance';
+            $impactRaw = 'maintenance';
         }
+
+        if ('zscaler' === $provider && self::isZscalerIpRangeAdvisory($title, $bodyText)) {
+            $status    = 'maintenance';
+            $impactRaw = 'maintenance';
+        }
+
         $impact = self::normalize_impact($impactRaw ?: self::impact_from_status($status));
 
         $url = '';
@@ -1273,6 +1280,17 @@ class IncidentAlerts {
         $haystack = $title . ' ' . $description;
 
         return 1 === preg_match('/\\b(scheduled|planned).{0,40}maintenance\\b/i', $haystack);
+    }
+
+    private static function isZscalerIpRangeAdvisory(string $title, string $description): bool
+    {
+        $haystack = strtolower($title . ' ' . $description);
+
+        if (false === strpos($haystack, 'ip address')) {
+            return false;
+        }
+
+        return 1 === preg_match('/\\b(additions?|updates?|changes?)\\b.{0,80}\\b(ip address ranges?)\\b/i', $haystack);
     }
 
     private static function log_error(string $provider, string $message): void {


### PR DESCRIPTION
## Summary
- treat Zscaler IP range change advisories as maintenance-only events
- ensure maintenance detection also updates the impact value

## Testing
- php -l lousy-outages/includes/IncidentAlerts.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691434e0706c832eb59d9e2895345c49)