### PR TITLE
UI: Incidents-first view + hide unverified by default

### DIFF
--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -105,6 +105,95 @@
   min-height: 56px;
 }
 
+.lo-mode-toggle {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.lo-mode-toggle__button {
+  border: 1px solid var(--lo-border);
+  background: rgba(18, 28, 51, 0.7);
+  color: var(--lo-text);
+  padding: 8px 16px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.lo-mode-toggle__button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(10, 20, 40, 0.35);
+}
+
+.lo-mode-toggle__button.is-active {
+  background: linear-gradient(135deg, rgba(138, 247, 228, 0.9), rgba(109, 255, 199, 0.7));
+  color: var(--lo-contrast);
+  border-color: rgba(138, 247, 228, 0.8);
+  box-shadow: 0 0 0 2px rgba(138, 247, 228, 0.2);
+}
+
+.lo-hero {
+  margin-bottom: 16px;
+}
+
+.lo-card--hero {
+  border: 2px solid rgba(138, 247, 228, 0.9);
+  background: linear-gradient(135deg, rgba(18, 28, 51, 0.95), rgba(10, 16, 32, 0.9));
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.4);
+}
+
+.lo-card--hero .lo-title {
+  color: var(--lo-accent);
+}
+
+.lo-incidents {
+  display: block;
+}
+
+.lo-section {
+  margin: 18px 0;
+}
+
+.lo-section__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.lo-section__toggle {
+  border: 1px solid var(--lo-border);
+  background: rgba(9, 14, 28, 0.7);
+  color: var(--lo-muted);
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.lo-section__toggle[aria-expanded='true'] {
+  background: rgba(138, 247, 228, 0.12);
+  color: var(--lo-text);
+}
+
+.lo-grid--section[hidden] {
+  display: none;
+}
+
+.lo-all[hidden],
+.lo-incidents[hidden],
+.lo-hero[hidden] {
+  display: none;
+}
+
 .lo-status-board {
   margin: 18px auto 10px;
   max-width: 1080px;

--- a/lousy-outages/includes/Fetcher.php
+++ b/lousy-outages/includes/Fetcher.php
@@ -496,6 +496,9 @@ class Fetcher {
         if ('manual' === $tileKind) {
             return 95;
         }
+        if ('operational' === $tileKind) {
+            return 70;
+        }
         return 100;
     }
 


### PR DESCRIPTION
### Motivation
- The default provider grid was surfacing `unknown`/`manual` tiles above confirmed `outage` tiles, making the page look like there were incidents when there were none.
- The UI should default to an “Incidents-first” view so users see a clear hero when there are zero active incidents and unverified signals are available but collapsed by default.
- The frontend needs page-level counts from the backend so the hero and section toggles can be rendered without recomputing on the client.

### Description
- Adjusted tile priority logic in `lousy-outages/includes/Fetcher.php` so `operational` tiles return `sort_key = 70`, keeping `outage`/`signal`/`unknown`/`manual` priorities aligned with the new bands.
- Added a `build_summary_meta` helper in `lousy-outages/includes/Api.php` and included `meta` (with `active_outage_count`, `signal_count`, `unverified_count`, `generated_at`) in the `/summary` payload.
- Extended `lousy-outages/public/shortcode.php` to emit initial `meta` counts and to annotate operational placeholders with `tile_kind`/`sort_key` so initial grid ordering matches new semantics.
- Implemented the incidents-first UX in `lousy-outages/assets/lousy-outages.js` plus styling in `lousy-outages/assets/lousy-outages.css`: new view-mode toggle (`Incidents / All providers`), hero card shown when `meta.active_outage_count === 0`, external signals pinned separately, and collapsible `Signals` and `Can’t verify` sections; `renderProviders` now partitions cards into sections and updates labels from `meta`.

### Testing
- No automated tests were executed against these changes in this rollout (no CI/test run was performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aa444bbfc832eb1a2c8065b8d877a)