### PR TITLE
Enhance goal riff and add shot tracking

### DIFF
--- a/page-arcade.php
+++ b/page-arcade.php
@@ -25,6 +25,7 @@ get_header();
                         <p class="pixel-font">CONTROLS:</p>
                         <p>Arrow Keys – Move Player</p>
                         <p>Spacebar – Shoot Puck</p>
+                        <button id="test-goal-sound" class="pixel-button">Test goal sound</button>
                     </div>
 
                     <div id="game-overlay" class="game-overlay">


### PR DESCRIPTION
## Summary
- Reworked the goal melody into a louder arena-style synth hook with envelopes, filtering, and a subtle crowd noise tail while ensuring the audio context reliably resumes.
- Tracked Canucks shot attempts with updated scoreboard text and added a slight goalie speed ramp as time winds down.
- Added an on-page "Test goal sound" button to trigger the riff without altering gameplay.

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924061576b4832e9c6b004ed337d503)