### PR TITLE
Fix outage tile status logic and recency-aware RSS handling

### DIFF
--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -398,6 +398,26 @@ function render_shortcode(): string {
         $format = get_option('date_format') . ' ' . get_option('time_format');
         return wp_date($format, $timestamp);
     };
+    $is_no_incidents_message = static function (string $text): bool {
+        $needle = strtolower(trim($text));
+        if ('' === $needle) {
+            return false;
+        }
+        $phrases = [
+            'no active incidents',
+            'no incidents',
+            'no current incidents',
+            'no known incidents',
+            'no reported incidents',
+            'all systems operational',
+        ];
+        foreach ($phrases as $phrase) {
+            if (false !== strpos($needle, $phrase)) {
+                return true;
+            }
+        }
+        return false;
+    };
 
     $fetched_label = ('snapshot' === strtolower((string) $source))
         ? 'Outage info last refreshed:'
@@ -570,6 +590,12 @@ function render_shortcode(): string {
                     $summary_display = '';
                     if ('' !== $summary_text && strcasecmp($summary_text, $message_text) !== 0) {
                         $summary_display = $summary_text;
+                    }
+                    if ($summary_display && $status === 'operational' && $is_no_incidents_message($summary_display)) {
+                        $summary_display = '';
+                    }
+                    if ($summary_display && $status === 'unknown' && $is_no_incidents_message($summary_display)) {
+                        $summary_display = '';
                     }
                     ?>
                     <p class="lo-message" data-lo-message><?php echo esc_html($message_text); ?></p>


### PR DESCRIPTION
### Motivation
- Prevent contradictory tile messaging such as showing an incident headline alongside “No active incidents” or “All systems operational.”
- Ensure RSS-based providers (Slack, Google Cloud, etc.) don’t stay in OUTAGE/DEGRADED because of old feed items. 
- Keep Statuspage-backed providers accurate by only marking OUTAGE/DEGRADED for truly active/unresolved incidents. 
- Avoid rendering redundant or misleading secondary summary lines on the frontend tiles.

### Description
- Added feed recency constants and filters `FEED_ACTIVE_WINDOW_HOURS` and `FEED_RECENT_INCIDENT_DAYS` and applied them in `Lousy_Outages_Fetcher::fetch_feed()` to treat feed items as active only when within the active window (defaults: 6 hours active, 7 days recent). 
- Updated RSS handling to only consider `outage`/`degraded` as active severities, compute an active window threshold, and when no active incidents exist set the tile to `operational` with `All systems operational.` and an optional secondary `Last incident: ... (reported <date>)` if a recent incident exists. 
- Normalized Statuspage handling in `fetch_statuspage()` and `normalize_statuspage_incident_array()` to ignore `postmortem`/resolved/completed incidents for active-state calculation and to normalize the operational message to `All systems operational.` via a new helper `is_no_incidents_message()`. 
- Added `is_no_incidents_message()` helper to `Fetcher` and a matching `is_no_incidents_message` guard in `lousy-outages/public/shortcode.php` to suppress redundant/contradictory secondary summaries when the tile is `operational` or `unknown`. 
- Files changed: `lousy-outages/includes/Fetcher.php` and `lousy-outages/public/shortcode.php` (changes include comments, filters, and message normalization). 

### Testing
- No automated tests were executed against these changes.
- (No other automated test runs to report.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695996f35108832e977bd9f96abe6225)