### PR TITLE
Fix Lousy Outages RSS links

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -179,7 +179,8 @@ add_action( 'phpmailer_init', function( $phpmailer ) {
 
 function lousy_outages_feed_autodiscovery() {
     if ( is_front_page() || is_page_template( 'page-lousy-outages.php' ) || is_page( 'lousy-outages' ) ) {
-        echo '\n<link rel="alternate" type="application/rss+xml" title="Lousy Outages" href="' . esc_url( home_url( '/lousy-outages/feed/' ) ) . '" />\n';
+        $feed_url = home_url( '/?feed=lousy_outages_status' ); // Pretty /feed/lousy_outages_status/ works once permalinks flush, but we keep the query form for reliability.
+        echo '\n<link rel="alternate" type="application/rss+xml" title="Lousy Outages" href="' . esc_url( $feed_url ) . '" />\n';
     }
 }
 add_action( 'wp_head', 'lousy_outages_feed_autodiscovery' );

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -355,7 +355,7 @@ function render_shortcode(): string {
     $config['initial']['source']    = $source;
     $config['initial']['errors']    = $snapshot_errors;
 
-    $rss_url = esc_url(get_feed_link('lousy_outages_status'));
+    $rss_url = home_url('/?feed=lousy_outages_status'); // Pretty /feed/lousy_outages_status/ works after a permalink flush, but the query form is safer.
 
     wp_localize_script('lousy-outages', 'LousyOutagesConfig', $config);
     wp_localize_script(
@@ -512,7 +512,7 @@ function render_shortcode(): string {
 function render_subscribe_shortcode(): string {
     $endpoint = esc_url_raw(rest_url('lousy-outages/v1/subscribe'));
     $nonce    = wp_create_nonce('lousy_outages_subscribe');
-    $rss_url  = esc_url(home_url('/lousy-outages/feed/'));
+    $rss_url  = esc_url(home_url('/?feed=lousy_outages_status'));
     $lyric_lines = [];
     foreach (\lo_lyric_fragment_bank() as $entry) {
         if (!is_array($entry)) {

--- a/parts/lousy-outages-teaser.php
+++ b/parts/lousy-outages-teaser.php
@@ -7,7 +7,7 @@ $teaser_strings = [
     'viewDashboard' => 'View Full Dashboard →',
 ];
 
-$feed_url     = esc_url( get_feed_link( 'lousy_outages_status' ) );
+$feed_url     = home_url( '/?feed=lousy_outages_status' ); // Pretty /feed/lousy_outages_status/ works after a permalink flush, but the query form is more reliable.
 
 if ( class_exists( '\\LousyOutages\\I18n' ) ) {
     $locale         = I18n::determine_locale();
@@ -66,7 +66,7 @@ if ( class_exists( '\\LousyOutages\\Summary' ) ) {
     <a class="lo-home-teaser-link" href="<?php echo esc_url( $teaser_href ); ?>"><?php echo esc_html( $teaser_strings['viewDashboard'] ); ?></a>
 
     <div class="lo-actions lo-actions--rss">
-      <a class="lo-link" href="<?php echo $feed_url; ?>" target="_blank" rel="noopener">
+      <a class="lo-link" href="<?php echo esc_url( $feed_url ); ?>" target="_blank" rel="noopener">
         <svg class="lo-icon" viewBox="0 0 24 24" aria-hidden="true">
           <path fill="currentColor" d="M6 17a2 2 0 11.001 3.999A2 2 0 016 17zm-2-7v3a8 8 0 018 8h3c0-6.075-4.925-11-11-11zm0-5v3c9.389 0 17 7.611 17 17h3C24 13.85 10.15 0 4 0z"/>
         </svg>


### PR DESCRIPTION
## Summary
- update the Lousy Outages teaser and shortcode templates to point the Subscribe buttons at the reliable `/?feed=lousy_outages_status` endpoint and document why we stick to that form
- adjust the RSS autodiscovery link in `functions.php` to use the same query-string feed so the header advertises a working URL as well

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d6b109698832e89f0fe11f11b3435)