### PR TITLE
Add rewrites for status feed slug

### DIFF
--- a/lousy-outages/includes/Feeds.php
+++ b/lousy-outages/includes/Feeds.php
@@ -25,7 +25,19 @@ class Feeds {
         );
 
         add_rewrite_rule(
+            '^feed/' . self::FEED_NAME . '/?$',
+            'index.php?feed=' . self::FEED_NAME,
+            'top'
+        );
+
+        add_rewrite_rule(
             '^lousy-outages/feed/status/?$',
+            'index.php?feed=' . self::FEED_NAME,
+            'top'
+        );
+
+        add_rewrite_rule(
+            '^' . self::FEED_NAME . '/feed/?$',
             'index.php?feed=' . self::FEED_NAME,
             'top'
         );


### PR DESCRIPTION
## Summary
- add rewrite rules for the `lousy_outages_status` feed so pretty URLs resolve for both `/feed/<slug>/` and `<slug>/feed/`

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926cff707b4832ea577324a92b35672)