### PR TITLE
Remove Downdetector provider and add External signals tile

### DIFF
--- a/lousy-outages/README.md
+++ b/lousy-outages/README.md
@@ -22,13 +22,9 @@ Monitor third‑party service status and get SMS and email alerts when things br
 | aws | AWS | https://status.aws.amazon.com/rss/all.rss |
 | azure | Azure | https://azurestatuscdn.azureedge.net/en-us/status/feed/ |
 | gcp | Google Cloud | https://www.google.com/appsstatus/dashboard/en-CA/feed.atom |
-| downdetector-ca | Downdetector (CA Aggregate) | https://downdetector.ca/archive/?format=rss |
 
 Zscaler is queried from `https://trust.zscaler.com` to dodge intermittent DNS failures. New default providers include TeamViewer, Linear, and Sentry—toggle any of them from **Settings → Lousy Outages**.
 
-Downdetector is disabled by default because the RSS feed is unofficial and can disappear; enable it from the settings page if it loads for you. When the feed is unreachable, the adapter reports an `unknown` state with an error badge rather than failing the whole poll.
-
-When enabled, downdetector trends are folded into the early-warning engine. If Downdetector publishes fresh reports for a service, the dashboard raises the provider’s risk score, surfaces the headlines in the card UI, and pushes a `[EARLY WARNING]` item into the RSS feed for quick triage.
 
 To add or remove a provider, edit `includes/Providers.php` or use the checkboxes under **Settings → Lousy Outages** in wp-admin.
 

--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -756,6 +756,23 @@
   display: none;
 }
 
+.lo-card--external .lo-summary {
+  margin-bottom: 4px;
+}
+
+.lo-links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.lo-links li {
+  margin: 0;
+}
+
 .lo-title {
   color: var(--lo-accent);
   font-weight: 700;

--- a/lousy-outages/includes/Providers.php
+++ b/lousy-outages/includes/Providers.php
@@ -108,8 +108,6 @@ class Providers {
             ],
             ['id' => 'azure', 'name' => 'Azure', 'type' => 'rss', 'url' => 'https://rssfeed.azure.status.microsoft/en-us/status/feed/'],
             ['id' => 'gcp', 'name' => 'Google Cloud', 'type' => 'atom', 'url' => 'https://www.google.com/appsstatus/dashboard/en-CA/feed.atom'],
-            // Optional aggregate (disabled by default in settings)
-            ['id' => 'downdetector-ca', 'name' => 'Downdetector (CA Aggregate)', 'type' => 'rss', 'url' => 'https://downdetector.ca/archive/?format=rss', 'disabled' => true, 'optional' => true],
         ];
     }
 

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -26,7 +26,6 @@ require_once LOUSY_OUTAGES_PATH . 'includes/Adapters/Statuspage.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Store.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Trending.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Fetcher.php';
-require_once LOUSY_OUTAGES_PATH . 'includes/Downdetector.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/I18n.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Detector.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/SMS.php';
@@ -1269,4 +1268,3 @@ add_action( 'rest_api_init', function () {
         },
     ] );
 } );
-

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -471,7 +471,6 @@ function render_shortcode(): string {
                 <strong data-lo-trending-text>Potential widespread issues detected — check affected providers</strong>
                 <span class="lo-trending__reasons" data-lo-trending-reasons<?php echo $trending_signals ? '' : ' hidden'; ?>><?php echo esc_html($trending_signals ? 'Signals: ' . implode(', ', array_slice($trending_signals, 0, 6)) : ''); ?></span>
             </div>
-            <a class="lo-link" href="https://downdetector.com/" target="_blank" rel="noopener">Downdetector →</a>
         </div>
         <?php endif; ?>
         <?php echo render_subscribe_shortcode(); ?>
@@ -571,6 +570,17 @@ function render_shortcode(): string {
                     <?php endif; ?>
                 </article>
             <?php endforeach; ?>
+            <article class="lo-card lo-card--external" data-provider-id="external-signals">
+                <div class="lo-head">
+                    <h3 class="lo-title">External signals</h3>
+                </div>
+                <p class="lo-summary">Quick links to community chatter and third-party status hints.</p>
+                <ul class="lo-links">
+                    <li><a class="lo-link" href="https://downdetector.com/" target="_blank" rel="noopener">Downdetector</a></li>
+                    <li><a class="lo-link" href="https://x.com/search?q=outage" target="_blank" rel="noopener">Twitter/X search</a></li>
+                    <li><a class="lo-link" href="https://www.reddit.com/r/sysadmin/" target="_blank" rel="noopener">Reddit r/sysadmin</a></li>
+                </ul>
+            </article>
         </div>
     </div>
     <?php


### PR DESCRIPTION
### Motivation
- Downdetector (CA Aggregate) is returning `OPTIONAL_UNAVAILABLE`/HTTP 403 and the plugin should not scrape or depend on it. 
- Remove the provider from the registry and stop any background fetches so no cron or polling hits Downdetector endpoints. 
- Eliminate the provider-specific error/UI noise so the dashboard no longer shows the red 403 banner. 
- Optionally provide a non-scraping informational tile linking to external community sources instead of attempting to parse Downdetector.

### Description
- Removed the `downdetector-ca` entry from the provider list in `includes/Providers.php`. 
- Stopped loading the adapter by removing the `require_once 'includes/Downdetector.php'` include and removed Downdetector enrichment from `includes/Precursor.php` so it no longer calls or depends on Downdetector. 
- Removed the Downdetector link in the trending banner and added a static `External signals` card in `public/shortcode.php` with outbound links to Downdetector, Twitter/X search, and Reddit, and added supporting styles in `assets/lousy-outages.css`. 
- Cleaned up the README (`lousy-outages/README.md`) to remove the Downdetector entry and explanatory text.

### Testing
- No automated tests were run against the modified code in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69596ee8b9f4832ea2a29c4c7722f249)