### PR TITLE
Fix last fetched timestamp handling and cron cadence

### DIFF
--- a/__tests__/refresh-loop.test.js
+++ b/__tests__/refresh-loop.test.js
@@ -149,3 +149,104 @@ test('manual refresh falls back to status endpoint when refresh endpoint fails',
   assert.ok(!countdown.textContent.startsWith('Status fetch failed'));
   assert.equal(button.disabled, false);
 });
+
+test('manual refresh treats skipped lock as success and keeps timestamp aligned', async () => {
+  const isoInitial = '2025-11-25T01:55:30-08:00';
+  const isoUpdated = '2025-11-25T02:25:30-08:00';
+  let fetchCount = 0;
+
+  mockFetch.mockImplementation((url, options = {}) => {
+    if (options && options.method === 'POST') {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            ok: false,
+            skipped: true,
+            refreshedAt: isoUpdated,
+            refreshed_at: Math.floor(new Date(isoUpdated).getTime() / 1000)
+          })
+      });
+    }
+
+    fetchCount += 1;
+    const isRefresh = String(url || '').includes('refresh=1');
+    const currentIso = isRefresh || fetchCount > 1 ? isoUpdated : isoInitial;
+    return Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          providers: [
+            {
+              id: 'github',
+              provider: 'GitHub',
+              name: 'GitHub',
+              stateCode: 'operational',
+              state: 'Operational',
+              summary: '',
+              incidents: [],
+              updatedAt: currentIso
+            }
+          ],
+          meta: { fetchedAt: currentIso }
+        })
+    });
+  });
+
+  app.init({
+    endpoint: '/api/outages',
+    pollInterval: 200,
+    refreshEndpoint: '/wp-json/lousy-outages/v1/refresh',
+    refreshNonce: 'skip-nonce',
+    providers: [{ id: 'github', name: 'GitHub' }],
+    strings: {},
+    fallbackStrings: {},
+    fetchTimeout: 150,
+    initial: {
+      fetchedAt: isoInitial,
+      meta: { fetchedAt: isoInitial },
+      providers: [
+        {
+          id: 'github',
+          name: 'GitHub',
+          state: 'Operational',
+          summary: '',
+          incidents: []
+        }
+      ]
+    }
+  });
+
+  await flushPromises();
+  await wait(50);
+  await flushPromises();
+
+  const formatter = new Intl.DateTimeFormat(undefined, {
+    weekday: 'short',
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit'
+  });
+
+  const lastUpdated = document.querySelector('.last-updated span');
+  const initialText = lastUpdated.textContent;
+  assert.equal(initialText, formatter.format(new Date(isoInitial)));
+
+  const button = document.querySelector('.coin-btn');
+  button.dispatchEvent({ type: 'click' });
+
+  await flushPromises();
+  await wait(120);
+  await flushPromises();
+
+  const refreshCall = mockFetch.calls.find(call => call[0] === '/wp-json/lousy-outages/v1/refresh');
+  assert.ok(refreshCall);
+
+  const updatedText = lastUpdated.textContent;
+  assert.equal(updatedText, formatter.format(new Date(isoUpdated)));
+  const countdown = document.querySelector('.board-subtitle');
+  assert.ok(!countdown.textContent.toLowerCase().startsWith('status fetch failed'));
+});

--- a/lousy-outages/assets/hud.js
+++ b/lousy-outages/assets/hud.js
@@ -60,8 +60,8 @@
     if (!value) {
       return '';
     }
-    var parsed = Date.parse(value);
-    if (Number.isNaN(parsed)) {
+    var d = new Date(value);
+    if (Number.isNaN(d.getTime())) {
       return value;
     }
     try {
@@ -72,9 +72,9 @@
         hour: '2-digit',
         minute: '2-digit',
         second: '2-digit'
-      }).format(new Date(parsed));
+      }).format(d);
     } catch (err) {
-      return new Date(parsed).toISOString();
+      return d.toISOString();
     }
   }
 

--- a/lousy-outages/assets/lousy-outages.js
+++ b/lousy-outages/assets/lousy-outages.js
@@ -1991,10 +1991,13 @@
       if (!res) {
         throw new Error('No response');
       }
-      if (!res.ok) {
-        throw new Error('HTTP ' + res.status);
-      }
-      return res.json().catch(function () { return null; });
+      var statusOk = !!res.ok;
+      return res.json().catch(function () { return null; }).then(function (data) {
+        if (!statusOk && !(data && data.skipped)) {
+          throw new Error('HTTP ' + res.status);
+        }
+        return data;
+      });
     });
   }
 

--- a/lousy-outages/includes/Cron/Refresh.php
+++ b/lousy-outages/includes/Cron/Refresh.php
@@ -27,8 +27,9 @@ class Refresh
 
         if (! isset($schedules['lousy_outages_15min'])) {
             $schedules['lousy_outages_15min'] = [
-                'interval' => 15 * MINUTE_IN_SECONDS,
-                'display'  => __('Every 15 Minutes', 'lousy-outages'),
+                // Snapshot refresh cadence for HUD data (~30 minutes).
+                'interval' => 30 * MINUTE_IN_SECONDS,
+                'display'  => __('Every 30 Minutes', 'lousy-outages'),
             ];
         }
 

--- a/lousy-outages/includes/Snapshot.php
+++ b/lousy-outages/includes/Snapshot.php
@@ -75,7 +75,14 @@ if (! function_exists('lo_snapshot_refresh')) {
         }
 
         $raw = lousy_outages_get_snapshot($force_refresh);
-        $updated_at = isset($raw['fetched_at']) ? (string) $raw['fetched_at'] : gmdate('c');
+        // Keep snapshot updated_at aligned with the canonical last-fetched option
+        // used by the HUD/meta displays.
+        $last_fetched_iso = function_exists('lousy_outages_get_last_fetched_iso')
+            ? lousy_outages_get_last_fetched_iso()
+            : null;
+        $updated_at = $last_fetched_iso
+            ? $last_fetched_iso
+            : (isset($raw['fetched_at']) ? (string) $raw['fetched_at'] : gmdate('c'));
         $services = [];
         if (! empty($raw['providers']) && is_array($raw['providers'])) {
             foreach ($raw['providers'] as $provider) {
@@ -141,8 +148,13 @@ if (! function_exists('lo_snapshot_prepare_response')) {
     function lo_snapshot_prepare_response(array $stored, bool $stale): array
     {
         $ttl = lo_snapshot_default_ttl();
+        $last_fetched_iso = function_exists('lousy_outages_get_last_fetched_iso')
+            ? lousy_outages_get_last_fetched_iso()
+            : null;
         $response = [
-            'updated_at'  => isset($stored['updated_at']) ? (string) $stored['updated_at'] : gmdate('c'),
+            'updated_at'  => $last_fetched_iso
+                ? $last_fetched_iso
+                : (isset($stored['updated_at']) ? (string) $stored['updated_at'] : gmdate('c')),
             'ttl_seconds' => $ttl,
             'services'    => [],
             'stale'       => $stale,

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -113,6 +113,9 @@ function render_shortcode(): string {
     }
 
     $fetched_at = '';
+    $last_fetched_iso = \function_exists('lousy_outages_get_last_fetched_iso')
+        ? \lousy_outages_get_last_fetched_iso()
+        : '';
     $tiles      = [];
     $config     = null;
     $refresh_interval = 60000;
@@ -243,12 +246,17 @@ function render_shortcode(): string {
         }
     }
 
-    $last_fetched_timestamp = \lousy_outages_get_last_fetched_timestamp();
-    if ($last_fetched_timestamp) {
-        $fetched_at = wp_date('c', $last_fetched_timestamp);
-        if (isset($config['initial']['fetched_at'])) {
-            $config['initial']['fetched_at'] = $fetched_at;
+    if ($last_fetched_iso) {
+        if ('' === $fetched_at) {
+            $fetched_at = $last_fetched_iso;
         }
+        if (isset($config['initial']['fetched_at'])) {
+            $config['initial']['fetched_at'] = $last_fetched_iso;
+        }
+    }
+
+    if ('' === $fetched_at) {
+        $fetched_at = $last_fetched_iso ?: gmdate('c');
     }
 
     $tiles_by_slug = [];


### PR DESCRIPTION
## Summary
- add a canonical last-fetched helper and ensure refreshes store and expose consistent epoch/ISO timestamps for the HUD and snapshot
- treat refresh lock skips as successful responses, update HUD formatting, and bump the refresh cron cadence to roughly 30 minutes
- improve shortcode/snapshot fallbacks and extend tests to cover skipped manual refreshes and timestamp alignment

## Testing
- php -l lousy-outages/lousy-outages.php
- php -l lousy-outages/includes/Api.php
- php -l lousy-outages/includes/Cron/Refresh.php
- php -l lousy-outages/includes/Snapshot.php
- php -l lousy-outages/public/shortcode.php
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692435e27444832e92ec11d5d69f1267)