### PR TITLE
Split Google providers, stop showing resolved RSS items as active, remove Downdetector, and add Statuspage fallback

### DIFF
--- a/lousy-outages/includes/Downdetector.php
+++ b/lousy-outages/includes/Downdetector.php
@@ -141,7 +141,8 @@ class Downdetector {
         $map = [
             'aws'         => ['amazon web services', 'amazon'],
             'azure'       => ['microsoft', 'microsoft azure'],
-            'gcp'         => ['google cloud', 'google'],
+            'google_cloud' => ['google cloud', 'google'],
+            'google_workspace' => ['google workspace', 'google apps', 'gmail', 'google meet', 'google calendar'],
             'github'      => ['github'],
             'zscaler'     => ['zscaler'],
             'cloudflare'  => ['cloudflare'],

--- a/lousy-outages/includes/Fetcher.php
+++ b/lousy-outages/includes/Fetcher.php
@@ -729,7 +729,16 @@ class Lousy_Outages_Fetcher {
         // Switch these to RSS/Atom (per Suzy’s feeds)
         'zscaler'    => ['kind' => 'rss', 'feed' => 'https://trust.zscaler.com/rss-feed', 'link' => 'https://trust.zscaler.com/cloud-status'],
         'slack'      => ['kind' => 'rss', 'feed' => 'https://slack-status.com/feed/rss', 'link' => 'https://status.slack.com'],
-        'gcp'        => ['kind' => 'atom', 'feed' => 'https://www.google.com/appsstatus/dashboard/en-CA/feed.atom', 'link' => 'https://www.google.com/appsstatus/dashboard/'],
+        'google_workspace' => [
+            'kind' => 'rss',
+            'feed' => 'https://www.google.com/appsstatus/rss/en-CA',
+            'link' => 'https://www.google.com/appsstatus/dashboard/',
+        ],
+        'google_cloud' => [
+            'kind' => 'rss',
+            'feed' => 'https://status.cloud.google.com/rss',
+            'link' => 'https://status.cloud.google.com/',
+        ],
         'azure'      => [
             'kind' => 'rss',
             'feed' => [
@@ -760,7 +769,8 @@ class Lousy_Outages_Fetcher {
         'teamviewer' => 'TeamViewer',
         'zscaler'    => 'Zscaler',
         'slack'      => 'Slack',
-        'gcp'        => 'Google Cloud',
+        'google_workspace' => 'Google Workspace',
+        'google_cloud'     => 'Google Cloud',
         'azure'      => 'Microsoft Azure',
         'aws'        => 'Amazon Web Services',
         'crowdstrike'=> 'CrowdStrike',
@@ -1569,4 +1579,3 @@ if (! class_exists('LousyOutages\\Fetcher')) {
 if (! class_exists('LousyOutages\\Lousy_Outages_Fetcher')) {
     class_alias(__NAMESPACE__ . '\\Lousy_Outages_Fetcher', 'LousyOutages\\Lousy_Outages_Fetcher');
 }
-

--- a/lousy-outages/includes/Providers.php
+++ b/lousy-outages/includes/Providers.php
@@ -107,7 +107,20 @@ class Providers {
                 'status_url' => 'https://trust.crowdstrike.com/',
             ],
             ['id' => 'azure', 'name' => 'Azure', 'type' => 'rss', 'url' => 'https://rssfeed.azure.status.microsoft/en-us/status/feed/'],
-            ['id' => 'gcp', 'name' => 'Google Cloud', 'type' => 'atom', 'url' => 'https://www.google.com/appsstatus/dashboard/en-CA/feed.atom'],
+            [
+                'id'         => 'google_workspace',
+                'name'       => 'Google Workspace',
+                'type'       => 'rss',
+                'url'        => 'https://www.google.com/appsstatus/rss/en-CA',
+                'status_url' => 'https://www.google.com/appsstatus/dashboard/',
+            ],
+            [
+                'id'         => 'google_cloud',
+                'name'       => 'Google Cloud',
+                'type'       => 'rss',
+                'url'        => 'https://status.cloud.google.com/rss',
+                'status_url' => 'https://status.cloud.google.com/',
+            ],
         ];
     }
 

--- a/lousy-outages/includes/Subscribe.php
+++ b/lousy-outages/includes/Subscribe.php
@@ -198,7 +198,7 @@ class Lousy_Outages_Subscribe {
 confirmed. you're now getting the Lousy Outages briefings. 🛰️
 
 expect:
-- outage and degradation alerts for cloudflare, aws, azure, gcp, slack, zscaler, qubeyond (and their friends)
+- outage and degradation alerts for cloudflare, aws, azure, google cloud, google workspace, slack, zscaler, qubeyond (and their friends)
 - mini postmortems with timelines + impact notes
 - security watch items so you can harden things before the next wobble
 
@@ -221,7 +221,7 @@ TEXT;
   <div style="max-width:560px;margin:24px auto;padding:20px;border:2px solid #ffb81c;border-radius:14px;background:linear-gradient(140deg,#0b0b0b,#1a0b00);box-shadow:0 18px 36px rgba(0,0,0,0.45);">
     <h2 style="margin:0 0 10px;font-size:20px;color:#ffb81c;text-transform:uppercase;letter-spacing:0.05em;">✅ link established</h2>
     <p style="margin:0 0 12px;">welcome to the status underground.</p>
-    <p style="margin:0 0 18px;">you'll get alerts when providers wobble: cloudflare • aws • azure • gcp • slack • zscaler • qubeyond.</p>
+    <p style="margin:0 0 18px;">you'll get alerts when providers wobble: cloudflare • aws • azure • google cloud • google workspace • slack • zscaler • qubeyond.</p>
     <p style="margin:0 0 18px;"><a href="{$dashboard_url}" style="display:inline-block;padding:12px 18px;border-radius:999px;border:2px solid #ffb81c;background:#f04e23;color:#050505;font-weight:700;text-decoration:none;">OPEN LIVE DASHBOARD</a></p>
     <blockquote style="margin:12px 0;padding:10px 14px;border-left:3px solid rgba(255,184,28,0.8);background:rgba(255,184,28,0.08);">
       "Stay hungry. Stay foolish."<br>

--- a/lousy-outages/includes/Trending.php
+++ b/lousy-outages/includes/Trending.php
@@ -5,7 +5,7 @@ namespace SuzyEaston\LousyOutages;
 
 class Trending
 {
-    private const CLOUD_SLUGS = ['aws', 'azure', 'gcp'];
+    private const CLOUD_SLUGS = ['aws', 'azure', 'google_cloud'];
     private const MAJOR_STATES = ['major', 'outage'];
     private const DEGRADED_STATES = ['degraded', 'major', 'outage'];
 
@@ -132,8 +132,7 @@ class Trending
                 $special = [
                     'aws'   => 'AWS',
                     'azure' => 'Azure',
-                    'gcp'   => 'GCP',
-                    'gcp-json' => 'GCP',
+                    'google_cloud' => 'Google Cloud',
                 ];
                 if (isset($special[$slug])) {
                     return $special[$slug];
@@ -150,4 +149,3 @@ class Trending
         return implode(', ', $labels);
     }
 }
-


### PR DESCRIPTION
### Motivation
- Remove the Downdetector promotional link and offer neutral community/search links instead.  
- Disambiguate Google Workspace vs Google Cloud so Workspace (appsstatus) covers Meet/Gmail and Cloud uses status.cloud.google.com.  
- Prevent RSS/Atom feed entries that are explicitly “RESOLVED” from being treated as active incidents.  
- Improve resilience for Statuspage-backed providers (e.g., Zscaler) by falling back to alternate Statuspage endpoints and caching recent good responses.

### Description
- Replaced the Downdetector link in `public/shortcode.php` with neutral external links (`Twitter/X search`, `Reddit search`, `Web search`) and wired them into the external signals card.  
- Split the prior `gcp` entry into two providers in `includes/Providers.php` and `includes/Fetcher.php`: `google_workspace` (appsstatus RSS: `https://www.google.com/appsstatus/rss/en-CA`) and `google_cloud` (Cloud RSS: `https://status.cloud.google.com/rss`) and updated naming references in `Trending.php`, `Subscribe.php`, and `Downdetector.php`.  
- Enhanced RSS/Atom adapter logic in `includes/Adapters.php` so `from_rss_atom()` derives incident `status` from titles (recognizes `RESOLVED`, `OUTAGE`, `DEGRADED`/`SERVICE DISRUPTION`/`INCIDENT`), sorts items newest-first, slices to 10, and computes provider `state` by ignoring resolved items and using worst-severity among non-resolved entries.  
- Improved card rendering in `public/shortcode.php` so resolved incidents are not shown as active: active incidents are shown when present, otherwise the most recent resolved incident is shown in a clearly labeled “Most recent incident (resolved)” panel, and the “No active incidents.” text only appears when there are truly no incidents.  
- Implemented robust Statuspage API fallback and caching in `includes/Sources/StatuspageSource.php`: attempt primary `summary.json`, fall back to `status.json` + `incidents/unresolved.json` if needed, use `Accept: application/json` and a User-Agent, and store last-good payload in a transient (6h) to serve stale-but-usable data when live fetches fail while marking results as stale in metadata.

### Testing
- No automated tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695975cd0c74832eaf66f741fdce684a)