### PR TITLE
Improve Coffee for Builders layout and CTA styling

### DIFF
--- a/page-coffee-for-builders.php
+++ b/page-coffee-for-builders.php
@@ -8,7 +8,7 @@ get_header();
 <main id="main-content">
     <section class="page-content">
         <h1>Coffee for Builders (Vancouver)</h1>
-        <p>(plus sports takes, riffs, and a little civic chaos)</p>
+        <p class="page-subtitle">(plus sports takes, riffs, and a little civic chaos)</p>
 
         <p>I’m Suzy, Vancouver-born engineer + musician. I came up through classical music and recording arts, toured for years as a bassist, and recorded in Chicago with Steve Albini. These days I build and run things in the identity/cloud/automation/QA/WordPress/DevOps-ish reliability universe — the unglamorous but sacred art of making systems behave.</p>
         <p>Outside work, I run a small lab on this site: tools like Lousy Outages (a retro outage dashboard to keep third-party providers honest) and an audio analysis tool for musicians using OpenAI/Whisper (hah thats a work in progress). I also still write, record, and release music.</p>
@@ -47,8 +47,10 @@ get_header();
             <li>Your ideal low-key Vancouver hang</li>
             <li>And if you’re a sports nerd: your team + your most controversial take</li>
         </ul>
-        <p>Email: <a href="mailto:suzyeaston@icloud.com?subject=Coffee%20for%20Builders%20%E2%80%94%20%5Byour%20project%5D">suzyeaston@icloud.com</a></p>
-        <p><strong>Pro tip:</strong> Subject line = <em>Coffee for Builders — [your project]</em>. It helps me spot the good stuff fast.</p>
+        <div class="coffee-cta">
+            <p>Email: <a href="mailto:suzyeaston@icloud.com?subject=Coffee%20for%20Builders%20%E2%80%94%20%5Byour%20project%5D">suzyeaston@icloud.com</a></p>
+            <p><strong>Pro tip:</strong> Subject line = <em>Coffee for Builders — [your project]</em>. It helps me spot the good stuff fast.</p>
+        </div>
 
         <h2>Small print (aka the adult section)</h2>
         <ul>

--- a/style.css
+++ b/style.css
@@ -40,6 +40,18 @@ a,
 }
 
 /* ====================== */
+/*    PAGE CONTENT BASE   */
+/* ====================== */
+.page-content {
+  max-width: 980px;
+  margin: 0 auto 60px;
+  padding: 0 18px;
+  font-size: 1.05rem;
+  line-height: 1.85;
+  text-align: left;
+}
+
+/* ====================== */
 /*    RETRO SCREEN EFFECT */
 /* ====================== */
 body::before {
@@ -2132,6 +2144,53 @@ body {
     }
 }
 
+/* Coffee for Builders page */
+.page-template-page-coffee-for-builders .page-content {
+    background: linear-gradient(135deg, rgba(6, 10, 4, 0.95), rgba(10, 18, 8, 0.92));
+    border: 2px solid rgba(57, 255, 20, 0.55);
+    border-radius: 18px;
+    box-shadow: 0 0 0 2px rgba(10, 12, 8, 0.9), 0 0 24px rgba(57, 255, 20, 0.25);
+    padding: 32px 28px 40px;
+}
+
+.page-template-page-coffee-for-builders .page-subtitle {
+    margin-top: 12px;
+    font-size: 0.95rem;
+    color: rgba(57, 255, 20, 0.9);
+}
+
+.page-template-page-coffee-for-builders .page-content p,
+.page-template-page-coffee-for-builders .page-content li {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+      "Courier New", monospace;
+    font-size: 1.02rem;
+    line-height: 1.85;
+    color: var(--primary-color);
+}
+
+.page-template-page-coffee-for-builders .coffee-cta {
+    margin: 28px 0 32px;
+    padding: 18px 20px;
+    border: 2px dashed rgba(57, 255, 20, 0.6);
+    border-radius: 14px;
+    background: rgba(6, 12, 6, 0.6);
+    box-shadow: inset 0 0 18px rgba(57, 255, 20, 0.12);
+}
+
+.page-template-page-coffee-for-builders .coffee-cta p {
+    margin: 0 0 12px;
+}
+
+.page-template-page-coffee-for-builders .coffee-cta p:last-child {
+    margin-bottom: 0;
+}
+
+@media (max-width: 640px) {
+    .page-template-page-coffee-for-builders .page-content {
+        padding: 24px 18px 32px;
+    }
+}
+
 /* Canucks stats placeholder */
 .canucks-stats-page .page-content {
     max-width: 720px;
@@ -2424,4 +2483,3 @@ body {
     text-align: center;
   }
 }
-


### PR DESCRIPTION
### Motivation
- Constrain article content so pages using `class="page-content"` don't render as full-width terminal text.
- Keep the retro CRT aesthetic while making body copy readable and scannable on the Coffee page.
- Make the email CTA and pro tip more prominent and easier to spot when shared.

### Description
- Add a base container rule in `style.css` for `.page-content` to set `max-width`, `margin`, `padding`, `font-size`, and `line-height`.
- Add Coffee-specific terminal-card styling in `style.css` under `.page-template-page-coffee-for-builders .page-content` including neon border, glow, and responsive padding.
- Use a readable monospace body font for `p` and `li` on the Coffee page while keeping headings in the arcade font, via `page-template-page-coffee-for-builders` selectors.
- Update `page-coffee-for-builders.php` to add a `page-subtitle` class and wrap the email + pro tip in a `.coffee-cta` block for styling.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953022dffb0832e8fce1fe0534023dd)