### PR TITLE
Filter Zscaler advisories and declutter recent incidents history

### DIFF
--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -591,6 +591,13 @@
 .lo-history__details {
   font-size: 0.95rem;
   line-height: 1.35;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
+.lo-history__summary {
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .lo-history__count {
@@ -615,6 +622,13 @@
 
 .lo-history__error {
   color: #ff6b6b;
+}
+
+.lo-history__toggle {
+  margin-top: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .lousy-outages.lo-theme-light .lo-history__empty {

--- a/lousy-outages/includes/Storage/IncidentStore.php
+++ b/lousy-outages/includes/Storage/IncidentStore.php
@@ -369,6 +369,25 @@ class IncidentStore
             $noisePatterns = [
                 'reminder',
                 'upcoming',
+                'url filtering',
+                'url filtering rules',
+                'pagination',
+                'search functionality',
+                'admin',
+                'administrator',
+                'portal',
+                'dashboard',
+                'analytics',
+                'audit log',
+                'policy',
+                'rules',
+                'allowlist',
+                'allow list',
+                'update to',
+                'scheduled update',
+                'security update',
+                'advisory',
+                'react2shell',
                 'data center expansions',
                 'data centre expansions',
                 'new dcs',
@@ -390,33 +409,50 @@ class IncidentStore
                 'action required',
                 'expansion',
             ];
-            foreach ($noisePatterns as $pattern) {
-                if (false !== strpos($titleLower, $pattern)) {
-                    $severity  = 'maintenance';
-                    $important = false;
-                    $summary   = 'Filtered Zscaler advisory';
+            $impactWords = [
+                'traffic forwarding',
+                'not loading',
+                'issue',
+                'degradation',
+                'customers may experience',
+                'impact',
+                'outage',
+                'disruption',
+                'failure',
+            ];
+
+            $filteredNoise = apply_filters('lo_zscaler_noise_patterns', $noisePatterns);
+            if (! is_array($filteredNoise)) {
+                $filteredNoise = $noisePatterns;
+            }
+            $noisePatterns = $filteredNoise;
+
+            $filteredImpact = apply_filters('lo_zscaler_impact_terms', $impactWords);
+            if (! is_array($filteredImpact)) {
+                $filteredImpact = $impactWords;
+            }
+            $impactWords = $filteredImpact;
+
+            $hasImpact = false;
+            foreach ($impactWords as $signal) {
+                if (false !== strpos($titleLower, (string) $signal)) {
+                    $hasImpact = true;
                     break;
                 }
             }
 
-            if ($important) {
-                $impactWords = [
-                    'traffic forwarding',
-                    'not loading',
-                    'issue',
-                    'degradation',
-                    'customers may experience',
-                    'impact',
-                    'outage',
-                    'disruption',
-                    'failure',
-                ];
-                foreach ($impactWords as $signal) {
-                    if (false !== strpos($titleLower, $signal)) {
-                        $important = true;
-                        break;
-                    }
+            $hasNoise = false;
+            foreach ($noisePatterns as $pattern) {
+                if (false !== strpos($titleLower, (string) $pattern)) {
+                    $hasNoise = true;
+                    break;
                 }
+            }
+
+            if ($hasNoise && ! $hasImpact) {
+                $severity  = 'maintenance';
+                $important = false;
+                $summary   = 'Filtered Zscaler advisory';
             }
         }
 


### PR DESCRIPTION
### Motivation
- Zscaler publishes noisy admin/advisory updates that generate alerts and clutter the "Recent incidents" history list. 
- These advisories should be suppressible from important-only views while remaining available when viewing "all incidents". 
- The history list is hard to scan because long titles and many entries dominate the view. 
- Provide a configurable, non-breaking solution that stays PHP 7.4 compatible and adds no new dependencies. 

### Description
- Expand Zscaler noise classification in `lousy-outages/includes/Storage/IncidentStore.php` with many admin/advisory patterns and keep existing impact words; non-impact Zscaler matches are marked `severity='maintenance'`, `important=false`, and given `impact_summary='Filtered Zscaler advisory'`. 
- Make Zscaler filters configurable via `apply_filters('lo_zscaler_noise_patterns', $noisePatterns)` and `apply_filters('lo_zscaler_impact_terms', $impactWords)`, with safe fallbacks to defaults if filters do not return arrays. 
- Improve history UI in `lousy-outages/assets/lousy-outages.js` by adding `HISTORY_RENDER_LIMIT = 12`, a `Show more` / `Show fewer` toggle (no refetch), severity-first sorting via `getSeverityRank()`, and a `condenseIncidentTitle()` helper that shortens long or domain-heavy Zscaler titles and preserves full text in the `title` tooltip. 
- Add CSS tweaks in `lousy-outages/assets/lousy-outages.css` to improve wrapping (`word-break` / `overflow-wrap`) and style the history toggle button. 

### Testing
- Launched a PHP built-in server and ran a headless Playwright script to load `page-lousy-outages.php` and capture a full-page screenshot, which completed successfully. 
- The page rendered without PHP fatal errors during the smoke test and the modified JS executed to produce the history list snapshot. 
- No automated unit tests were added or run for this change beyond the smoke rendering check. 
- All changes were implemented without adding new dependencies and retain existing provider behavior and history retention semantics.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695948f6c284832ea1e4311f7efef721)