### PR TITLE
Show community reports in history and refresh on submit

### DIFF
--- a/lousy-outages/assets/lousy-outages.js
+++ b/lousy-outages/assets/lousy-outages.js
@@ -1952,6 +1952,14 @@
         return prefs[String(id).toLowerCase()] !== false;
       });
     }
+    if (hasPrefs) {
+      var hasOther = providerIds.some(function (id) {
+        return String(id).toLowerCase() === 'other';
+      });
+      if (!hasOther) {
+        providerIds.push('other');
+      }
+    }
 
     var windowDays = Number.isFinite(state.historyWindowDays) && state.historyWindowDays > 0
       ? state.historyWindowDays
@@ -1959,7 +1967,7 @@
     var url = appendQuery(state.historyEndpoint, 'days', String(windowDays));
     url = appendQuery(url, 'limit', String(HISTORY_LIMIT));
     url = appendQuery(url, 'severity', state.historyImportantOnly ? 'important' : 'all');
-    if (providerIds.length) {
+    if (hasPrefs && providerIds.length) {
       url = appendQuery(url, 'provider', providerIds.join(','));
     }
 
@@ -2306,6 +2314,9 @@
           }
           requestReportPhrase();
           setReportStatus(message || 'Thanks for the report. We will review it shortly.', 'success');
+          fetchHistoryData().catch(function () {
+            // Ignore history refresh errors after submit.
+          });
         } else {
           setReportStatus(message || 'Could not submit report right now, please try again later.', 'error');
         }

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -437,7 +437,7 @@ function render_shortcode(): string {
         <section class="lo-history" data-lo-history>
             <div class="lo-history__heading">
                 <div>
-                    <h3 class="lo-block-title">Recent incidents (GitHub)</h3>
+                    <h3 class="lo-block-title">Recent incidents (Status feeds + community)</h3>
                     <p class="lo-history__meta">Last 30 days of non-operational blips.</p>
                 </div>
                 <div class="lo-history__controls">


### PR DESCRIPTION
### Motivation
- The history view always appended a `provider=` filter which excluded user-submitted reports stored with `provider_id = "other"`.
- Community reports should appear in the Recent incidents list and charts alongside provider feeds.
- After a user submits a report, the history UI should refresh immediately so the new report appears without a page reload.

### Description
- Updated `fetchHistoryData()` in `lousy-outages/assets/lousy-outages.js` to only append the `provider` query when saved provider visibility prefs exist and to always include `other` in the provider list when prefs are present.
- Changed `handleReportSubmit()` in `lousy-outages/assets/lousy-outages.js` to call `fetchHistoryData()` after a successful report submit so the history list and charts update immediately.
- Renamed the history header in `lousy-outages/public/shortcode.php` from `Recent incidents (GitHub)` to `Recent incidents (Status feeds + community)` to accurately reflect mixed sources.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69596c649520832e8dcc1f29e8f83b93)