### PR TITLE
Improve lousy outages RSS feed

### DIFF
--- a/lousy-outages/includes/Feeds.php
+++ b/lousy-outages/includes/Feeds.php
@@ -3,8 +3,12 @@ declare(strict_types=1);
 
 namespace SuzyEaston\LousyOutages;
 
+use SuzyEaston\LousyOutages\Storage\IncidentStore;
+
 class Feeds {
     private const FEED_NAME = 'lousy_outages_status';
+    private const INCIDENT_WINDOW_DAYS = 30;
+    private const INCIDENT_LIMIT = 25;
 
     public static function bootstrap(): void {
         add_action('init', [self::class, 'register']);
@@ -35,37 +39,16 @@ class Feeds {
         $charset = (string) get_option('blog_charset', 'UTF-8');
         header('Content-Type: application/rss+xml; charset=' . $charset, true);
 
-        $snapshot  = function_exists('lousy_outages_get_snapshot') ? lousy_outages_get_snapshot(false) : [];
-        $providers = is_array($snapshot['providers'] ?? null) ? $snapshot['providers'] : [];
-        $fetched   = (string) ($snapshot['fetched_at'] ?? $snapshot['updated_at'] ?? gmdate('c'));
-
-        if (empty($providers)) {
-            $store  = new Store();
-            $states = $store->get_all();
-            if (empty($states)) {
-                $states = lousy_outages_collect_statuses(false);
-            }
-
-            $fetched = get_option('lousy_outages_last_poll') ?: gmdate('c');
-            foreach ($states as $id => $state) {
-                $providers[] = lousy_outages_build_provider_payload((string) $id, $state, (string) $fetched);
-            }
-        }
-
-        if (function_exists('lousy_outages_sort_providers')) {
-            $providers = lousy_outages_sort_providers($providers);
-        }
-
-        [$items, $last_updated] = self::build_incident_items($providers, (string) $fetched);
+        [$items, $last_updated] = self::collect_incident_items();
 
         echo '<?xml version="1.0" encoding="' . esc_attr($charset ?: 'UTF-8') . '"?>';
         ?>
 <rss version="2.0">
   <channel>
-    <title><?php bloginfo_rss('name'); ?> – Lousy Outages Status Feed</title>
+    <title><?php echo esc_html('Suzy Easton – Lousy Outages Status Feed'); ?></title>
     <link><?php echo esc_url(home_url('/lousy-outages/')); ?></link>
-    <description><?php echo esc_html('Latest incident updates from the Lousy Outages dashboard.'); ?></description>
-    <lastBuildDate><?php echo esc_html(self::format_rss_date($last_updated ?: (string) $fetched)); ?></lastBuildDate>
+    <description><?php echo esc_html('Major outage shenanigans curated by Suzy Easton. Serious incidents, delightfully unserious commentary.'); ?></description>
+    <lastBuildDate><?php echo esc_html(self::format_rss_date($last_updated)); ?></lastBuildDate>
 <?php foreach ($items as $item) : ?>
     <item>
       <title><?php echo esc_html($item['title']); ?></title>
@@ -81,43 +64,82 @@ class Feeds {
         exit;
     }
 
-    private static function build_incident_items(array $providers, string $fallback_time): array {
-        $items      = [];
-        $timestamps = [];
+    private static function collect_incident_items(): array {
+        $items          = [];
+        $timestamps     = [];
+        $fallback_time  = gmdate('c');
+        $cutoff         = time() - (self::INCIDENT_WINDOW_DAYS * DAY_IN_SECONDS);
+        $store          = new IncidentStore();
+        $providers      = Providers::list();
+        $events         = $store->getStoredIncidents();
+        $seenGuids      = [];
 
-        foreach ($providers as $provider) {
-            if (!is_array($provider)) {
-                continue;
-            }
-
-            $provider_id   = (string) ($provider['id'] ?? '');
-            $provider_name = (string) ($provider['name'] ?? ($provider['provider'] ?? 'Provider'));
-            $provider_link = (string) ($provider['url'] ?? self::provider_link($provider_id));
-            $incidents     = isset($provider['incidents']) && is_array($provider['incidents']) ? $provider['incidents'] : [];
-
-            foreach ($incidents as $incident) {
-                if (!is_array($incident)) {
+        if (is_array($events)) {
+            foreach ($events as $event) {
+                if (!is_array($event)) {
                     continue;
                 }
 
-                $updated_iso = (string) ($incident['updatedAt'] ?? $incident['updated_at'] ?? '');
-                $started_iso = (string) ($incident['startedAt'] ?? $incident['started_at'] ?? '');
-                $timestamp   = self::parse_time($updated_iso ?: $started_iso ?: $fallback_time);
-                $impact      = strtolower((string) ($incident['impact'] ?? $incident['status'] ?? 'unknown'));
-                $status      = Fetcher::status_label($impact ?: 'unknown');
-                $title_text  = (string) ($incident['title'] ?? $incident['summary'] ?? 'Incident');
-                $summary     = (string) ($incident['summary'] ?? $title_text);
+                $event = $store->normalizeEvent($event);
 
-                $items[]      = [
-                    'title'       => sprintf('%s – %s (%s)', $provider_name, $title_text, $status),
-                    'link'        => !empty($incident['url']) ? (string) $incident['url'] : $provider_link,
-                    'guid'        => self::build_guid($provider_id, (string) ($incident['id'] ?? ''), $summary, $updated_iso ?: $started_iso),
-                    'pubDate'     => self::format_rss_date($updated_iso ?: ($started_iso ?: $fallback_time)),
-                    'description' => sprintf('%s: %s', $status, $summary ?: 'Details unavailable'),
-                    'timestamp'   => $timestamp,
+                $severity  = strtolower((string) ($event['severity'] ?? ''));
+                $important = isset($event['important']) ? (bool) $event['important'] : false;
+
+                if (!$important || !in_array($severity, ['outage', 'degraded'], true)) {
+                    continue;
+                }
+
+                $firstSeen = isset($event['first_seen']) ? (int) $event['first_seen'] : 0;
+                $lastSeen  = isset($event['last_seen']) ? (int) $event['last_seen'] : $firstSeen;
+                $timestamp = $firstSeen ?: $lastSeen;
+
+                if ($timestamp && $timestamp < $cutoff) {
+                    continue;
+                }
+
+                $provider_id   = sanitize_key((string) ($event['provider'] ?? ''));
+                $provider_data = $providers[$provider_id] ?? [];
+                $provider_name = (string) ($event['provider_label'] ?? ($provider_data['name'] ?? ($provider_id ? ucfirst($provider_id) : 'Provider')));
+                $status_url    = isset($provider_data['status_url']) ? (string) $provider_data['status_url'] : (string) ($provider_data['url'] ?? '');
+
+                $title_text = trim((string) ($event['title'] ?? $event['description'] ?? 'Incident'));
+                $status     = (string) ($event['status'] ?? $event['status_normal'] ?? '');
+                $guid       = (string) ($event['guid'] ?? '');
+
+                if ('' === $guid) {
+                    $guid = self::build_guid($provider_id, '', $title_text, $firstSeen ? gmdate('c', (int) $firstSeen) : $fallback_time);
+                }
+
+                if ($guid && isset($seenGuids[$guid])) {
+                    continue;
+                }
+
+                $seenGuids[$guid] = true;
+
+                $incidentLink = (string) ($event['url'] ?? '');
+                if ('' === $incidentLink) {
+                    $incidentLink = self::provider_link($provider_id, $status_url);
+                }
+
+                $itemTimestamp = $timestamp ?: self::parse_time($fallback_time);
+
+                $items[] = [
+                    'title'       => sprintf('[%s] %s – %s', strtoupper($severity ?: 'incident'), $provider_name, $title_text ?: 'Incident'),
+                    'link'        => $incidentLink,
+                    'guid'        => $guid,
+                    'pubDate'     => self::format_rss_date($timestamp ? gmdate('c', (int) $timestamp) : $fallback_time),
+                    'description' => self::build_funny_summary([
+                        'provider_label' => $provider_name,
+                        'severity'       => $severity,
+                        'status'         => $status,
+                        'title'          => $title_text,
+                        'impact_summary' => (string) ($event['impact_summary'] ?? ''),
+                        'summary'        => (string) ($event['description'] ?? ''),
+                    ]),
+                    'timestamp'   => $itemTimestamp,
                 ];
 
-                $timestamps[] = $timestamp;
+                $timestamps[] = $itemTimestamp;
             }
         }
 
@@ -128,18 +150,8 @@ class Feeds {
             }
         );
 
-        $items = array_slice($items, 0, 50);
-
-        if (empty($items)) {
-            $items[]      = [
-                'title'       => 'All systems operational',
-                'link'        => home_url('/lousy-outages/'),
-                'guid'        => 'lousy-outages-status-' . gmdate('Ymd'),
-                'pubDate'     => self::format_rss_date($fallback_time),
-                'description' => 'No active incidents reported across monitored providers.',
-                'timestamp'   => self::parse_time($fallback_time),
-            ];
-            $timestamps[] = self::parse_time($fallback_time);
+        if (count($items) > self::INCIDENT_LIMIT) {
+            $items = array_slice($items, 0, self::INCIDENT_LIMIT);
         }
 
         return [
@@ -162,9 +174,72 @@ class Feeds {
         return sha1($provider_id . '|' . $summary . '|' . $time);
     }
 
-    private static function provider_link(string $provider_id): string {
+    private static function provider_link(string $provider_id, string $status_url = ''): string {
+        if ('' !== $status_url) {
+            return $status_url;
+        }
         $anchor = sanitize_title($provider_id ?: 'provider');
         return home_url('/lousy-outages/#provider-' . $anchor);
+    }
+
+    /**
+     * Build a theatrical but informative summary for the feed description.
+     *
+     * @param array<string, mixed> $incident
+     */
+    private static function build_funny_summary(array $incident): string {
+        $provider = trim((string) ($incident['provider_label'] ?? 'The provider'));
+        $severity = strtolower((string) ($incident['severity'] ?? ''));
+        $status   = trim((string) ($incident['status'] ?? ''));
+        $title    = trim((string) ($incident['title'] ?? ''));
+        $notes    = trim((string) ($incident['impact_summary'] ?? ($incident['summary'] ?? '')));
+
+        $statusText = $status ? 'Status: ' . $status . '. ' : '';
+
+        if ('outage' === $severity) {
+            $lead = sprintf(
+                '%1$s just unplugged reality. %2$sThis is the part of the keynote where everything goes dark and we pretend it’s “planned.”',
+                $provider,
+                $statusText
+            );
+        } else {
+            $lead = sprintf(
+                '%1$s is in “reality distortion field” mode: technically running, spiritually napping. %2$sExpect dramatic limping worthy of a method actor.',
+                $provider,
+                $statusText
+            );
+        }
+
+        if ('' !== $title) {
+            $lead .= ' Headline: ' . self::truncate_text($title, 180);
+        }
+
+        if ('' !== $notes && $notes !== $title) {
+            $lead .= ' Vendor notes: ' . self::truncate_text($notes, 200);
+        }
+
+        return $lead;
+    }
+
+    private static function truncate_text(string $text, int $limit = 180): string {
+        $text = trim($text);
+        if ('' === $text || $limit <= 0) {
+            return '';
+        }
+
+        if (function_exists('mb_strlen')) {
+            if (mb_strlen($text, 'UTF-8') > $limit) {
+                return rtrim(mb_substr($text, 0, $limit - 1, 'UTF-8')) . '…';
+            }
+
+            return $text;
+        }
+
+        if (strlen($text) > $limit) {
+            return rtrim(substr($text, 0, $limit - 1)) . '…';
+        }
+
+        return $text;
     }
 
     private static function parse_time(?string $time): int {


### PR DESCRIPTION
## Summary
- rebuild the `lousy_outages_status` feed to pull recent important outage/degraded incidents from the incident store with sensible limits
- refresh channel metadata and item text to match the Jobs-meets-Ace-Ventura tone while keeping useful links and GUIDs
- add helper utilities for humorous summaries, trimming, and provider fallbacks

## Testing
- php -l lousy-outages/includes/Feeds.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923c5dd7d0c832ea65c1305e930bf72)