### PR TITLE
Replace incident chart with compact history list

### DIFF
--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -132,23 +132,20 @@
   cursor: progress;
 }
 
-.lo-chart {
+.lo-history {
   background: #0a0a0a;
   border: 2px solid rgba(255, 184, 28, 0.65);
   border-radius: 12px;
   padding: 12px;
   margin-bottom: 16px;
-  position: relative;
-  overflow: hidden;
-  min-height: 320px;
 }
 
-.lousy-outages.lo-theme-light .lo-chart {
+.lousy-outages.lo-theme-light .lo-history {
   background: #ffffff;
   border-color: #d2b48c;
 }
 
-.lo-chart__heading {
+.lo-history__heading {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -156,21 +153,111 @@
   flex-wrap: wrap;
 }
 
-.lo-chart__meta {
+.lo-history__meta {
   margin: 0;
   color: rgba(255, 233, 196, 0.8);
   font-size: 0.9rem;
 }
 
-.lousy-outages.lo-theme-light .lo-chart__meta {
+.lousy-outages.lo-theme-light .lo-history__meta {
   color: rgba(32, 32, 32, 0.75);
 }
 
-#lo-outage-chart {
-  display: block;
-  width: 100%;
-  height: 260px;
-  min-height: 220px;
+.lo-history__body {
+  margin-top: 12px;
+  max-height: 80vh;
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+.lo-history__list {
+  list-style: decimal;
+  list-style-position: inside;
+  margin: 0;
+  padding-left: 8px;
+}
+
+.lo-history__item + .lo-history__item {
+  margin-top: 10px;
+}
+
+.lo-history__item {
+  background: rgba(240, 78, 35, 0.12);
+  border: 1px solid rgba(255, 184, 28, 0.35);
+  border-radius: 10px;
+  padding: 10px 12px;
+  color: #ffe9c4;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 8px;
+}
+
+.lousy-outages.lo-theme-light .lo-history__item {
+  background: rgba(240, 78, 35, 0.07);
+  border-color: rgba(179, 91, 0, 0.4);
+  color: #202020;
+}
+
+.lo-history__item--placeholder {
+  font-style: italic;
+  color: rgba(255, 233, 196, 0.75);
+}
+
+.lousy-outages.lo-theme-light .lo-history__item--placeholder {
+  color: rgba(32, 32, 32, 0.6);
+}
+
+.lo-history__time {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.lo-history__time time {
+  font-weight: 700;
+  color: #ffb81c;
+}
+
+.lousy-outages.lo-theme-light .lo-history__time time {
+  color: #b35b00;
+}
+
+.lo-history__details {
+  font-size: 0.95rem;
+  line-height: 1.35;
+}
+
+.lo-history__count {
+  font-size: 0.85rem;
+  color: rgba(255, 233, 196, 0.8);
+}
+
+.lousy-outages.lo-theme-light .lo-history__count {
+  color: rgba(32, 32, 32, 0.7);
+}
+
+.lo-history__badge {
+  justify-self: end;
+}
+
+.lo-history__empty,
+.lo-history__error {
+  margin: 10px 0 0;
+  font-size: 0.9rem;
+  color: rgba(255, 233, 196, 0.8);
+}
+
+.lo-history__error {
+  color: #ff6b6b;
+}
+
+.lousy-outages.lo-theme-light .lo-history__empty {
+  color: rgba(32, 32, 32, 0.7);
+}
+
+.lousy-outages.lo-theme-light .lo-history__error {
+  color: #b00020;
 }
 
 .lo-icon {

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -67,17 +67,9 @@ function render_shortcode(): string {
     );
 
     wp_enqueue_script(
-        'chart.js',
-        'https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js',
-        [],
-        '4.4.3',
-        true
-    );
-
-    wp_enqueue_script(
         'lousy-outages',
         $base_url . 'lousy-outages.js',
-        ['chart.js'],
+        [],
         file_exists($base_path . 'lousy-outages.js') ? filemtime($base_path . 'lousy-outages.js') : null,
         true
     );
@@ -426,13 +418,21 @@ function render_shortcode(): string {
                 <a class="lo-link" href="<?php echo esc_url($rss_url); ?>" target="_blank" rel="noopener">Subscribe (RSS)</a>
             </div>
         </div>
-        <div class="lo-chart" data-lo-chart>
-            <div class="lo-chart__heading">
-                <h3 class="lo-block-title">Recent incidents (GitHub)</h3>
-                <p class="lo-chart__meta">Last 30 days of non-operational blips.</p>
+        <section class="lo-history" data-lo-history>
+            <div class="lo-history__heading">
+                <div>
+                    <h3 class="lo-block-title">Recent incidents (GitHub)</h3>
+                    <p class="lo-history__meta">Last 30 days of non-operational blips.</p>
+                </div>
             </div>
-            <canvas id="lo-outage-chart" aria-label="GitHub incidents over time" role="img"></canvas>
-        </div>
+            <div class="lo-history__body">
+                <ol class="lo-history__list" data-lo-history-list>
+                    <li class="lo-history__item lo-history__item--placeholder">Loading incidents…</li>
+                </ol>
+                <p class="lo-history__empty" data-lo-history-empty hidden>No incidents in the past 30 days.</p>
+                <p class="lo-history__error" data-lo-history-error hidden>Unable to load incident history right now.</p>
+            </div>
+        </section>
         <?php if (LO_SHOW_WIDESPREAD) : ?>
         <div class="lo-trending" data-lo-trending<?php echo $trending_active ? '' : ' hidden'; ?> data-lo-trending-generated="<?php echo esc_attr($trending_generated); ?>" aria-live="assertive">
             <span class="lo-trending__icon" aria-hidden="true">⚡</span>


### PR DESCRIPTION
## Summary
- replace the retro incident chart with a compact ordered history list that caps height and shows empty/error states
- restyle the incident section for the new list layout in both themes while keeping the retro palette
- simplify client JS by removing Chart.js usage and rendering history entries with accessible text labels

## Testing
- npm test *(fails: manual refresh falls back to status endpoint when refresh endpoint fails)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692039f9c718832e946157116277efbb)