### PR TITLE
Fix scoring logic and add retro flair to Canucks game

### DIFF
--- a/page-arcade.php
+++ b/page-arcade.php
@@ -19,6 +19,16 @@ get_header();
                         <div id="scoreboard" class="scoreboard"></div>
                     </div>
 
+                    <div class="avatar-select">
+                        <label for="avatar-select-input" class="pixel-font">Choose Your Avatar</label>
+                        <select id="avatar-select-input" aria-label="Choose your Canucks legend" class="pixel-select">
+                            <option value="classic" selected>Classic Canuck</option>
+                            <option value="gino">Gino Odjick</option>
+                            <option value="captain">The Captain</option>
+                        </select>
+                        <p class="avatar-tip">Press "G" anytime to toggle Gino mode for a surprise.</p>
+                    </div>
+
                     <canvas id="canucks-game" class="game-canvas" role="img" aria-label="Canucks retro hockey game"></canvas>
 
                     <div class="controls">

--- a/style.css
+++ b/style.css
@@ -292,22 +292,128 @@ body::before {
 }
 
 .goal-animation {
-  animation: goalPop 0.8s ease-out;
+  position: relative;
+  animation: goalPop 0.9s ease-out, goalFlash 0.18s steps(2) 5;
+}
+
+.goal-animation .goal-light {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  margin: 0 auto 12px;
+  background: radial-gradient(circle, #ff7777 0%, #aa0000 50%, #330000 100%);
+  box-shadow: 0 0 24px 8px rgba(255, 0, 0, 0.7), 0 0 60px 24px rgba(255, 0, 0, 0.35);
+  animation: sirenSpin 1s linear infinite;
+}
+
+.goal-animation .goal-text {
+  font-size: 28px;
+  letter-spacing: 3px;
+}
+
+.goal-animation .goal-subtext {
+  font-size: 12px;
+  margin-top: 8px;
+  opacity: 0.9;
+}
+
+.miss-animation {
+  animation: missShake 0.35s ease-in-out;
+}
+
+.miss-animation .miss-text {
+  color: #ffcc00;
+  text-shadow: 2px 2px #000;
+}
+
+.miss-animation .miss-subtext {
+  font-size: 12px;
+  opacity: 0.8;
 }
 
 @keyframes goalPop {
   0% {
-    transform: scale(0.5);
+    transform: scale(0.6) rotate(-4deg);
     opacity: 0;
   }
-  50% {
-    transform: scale(1.2);
+  45% {
+    transform: scale(1.25) rotate(3deg);
     opacity: 1;
   }
   100% {
     transform: scale(1);
     opacity: 1;
   }
+}
+
+@keyframes goalFlash {
+  0% {
+    filter: brightness(1);
+  }
+  50% {
+    filter: brightness(1.4);
+  }
+  100% {
+    filter: brightness(1);
+  }
+}
+
+@keyframes sirenSpin {
+  0% {
+    transform: rotate(0deg) scale(0.95);
+  }
+  50% {
+    transform: rotate(180deg) scale(1.05);
+  }
+  100% {
+    transform: rotate(360deg) scale(0.95);
+  }
+}
+
+@keyframes missShake {
+  0% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-8px);
+  }
+  50% {
+    transform: translateX(8px);
+  }
+  75% {
+    transform: translateX(-4px);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
+.avatar-select {
+  margin: 10px 0 14px;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.avatar-select label {
+  font-size: 14px;
+}
+
+.pixel-select {
+  font-family: "Press Start 2P", cursive;
+  background: #0b1b34;
+  color: #fff;
+  border: 2px solid var(--primary-color);
+  padding: 8px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.avatar-tip {
+  margin: 0;
+  font-size: 12px;
+  opacity: 0.8;
 }
 
 /* ====================== */


### PR DESCRIPTION
## Summary
- tighten goal detection so only true net shots score and missed or saved shots can trigger miss feedback
- add retro-inspired goal/miss overlays, siren effects, and crowd/buzzer audio to the mini-game
- introduce selectable avatars (including Gino Odjick easter egg) with jersey art and UI controls

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69258ce133f4832ea592520abc9b20b3)