### PR TITLE
Resolve Lousy Outages feed slug conflict

### DIFF
--- a/lousy-outages/README.md
+++ b/lousy-outages/README.md
@@ -56,5 +56,5 @@ Polling runs via WP-Cron (`lousy_outages_poll`). A separate background refresh (
 
 ## How to subscribe to RSS
 
-- RSS reader: add `https://suzyeaston.ca/lousy-outages/feed/` to NetNewsWire, Feedly, or your preferred client to receive incident alerts.
+- RSS reader: add `https://suzyeaston.ca/lousy-outages/feed/status/` (or `https://suzyeaston.ca/feed/lousy-outages-status/`) to NetNewsWire, Feedly, or your preferred client to receive incident alerts.
 - Slack or email: point an automation tool such as IFTTT or Zapier at the same feed (trigger: “New RSS item”) and forward the payload to a Slack webhook, email address, or other notification channel.

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -38,7 +38,6 @@ require_once LOUSY_OUTAGES_PATH . 'includes/Precursor.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Subscriptions.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Subscribe.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Api.php';
-require_once LOUSY_OUTAGES_PATH . 'includes/Feed.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Feeds.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Summary.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/IncidentAlerts.php';
@@ -67,14 +66,13 @@ use SuzyEaston\LousyOutages\Email;
 use SuzyEaston\LousyOutages\Precursor;
 use SuzyEaston\LousyOutages\Subscriptions;
 use SuzyEaston\LousyOutages\Api;
-use SuzyEaston\LousyOutages\Feed;
 use SuzyEaston\LousyOutages\Feeds;
 use SuzyEaston\LousyOutages\MailTransport;
 use SuzyEaston\LousyOutages\IncidentAlerts;
 use SuzyEaston\LousyOutages\Cron\Refresh as RefreshCron;
 
 Api::bootstrap();
-Feed::bootstrap();
+// LO: Legacy feed slug removed to avoid clashing with the dashboard page; status feed now handled below.
 Feeds::bootstrap();
 MailTransport::bootstrap();
 IncidentAlerts::bootstrap();
@@ -84,14 +82,6 @@ lo_snapshot_bootstrap();
 lo_cron_bootstrap();
 
 add_action('lousy_outages_purge_pending', [Subscriptions::class, 'purge_stale_pending']);
-
-// LO: pretty URL for custom incidents feed.
-add_action(
-    'init',
-    static function () {
-        add_rewrite_rule( '^lousy-outages/feed/incidents/?$', 'index.php?feed=lousy-outages-incidents', 'top' );
-    }
-);
 
 add_action(
     'lousy_outages_log',


### PR DESCRIPTION
## Summary
- remove the legacy feed bootstrap that conflicted with the Lousy Outages page slug
- keep the status feed registration while clarifying the expected feed URLs in the README

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693986ef5674832eb695cdf4422ee476)