### PR TITLE
Fix outage chart overflow

### DIFF
--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -136,6 +136,8 @@
   border-radius: 12px;
   padding: 12px;
   margin-bottom: 16px;
+  position: relative;
+  overflow: hidden;
 }
 
 .lousy-outages.lo-theme-light .lo-chart {
@@ -162,7 +164,9 @@
 }
 
 #lo-outage-chart {
+  display: block;
   width: 100%;
+  height: 260px;
   min-height: 220px;
 }
 


### PR DESCRIPTION
## Summary
- add overflow protection to outage chart container
- force outage chart canvas to block layout with fixed height for consistent sizing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69202369f140832eb8d37aa419c0d645)