### PR TITLE
FE: make UNKNOWN status less alarming + show last checked/last known

### DIFF
--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -737,6 +737,30 @@
   line-height: 1.4;
 }
 
+.lo-card-meta-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.lo-card-meta {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--lo-muted);
+  line-height: 1.3;
+}
+
+.lo-card-meta--hint {
+  color: rgba(232, 243, 255, 0.6);
+}
+
+.lo-card-debug {
+  margin: 0;
+  font-size: 0.75rem;
+  font-family: 'IBM Plex Mono', 'Courier New', monospace;
+  color: #ffd9a0;
+}
+
 .lo-snark {
   color: var(--lo-accent);
   font-style: italic;


### PR DESCRIPTION
### Motivation
- Unknown provider tiles currently read as outages and should instead indicate our inability to verify the provider status and show when we last checked.
- Displaying a small “Last checked” and the provider’s last-known-good status reduces false alarm for providers like Google Cloud and Zscaler.
- Expose optional diagnostic details only when requested via query string so normal users aren't overwhelmed by fetch errors.

### Description
- Client-side: updated `lousy-outages/assets/lousy-outages.js` to add `LAST_OK_STORAGE_PREFIX` and implement `writeLastKnown`/`readLastKnown` to persist `lo_last_ok_<provider>` in `localStorage`, plus `updateCardMeta` to render `Last checked` and `Last known` lines and a debug line when `?lo_debug=1` is present.
- Copy/logic: introduced `UNKNOWN_MESSAGE`/`UNKNOWN_HINT`, treated the new phrasing as a generic unavailable copy, and updated message helpers so `unknown` tiles say `Can’t verify status right now.` instead of implying an outage.
- Server-side: updated `lousy-outages/public/shortcode.php` to emit the initial `Last checked` meta, the `Last known`/hint/debug placeholders, and to use the softer unknown copy for initial render so SSR matches the JS behavior.
- Styling: added minimal CSS in `lousy-outages/assets/lousy-outages.css` to style `.lo-card-meta`, `.lo-card-meta--hint`, and `.lo-card-debug` to match the existing CRT/retro theme.

### Testing
- No automated tests were executed against these changes in this rollout.
- Changes were committed locally with message `FE: make UNKNOWN status less alarming + show last checked/last known`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a9b90bbf0832eb064c48a11b45c38)