### PR TITLE
Simplify header branding bar

### DIFF
--- a/header.php
+++ b/header.php
@@ -112,16 +112,20 @@
 ?>
 
 <header class="main-header">
-  <a class="brand-logo" href="<?php echo esc_url( home_url( '/' ) ); ?>" aria-label="Home">
-    <img
-      src="<?php echo esc_url( get_stylesheet_directory_uri() . '/assets/brand/suzanne-logo.svg' ); ?>"
-      alt="Suzanne (Suzy) Easton"
-      width="420" height="150"
-      decoding="async" loading="eager" />
-  </a>
-  <?php get_template_part( 'parts/bmc-button' ); ?>
+  <!-- Header wordmark (compact bar) -->
+  <div class="se-header-branding">
+    <a href="<?php echo esc_url( home_url( '/' ) ); ?>" class="se-header-wordmark">
+      <span class="se-header-name-main">SUZANNE</span>
+      <span class="se-header-name-nick">(SUZY)</span>
+      <span class="se-header-name-last">EASTON</span>
+    </a>
+  </div>
+  <div class="header-actions">
+    <?php get_template_part( 'parts/bmc-button' ); ?>
+  </div>
 </header>
 
+<!-- Hero banner lives in page templates (e.g., homepage hero); this header stays compact above it -->
 <!-- Full‑screen moving starfield background -->
 <canvas id="starfield" role="img" aria-label="Animated starfield background"></canvas>
 

--- a/style.css
+++ b/style.css
@@ -1234,21 +1234,53 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 10px;
+  gap: 1rem;
+  padding: 0.75rem 1.5rem;
   background: rgba(0, 0, 0, 0.85);
   border-bottom: 2px solid var(--accent-color);
   z-index: 10000;
 }
 
-.main-header .logo {
-  font-family: "Press Start 2P", cursive;
-  font-size: 0.85rem;
-  color: var(--accent-color);
-  text-decoration: none;
+.main-header .header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
 }
 
-.main-header .logo:hover {
-  text-shadow: 0 0 4px var(--accent-color);
+.se-header-branding {
+  display: flex;
+  align-items: center;
+}
+
+.se-header-wordmark {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  font-family: var(--arcade-heading-font, 'Press Start 2P', monospace);
+  font-size: 0.9rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-decoration: none;
+  color: var(--arcade-neon-green, #39ff14);
+  line-height: 1.2;
+}
+
+.se-header-name-main,
+.se-header-name-last {
+  font-weight: 700;
+}
+
+.se-header-name-nick {
+  font-size: 0.7em;
+  opacity: 0.85;
+}
+
+@media (max-width: 768px) {
+  .se-header-wordmark {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    flex-wrap: wrap;
+  }
 }
 
 .pixel-font {


### PR DESCRIPTION
## Summary
- replace the large logo block with a compact text wordmark bar and clarify header vs hero comments
- tighten the fixed header layout/padding and add arcade-style wordmark styling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c2dccdaf8832e81188ba0060170d0)