### PR TITLE
Improve outage tile classification and sorting (GCP JSON adapter, Zscaler fallback)

### DIFF
--- a/lousy-outages/includes/Providers.php
+++ b/lousy-outages/includes/Providers.php
@@ -118,8 +118,8 @@ class Providers {
             [
                 'id'         => 'google_cloud',
                 'name'       => 'Google Cloud',
-                'type'       => 'rss',
-                'url'        => 'https://status.cloud.google.com/rss',
+                'type'       => 'gcp_json',
+                'url'        => 'https://status.cloud.google.com/incidents.json',
                 'status_url' => 'https://status.cloud.google.com/',
             ],
         ];

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -1175,6 +1175,9 @@ function lousy_outages_build_provider_payload( string $id, array $state, string 
         'name'       => $state['name'] ?? $state['provider'] ?? $id,
         'state'      => $label,
         'stateCode'  => $status,
+        'tile_kind'  => $state['tile_kind'] ?? null,
+        'sort_key'   => $state['sort_key'] ?? null,
+        'confidence'=> $state['confidence'] ?? null,
         'summary'    => $state['summary'] ?? $label,
         'updatedAt'  => $updated_at,
         'url'        => $url,
@@ -1199,8 +1202,27 @@ function lousy_outages_sort_providers( array $providers ): array {
         'unknown'     => 3,
         'operational' => 4,
     ];
+    $tile_priority = [
+        'outage'      => 0,
+        'signal'      => 1,
+        'unknown'     => 2,
+        'manual'      => 3,
+        'operational' => 4,
+    ];
 
-    $sort_key = static function ( array $provider ) use ( $state_priority ): array {
+    $sort_key = static function ( array $provider ) use ( $state_priority, $tile_priority ): array {
+        $sort_key_value = $provider['sort_key'] ?? null;
+        $tile_kind = strtolower( (string) ( $provider['tile_kind'] ?? '' ) );
+        if ( is_numeric( $sort_key_value ) ) {
+            $name = strtolower( (string) ( $provider['name'] ?? $provider['id'] ?? '' ) );
+            $tile_rank = $tile_priority[ $tile_kind ] ?? $tile_priority['unknown'];
+            return [
+                (int) $sort_key_value,
+                $tile_rank,
+                $name,
+            ];
+        }
+
         $state      = strtolower( (string) ( $provider['stateCode'] ?? 'unknown' ) );
         $state_rank = $state_priority[ $state ] ?? $state_priority['unknown'];
 

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -699,6 +699,8 @@ function render_shortcode(): string {
                     <?php endif; ?>
                 </article>
             <?php endforeach; ?>
+        </div>
+        <div class="lo-external" data-lo-external>
             <article class="lo-card lo-card--external" data-provider-id="external-signals">
                 <div class="lo-head">
                     <h3 class="lo-title">External signals</h3>


### PR DESCRIPTION
### Motivation
- Some providers were surfacing "outage-looking" tiles due to flaky feeds or status indicators without active incidents, creating false alarms.  
- Google Cloud's RSS feed was unreliable, so a more reliable JSON incidents feed is needed.  
- Transient errors (for example Zscaler 502s or HTML bot pages) should not promote a provider above real incidents.  
- The frontend must place only verified outages above other signals by relying on a backend-provided numeric sort key.

### Description
- Added a new adapter `from_gcp_incidents_json` and switched `google_cloud` to use `https://status.cloud.google.com/incidents.json` in `includes/Adapters.php` and `includes/Providers.php`.  
- Implemented backend tile metadata in `includes/Fetcher.php` (`apply_tile_metadata`, `determine_tile_kind`, `sort_key_for_tile`) and wired `gcp_json` into `adapt_response`, plus `handle_failed_response` with Zscaler HTML-detection and recent cached fallback.  
- Exposed `tile_kind`, `sort_key`, and optional `confidence` in provider payloads and updated server-side sorting in `lousy-outages.php` to prefer numeric `sort_key` (with a tile priority fallback).  
- Updated the frontend `assets/lousy-outages.js` to sort by backend `sort_key` (falling back to legacy logic) and moved the External Signals panel out of the outage grid in `public/shortcode.php` so it no longer competes with outages.

### Testing
- No automated tests were run on this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a9feb9d88832e9978bfde7cfcd5d6)