### PR TITLE
Show latest active outage on homepage teaser

### DIFF
--- a/lousy-outages/includes/Summary.php
+++ b/lousy-outages/includes/Summary.php
@@ -5,86 +5,37 @@ namespace SuzyEaston\LousyOutages;
 
 class Summary {
     public static function current(): array {
-        $store  = new Store();
-        $states = $store->get_all();
-        $latest = null;
-        $fallback = null;
-        $recent_cutoff = time() - DAY_IN_SECONDS;
+        $providers = self::providers();
+        $latestIncident = self::latest_incident($providers);
 
-        foreach ($states as $id => $state) {
-            if (!is_array($state)) {
-                continue;
-            }
-            $status = strtolower((string) ($state['status'] ?? 'unknown'));
-            $provider_name = (string) ($state['name'] ?? $state['provider'] ?? $id);
-            $incidents = isset($state['incidents']) && is_array($state['incidents']) ? $state['incidents'] : [];
+        if ($latestIncident) {
+            $slug = sanitize_title($latestIncident['provider_id'] ?: $latestIncident['provider_name']);
 
-            foreach ($incidents as $incident) {
-                if (!is_array($incident)) {
-                    continue;
-                }
-                $updatedRaw = $incident['updated_at'] ?? $incident['updatedAt'] ?? null;
-                $startedRaw = $incident['started_at'] ?? $incident['startedAt'] ?? null;
-                $updated = self::parse_time($updatedRaw ?? $startedRaw);
-                $started = self::parse_time($startedRaw);
-                $effective = $updated ?? $started;
-                if ($effective && $effective < $recent_cutoff) {
-                    continue;
-                }
-                if (null === $latest || $updated > $latest['timestamp']) {
-                    $latest = [
-                        'provider_id'   => $id,
-                        'provider_name' => $provider_name,
-                        'title'         => (string) ($incident['title'] ?? 'Incident'),
-                        'summary'       => (string) ($incident['summary'] ?? ''),
-                        'status'        => ucfirst((string) ($incident['impact'] ?? 'incident')),
-                        'started_at'    => (string) ($incident['started_at'] ?? $incident['startedAt'] ?? ''),
-                        'updated_at'    => (string) ($incident['updated_at'] ?? $incident['updatedAt'] ?? ''),
-                        'timestamp'     => $updated,
-                    ];
-                }
-            }
-
-            $eligibleFallbackStates = ['degraded', 'outage', 'major', 'partial', 'monitoring', 'investigating'];
-            if (in_array($status, $eligibleFallbackStates, true) && null === $latest) {
-                $updated = self::parse_time($state['updated_at'] ?? $state['updatedAt'] ?? null);
-                if ($updated && $updated < $recent_cutoff) {
-                    continue;
-                }
-                if (null === $fallback || $updated > $fallback['timestamp']) {
-                    $fallback = [
-                        'provider_id'   => $id,
-                        'provider_name' => $provider_name,
-                        'title'         => (string) ($state['summary'] ?? Fetcher::status_label($status)),
-                        'status'        => Fetcher::status_label($status),
-                        'started_at'    => (string) ($state['updated_at'] ?? $state['updatedAt'] ?? ''),
-                        'timestamp'     => $updated,
-                    ];
-                }
-            }
-        }
-
-        if ($latest) {
             return [
                 'hasIncident' => true,
-                'providerId'  => $latest['provider_id'],
-                'provider'    => $latest['provider_name'],
-                'title'       => $latest['title'],
-                'status'      => $latest['status'],
-                'relative'    => self::relative_time($latest['started_at'] ?: $latest['updated_at']),
-                'started_at'  => $latest['started_at'],
+                'providerId'  => $latestIncident['provider_id'],
+                'provider'    => $latestIncident['provider_name'],
+                'title'       => $latestIncident['title'],
+                'status'      => $latestIncident['status'],
+                'relative'    => self::relative_time_from_timestamp($latestIncident['timestamp']),
+                'started_at'  => $latestIncident['started_at'],
+                'href'        => $slug ? home_url('/lousy-outages/#provider-' . $slug) : home_url('/lousy-outages/'),
             ];
         }
 
+        $fallback = self::latest_degraded_provider($providers);
         if ($fallback) {
+            $slug = sanitize_title($fallback['provider_id'] ?: $fallback['provider_name']);
+
             return [
                 'hasIncident' => true,
                 'providerId'  => $fallback['provider_id'],
                 'provider'    => $fallback['provider_name'],
                 'title'       => $fallback['title'],
                 'status'      => $fallback['status'],
-                'relative'    => self::relative_time($fallback['started_at']),
+                'relative'    => self::relative_time_from_timestamp($fallback['timestamp']),
                 'started_at'  => $fallback['started_at'],
+                'href'        => $slug ? home_url('/lousy-outages/#provider-' . $slug) : home_url('/lousy-outages/'),
             ];
         }
 
@@ -96,13 +47,216 @@ class Summary {
             'status'      => 'Operational',
             'relative'    => '',
             'started_at'  => '',
+            'href'        => home_url('/lousy-outages/'),
         ];
     }
 
+    private static function providers(): array
+    {
+        $providers = [];
+
+        if (function_exists('lousy_outages_get_snapshot')) {
+            $snapshot = \lousy_outages_get_snapshot(false);
+            if (empty($snapshot['providers'])) {
+                $snapshot = \lousy_outages_get_snapshot(true);
+            }
+
+            if (!empty($snapshot['providers']) && is_array($snapshot['providers'])) {
+                $providers = array_values($snapshot['providers']);
+            }
+        }
+
+        if ($providers) {
+            return $providers;
+        }
+
+        $store  = new Store();
+        $states = $store->get_all();
+        if (!$states) {
+            return [];
+        }
+
+        $timestamp = get_option('lousy_outages_last_poll');
+        if (!$timestamp) {
+            $timestamp = gmdate('c');
+        }
+
+        foreach ($states as $id => $state) {
+            if (!is_array($state)) {
+                continue;
+            }
+
+            if (function_exists('lousy_outages_build_provider_payload')) {
+                $providers[] = \lousy_outages_build_provider_payload((string) $id, $state, (string) $timestamp);
+                continue;
+            }
+
+            $providers[] = [
+                'id'        => (string) $id,
+                'provider'  => (string) ($state['provider'] ?? $state['name'] ?? $id),
+                'name'      => (string) ($state['name'] ?? $state['provider'] ?? $id),
+                'stateCode' => (string) ($state['status'] ?? 'unknown'),
+                'updatedAt' => (string) ($state['updated_at'] ?? $state['updatedAt'] ?? $timestamp),
+                'incidents' => isset($state['incidents']) && is_array($state['incidents']) ? $state['incidents'] : [],
+                'summary'   => (string) ($state['summary'] ?? ''),
+            ];
+        }
+
+        return $providers;
+    }
+
+    private static function latest_incident(array $providers): ?array
+    {
+        $latest = null;
+        $recent_cutoff = time() - (2 * DAY_IN_SECONDS);
+
+        foreach ($providers as $provider) {
+            if (!is_array($provider)) {
+                continue;
+            }
+
+            $providerId = (string) ($provider['id'] ?? $provider['provider'] ?? '');
+            $providerName = (string) ($provider['name'] ?? $provider['provider'] ?? $providerId);
+            $incidents = isset($provider['incidents']) && is_array($provider['incidents']) ? $provider['incidents'] : [];
+
+            foreach ($incidents as $incident) {
+                if (!is_array($incident)) {
+                    continue;
+                }
+
+                $statusCode = strtolower((string) ($incident['impact'] ?? $incident['status'] ?? ''));
+                if (in_array($statusCode, ['operational', 'resolved', 'maintenance'], true)) {
+                    continue;
+                }
+
+                if (!empty($incident['resolved_at']) || !empty($incident['resolvedAt'])) {
+                    continue;
+                }
+
+                $timestamp = self::incident_timestamp($incident);
+                if (null === $timestamp || $timestamp < $recent_cutoff) {
+                    continue;
+                }
+
+                if (null === $latest || $timestamp > $latest['timestamp']) {
+                    $startedIso = self::incident_start_iso($incident, $timestamp);
+
+                    $latest = [
+                        'provider_id'   => $providerId,
+                        'provider_name' => $providerName ?: $providerId,
+                        'title'         => (string) ($incident['title'] ?? $incident['name'] ?? 'Incident'),
+                        'status'        => Fetcher::status_label($statusCode ?: 'incident'),
+                        'started_at'    => $startedIso,
+                        'timestamp'     => $timestamp,
+                    ];
+                }
+            }
+        }
+
+        return $latest;
+    }
+
+    private static function latest_degraded_provider(array $providers): ?array
+    {
+        $fallback = null;
+        $recent_cutoff = time() - DAY_IN_SECONDS;
+        $eligibleFallbackStates = ['degraded', 'outage', 'major', 'partial', 'monitoring', 'investigating'];
+
+        foreach ($providers as $provider) {
+            if (!is_array($provider)) {
+                continue;
+            }
+
+            $status = strtolower((string) ($provider['stateCode'] ?? $provider['status'] ?? 'unknown'));
+            if (!in_array($status, $eligibleFallbackStates, true)) {
+                continue;
+            }
+
+            $providerId = (string) ($provider['id'] ?? $provider['provider'] ?? '');
+            $providerName = (string) ($provider['name'] ?? $provider['provider'] ?? $providerId);
+            $updated = self::parse_time($provider['updatedAt'] ?? $provider['updated_at'] ?? null);
+            if ($updated && $updated < $recent_cutoff) {
+                continue;
+            }
+
+            if (null === $fallback || $updated > $fallback['timestamp']) {
+                $fallback = [
+                    'provider_id'   => $providerId,
+                    'provider_name' => $providerName,
+                    'title'         => (string) ($provider['summary'] ?? Fetcher::status_label($status)),
+                    'status'        => Fetcher::status_label($status),
+                    'started_at'    => (string) ($provider['updatedAt'] ?? $provider['updated_at'] ?? ''),
+                    'timestamp'     => $updated ?? time(),
+                ];
+            }
+        }
+
+        return $fallback;
+    }
+
+    private static function incident_timestamp(array $incident): ?int
+    {
+        $candidates = [
+            $incident['detected_at'] ?? null,
+            $incident['detectedAt'] ?? null,
+            $incident['timestamp'] ?? null,
+            $incident['updated_at'] ?? null,
+            $incident['updatedAt'] ?? null,
+            $incident['started_at'] ?? null,
+            $incident['startedAt'] ?? null,
+        ];
+
+        foreach ($candidates as $value) {
+            $parsed = self::parse_time($value);
+            if (null !== $parsed) {
+                return $parsed;
+            }
+        }
+
+        return null;
+    }
+
+    private static function incident_start_iso(array $incident, int $timestamp): string
+    {
+        $fields = [
+            $incident['detected_at'] ?? null,
+            $incident['detectedAt'] ?? null,
+            $incident['started_at'] ?? null,
+            $incident['startedAt'] ?? null,
+            $incident['updated_at'] ?? null,
+            $incident['updatedAt'] ?? null,
+        ];
+
+        foreach ($fields as $field) {
+            if (is_string($field) && '' !== trim($field)) {
+                return (string) $field;
+            }
+
+            if (is_numeric($field)) {
+                $ts = self::parse_time($field);
+                if ($ts) {
+                    return gmdate('c', $ts);
+                }
+            }
+        }
+
+        return gmdate('c', $timestamp);
+    }
+
     private static function parse_time($value): ?int {
+        if (is_int($value)) {
+            return $value > 0 ? $value : null;
+        }
+
+        if (is_string($value) && ctype_digit($value)) {
+            $int = (int) $value;
+            return $int > 0 ? $int : null;
+        }
+
         if (empty($value)) {
             return null;
         }
+
         $timestamp = strtotime((string) $value);
         if (false === $timestamp) {
             return null;
@@ -110,21 +264,21 @@ class Summary {
         return $timestamp;
     }
 
-    private static function relative_time(?string $iso): string {
-        if (empty($iso)) {
+    private static function relative_time_from_timestamp(int $timestamp): string
+    {
+        if ($timestamp <= 0) {
             return '';
         }
-        $timestamp = strtotime($iso);
-        if (false === $timestamp) {
-            return '';
-        }
+
         $now = current_time('timestamp', true);
         if (!is_int($now)) {
             $now = time();
         }
+
         if ($timestamp > $now) {
             $timestamp = $now;
         }
+
         $diff = human_time_diff($timestamp, $now);
         return $diff ? sprintf('%s ago', $diff) : '';
     }

--- a/style.css
+++ b/style.css
@@ -1120,6 +1120,107 @@ footer,
   font-family: 'Press Start 2P', monospace;
 }
 
+.lo-home-teaser {
+  margin-top: 3rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: 999px;
+  border: 2px solid var(--arcade-neon-green, #39ff14);
+  background: rgba(0, 0, 0, 0.85);
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 48rem;
+}
+
+.lo-home-heading {
+  font-family: var(--arcade-heading-font, inherit);
+  font-size: 1.4rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0;
+  color: var(--arcade-neon-green, #39ff14);
+}
+
+.lo-home-pacman-alert {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-family: var(--arcade-body-font, inherit);
+  font-size: 0.95rem;
+  color: #e5f9ff;
+}
+
+.lo-home-pacman-alert--clear {
+  color: #9bffc6;
+}
+
+.lo-pacman {
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 50%;
+  background: #ffd800;
+  position: relative;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.lo-pacman::before {
+  content: "";
+  position: absolute;
+  width: 1.6rem;
+  height: 1.6rem;
+  background: #000;
+  transform-origin: center;
+  clip-path: polygon(0% 0%, 100% 50%, 0% 100%);
+  animation: lo-pacman-chomp 0.35s infinite alternate;
+}
+
+.lo-pacman-dots {
+  flex: 1;
+  display: inline-block;
+  position: relative;
+  height: 0.3rem;
+  overflow: hidden;
+}
+
+.lo-pacman-dots::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(circle, #ffd800 25%, transparent 35%);
+  background-size: 0.5rem 0.5rem;
+  animation: lo-pacman-dots-move 1.4s linear infinite;
+  opacity: 0.9;
+}
+
+.lo-alert-text strong {
+  color: #ffea7a;
+}
+
+.lo-home-teaser-link {
+  align-self: flex-start;
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  text-decoration: none;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--arcade-neon-green, #39ff14);
+  color: var(--arcade-neon-green, #39ff14);
+  background: rgba(57, 255, 20, 0.05);
+}
+
+@keyframes lo-pacman-chomp {
+  from { transform: rotate(35deg); }
+  to   { transform: rotate(-35deg); }
+}
+
+@keyframes lo-pacman-dots-move {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-1.5rem); }
+}
+
 
 body {
   padding-top: 60px;


### PR DESCRIPTION
## Summary
- source the homepage Lousy Outages teaser from the shared snapshot data and pick the newest active incident
- gracefully fall back to an all-clear message when nothing is active and keep links pointing to the dashboard
- restyle the teaser with the new Pac-Man alert treatment

## Testing
- php -l lousy-outages/includes/Summary.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c259468a0832e8140a277efddaa7e)