### PR TITLE
Add "Coffee for Builders" page, SEO meta, and site links

### DIFF
--- a/header.php
+++ b/header.php
@@ -40,6 +40,11 @@
       $meta_desc  = "Shoot, score, and hear 'Don't You Forget About Me' in this 80s-style hockey arcade game.";
       $meta_keywords = 'Canucks arcade game, retro hockey game, Suzy Easton arcade';
       $meta_img   = $default_img;
+    } elseif ( is_page_template( 'page-coffee-for-builders.php' ) ) {
+      $meta_title = 'Coffee for Builders in Vancouver | Suzy Easton';
+      $meta_desc  = 'Coffee chats in Vancouver for people building things—tech, music, civic projects, and sports takes. Low-key, public, and intentional.';
+      $meta_keywords = 'coffee chats Vancouver, builders, Suzy Easton, tech, music, civic projects, sports takes';
+      $meta_img   = $default_img;
     } else {
       $meta_title = wp_title( '|', false, 'right' ) . $site_name;
       $meta_desc  = get_bloginfo( 'description' );

--- a/page-bio.php
+++ b/page-bio.php
@@ -14,6 +14,7 @@ get_header();
             
             <p>My creative pursuits include live video jam sessions, new music releases, and comedic documentary filmmaking about life in Vancouver. Lately I'm focused on writing album reviews of classic jazz and rock records I uncovered while working at HMV (2007&ndash;2012, Burrard &amp; Robson). After the single <em>A Little Louder</em> aired on CiTR, I'm shifting toward producing a series of hard rock demos. CiTR even spun my electronica track <em>Obsolete</em> again &mdash; it's not my favourite anymore, but I love CiTR!</p>
             
+            <p>If you’re into building things and want to grab a coffee, check out <a href="/coffee-for-builders">Coffee for Builders (Vancouver)</a>.</p>
             <p>For collaborations or just to chat, reach out at <a href="mailto:suzyeaston@icloud.com">suzyeaston@icloud.com</a>.</p>
             <p style="text-align:center;">🎶 <a href="https://suzyeaston.bandcamp.com" target="_blank">Support on Bandcamp</a></p>
             <p style="text-align:center;">New demo drops this weekend. Stay noisy.</p>

--- a/page-coffee-for-builders.php
+++ b/page-coffee-for-builders.php
@@ -1,0 +1,62 @@
+<?php
+/*
+Template Name: Coffee for Builders
+*/
+get_header();
+?>
+
+<main id="main-content">
+    <section class="page-content">
+        <h1>Coffee for Builders (Vancouver)</h1>
+        <p>(plus sports takes, riffs, and general civic chaos)</p>
+
+        <p>I’m Suzy — Vancouver-born engineer + musician. I’ve toured as a bassist, recorded in Chicago with Steve Albini, and now I work in the world of identity/cloud/automation/QA/WordPress/DevOps-ish reliability stuff.</p>
+        <p>This page is simple: I want to meet more people outside my existing sphere — folks building things (tech, music, creative projects, startups, community work)… and yes, I also love sports, so I’m never mad if the conversation detours into Canucks pain, NFL picks, or “why did the coach do that?!”</p>
+
+        <h2>What this is</h2>
+        <p>A low-key coffee chat with a stranger who builds things. No networking theatre. No “let’s circle back.” Just a human conversation.</p>
+
+        <h2>What we can talk about</h2>
+        <p>Pick your own adventure:</p>
+        <ul>
+            <li>Shipping software, automating boring stuff, keeping systems from melting</li>
+            <li>Music-making, recording, songwriting, gear rabbit holes</li>
+            <li>Side projects (I run a little lab on my site — outage dashboards, audio tools, etc.)</li>
+            <li>Vancouver civic stuff (tenant advocacy / city decisions / local weirdness)</li>
+            <li>Sports: NHL/NFL/NBA hot takes, analytics, pools, “capper logic,” whatever</li>
+        </ul>
+
+        <h2>How it works</h2>
+        <ul>
+            <li>30–45 minutes</li>
+            <li>Public spot (coffee shop / lobby / busy place)</li>
+            <li>Vancouver proper (I’m not commuting to Mars, sorry)</li>
+            <li>If we vibe, we can do it again. If not, we had a nice coffee and return to our respective caves.</li>
+        </ul>
+
+        <h2>The only rule</h2>
+        <p>Bring one thing you’re excited about right now — a project, a question, a plan, a weird obsession. Curiosity required.</p>
+
+        <h2>How to say hi</h2>
+        <p>Send me a message with:</p>
+        <ul>
+            <li>What you’re building (or learning)</li>
+            <li>A song you’ve had on repeat</li>
+            <li>Your ideal low-key Vancouver hang</li>
+            <li>And if you’re a sports nerd: your team + your most controversial take</li>
+        </ul>
+        <p>Contact: (use a form here)</p>
+        <p>—or— email: <a href="mailto:suzyeaston@icloud.com?subject=Coffee%20for%20Builders">suzyeaston@icloud.com</a> with subject: Coffee for Builders</p>
+        <p><strong>One tweak I strongly recommend (because it’ll pull better dudes):</strong><br>
+        Subject: Coffee for Builders — [their project]. Lazy guys won’t do it. Good.</p>
+
+        <h2>Small print (aka the adult section)</h2>
+        <ul>
+            <li>First meet is public. Always.</li>
+            <li>No pitches for crypto casinos, “marketing partnerships,” or “let me 10x your SEO.”</li>
+            <li>If you’re reading this as a single person: cool — I’m not allergic to romance — but I’m starting with coffee + conversation like a functioning grown-up.</li>
+        </ul>
+    </section>
+</main>
+
+<?php get_footer(); ?>

--- a/page-home.php
+++ b/page-home.php
@@ -118,6 +118,7 @@ get_header();
                 <h3 class="group-title">📚 About &amp; Info</h3>
                 <div class="group-buttons">
                     <a href="/bio" class="pixel-button">About Suzy</a>
+                    <a href="/coffee-for-builders" class="pixel-button">Coffee for Builders</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
### Motivation
- Add a new public-facing page to invite local builders to low-key coffee chats and capture the supplied copy in a WordPress page template.
- Ensure the new page has appropriate SEO metadata so it displays a good title/description when shared or crawled.
- Make the page discoverable from the site by linking it from the homepage and the bio page.

### Description
- Add a new template `page-coffee-for-builders.php` containing the provided page copy and structure for the Coffee for Builders content.
- Wire a template-specific meta block into `header.php` so that `is_page_template('page-coffee-for-builders.php')` sets the meta title, description, keywords, and Open Graph image.
- Add a homepage link to the new page in `page-home.php` and a reference from the bio in `page-bio.php` to improve discoverability.
- Commit includes the new file and updates to `header.php`, `page-home.php`, and `page-bio.php`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69529f66870c832e93c35c7a3dd19e71)