### PR TITLE
Fix hero photo visibility in homepage hero

### DIFF
--- a/assets/brand/hero-wordmark.css
+++ b/assets/brand/hero-wordmark.css
@@ -79,8 +79,7 @@
 }
 
 /* Kill the old bitmap/logo in hero only */
-.home .hero img[alt*="EASTON"],
-.home .hero img[src*="east"],
+.home .hero .old-logo,
 .home .hero .logo,
 .home .hero .site-logo {
   display: none !important;


### PR DESCRIPTION
### Motivation
- The homepage hero image was being hidden unintentionally because CSS matched image `alt`/`src` substrings like "EASTON"/"east`. 
- The change aims to stop suppressing non-logo images while still removing the legacy bitmap logo from the hero. 
- Preserve the new wordmark styling while limiting the hide rule to known legacy logo elements.

### Description
- Updated `assets/brand/hero-wordmark.css` to replace attribute selectors `img[alt*="EASTON"]` and `img[src*="east"]` with the legacy `.old-logo` class in the hero hide rule. 
- The hero hide rule now uses `.home .hero .old-logo, .home .hero .logo, .home .hero .site-logo { display: none !important; }` to avoid catching regular photos. 
- Change was committed with the message `Fix hero photo visibility`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69593d9bfb38832e8113bdcdcf6464be)