### PR TITLE
Tighten outage history and add retro charts

### DIFF
--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -175,6 +175,97 @@
   flex-wrap: wrap;
 }
 
+.lo-history__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  margin: 4px 0 12px;
+}
+
+.lo-history__controls label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+}
+
+.lo-history__controls select {
+  background: #0e1117;
+  color: #f8f8f2;
+  border: 1px solid #353535;
+  padding: 4px 8px;
+  font-family: inherit;
+  font-size: 13px;
+}
+
+.lousy-outages.lo-theme-light .lo-history__controls select {
+  background: #f7f7f7;
+  color: #222;
+  border-color: #ccc;
+}
+
+.lo-history__charts {
+  margin: 10px 0 16px;
+  padding: 8px 10px;
+  border: 2px solid #222;
+  background: #0c0c0c;
+}
+
+.lousy-outages.lo-theme-light .lo-history__charts {
+  background: #fafafa;
+  border-color: #ccc;
+}
+
+.lo-history__chart {
+  margin-bottom: 12px;
+}
+
+.lo-history__chart:last-child {
+  margin-bottom: 0;
+}
+
+.lo-history__chart-title {
+  font-size: 12px;
+  margin-bottom: 4px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+.lo-history__chart svg {
+  width: 100%;
+  height: auto;
+  border: 1px solid #222;
+  background: repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.03) 0, rgba(255, 255, 255, 0.03) 4px, transparent 4px, transparent 8px);
+}
+
+.lousy-outages.lo-theme-light .lo-history__chart svg {
+  border-color: #ccc;
+}
+
+.lo-history__chart-bar {
+  fill: #6df28c;
+  stroke: #0c0c0c;
+  stroke-width: 1;
+}
+
+.lo-history__chart-bar--thin {
+  fill: #ffb347;
+}
+
+.lousy-outages.lo-theme-light .lo-history__chart-bar {
+  stroke: #222;
+}
+
+.lo-history__chart-text {
+  font-size: 10px;
+  fill: #fefefe;
+}
+
+.lousy-outages.lo-theme-light .lo-history__chart-text {
+  fill: #222;
+}
+
 .lo-history__meta {
   margin: 0;
   color: var(--lo-muted);

--- a/lousy-outages/includes/IncidentAlerts.php
+++ b/lousy-outages/includes/IncidentAlerts.php
@@ -463,9 +463,14 @@ class IncidentAlerts {
      */
     private static function collect_from_registered_sources(): array {
         $incidents = [];
+        $allowed   = array_fill_keys(array_keys(Providers::enabled()), true);
 
         foreach (Sources::all() as $slug => $source) {
             if (! $source instanceof StatuspageSource) {
+                continue;
+            }
+
+            if (!isset($allowed[$slug])) {
                 continue;
             }
 

--- a/lousy-outages/includes/Providers.php
+++ b/lousy-outages/includes/Providers.php
@@ -87,6 +87,7 @@ class Providers {
                 'type'       => 'statuspage',
                 'url'        => 'https://status.linear.app/api/v2/summary.json',
                 'status_url' => 'https://status.linear.app/',
+                'enabled'    => false,
             ],
             [
                 'id'         => 'sentry',
@@ -101,6 +102,7 @@ class Providers {
                 'type'       => 'manual',
                 'url'        => 'https://www.rogers.com/support/service-updates',
                 'status_url' => 'https://www.rogers.com/support/service-updates',
+                'enabled'    => false,
             ],
             [
                 'id'         => 'bell',
@@ -108,6 +110,7 @@ class Providers {
                 'type'       => 'manual',
                 'url'        => 'https://support.bell.ca/networkstatus',
                 'status_url' => 'https://support.bell.ca/networkstatus',
+                'enabled'    => false,
             ],
             [
                 'id'         => 'telus',
@@ -115,6 +118,7 @@ class Providers {
                 'type'       => 'manual',
                 'url'        => 'https://www.telus.com/en/support/outages',
                 'status_url' => 'https://www.telus.com/en/support/outages',
+                'enabled'    => false,
             ],
 
             // RSS/Atom feeds

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -424,8 +424,23 @@ function render_shortcode(): string {
                     <h3 class="lo-block-title">Recent incidents (GitHub)</h3>
                     <p class="lo-history__meta">Last 30 days of non-operational blips.</p>
                 </div>
+                <div class="lo-history__controls">
+                    <label>
+                        <input type="checkbox" data-lo-history-important checked>
+                        <span>Show only major incidents</span>
+                    </label>
+                    <label>
+                        <span class="sr-only">History window</span>
+                        <select data-lo-history-window>
+                            <option value="1">24h</option>
+                            <option value="7">7d</option>
+                            <option value="30" selected>30d</option>
+                        </select>
+                    </label>
+                </div>
             </div>
             <div class="lo-history__body">
+                <div class="lo-history__charts" data-lo-history-charts hidden></div>
                 <ol class="lo-history__list" data-lo-history-list>
                     <li class="lo-history__item lo-history__item--placeholder">Loading incidents…</li>
                 </ol>


### PR DESCRIPTION
## Summary
- disable low-signal providers by default so they drop from tiles, filters, and history
- classify and dedupe incidents on the server to suppress Zscaler/Cloudflare noise and support important-only history queries
- add front-end controls, timelines, and provider bar charts while keeping the retro dashboard style

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692271a642c8832eb0b9cd5fb0851280)