### PR TITLE
Enhance lousy outages history clarity and exports

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -37,8 +37,9 @@ get_header();
             </div>
         </div>
         <section class="lo-callout lo-8bit">
-          <h2>Weekly Show: <span>Lousy Outages</span></h2>
-          <p>New episodes drop every week on YouTube where Suzanne unpacks outage chaos, security quirks, and her sharp tech riffs.</p>
+          <h2>LOUSY OUTAGES<br><span>LIVE STATUS DASHBOARD</span></h2>
+          <p>Track real-world outage chaos in arcade style.<br>
+          Suzanne (Suzy) Easton watches the clouds, ISPs, and tools you rely on — while dropping new indie tracks from Vancouver.</p>
           <a class="btn-8bit" href="/lousy-outages/">OPEN THE LIVE DASHBOARD →</a>
         </section>
         <h2 class="retro-title glow-lite">Musician &amp; Creative Technologist</h2>


### PR DESCRIPTION
## Summary
- add history window start/end metadata and show readable range subtitles on charts
- refine chart layout to avoid label collisions and gate count labels for short bars
- export the rendered incident list to CSV, extend retention for important events, and refresh homepage Lousy Outages promo copy

## Testing
- php -l lousy-outages/includes/Api.php
- php -l lousy-outages/includes/Storage/IncidentStore.php
- php -l page-home.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69237df09244832ea6d0bb222792a710)