### PR TITLE
Use site host for homepage hero image URL

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -38,7 +38,7 @@ get_header();
             <div class="hero-side hero-photo-card">
                 <p class="hero-side-header">Feature photo</p>
                 <div class="hero-photo-frame">
-                    <img class="hero-photo" src="https://www.suzyeaston.ca/wp-content/uploads/2026/01/IMG_9003.jpg" alt="Suzanne (Suzy) Easton in a retro-styled portrait" loading="lazy" decoding="async">
+                    <img class="hero-photo" src="<?php echo esc_url(home_url('/wp-content/uploads/2026/01/IMG_9003.jpg')); ?>" alt="Suzanne (Suzy) Easton in a retro-styled portrait" loading="lazy" decoding="async">
                 </div>
                 <p class="hero-photo-caption pixel-font">Vancouver, BC</p>
             </div>


### PR DESCRIPTION
### Motivation
- The homepage used a hard-coded absolute image URL pointing at `https://www.suzyeaston.ca/...` which caused the feature photo to fail loading when the site is served from a different host (a `403` was observed when requesting the absolute URL).
- Making the image URL dynamic prevents host mismatches between `www` and non-`www` domains and avoids cross-host access issues.
- This improves portability of the theme across environments and domain configurations.

### Description
- Replaced the hard-coded `https://www.suzyeaston.ca/wp-content/uploads/2026/01/IMG_9003.jpg` with `<?php echo esc_url(home_url('/wp-content/uploads/2026/01/IMG_9003.jpg')); ?>` in `page-home.php`.
- The inserted call uses `home_url()` to derive the current site host and `esc_url()` for safe output.
- Only `page-home.php` was modified.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69593c4dc8bc832e840ea88699c10cd8)