### PR TITLE
Fix outage history display for recent incidents

### DIFF
--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -241,6 +241,11 @@
   color: var(--lo-accent);
 }
 
+.lo-history__time-range {
+  color: #b4b4be;
+  font-size: 0.8rem;
+}
+
 .lousy-outages.lo-theme-light .lo-history__time time {
   color: var(--lo-accent);
 }

--- a/lousy-outages/includes/Storage/IncidentStore.php
+++ b/lousy-outages/includes/Storage/IncidentStore.php
@@ -10,7 +10,9 @@ class IncidentStore
     private const OPTION_EVENTS = 'lo_event_log';
     private const OPTION_LAST_DIGEST = 'lousy_outages_daily_digest_last_sent';
     private const ALERT_COOLDOWN = 90; // Minutes.
-    private const EVENT_RETENTION = 36; // Hours.
+    // Keep events long enough for 30+ day history; previously capped at ~36 hours,
+    // which caused the dashboard history to go empty even when recent incidents existed.
+    private const EVENT_RETENTION = 60 * 24; // Hours (~60 days).
 
     /**
      * Determine whether an alert email should fire for the incident.


### PR DESCRIPTION
## Summary
- use persisted incidents (with extended retention) when building history responses so recent outages remain in the 30-day window
- enrich history payload with incident details and provider labels while keeping legacy counts as a fallback
- render incident rows on the dashboard with provider, status badges, summary, and timestamps plus improved status mapping and styling

## Testing
- php -l lousy-outages/includes/Api.php
- php -l lousy-outages/includes/Storage/IncidentStore.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692134fac284832e9e55e4ab38cdeca3)