### PR TITLE
Remove Canadian telco tiles from Lousy Outages dashboard

### DIFF
--- a/lousy-outages/README.md
+++ b/lousy-outages/README.md
@@ -19,15 +19,12 @@ Monitor third‑party service status and get SMS and email alerts when things br
 | teamviewer | TeamViewer | https://status.teamviewer.com/api/v2/summary.json |
 | linear | Linear | https://status.linear.app/api/v2/summary.json |
 | sentry | Sentry | https://status.sentry.io/api/v2/summary.json |
-| rogers | Rogers | https://status.rogers.com/api/v2/summary.json |
-| bell | Bell Canada | https://status.bell.ca/api/v2/summary.json |
-| telus | TELUS | https://status.telus.com/api/v2/summary.json |
 | aws | AWS | https://status.aws.amazon.com/rss/all.rss |
 | azure | Azure | https://azurestatuscdn.azureedge.net/en-us/status/feed/ |
 | gcp | Google Cloud | https://www.google.com/appsstatus/dashboard/en-CA/feed.atom |
 | downdetector-ca | Downdetector (CA Aggregate) | https://downdetector.ca/archive/?format=rss |
 
-Zscaler is queried from `https://trust.zscaler.com` to dodge intermittent DNS failures. New default providers include TeamViewer, Linear, Sentry, and Canadian telcos—toggle any of them from **Settings → Lousy Outages**.
+Zscaler is queried from `https://trust.zscaler.com` to dodge intermittent DNS failures. New default providers include TeamViewer, Linear, and Sentry—toggle any of them from **Settings → Lousy Outages**.
 
 Downdetector is disabled by default because the RSS feed is unofficial and can disappear; enable it from the settings page if it loads for you. When the feed is unreachable, the adapter reports an `unknown` state with an error badge rather than failing the whole poll.
 

--- a/lousy-outages/includes/Fetcher.php
+++ b/lousy-outages/includes/Fetcher.php
@@ -725,9 +725,6 @@ class Lousy_Outages_Fetcher {
         'cloudflare' => ['kind' => 'statuspage', 'base' => 'https://www.cloudflarestatus.com'],
         'zoom'       => ['kind' => 'statuspage', 'base' => 'https://status.zoom.us'],
         'teamviewer' => ['kind' => 'statuspage', 'base' => 'https://status.teamviewer.com'],
-        'rogers'     => ['kind' => 'statuspage', 'base' => 'https://status.rogers.com'],
-        'bell'       => ['kind' => 'statuspage', 'base' => 'https://status.bell.ca'],
-        'telus'      => ['kind' => 'statuspage', 'base' => 'https://status.telus.com'],
 
         // Switch these to RSS/Atom (per Suzy’s feeds)
         'zscaler'    => ['kind' => 'rss', 'feed' => 'https://trust.zscaler.com/rss-feed', 'link' => 'https://trust.zscaler.com/cloud-status'],
@@ -761,9 +758,6 @@ class Lousy_Outages_Fetcher {
         'cloudflare' => 'Cloudflare',
         'zoom'       => 'Zoom',
         'teamviewer' => 'TeamViewer',
-        'rogers'     => 'Rogers',
-        'bell'       => 'Bell Canada',
-        'telus'      => 'TELUS',
         'zscaler'    => 'Zscaler',
         'slack'      => 'Slack',
         'gcp'        => 'Google Cloud',

--- a/lousy-outages/includes/Providers.php
+++ b/lousy-outages/includes/Providers.php
@@ -5,7 +5,7 @@ namespace SuzyEaston\LousyOutages;
 
 class Providers {
     private const OPTION_DEFAULT_ENABLED = 'lousy_outages_default_enabled_providers';
-    private const BLOCKED_PROVIDER_IDS = ['rogers', 'bell', 'telus', 'linear'];
+    private const BLOCKED_PROVIDER_IDS = ['linear'];
 
     private static function defaultProviders(): array {
         return [

--- a/lousy-outages/includes/Sources/index.php
+++ b/lousy-outages/includes/Sources/index.php
@@ -5,9 +5,6 @@ namespace SuzyEaston\LousyOutages\Sources;
 
 Sources::register('openai', new StatuspageSource('OpenAI', 'https://status.openai.com/api/v2/summary.json', 'https://status.openai.com'));
 Sources::register('teamviewer', new StatuspageSource('TeamViewer', 'https://status.teamviewer.com/api/v2/summary.json', 'https://status.teamviewer.com'));
-Sources::register('rogers', new StatuspageSource('Rogers', 'https://status.rogers.com/api/v2/summary.json', 'https://status.rogers.com'));
-Sources::register('bell', new StatuspageSource('Bell Canada', 'https://status.bell.ca/api/v2/summary.json', 'https://status.bell.ca'));
-Sources::register('telus', new StatuspageSource('TELUS', 'https://status.telus.com/api/v2/summary.json', 'https://status.telus.com'));
 Sources::register('zscaler', new StatuspageSource('Zscaler', 'https://status.zscaler.com/api/v2/summary.json', 'https://status.zscaler.com'));
 Sources::register('cloudflare', new StatuspageSource('Cloudflare', 'https://www.cloudflarestatus.com/api/v2/summary.json', 'https://www.cloudflarestatus.com'));
 Sources::register('zoom', new StatuspageSource('Zoom', 'https://status.zoom.us/api/v2/summary.json', 'https://status.zoom.us'));


### PR DESCRIPTION
## Summary
- remove Rogers, Bell, and TELUS provider definitions from Lousy Outages sources and fetcher
- clean up provider block list and documentation now that the telco tiles are gone

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922986707c4832eb5f3a96c2556302f)