### PR TITLE
Add select-all controls for provider checkboxes

### DIFF
--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -1028,6 +1028,43 @@
   background: rgba(255, 255, 255, 0.85);
 }
 
+.lo-settings__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0 0 10px;
+}
+
+.lo-settings__button {
+  appearance: none;
+  border: 1px solid var(--lo-border);
+  background: var(--lo-accent);
+  color: #0b0b0b;
+  font-weight: 700;
+  border-radius: 8px;
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.lo-settings__button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.lo-settings__button--ghost {
+  background: transparent;
+  color: var(--lo-accent);
+}
+
+.lousy-outages.lo-theme-light .lo-settings__button {
+  color: #0b0b0b;
+}
+
+.lousy-outages.lo-theme-light .lo-settings__button--ghost {
+  background: rgba(92, 75, 216, 0.08);
+}
+
 .lo-settings__hint {
   margin: 0 0 10px;
   font-size: 0.95rem;

--- a/lousy-outages/assets/lousy-outages.js
+++ b/lousy-outages/assets/lousy-outages.js
@@ -305,6 +305,25 @@
     applyProviderVisibility();
   }
 
+  function setAllProvidersVisibility(visible) {
+    if (!state.providerToggles || !state.providerToggles.length) {
+      return;
+    }
+    var prefs = {};
+    state.providerToggles.forEach(function (input) {
+      if (!input || !input.value) {
+        return;
+      }
+      input.checked = visible;
+      if (!visible) {
+        prefs[input.value] = false;
+      }
+    });
+    state.visibleProviders = prefs;
+    persistVisibleProviders(prefs);
+    applyProviderVisibility();
+  }
+
   function initProviderVisibility() {
     state.visibleProviders = loadVisibleProviders();
     var toggles = state.container ? state.container.querySelectorAll('[data-lo-provider-toggle]') : [];
@@ -314,6 +333,24 @@
         input.addEventListener('change', handleProviderToggle);
       });
       syncProviderToggleUI();
+    }
+
+    var selectAll = state.container ? state.container.querySelector('[data-lo-provider-select="all"]') : null;
+    if (selectAll) {
+      selectAll.addEventListener('click', function (event) {
+        event.preventDefault();
+        setAllProvidersVisibility(true);
+        syncProviderToggleUI();
+      });
+    }
+
+    var selectNone = state.container ? state.container.querySelector('[data-lo-provider-select="none"]') : null;
+    if (selectNone) {
+      selectNone.addEventListener('click', function (event) {
+        event.preventDefault();
+        setAllProvidersVisibility(false);
+        syncProviderToggleUI();
+      });
     }
     applyProviderVisibility();
   }

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -462,6 +462,10 @@ function render_shortcode(): string {
         <div class="lo-settings" data-lo-settings>
             <h3 class="lo-block-title">Customize view</h3>
             <p class="lo-settings__hint">Pick which providers appear below. Preferences stay on this browser only.</p>
+            <div class="lo-settings__actions">
+                <button type="button" class="lo-settings__button" data-lo-provider-select="all">Select all</button>
+                <button type="button" class="lo-settings__button lo-settings__button--ghost" data-lo-provider-select="none">Select none</button>
+            </div>
             <div class="lo-settings__options">
                 <?php foreach ($ordered_tiles as $tile) :
                     $slug = (string) ($tile['provider'] ?? '');


### PR DESCRIPTION
## Summary
- add Select all/Select none controls to the Customize view provider list
- style the new settings buttons to match the outages UI
- wire up JavaScript to persist and apply the bulk visibility selection

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69229d936a38832e84fb41505f85a83a)