### PR TITLE
Add WP-Cron background refresh for Lousy Outages snapshots

### DIFF
--- a/lousy-outages/README.md
+++ b/lousy-outages/README.md
@@ -52,7 +52,7 @@ Place `[lousy_outages]` in any page or post to render the status table. A page t
 
 ## Development
 
-Polling runs via WP-Cron (`lousy_outages_poll`). Results are stored in an option and also exposed at `/wp-json/lousy-outages/v1/status`.
+Polling runs via WP-Cron (`lousy_outages_poll`). A separate background refresh (`lousy_outages_cron_refresh`) updates the snapshot and "Last fetched" timestamp every 15 minutes; on low-traffic sites, point a system cron at `wp-cron.php` to keep it firing. Results are stored in an option and also exposed at `/wp-json/lousy-outages/v1/status`.
 
 ## How to subscribe to RSS
 

--- a/lousy-outages/includes/Cron/Refresh.php
+++ b/lousy-outages/includes/Cron/Refresh.php
@@ -11,6 +11,7 @@ class Refresh
     {
         add_filter('cron_schedules', [self::class, 'registerSchedule']);
         add_action('init', [self::class, 'ensureScheduled']);
+        add_action('lousy_outages_cron_refresh', '\\lousy_outages_refresh_data');
         add_action('lousy_outages_refresh', [IncidentAlerts::class, 'run']);
         add_action('lo_send_daily_digest', [IncidentAlerts::class, 'send_daily_digest']);
     }
@@ -21,6 +22,13 @@ class Refresh
             $schedules['five_minutes'] = [
                 'interval' => 5 * MINUTE_IN_SECONDS,
                 'display'  => __('Every 5 Minutes', 'lousy-outages'),
+            ];
+        }
+
+        if (! isset($schedules['lousy_outages_15min'])) {
+            $schedules['lousy_outages_15min'] = [
+                'interval' => 15 * MINUTE_IN_SECONDS,
+                'display'  => __('Every 15 Minutes', 'lousy-outages'),
             ];
         }
 
@@ -36,6 +44,10 @@ class Refresh
 
     public static function ensureScheduled(): void
     {
+        if (! wp_next_scheduled('lousy_outages_cron_refresh')) {
+            wp_schedule_event(time() + MINUTE_IN_SECONDS, 'lousy_outages_15min', 'lousy_outages_cron_refresh');
+        }
+
         if (! wp_next_scheduled('lousy_outages_refresh')) {
             wp_schedule_event(time() + MINUTE_IN_SECONDS, 'five_minutes', 'lousy_outages_refresh');
         }

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -112,7 +112,7 @@ function render_shortcode(): string {
         }
     }
 
-    $fetched_at = gmdate('c');
+    $fetched_at = '';
     $tiles      = [];
     $config     = null;
     $refresh_interval = 60000;
@@ -240,6 +240,14 @@ function render_shortcode(): string {
         }
         if (!isset($config['historyEndpoint'])) {
             $config['historyEndpoint'] = esc_url_raw(rest_url('lousy-outages/v1/history'));
+        }
+    }
+
+    $last_fetched_timestamp = \lousy_outages_get_last_fetched_timestamp();
+    if ($last_fetched_timestamp) {
+        $fetched_at = wp_date('c', $last_fetched_timestamp);
+        if (isset($config['initial']['fetched_at'])) {
+            $config['initial']['fetched_at'] = $fetched_at;
         }
     }
 


### PR DESCRIPTION
## Summary
- add background WP-Cron schedule for refreshing Lousy Outages data and tracking last fetched time
- centralize refresh logic with locking and reuse it for manual refreshes and snapshot updates
- feed the shortcode with stored last fetched timestamps and document the new cron behavior

## Testing
- php -l lousy-outages/lousy-outages.php
- php -l lousy-outages/includes/Api.php
- php -l lousy-outages/includes/Cron/Refresh.php
- php -l lousy-outages/public/shortcode.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69242cf28848832e82285e369578e004)