### PR TITLE
Pin Chart.js UMD build for Lousy Outages dashboard

### DIFF
--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -68,9 +68,9 @@ function render_shortcode(): string {
 
     wp_enqueue_script(
         'chart.js',
-        'https://cdn.jsdelivr.net/npm/chart.js',
+        'https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js',
         [],
-        null,
+        '4.4.3',
         true
     );
 


### PR DESCRIPTION
## Summary
- pin the Chart.js dependency to the UMD build on jsDelivr to ensure the global bundle loads correctly
- keep the Lousy Outages dashboard scripts working even if the CDN defaults to an ESM build

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692028359f1c832e96bb6ba350d8094a)