### PR TITLE
Add hero feature photo card to homepage

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -35,6 +35,13 @@ get_header();
                 </div>
                 <p class="hero-copy"><?php echo esc_html($hero_copy); ?></p>
             </div>
+            <div class="hero-side hero-photo-card">
+                <p class="hero-side-header">Feature photo</p>
+                <div class="hero-photo-frame">
+                    <img class="hero-photo" src="https://www.suzyeaston.ca/wp-content/uploads/2026/01/IMG_9003.jpg" alt="Suzanne (Suzy) Easton in a retro-styled portrait" loading="lazy" decoding="async">
+                </div>
+                <p class="hero-photo-caption pixel-font">Vancouver, BC</p>
+            </div>
         </div>
         <section class="lo-callout lo-8bit">
           <h2>LOUSY OUTAGES<br><span>LIVE STATUS DASHBOARD</span></h2>

--- a/style.css
+++ b/style.css
@@ -2436,6 +2436,51 @@ body {
   margin-bottom: 0.25rem;
 }
 
+.hero-photo-card {
+  padding: 1.75rem;
+  background: rgba(10, 14, 24, 0.78);
+  border: 1px solid rgba(146, 210, 255, 0.3);
+  box-shadow: inset 0 0 0 1px rgba(120, 180, 255, 0.12), 0 18px 40px rgba(0, 0, 0, 0.45);
+}
+
+.hero-photo-frame {
+  position: relative;
+  padding: 0.75rem;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(29, 44, 70, 0.95), rgba(14, 18, 34, 0.96));
+  box-shadow: 0 0 0 1px rgba(135, 207, 255, 0.22), inset 0 0 18px rgba(69, 148, 255, 0.2);
+  overflow: hidden;
+  z-index: 1;
+}
+
+.hero-photo-frame::after {
+  content: "";
+  position: absolute;
+  inset: 8% 12%;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(110, 240, 255, 0.2), transparent 70%);
+  opacity: 0.65;
+  pointer-events: none;
+}
+
+.hero-photo {
+  width: 100%;
+  display: block;
+  border-radius: 12px;
+  border: 1px solid rgba(208, 236, 255, 0.5);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+  filter: saturate(1.08) contrast(1.05);
+}
+
+.hero-photo-caption {
+  margin: 0.9rem 0 0;
+  font-size: 0.82rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(190, 225, 255, 0.75);
+  text-align: center;
+}
+
 .grimes-sidequest {
   background: rgba(24, 32, 48, 0.72);
   border: 1px solid rgba(142, 221, 255, 0.28);


### PR DESCRIPTION
### Motivation
- Add a feature image block to the homepage hero so a portrait appears near the top of the layout and matches the retro/CRT styling. 
- Keep the image as a default media URL that can be replaced later. 

### Description
- Inserted a new `div` inside `.hero-grid` (`<div class="hero-side hero-photo-card">...`) in `page-home.php` that renders the feature image using the exact default URL `https://www.suzyeaston.ca/wp-content/uploads/2026/01/IMG_9003.jpg` and a caption. 
- Added styling for the new components in `style.css`: `.hero-photo-card`, `.hero-photo-frame`, `.hero-photo-frame::after`, `.hero-photo`, and `.hero-photo-caption`. 
- The block is placed as `.hero-side` so it sits as the right-side column on desktop and stacks under the main hero on narrow screens. 
- Files modified: `page-home.php` and `style.css`.

### Testing
- Launched a local PHP server with `php -S` and ran a Playwright script to render `/page-home.php` and capture a screenshot, which completed successfully and produced `artifacts/home-hero.png`. 
- Verified changes were staged and committed (`git` commit succeeded). 
- No unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69593aaed788832e9eaf80cdedef335c)