### PR TITLE
Upgrade riff generator instruments and tips

### DIFF
--- a/inc/openai.php
+++ b/inc/openai.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Shared OpenAI helper functions.
+ */
+
+if ( ! function_exists( 'se_openai_chat' ) ) {
+    /**
+     * Send a chat completion request to OpenAI.
+     *
+     * @param array $messages Chat messages [{ role, content }].
+     * @param array $options  Additional request options (model, max_tokens, temperature, etc.).
+     *
+     * @return array|WP_Error Decoded response array on success or WP_Error on failure.
+     */
+    function se_openai_chat( $messages, $options = array() ) {
+        if ( ! defined( 'OPENAI_API_KEY' ) || ! OPENAI_API_KEY ) {
+            return new WP_Error( 'no_key', __( 'OpenAI API key is not configured.', 'suzys-music-theme' ) );
+        }
+
+        if ( empty( $messages ) || ! is_array( $messages ) ) {
+            return new WP_Error( 'invalid_messages', __( 'Invalid chat payload.', 'suzys-music-theme' ) );
+        }
+
+        $body = array_merge(
+            array(
+                'model'    => 'gpt-4o',
+                'messages' => $messages,
+            ),
+            $options
+        );
+
+        // Always use the provided messages to avoid accidental overrides.
+        $body['messages'] = $messages;
+
+        $response = wp_remote_post(
+            'https://api.openai.com/v1/chat/completions',
+            array(
+                'headers' => array(
+                    'Authorization' => 'Bearer ' . OPENAI_API_KEY,
+                    'Content-Type'  => 'application/json',
+                ),
+                'body'    => wp_json_encode( $body ),
+                'timeout' => isset( $options['timeout'] ) ? (int) $options['timeout'] : 30,
+            )
+        );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $code = wp_remote_retrieve_response_code( $response );
+        $data = json_decode( wp_remote_retrieve_body( $response ), true );
+
+        if ( 200 !== $code ) {
+            $message = is_array( $data ) && isset( $data['error']['message'] )
+                ? $data['error']['message']
+                : wp_remote_retrieve_body( $response );
+
+            return new WP_Error( 'openai_http_error', sprintf( 'OpenAI HTTP %s: %s', $code, $message ) );
+        }
+
+        if ( null === $data || json_last_error() !== JSON_ERROR_NONE ) {
+            return new WP_Error( 'openai_json_error', __( 'Invalid OpenAI response.', 'suzys-music-theme' ) );
+        }
+
+        return $data;
+    }
+}

--- a/js/riff-generator.js
+++ b/js/riff-generator.js
@@ -1,17 +1,23 @@
 // Riff Generator Vue App using Tone.js
 
 const MODE_INTERVALS = {
-  major:     [0,2,4,5,7,9,11],
-  minor:     [0,2,3,5,7,8,10],
-  dorian:    [0,2,3,5,7,9,10],
-  mixolydian:[0,2,4,5,7,9,10]
+  major:      [0, 2, 4, 5, 7, 9, 11],
+  minor:      [0, 2, 3, 5, 7, 8, 10],
+  dorian:     [0, 2, 3, 5, 7, 9, 10],
+  mixolydian: [0, 2, 4, 5, 7, 9, 10]
 };
 const NOTE_NAMES = ['C','C#','D','D#','E','F','F#','G','G#','A','A#','B'];
-const PROGRESSIONS = [
-  [1,4,5,1],
-  [1,6,4,5],
-  [2,5,1,1],
-  [1,5,6,4]
+const MODE_PROGRESSIONS = {
+  major:      [1, 5, 6, 4],
+  mixolydian: [1, 4, 5, 1],
+  minor:      [1, 6, 7, 5],
+  dorian:     [1, 4, 5, 1]
+};
+const PATTERN_LIBRARY = [
+  [0, 1, 2, 3, 1, 2, 0, 1],
+  [0, 2, 1, 2, 3, 2, 1, 0],
+  [0, 1, 0, 2, 3, 2, 1, 1],
+  [0, 1, 2, 1, 3, 2, 1, 0]
 ];
 const TIPS = [
   'Leave space for the groove.',
@@ -21,40 +27,117 @@ const TIPS = [
   'Layer subtle textures for depth.'
 ];
 
-function noteName(semi, oct=4){
-  const name = NOTE_NAMES[((semi%12)+12)%12];
-  return name+oct;
-}
-
-function chordNotes(rootName, mode, degree){
-  const base = NOTE_NAMES.indexOf(rootName);
-  const scale = MODE_INTERVALS[mode].map(s=> (s+base)%12);
-  const idx = (degree-1)%7;
-  const semis = [scale[idx], scale[(idx+2)%7], scale[(idx+4)%7]];
-  return [noteName(semis[0],3), noteName(semis[1],4), noteName(semis[2],4)];
-}
-
-function generateMelody(scale, chord, steps){
-  const notes = [];
-  for(let i=0;i<steps;i++){
-    const source = Math.random()<0.6? chord : scale;
-    const semi = source[Math.floor(Math.random()*source.length)];
-    notes.push(noteName(semi,5));
+const INSTRUMENT_PROFILES = {
+  piano: {
+    library: 'piano',
+    chordOctaves: [4, 4, 5],
+    reverb: { decay: 2.8, wet: 0.35 },
+    filter: null,
+    distortion: null,
+    chorus: null,
+    volume: -3
+  },
+  bass: {
+    library: 'bass-electric',
+    chordOctaves: [2, 3, 3],
+    reverb: { decay: 1.2, wet: 0.12 },
+    filter: { type: 'lowpass', frequency: 600, rolloff: -24 },
+    distortion: null,
+    chorus: null,
+    volume: -2
+  },
+  guitar: {
+    library: 'guitar-electric',
+    chordOctaves: [3, 4, 4],
+    reverb: { decay: 1.6, wet: 0.25 },
+    filter: { type: 'highpass', frequency: 90 },
+    distortion: null,
+    chorus: { frequency: 3, delayTime: 2.5, depth: 0.2 },
+    volume: -4
+  },
+  distortion_guitar: {
+    library: 'guitar-electric',
+    chordOctaves: [3, 4, 4],
+    reverb: { decay: 1.8, wet: 0.28 },
+    filter: { type: 'highpass', frequency: 120 },
+    distortion: 0.4,
+    chorus: null,
+    volume: -6
   }
-  return notes;
-}
-
-function scaleSemis(rootName, mode){
-  const base = NOTE_NAMES.indexOf(rootName);
-  return MODE_INTERVALS[mode].map(s=> (s+base)%12);
-}
-
-const SYNTH_SETTINGS = {
-  electric_guitar_clean: { oscillator: { type: 'square' } },
-  acoustic_grand_piano:  { oscillator: { type: 'triangle' } },
-  electric_bass_finger:  { oscillator: { type: 'sawtooth' } },
-  distortion_guitar:     { oscillator: { type: 'sawtooth' } }
 };
+
+const instrumentChains = {};
+
+function noteName(semi, oct = 4) {
+  const name = NOTE_NAMES[((semi % 12) + 12) % 12];
+  return name + oct;
+}
+
+function adjustOctave(note, shift) {
+  const match = note.match(/([A-G]#?)(\d+)/);
+  if (!match) return note;
+  const base = match[1];
+  const octave = parseInt(match[2], 10) + shift;
+  return base + octave;
+}
+
+function chordSemitones(rootName, mode, degree) {
+  const base = NOTE_NAMES.indexOf(rootName);
+  const scale = MODE_INTERVALS[mode].map((s) => (s + base) % 12);
+  const idx = (degree - 1) % 7;
+  return [scale[idx], scale[(idx + 2) % 7], scale[(idx + 4) % 7]];
+}
+
+function chordNotes(rootName, mode, degree, octaves) {
+  const semis = chordSemitones(rootName, mode, degree);
+  return semis.map((semi, i) => noteName(semi, octaves[i] || octaves[octaves.length - 1]));
+}
+
+function chordDisplay(semis) {
+  return semis.map((s) => NOTE_NAMES[((s % 12) + 12) % 12]).join('–');
+}
+
+async function ensureInstrumentChain(key) {
+  if (instrumentChains[key]) return instrumentChains[key];
+  const profile = INSTRUMENT_PROFILES[key] || INSTRUMENT_PROFILES.piano;
+  if (typeof SampleLibrary === 'undefined') {
+    throw new Error('SampleLibrary not loaded');
+  }
+  const sampler = SampleLibrary.load({
+    instruments: profile.library,
+    baseUrl: 'https://nbrosowsky.github.io/tonejs-instruments/samples/',
+    minify: true,
+    release: 1
+  });
+  await Tone.loaded();
+
+  const reverb = new Tone.Reverb(profile.reverb).toDestination();
+  let chainEnd = reverb;
+
+  if (profile.distortion) {
+    const dist = new Tone.Distortion(profile.distortion);
+    dist.connect(chainEnd);
+    chainEnd = dist;
+  }
+
+  if (profile.chorus) {
+    const chorus = new Tone.Chorus(profile.chorus.frequency, profile.chorus.delayTime, profile.chorus.depth).start();
+    chorus.connect(chainEnd);
+    chainEnd = chorus;
+  }
+
+  if (profile.filter) {
+    const filter = new Tone.Filter(profile.filter);
+    filter.connect(chainEnd);
+    chainEnd = filter;
+  }
+
+  sampler.connect(chainEnd);
+  sampler.volume.value = profile.volume || 0;
+
+  instrumentChains[key] = { sampler, output: reverb };
+  return instrumentChains[key];
+}
 
 const app = Vue.createApp({
   template: `
@@ -73,10 +156,18 @@ const app = Vue.createApp({
         </label>
         <label>Instrument
           <select v-model="instrument">
-            <option value="electric_guitar_clean">Electric Guitar</option>
-            <option value="acoustic_grand_piano">Piano</option>
-            <option value="electric_bass_finger">Bass</option>
+            <option value="guitar">Electric Guitar</option>
+            <option value="piano">Piano</option>
+            <option value="bass">Bass</option>
             <option value="distortion_guitar">Distortion Guitar</option>
+          </select>
+        </label>
+        <label>Bars
+          <select v-model.number="bars">
+            <option value="4">4</option>
+            <option value="8">8</option>
+            <option value="12">12</option>
+            <option value="16">16</option>
           </select>
         </label>
         <button @click="generate" :disabled="isPlaying">Generate Riff</button>
@@ -84,68 +175,147 @@ const app = Vue.createApp({
       <div class="producer-tip" v-if="tip">
         <strong>Producer's Tip:</strong> {{ tip }}
       </div>
-      <textarea v-model="progressionText" rows="2"></textarea>
+      <textarea v-model="progressionText" rows="2" readonly></textarea>
     </div>
   `,
-  data(){
+  data() {
     return {
       tempo: 120,
       mode: 'major',
-      instrument: 'electric_guitar_clean',
+      instrument: 'guitar',
+      bars: 8,
       progressionText: '',
-      tip: TIPS[Math.floor(Math.random()*TIPS.length)],
+      tip: TIPS[Math.floor(Math.random() * TIPS.length)],
       isPlaying: false
     };
   },
-  methods:{
-    async generate(){
+  computed: {
+    instrumentProfile() {
+      return INSTRUMENT_PROFILES[this.instrument] || INSTRUMENT_PROFILES.piano;
+    }
+  },
+  methods: {
+    randomTip() {
+      return TIPS[Math.floor(Math.random() * TIPS.length)];
+    },
+    getProgression() {
+      return MODE_PROGRESSIONS[this.mode] || MODE_PROGRESSIONS.major;
+    },
+    buildTonePool(chord) {
+      const pool = [chord.notes[0], chord.notes[1], chord.notes[2]];
+      pool.push(adjustOctave(chord.notes[0], 1));
+      return pool;
+    },
+    generateBarPattern(chord, barIndex) {
+      const pool = this.buildTonePool(chord);
+      const pattern = PATTERN_LIBRARY[(barIndex + Math.floor(Math.random() * PATTERN_LIBRARY.length)) % PATTERN_LIBRARY.length];
+      return pattern.map((step) => pool[step % pool.length]);
+    },
+    buildChords(root) {
+      const pattern = this.getProgression();
+      const chords = [];
+      for (let i = 0; i < this.bars; i++) {
+        const degree = pattern[i % pattern.length];
+        const semis = chordSemitones(root, this.mode, degree);
+        const notes = chordNotes(root, this.mode, degree, this.instrumentProfile.chordOctaves);
+        chords.push({
+          display: chordDisplay(semis),
+          notes
+        });
+      }
+      return chords;
+    },
+    async fetchProducerTip(summary) {
       const statusEl = document.getElementById('riff-status');
-      if(statusEl){
+      if (statusEl) statusEl.textContent = "Producer's Tip: thinking...";
+      const config = window.seRiffConfig || {};
+      if (!config.tipEndpoint) {
+        this.tip = this.randomTip();
+        return;
+      }
+      try {
+        const res = await fetch(config.tipEndpoint, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-WP-Nonce': config.nonce || ''
+          },
+          body: JSON.stringify({
+            mode: this.mode,
+            tempo: this.tempo,
+            instrument: this.instrument,
+            summary: summary
+          })
+        });
+        if (!res.ok) throw new Error('Tip request failed');
+        const data = await res.json();
+        if (data && data.tip) {
+          this.tip = data.tip;
+          return;
+        }
+      } catch (err) {
+        console.error('Tip fetch failed', err);
+      }
+      this.tip = this.randomTip();
+    },
+    async generate() {
+      const statusEl = document.getElementById('riff-status');
+      if (statusEl) {
         statusEl.textContent = 'Generating...';
         statusEl.style.display = 'block';
       }
-      const root = NOTE_NAMES[Math.floor(Math.random()*NOTE_NAMES.length)];
-      const pattern = PROGRESSIONS[Math.floor(Math.random()*PROGRESSIONS.length)];
-      const chords = pattern.map(d=> chordNotes(root,this.mode,d));
-      const scale = scaleSemis(root,this.mode);
-      const melody = chords.flatMap(ch => generateMelody(scale,ch.map(n=>NOTE_NAMES.indexOf(n.slice(0,-1))),2));
-      this.progressionText = chords.map(c=>c.map(n=>n.slice(0,-1)).join('-')).join(' | ');
+
+      const root = NOTE_NAMES[Math.floor(Math.random() * NOTE_NAMES.length)];
+      const chords = this.buildChords(root);
+      const patterns = chords.map((ch, idx) => this.generateBarPattern(ch, idx));
+
+      this.progressionText = chords.map((c) => c.display).join(' | ');
+      this.tip = "Producer's Tip: thinking...";
+
       try {
-        await this.play(chords, melody);
-        if(statusEl) statusEl.textContent = 'Riff ready!';
-      } catch(e){
-        if(statusEl) statusEl.textContent = 'Error generating riff';
+        await this.play(chords, patterns);
+        if (statusEl) statusEl.textContent = 'Riff ready!';
+      } catch (e) {
+        if (statusEl) statusEl.textContent = 'Error generating riff';
         console.error(e);
       }
-      this.tip = TIPS[Math.floor(Math.random()*TIPS.length)];
+
+      this.fetchProducerTip(this.progressionText + ` @ ${this.tempo} BPM (${this.mode})`);
     },
-    async play(chords, melody){
+    async play(chords, patterns) {
       this.isPlaying = true;
       await Tone.start();
-      const synth = new Tone.PolySynth(Tone.Synth, SYNTH_SETTINGS[this.instrument]);
-      const reverb = new Tone.Reverb({decay:2,wet:0.3}).toDestination();
-      const delay  = new Tone.FeedbackDelay({delayTime:'8n',feedback:0.2,wet:0.2});
-      synth.chain(delay,reverb);
+      const chain = await ensureInstrumentChain(this.instrument);
+      const sampler = chain.sampler;
       const recorder = new Tone.Recorder();
-      synth.connect(recorder);
+      chain.output.connect(recorder);
       recorder.start();
-      const noteDur = 60/this.tempo;
-      let t = Tone.now()+0.3;
-      chords.forEach(ch => {
-        ch.forEach(n=> synth.triggerAttackRelease(n,noteDur,t));
-        t += noteDur;
+
+      const beat = 60 / this.tempo;
+      const barDuration = beat * 4;
+      const stepDuration = barDuration / (patterns[0] ? patterns[0].length : 8);
+      const startTime = Tone.now() + 0.4;
+
+      patterns.forEach((pattern, barIndex) => {
+        const barStart = startTime + barIndex * barDuration;
+        const chord = chords[barIndex];
+        sampler.triggerAttackRelease(chord.notes, barDuration * 0.9, barStart);
+        pattern.forEach((note, step) => {
+          sampler.triggerAttackRelease(note, stepDuration * 0.9, barStart + step * stepDuration);
+        });
       });
-      melody.forEach((n,i)=>{
-        synth.triggerAttackRelease(n,noteDur/2, Tone.now()+0.3+i*(noteDur/2));
-      });
-      setTimeout(async()=>{
-        const rec = await recorder.stop();
-        const url = URL.createObjectURL(rec);
+
+      const totalDuration = barDuration * patterns.length + 0.8;
+      setTimeout(async () => {
+        const recording = await recorder.stop();
+        const url = URL.createObjectURL(recording);
         const audio = document.getElementById('riff-audio');
-        audio.src = url;
-        audio.style.display='block';
-        this.isPlaying=false;
-      }, (chords.length+1)*noteDur*1000);
+        if (audio) {
+          audio.src = url;
+          audio.style.display = 'block';
+        }
+        this.isPlaying = false;
+      }, totalDuration * 1000);
     }
   }
 });

--- a/page-riff-generator.php
+++ b/page-riff-generator.php
@@ -18,6 +18,13 @@ get_header();
 </div>
 
 <script src="https://unpkg.com/tone@14.7.77/build/Tone.js"></script>
+<script src="https://unpkg.com/tonejs-instruments@1.0.25/dist/tonejs-instruments.min.js"></script>
+<script>
+  window.seRiffConfig = {
+    tipEndpoint: '<?php echo esc_url( rest_url( 'se/v1/riff-tip' ) ); ?>',
+    nonce: '<?php echo wp_create_nonce( 'wp_rest' ); ?>'
+  };
+</script>
 <script src="https://cdn.jsdelivr.net/npm/vue@3.3.4/dist/vue.global.prod.js"></script>
 <script src="<?php echo get_template_directory_uri(); ?>/js/riff-generator.js"></script>
 <?php get_footer(); ?>


### PR DESCRIPTION
## Summary
- add sample-based Tone.js instrument chains with distinct processing and user-selectable bar lengths for riffs
- generate chord-based arpeggios with clearer chord text and asynchronously fetch producer tips via OpenAI
- centralize OpenAI chat helper for Albini Q&A, track analyzer, and the new riff-tip REST endpoint

## Testing
- php -l functions.php
- php -l page-riff-generator.php
- php -l page-track-analyzer.php
- php -l inc/openai.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923d0f575b4832e9d76c805647590f3)