### PR TITLE
Refine Albini Q&A speech and prompt

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -369,7 +369,14 @@ function albini_handle_query( WP_REST_Request $req ) {
     }
 
     $matched_quotes = suzy_albini_match_quotes( $question );
-    $system_prompt  = "You are a neutral music and recording engineer who is very familiar with Steve Albini's publicly documented views. You will be given a user question and a small library of short Steve Albini quotes with topics and sources. Your job: pick the provided quotes that best relate to the question, do not invent new quotes, and output JSON with keys \"quotes\" (the selected quotes with attribution), \"commentary\" (a short neutral explanation in your own voice), and \"topics\" (optional keywords). Never speak in the first person as Steve Albini or claim to be him.";
+    $system_prompt  = "You are a neutral engineer and writer who is very familiar with Steve Albini's publicly documented views. "
+        . "You will be given a user question and a small library of short Steve Albini quotes with topics and sources. "
+        . "Your job: pick the provided quotes that best relate to the question, do not invent new quotes, "
+        . "and return STRICT JSON with keys: "
+        . "\"quotes\" (array of the chosen quotes with id, quote, source, year, topics), "
+        . "\"commentary\" (a short neutral explanation in your own voice), "
+        . "and optionally \"topics\" (array of keywords). "
+        . "Never write in the first person as Steve Albini or claim to be him.";
 
     $user_payload = [
         'question' => $question,

--- a/page-albini-qa.php
+++ b/page-albini-qa.php
@@ -83,6 +83,31 @@ document.addEventListener('DOMContentLoaded', () => {
     return `<ul class="albini-quote-list">${items}</ul>`;
   }
 
+  function speakResponse(text) {
+    if (!text || !('speechSynthesis' in window)) return;
+    const synth = window.speechSynthesis;
+    const utterance = new SpeechSynthesisUtterance(text);
+    let voices = synth.getVoices();
+    const pickVoice = () => {
+      voices = synth.getVoices();
+      const preferred = voices.find(v =>
+        v.name.includes('Google UK English Male') ||
+        v.name.includes('Microsoft David') ||
+        /en/i.test(v.lang)
+      );
+      utterance.voice = preferred || null;
+      utterance.rate = 0.9;
+      utterance.pitch = 0.9;
+      synth.cancel();
+      synth.speak(utterance);
+    };
+    if (!voices || voices.length === 0) {
+      synth.addEventListener('voiceschanged', pickVoice, { once: true });
+    } else {
+      pickVoice();
+    }
+  }
+
   function renderResponse(data) {
     const quotes = data.quotes || [];
     const commentary = data.commentary || '';
@@ -94,6 +119,11 @@ document.addEventListener('DOMContentLoaded', () => {
         ${commentary ? `<div class="albini-commentary"><h4>Why these quotes</h4><p>${escapeHTML(commentary)}</p></div>` : ''}
       </section>
     `;
+    if (commentary) {
+      speakResponse(commentary);
+    } else if (quotes && quotes.length) {
+      speakResponse(quotes[0].quote);
+    }
   }
 
   async function askAlbini(question) {


### PR DESCRIPTION
## Summary
- add neutral speech synthesis helper to Albini Q&A and read commentary or fallback quote
- ensure random prompt seeding triggers the REST lookup with curated quotes
- tighten the OpenAI system prompt to demand strict JSON without Albini impersonation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c3ffaa028832e96c2a31c91861227)