### PR TITLE
Fix outage tile messaging and dark mode

### DIFF
--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -1721,14 +1721,6 @@
   letter-spacing: 0.04em;
 }
 
-@media (prefers-color-scheme: light) {
-  .lousy-outages-root:not(.lo-theme-dark),
-  .lousy-outages:not(.lo-theme-dark) {
-    background: #faf8f0;
-    color: var(--lo-text);
-  }
-}
-
 @media print {
   body * {
     visibility: hidden;


### PR DESCRIPTION
### Motivation
- Remove the light/dark toggle and make the outages board dark-mode only to simplify UI and avoid inconsistent styling.
- Ensure each provider tile shows a single, unambiguous status line (error, incident, operational, or unknown) to avoid conflicting messages.
- Stop promoting historical/status-history data into the current tile state when a feed fails so tiles don’t show fake "Incident:" summaries.
- Hide the incidents panel when there are no active incidents so the status line is the single source-of-truth for tile state.

### Description
- Enforced dark mode by adding `lo-theme-dark` to the outages container and removed the theme toggle button and related markup in `public/shortcode.php`.
- Removed theme preference/storage and toggle code from `assets/lousy-outages.js` and stopped initializing theme handlers, and removed light-theme CSS application in `assets/lousy-outages.css`.
- Introduced `getStatusLine()` in `assets/lousy-outages.js` and updated `updateModernCard`/`updateLegacyCard` to set a single summary/status line, hide the incidents panel when `incidents.length === 0` or when the provider is unavailable, and only render incident lists when active incidents exist.
- Changed `lousy-outages/includes/Fetcher.php` to stop promoting statuspage/history fallbacks into the current tile state by treating history fallbacks as an unavailable/error condition (returning a failed default summary) and removed the `status_only_summary` helper that appended “(incidents unavailable)”.

### Testing
- No automated tests were run in this environment after the changes were made.
- The changes were committed and the diff includes modifications to `public/shortcode.php`, `assets/lousy-outages.js`, `assets/lousy-outages.css`, and `includes/Fetcher.php`.
- Manual review focused on ensuring the tile messaging rules are applied: fetch failure → `Status temporarily unavailable.`, active incidents → `Incident: …` + list, operational → `All systems operational.`, unknown → `Status unknown.`.
- No UI screenshot or browser run was executed in this rollout environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959802a6c8c832eb6a9a589be8bfaba)