### PR TITLE
Improve outage feeds and retro charts

### DIFF
--- a/lousy-outages/includes/Api.php
+++ b/lousy-outages/includes/Api.php
@@ -632,6 +632,23 @@ class Api {
             'providers'    => [],
         ];
 
+        $yearOverYear = $incidentStore->getYearOverYearWindow($days, $importantOnly);
+        $response['meta']['year_over_year'] = [
+            'current'  => [
+                'start'        => gmdate('Y-m-d', $yearOverYear['current']['start'] ?? $windowStart),
+                'end'          => gmdate('Y-m-d', $yearOverYear['current']['end'] ?? $windowEnd),
+                'total'        => $yearOverYear['current']['total'] ?? 0,
+                'daily_counts' => $yearOverYear['current']['daily_counts'] ?? [],
+            ],
+            'previous' => [
+                'start'        => gmdate('Y-m-d', $yearOverYear['previous']['start'] ?? ($windowStart - YEAR_IN_SECONDS)),
+                'end'          => gmdate('Y-m-d', $yearOverYear['previous']['end'] ?? ($windowEnd - YEAR_IN_SECONDS)),
+                'total'        => $yearOverYear['previous']['total'] ?? 0,
+                'daily_counts' => $yearOverYear['previous']['daily_counts'] ?? [],
+            ],
+            'delta'    => ($yearOverYear['current']['total'] ?? 0) - ($yearOverYear['previous']['total'] ?? 0),
+        ];
+
         foreach ($providers as $provider) {
             $history = $provider['history'];
             ksort($history);


### PR DESCRIPTION
## Summary
- fix custom Lousy Outages feeds by adding rewrite rules, charset handling, and pulling recent incidents from the persistent store
- extend outage history retention with new date-range helpers and year-over-year summaries for reporting
- refresh the history visualizations with a retro-styled theme and add a canvas-based year-over-year comparison chart

## Testing
- php -l includes/Feed.php
- php -l includes/Api.php
- php -l includes/Storage/IncidentStore.php
- php -l includes/Store.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926b1ff4e20832e9319ae80b12f0dff)