### PR TITLE
Restore report submit button + scope Lousy Outages light theme

### DIFF
--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -1,3 +1,4 @@
+.lousy-outages-root,
 .lousy-outages {
   --lo-bg: radial-gradient(circle at 12% 20%, rgba(96, 255, 214, 0.08), transparent 28%),
     radial-gradient(circle at 80% 10%, rgba(255, 168, 255, 0.12), transparent 32%),
@@ -10,17 +11,25 @@
   --lo-pop: #f49ae5;
   --lo-border: rgba(138, 247, 228, 0.42);
   --lo-contrast: #04070f;
+  font-family: 'IBM Plex Mono', 'Courier New', monospace;
+  color: var(--lo-text);
+}
+
+.lousy-outages-root {
+  background: var(--lo-bg);
+}
+
+.lousy-outages {
   max-width: 960px;
   margin: 0 auto;
   padding: 8px 16px;
-  font-family: 'IBM Plex Mono', 'Courier New', monospace;
   background: var(--lo-bg);
-  color: var(--lo-text);
   min-height: 60vh;
   position: relative;
   overflow: hidden;
 }
 
+.lousy-outages-root.lo-theme-light,
 .lousy-outages.lo-theme-light {
   --lo-bg: radial-gradient(circle at 22% 16%, rgba(90, 74, 208, 0.09), transparent 32%),
     radial-gradient(circle at 78% 0%, rgba(245, 111, 191, 0.14), transparent 34%),
@@ -1252,6 +1261,14 @@
   text-align: left;
 }
 
+.lousy-outages-root.lo-theme-light .lo-panel,
+.lousy-outages.lo-theme-light .lo-panel {
+  border-color: rgba(92, 75, 216, 0.45);
+  background: linear-gradient(160deg, rgba(245, 111, 191, 0.12), rgba(255, 255, 255, 0.94));
+  color: var(--lo-text);
+  box-shadow: 0 10px 18px rgba(15, 10, 43, 0.12);
+}
+
 .lo-panel--report {
   max-width: 760px;
 }
@@ -1292,6 +1309,11 @@
   letter-spacing: 0.04em;
 }
 
+.lousy-outages-root.lo-theme-light .lo-label,
+.lousy-outages.lo-theme-light .lo-label {
+  color: rgba(32, 32, 32, 0.85);
+}
+
 .lo-input {
   width: 100%;
   padding: 10px 12px;
@@ -1301,6 +1323,18 @@
   color: var(--lo-text);
   font-size: 0.95rem;
   font-family: inherit;
+}
+
+.lousy-outages-root.lo-theme-light .lo-input,
+.lousy-outages.lo-theme-light .lo-input {
+  background: rgba(255, 255, 255, 0.95);
+  color: #1e1c33;
+  border-color: rgba(92, 75, 216, 0.45);
+}
+
+.lousy-outages-root.lo-theme-light .lo-input::placeholder,
+.lousy-outages.lo-theme-light .lo-input::placeholder {
+  color: rgba(30, 28, 51, 0.55);
 }
 
 .lo-input:focus {
@@ -1363,11 +1397,14 @@
   text-decoration: underline;
 }
 
+.lousy-outages-root.lo-theme-light .lo-report__prompt,
 .lousy-outages.lo-theme-light .lo-report__prompt,
+.lousy-outages-root.lo-theme-light .lo-report__help,
 .lousy-outages.lo-theme-light .lo-report__help {
   color: rgba(32, 32, 32, 0.8);
 }
 
+.lousy-outages-root.lo-theme-light .lo-report__captcha-display,
 .lousy-outages.lo-theme-light .lo-report__captcha-display {
   background: rgba(255, 255, 255, 0.9);
   color: #1f1f1f;
@@ -1381,6 +1418,11 @@
   flex-wrap: wrap;
 }
 
+.lo-report-submit {
+  position: relative;
+  z-index: 2;
+}
+
 .lo-button {
   background: var(--lo-pop);
   color: #050505;
@@ -1392,6 +1434,12 @@
   letter-spacing: 0.05em;
   cursor: pointer;
   transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.lousy-outages-root.lo-theme-light .lo-button,
+.lousy-outages.lo-theme-light .lo-button {
+  color: #1e1c33;
+  box-shadow: 0 6px 14px rgba(92, 75, 216, 0.2);
 }
 
 .lo-button:disabled {
@@ -1454,6 +1502,7 @@
   box-shadow: 0 20px 36px rgba(0, 0, 0, 0.4);
 }
 
+.lousy-outages-root.lo-theme-light .lo-banner,
 .lousy-outages.lo-theme-light .lo-banner {
   background: #fff6e9;
   border-color: rgba(92, 75, 216, 0.45);
@@ -1470,6 +1519,7 @@
   color: #ffecc7;
 }
 
+.lousy-outages-root.lo-theme-light .lo-banner--success,
 .lousy-outages.lo-theme-light .lo-banner--success {
   border-color: rgba(66, 157, 66, 0.7);
   color: #1f5526;
@@ -1480,6 +1530,7 @@
   color: #ffe3cc;
 }
 
+.lousy-outages-root.lo-theme-light .lo-banner--info,
 .lousy-outages.lo-theme-light .lo-banner--info {
   border-color: rgba(0, 93, 173, 0.4);
   color: #1f1f1f;
@@ -1490,6 +1541,7 @@
   color: var(--lo-text);
 }
 
+.lousy-outages-root.lo-theme-light .lo-banner--warning,
 .lousy-outages.lo-theme-light .lo-banner--warning {
   border-color: rgba(92, 75, 216, 0.7);
   color: #1f1f1f;
@@ -1500,6 +1552,7 @@
   color: #ffd7ca;
 }
 
+.lousy-outages-root.lo-theme-light .lo-banner--error,
 .lousy-outages.lo-theme-light .lo-banner--error {
   border-color: rgba(192, 56, 31, 0.7);
   color: #b00020;
@@ -1626,6 +1679,7 @@
   color: var(--lo-muted);
 }
 
+.lousy-outages-root.lo-theme-light .lo-support,
 .lousy-outages.lo-theme-light .lo-support {
   color: rgba(32, 32, 32, 0.85);
   border-color: rgba(92, 75, 216, 0.35);
@@ -1651,6 +1705,7 @@
 }
 
 @media (prefers-color-scheme: light) {
+  .lousy-outages-root:not(.lo-theme-dark),
   .lousy-outages:not(.lo-theme-dark) {
     background: #faf8f0;
     color: var(--lo-text);
@@ -1662,11 +1717,14 @@
     visibility: hidden;
   }
 
+  .lousy-outages-root,
+  .lousy-outages-root *,
   .lousy-outages,
   .lousy-outages * {
     visibility: visible;
   }
 
+  .lousy-outages-root,
   .lousy-outages {
     position: relative;
     background: #ffffff;

--- a/lousy-outages/assets/lousy-outages.js
+++ b/lousy-outages/assets/lousy-outages.js
@@ -231,8 +231,20 @@
       return;
     }
     var desired = theme === 'light' ? 'light' : 'dark';
-    state.container.classList.remove('lo-theme-light', 'lo-theme-dark');
-    state.container.classList.add(desired === 'light' ? 'lo-theme-light' : 'lo-theme-dark');
+    var className = desired === 'light' ? 'lo-theme-light' : 'lo-theme-dark';
+    var targets = [state.container];
+
+    if (!state.container.classList.contains('lousy-outages') && state.container.querySelector) {
+      var nested = state.container.querySelector('.lousy-outages');
+      if (nested && nested.classList) {
+        targets.push(nested);
+      }
+    }
+
+    for (var i = 0; i < targets.length; i += 1) {
+      targets[i].classList.remove('lo-theme-light', 'lo-theme-dark');
+      targets[i].classList.add(className);
+    }
     updateThemeToggleLabel(desired);
     if (persist) {
       storeTheme(desired);
@@ -2693,7 +2705,11 @@
     if (!state.fetchImpl) {
       return;
     }
-    state.container = config.container || state.doc.querySelector('.lousy-outages') || state.doc.getElementById('lousy-outages') || state.doc.querySelector('.lousy-outages-board');
+    state.container = config.container
+      || state.doc.querySelector('.lousy-outages-root')
+      || state.doc.querySelector('.lousy-outages')
+      || state.doc.getElementById('lousy-outages')
+      || state.doc.querySelector('.lousy-outages-board');
     if (!state.container) {
       return;
     }

--- a/page-lousy-outages.php
+++ b/page-lousy-outages.php
@@ -46,128 +46,130 @@ if ($unsub_success) {
 ?>
 
 <main class="lousy-outages-page">
-  <div class="lo-atmosphere">
-    <h1 class="retro-title glow-lite">Lousy Outages</h1>
-    <p class="lo-atmosphere__lede">Retro radar for when the internet goes sideways.</p>
-  </div>
-  <?php if ($banner) : ?>
-    <div class="lo-banner lo-banner--<?php echo esc_attr($tone); ?>">
-      <p><?php echo esc_html($banner); ?></p>
+  <div class="lousy-outages-root lo-theme-dark">
+    <div class="lo-atmosphere">
+      <h1 class="retro-title glow-lite">Lousy Outages</h1>
+      <p class="lo-atmosphere__lede">Retro radar for when the internet goes sideways.</p>
     </div>
-  <?php endif; ?>
-  <section class="lo-panel lo-panel--report" data-lo-report>
-    <header class="lo-panel__header">
-      <h2 class="lo-panel__title">Report a problem</h2>
-      <p class="lo-panel__subtitle">
-        If you’re seeing issues with a provider that aren’t reflected below, send a quick community report.
-      </p>
-    </header>
-
-    <form
-      class="lo-report__form"
-      data-lo-report-form
-      data-lo-report-phrase-endpoint="<?php echo esc_url(admin_url('admin-ajax.php')); ?>"
-      novalidate
-    >
-      <div class="lo-field">
-        <label class="lo-label" for="lo-report-provider">Provider</label>
-        <select id="lo-report-provider" name="provider_id" class="lo-input" data-lo-report-provider>
-          <!-- Options will be populated by JS from the summary API -->
-        </select>
+    <?php if ($banner) : ?>
+      <div class="lo-banner lo-banner--<?php echo esc_attr($tone); ?>">
+        <p><?php echo esc_html($banner); ?></p>
       </div>
+    <?php endif; ?>
+    <section class="lo-panel lo-panel--report" data-lo-report>
+      <header class="lo-panel__header">
+        <h2 class="lo-panel__title">Report a problem</h2>
+        <p class="lo-panel__subtitle">
+          If you’re seeing issues with a provider that aren’t reflected below, send a quick community report.
+        </p>
+      </header>
 
-      <div class="lo-field lo-report__other" data-lo-report-other hidden>
-        <label class="lo-label" for="lo-report-provider-name">Provider name</label>
-        <input
-          id="lo-report-provider-name"
-          name="provider_name"
-          type="text"
-          class="lo-input"
-          data-lo-report-provider-name
-          maxlength="80"
-          placeholder="e.g., Telus, Shaw, Discord, Notion"
-        />
-        <p class="lo-report__help">Required when “Other (not listed)” is selected.</p>
-      </div>
+      <form
+        class="lo-report__form"
+        data-lo-report-form
+        data-lo-report-phrase-endpoint="<?php echo esc_url(admin_url('admin-ajax.php')); ?>"
+        novalidate
+      >
+        <div class="lo-field">
+          <label class="lo-label" for="lo-report-provider">Provider</label>
+          <select id="lo-report-provider" name="provider_id" class="lo-input" data-lo-report-provider>
+            <!-- Options will be populated by JS from the summary API -->
+          </select>
+        </div>
 
-      <div class="lo-field">
-        <label class="lo-label" for="lo-report-summary">What are you seeing?</label>
-        <textarea
-          id="lo-report-summary"
-          name="summary"
-          rows="3"
-          class="lo-input lo-input--textarea"
-          data-lo-report-summary
-          placeholder="Short description of the issue (timeouts, errors, etc.)"
-        ></textarea>
-      </div>
-
-      <div class="lo-field">
-        <label class="lo-label" for="lo-report-contact">Contact (optional)</label>
-        <input
-          id="lo-report-contact"
-          name="contact"
-          type="text"
-          class="lo-input"
-          data-lo-report-contact
-          placeholder="Email or handle (optional)"
-        />
-      </div>
-
-      <div class="lo-field lo-report__captcha" data-lo-report-captcha>
-        <p class="lo-report__prompt">Type the 3-word phrase shown below</p>
-        <div class="lo-report__captcha-display" data-lo-report-captcha-phrase aria-live="polite">Loading phrase…</div>
-        <div class="lo-report__captcha-controls">
-          <label class="lo-label" for="lo-report-captcha">Type the phrase</label>
+        <div class="lo-field lo-report__other" data-lo-report-other hidden>
+          <label class="lo-label" for="lo-report-provider-name">Provider name</label>
           <input
-            id="lo-report-captcha"
-            name="captcha_answer"
+            id="lo-report-provider-name"
+            name="provider_name"
             type="text"
             class="lo-input"
-            data-lo-report-captcha-input
-            placeholder="Type the phrase"
+            data-lo-report-provider-name
+            maxlength="80"
+            placeholder="e.g., Telus, Shaw, Discord, Notion"
           />
-          <input type="hidden" name="captcha_token" data-lo-report-captcha-token />
-          <button type="button" class="lo-report__captcha-refresh" data-lo-report-captcha-refresh>New phrase</button>
+          <p class="lo-report__help">Required when “Other (not listed)” is selected.</p>
         </div>
-        <p class="lo-report__help">Case doesn’t matter, punctuation optional.</p>
-      </div>
 
-      <div class="lo-report__actions">
-        <button type="submit" class="lo-button" data-lo-report-submit>Submit report</button>
-        <p class="lo-report__status" data-lo-report-status aria-live="polite"></p>
-      </div>
-    </form>
-  </section>
-  <section class="lo-status-board">
-    <div class="lo-status-board__frame">
-      <header class="lo-status-board__header">
-        <div class="lo-status-board__lights" aria-hidden="true">
-          <span class="lo-led lo-led--green"></span>
-          <span class="lo-led lo-led--amber"></span>
-          <span class="lo-led lo-led--red"></span>
+        <div class="lo-field">
+          <label class="lo-label" for="lo-report-summary">What are you seeing?</label>
+          <textarea
+            id="lo-report-summary"
+            name="summary"
+            rows="3"
+            class="lo-input lo-input--textarea"
+            data-lo-report-summary
+            placeholder="Short description of the issue (timeouts, errors, etc.)"
+          ></textarea>
         </div>
-        <div class="lo-status-board__titles">
-          <p class="lo-status-board__eyebrow">System Status Console</p>
-          <h2 class="lo-status-board__title">Current Outages</h2>
+
+        <div class="lo-field">
+          <label class="lo-label" for="lo-report-contact">Contact (optional)</label>
+          <input
+            id="lo-report-contact"
+            name="contact"
+            type="text"
+            class="lo-input"
+            data-lo-report-contact
+            placeholder="Email or handle (optional)"
+          />
         </div>
-        <div class="lo-status-board__badge" aria-hidden="true">v3.0 arcade build</div>
-      </header>
-      <div class="lo-status-board__body">
-        <div class="lo-scanline" aria-hidden="true"></div>
-        <?php echo do_shortcode('[lousy_outages]'); ?>
+
+        <div class="lo-field lo-report__captcha" data-lo-report-captcha>
+          <p class="lo-report__prompt">Type the 3-word phrase shown below</p>
+          <div class="lo-report__captcha-display" data-lo-report-captcha-phrase aria-live="polite">Loading phrase…</div>
+          <div class="lo-report__captcha-controls">
+            <label class="lo-label" for="lo-report-captcha">Type the phrase</label>
+            <input
+              id="lo-report-captcha"
+              name="captcha_answer"
+              type="text"
+              class="lo-input"
+              data-lo-report-captcha-input
+              placeholder="Type the phrase"
+            />
+            <input type="hidden" name="captcha_token" data-lo-report-captcha-token />
+            <button type="button" class="lo-report__captcha-refresh" data-lo-report-captcha-refresh>New phrase</button>
+          </div>
+          <p class="lo-report__help">Case doesn’t matter, punctuation optional.</p>
+        </div>
+
+        <div class="lo-report__actions">
+          <button type="submit" class="lo-button lo-report-submit" data-lo-report-submit>Submit report</button>
+          <p class="lo-report__status" data-lo-report-status aria-live="polite"></p>
+        </div>
+      </form>
+    </section>
+    <section class="lo-status-board">
+      <div class="lo-status-board__frame">
+        <header class="lo-status-board__header">
+          <div class="lo-status-board__lights" aria-hidden="true">
+            <span class="lo-led lo-led--green"></span>
+            <span class="lo-led lo-led--amber"></span>
+            <span class="lo-led lo-led--red"></span>
+          </div>
+          <div class="lo-status-board__titles">
+            <p class="lo-status-board__eyebrow">System Status Console</p>
+            <h2 class="lo-status-board__title">Current Outages</h2>
+          </div>
+          <div class="lo-status-board__badge" aria-hidden="true">v3.0 arcade build</div>
+        </header>
+        <div class="lo-status-board__body">
+          <div class="lo-scanline" aria-hidden="true"></div>
+          <?php echo do_shortcode('[lousy_outages]'); ?>
+        </div>
       </div>
-    </div>
-  </section>
-  <footer class="lo-support">
-    <p class="lo-support__lead">If this dashboard makes your on-call a little less lousy, you can help keep it running:</p>
-    <ul class="lo-support__links">
-      <li>☕ <a class="lo-link" href="https://buymeacoffee.com/wi0amge" target="_blank" rel="noopener">Buy Me a Coffee</a></li>
-      <li>💖 <a class="lo-link" href="https://paypal.me/suzyeaston" target="_blank" rel="noopener">Donate via PayPal</a></li>
-      <li>🎵 <a class="lo-link" href="https://suzyeaston.bandcamp.com/" target="_blank" rel="noopener">Listen on Bandcamp (new release coming soon!)</a></li>
-    </ul>
-    <p class="lo-support__note">Thanks for fueling the retro outage radar.</p>
-  </footer>
+    </section>
+    <footer class="lo-support">
+      <p class="lo-support__lead">If this dashboard makes your on-call a little less lousy, you can help keep it running:</p>
+      <ul class="lo-support__links">
+        <li>☕ <a class="lo-link" href="https://buymeacoffee.com/wi0amge" target="_blank" rel="noopener">Buy Me a Coffee</a></li>
+        <li>💖 <a class="lo-link" href="https://paypal.me/suzyeaston" target="_blank" rel="noopener">Donate via PayPal</a></li>
+        <li>🎵 <a class="lo-link" href="https://suzyeaston.bandcamp.com/" target="_blank" rel="noopener">Listen on Bandcamp (new release coming soon!)</a></li>
+      </ul>
+      <p class="lo-support__note">Thanks for fueling the retro outage radar.</p>
+    </footer>
+  </div>
 </main>
 
 <?php get_footer(); ?>


### PR DESCRIPTION
### Motivation
- Make the Report a problem form usable again by restoring a visible, clickable Submit button that follows the arcade styling. 
- Fix broken light mode by scoping theme classes to a dedicated Lousy Outages root to avoid collisions with the site theme. 
- Persist the existing retro UI and avoid adding new dependencies or changing global site theming. 

### Description
- Added a dedicated root wrapper (`.lousy-outages-root`) in `page-lousy-outages.php` and initialize it as `lo-theme-dark` to scope theme toggling to the plugin UI. 
- Updated `lousy-outages/assets/lousy-outages.js` to look for `.lousy-outages-root`, and changed `applyTheme` to apply `lo-theme-light`/`lo-theme-dark` to both the root container and any nested `.lousy-outages` element. 
- Restored and emphasized the form submit button by adding `lo-report-submit` to the submit `button` in `page-lousy-outages.php` and ensured it is not hidden; added related CSS rules and light-mode adjustments in `lousy-outages/assets/lousy-outages.css` (scoped under `.lousy-outages-root.lo-theme-light` and `.lousy-outages.lo-theme-light`). 
- Scoped numerous light-mode overrides (panels, inputs, banners, support area, placeholders, button styles) under the new root to preserve the rest of the site theme and retain the retro arcade look. 

### Testing
- No automated tests were run against these changes. 
- Changes are template/CSS/JS-only and were crafted to be PHP 7.4 compatible with no new dependencies. 
- Manual inspection expected: submit button visible and clickable, Enter still submits, light/dark toggle switches and persists via the existing storage key. 
- Dark mode behavior was preserved by applying theme classes to the scoped root only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959561224b0832e9bc5fe1e77ea3d5e)