### PR TITLE
Reclassify stored incidents, dedupe indicator events, and stable Statuspage indicator IDs

### DIFF
--- a/lousy-outages/includes/Sources/StatuspageSource.php
+++ b/lousy-outages/includes/Sources/StatuspageSource.php
@@ -99,7 +99,14 @@ if ( ! class_exists('LO_StatuspageSource') ) {
         } else {
           $title = 'Provider reports ' . $ind . ' impact';
           $state = ($ind==='minor' ? 'degraded' : ($ind==='major' ? 'partial_outage' : ($ind==='critical' ? 'major_outage' : 'maintenance')));
-          $out[] = LO_Incident::create($this->name, LO_Incident::make_id($this->name, $title, time()), $title, $state, $this->home, null, null, time(), null);
+          $slug = sanitize_key($this->name);
+          $id = $slug . ':indicator:' . $ind;
+          $updated = time();
+          if (!empty($json['page']['updated_at'])) {
+            $ts = strtotime((string)$json['page']['updated_at']);
+            if ($ts) $updated = $ts;
+          }
+          $out[] = LO_Incident::create($this->name, $id, $title, $state, $this->home, null, null, $updated, null);
         }
       }
 


### PR DESCRIPTION
### Motivation
- Apply the latest classification rules to historical events so old spam (e.g., Zscaler advisories and Cloudflare "Provider reports minor impact") is filtered immediately.  
- Prevent infinite creation of synthetic "Provider reports {ind} impact" history entries on each Statuspage refresh.  
- Compact legacy noisy indicator events once so stored totals and chart/YoY counts drop and performance improves.

### Description
- `lousy-outages/includes/Storage/IncidentStore.php`: `normalizeEvent()` now recomputes and overrides `severity`, `important`, and `impact_summary` for provider incidents while preserving `user_report` entries and operational/ok/none entries, and optionally sets a display-safe `status_normal` of `maintenance` when classification downgrades a `degraded` entry.  
- `IncidentStore` now adds `OPTION_EVENTS_COMPACTED` and calls a one-time `compactNoisyEvents()` from `loadEvents()` when the stored events exceed a threshold, and `compactNoisyEvents()` deduplicates synthetic indicator events (keeps the most recent per `provider|indicator`) and drops stale Cloudflare indicator entries older than 7 days.  
- `lousy-outages/includes/Sources/StatuspageSource.php`: synthetic indicator incidents now use stable IDs built as ``$slug . ':indicator:' . $ind`` instead of `make_id(..., time())`, and set the incident timestamp to the page `updated_at` when available to avoid creating new unique history items per refresh.  
- No new dependencies were added and changes are PHP 7.4 compatible and limited to the two specified files so endpoints/shortcodes/UI are preserved.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69594d2be3d8832ea03f69728aa6d2a1)