### PR TITLE
Harden community report form with “Other” provider, phrase captcha and rate limiting

### DIFF
--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -1313,6 +1313,67 @@
   resize: vertical;
 }
 
+.lo-report__prompt {
+  margin: 0;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--lo-muted);
+}
+
+.lo-report__help {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--lo-muted);
+}
+
+.lo-report__captcha-display {
+  margin: 6px 0;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--lo-border);
+  background: rgba(0, 0, 0, 0.45);
+  color: #f6ff8f;
+  font-family: "IBM Plex Mono", "VT323", monospace;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+}
+
+.lo-report__captcha-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.lo-report__captcha-refresh {
+  align-self: flex-start;
+  border: none;
+  background: none;
+  color: var(--lo-accent);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  padding: 0;
+}
+
+.lo-report__captcha-refresh:hover,
+.lo-report__captcha-refresh:focus {
+  color: #ff6a3a;
+  text-decoration: underline;
+}
+
+.lousy-outages.lo-theme-light .lo-report__prompt,
+.lousy-outages.lo-theme-light .lo-report__help {
+  color: rgba(32, 32, 32, 0.8);
+}
+
+.lousy-outages.lo-theme-light .lo-report__captcha-display {
+  background: rgba(255, 255, 255, 0.9);
+  color: #1f1f1f;
+  border-color: rgba(92, 75, 216, 0.55);
+}
+
 .lo-report__actions {
   display: flex;
   align-items: center;

--- a/page-lousy-outages.php
+++ b/page-lousy-outages.php
@@ -63,12 +63,31 @@ if ($unsub_success) {
       </p>
     </header>
 
-    <form class="lo-report__form" data-lo-report-form novalidate>
+    <form
+      class="lo-report__form"
+      data-lo-report-form
+      data-lo-report-phrase-endpoint="<?php echo esc_url(admin_url('admin-ajax.php')); ?>"
+      novalidate
+    >
       <div class="lo-field">
         <label class="lo-label" for="lo-report-provider">Provider</label>
         <select id="lo-report-provider" name="provider_id" class="lo-input" data-lo-report-provider>
           <!-- Options will be populated by JS from the summary API -->
         </select>
+      </div>
+
+      <div class="lo-field lo-report__other" data-lo-report-other hidden>
+        <label class="lo-label" for="lo-report-provider-name">Provider name</label>
+        <input
+          id="lo-report-provider-name"
+          name="provider_name"
+          type="text"
+          class="lo-input"
+          data-lo-report-provider-name
+          maxlength="80"
+          placeholder="e.g., Telus, Shaw, Discord, Notion"
+        />
+        <p class="lo-report__help">Required when “Other (not listed)” is selected.</p>
       </div>
 
       <div class="lo-field">
@@ -93,6 +112,25 @@ if ($unsub_success) {
           data-lo-report-contact
           placeholder="Email or handle (optional)"
         />
+      </div>
+
+      <div class="lo-field lo-report__captcha" data-lo-report-captcha>
+        <p class="lo-report__prompt">Type the 3-word phrase shown below</p>
+        <div class="lo-report__captcha-display" data-lo-report-captcha-phrase aria-live="polite">Loading phrase…</div>
+        <div class="lo-report__captcha-controls">
+          <label class="lo-label" for="lo-report-captcha">Type the phrase</label>
+          <input
+            id="lo-report-captcha"
+            name="captcha_answer"
+            type="text"
+            class="lo-input"
+            data-lo-report-captcha-input
+            placeholder="Type the phrase"
+          />
+          <input type="hidden" name="captcha_token" data-lo-report-captcha-token />
+          <button type="button" class="lo-report__captcha-refresh" data-lo-report-captcha-refresh>New phrase</button>
+        </div>
+        <p class="lo-report__help">Case doesn’t matter, punctuation optional.</p>
       </div>
 
       <div class="lo-report__actions">


### PR DESCRIPTION
### Motivation
- Reduce spam and drive-by submissions on the community "Report a problem" form while preserving the existing UX and theme.
- Allow users to report providers not present in the tracked dropdown without creating new provider cards.
- Use an in-project lightweight phrase captcha (no third-party services) and server-side validation for robustness.
- Add cheap rate limiting and content checks to further reduce automated abuse.

### Description
- UI: extended the report form (`page-lousy-outages.php`) with an `Other (not listed)` option, a `provider_name` text input, and a 3-word phrase captcha block with a `New phrase` refresh control.
- Frontend: updated `lousy-outages/assets/lousy-outages.js` to populate the `other` option, reveal/validate `provider_name`, fetch/refresh the captcha phrase from `admin-ajax.php?action=lo_get_report_phrase`, normalize answers client-side, and include `provider_name`, `captcha_answer`, and `captcha_token` in the report payload.
- Backend: extended `lousy-outages/includes/Api.php` with a `wp_ajax` handler `handle_report_phrase` to emit a phrase and token (stored in a transient), added server-side normalization/validation for the captcha, enforced `provider_name` length and sanitization with `sanitize_text_field`, guarded against spam tokens and excessive URLs, and added IP-rate limiting (3 reports per IP per hour) using transients.
- Styling: added matching styles in `lousy-outages/assets/lousy-outages.css` to keep the new UI consistent with the theme, and ensured the subscribe forms existing Steve Jobs lyric captcha was left unchanged.

### Testing
- No automated tests were executed as part of this change; `__tests__` were not run in this rollout.
- Basic server-side validation paths added: `sanitize_text_field` and length checks are applied to `provider_name`, and transient-based captcha validation is enforced in the `handle_report` REST handler.
- Rate limiting returns HTTP `429` when the `REPORT_RATE_LIMIT` is exceeded and captcha mismatches return HTTP `400` as coded in `handle_report`.
- Manual frontend flows were wired to request and refresh phrases via `admin-ajax.php?action=lo_get_report_phrase` and to include the token in the submission payload (no automated success/failure run reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959516eb700832e8c0141b745fe3cd1)