### PR TITLE
Restrict Vancouver tech events debug UI to admins

### DIFF
--- a/inc/vancouver-tech-events.php
+++ b/inc/vancouver-tech-events.php
@@ -1086,7 +1086,8 @@ function suzy_vte_make_absolute_url( string $url, string $base_url ): string {
  * @return array<int, array<string, mixed>>
  */
 function suzy_get_vancouver_tech_events(): array {
-    $debug          = ( isset( $_GET['vte_debug'] ) && '1' === $_GET['vte_debug'] ) || ( defined( 'WP_DEBUG' ) && WP_DEBUG );
+    // Only show debug output when explicitly requested AND user is an admin.
+    $debug          = ( isset( $_GET['vte_debug'] ) && '1' === $_GET['vte_debug'] && current_user_can( 'manage_options' ) );
     $transient_key  = 'suzy_vancouver_tech_events_cache';
     $cached         = $debug ? false : get_transient( $transient_key );
     $debug_report   = [];


### PR DESCRIPTION
### Motivation
- The debug panel for Vancouver tech events was being enabled whenever `WP_DEBUG` was true, risking leakage of internals to public pages.
- Debug output should only appear when explicitly requested and when the viewer is an administrator.
- This change reduces accidental exposure of debug information while preserving the ability to bypass cache for debugging purposes.

### Description
- Updated `suzy_get_vancouver_tech_events()` in `inc/vancouver-tech-events.php` to gate debug output with `current_user_can('manage_options')`.
- Replaced the previous `$debug` assignment so debug is only enabled when `?vte_debug=1` is present and the current user has admin capability, and added a clarifying comment.
- Preserved existing transient caching behavior where entering debug mode still bypasses the cache.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69529a052728832e8f0468b1356d55b3)