### PR TITLE
History charts: add heatmap & trend views, cleaner bars, report card, and PDF canvas rasterization

### DIFF
--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -461,12 +461,109 @@
   background: #0c0c0c;
 }
 
+.lo-history__report {
+  margin-bottom: 12px;
+  padding: 12px;
+  border: 1px solid rgba(138, 247, 228, 0.4);
+  background: linear-gradient(135deg, rgba(18, 28, 51, 0.85), rgba(10, 16, 32, 0.9));
+  box-shadow: inset 0 0 0 1px rgba(244, 154, 229, 0.2);
+}
+
+.lo-history__report-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.lo-history__report-stat {
+  border: 1px solid rgba(138, 247, 228, 0.4);
+  background: rgba(8, 12, 24, 0.75);
+  padding: 10px;
+  border-radius: 8px;
+}
+
+.lo-history__report-label {
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(138, 247, 228, 0.9);
+  margin-bottom: 4px;
+}
+
+.lo-history__report-value {
+  font-size: 14px;
+  font-weight: 700;
+  color: #fefefe;
+}
+
+.lo-history__report-sub {
+  margin-top: 4px;
+  font-size: 11px;
+  color: #f6ff8f;
+}
+
+.lo-history__report-table-wrap {
+  border-top: 1px dashed rgba(138, 247, 228, 0.4);
+  padding-top: 10px;
+}
+
+.lo-history__report-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.lo-history__report-table th,
+.lo-history__report-table td {
+  border: 1px solid rgba(138, 247, 228, 0.2);
+  padding: 6px 8px;
+  text-align: left;
+}
+
+.lo-history__report-table th {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(232, 243, 255, 0.8);
+  font-size: 10px;
+}
+
 .lo-history__chart {
   margin-bottom: 12px;
 }
 
 .lo-history__chart:last-child {
   margin-bottom: 0;
+}
+
+.lo-history__chart-content {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.lo-history__view-toggle {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 6px 0 8px;
+}
+
+.lo-history__view-button {
+  border: 1px solid rgba(138, 247, 228, 0.6);
+  background: rgba(8, 12, 24, 0.8);
+  color: var(--lo-text);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 6px 10px;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.lo-history__view-button.is-active {
+  background: linear-gradient(135deg, rgba(244, 154, 229, 0.9), rgba(138, 247, 228, 0.9));
+  color: #050510;
 }
 
 .lo-history__chart-title {
@@ -502,6 +599,80 @@
 .lo-history__chart-text {
   font-size: 10px;
   fill: #fefefe;
+}
+
+.lo-heatmap__cell {
+  stroke: rgba(0, 0, 0, 0.6);
+  stroke-width: 1;
+}
+
+.lo-heatmap__cell--level-0 {
+  fill: rgba(255, 255, 255, 0.08);
+}
+
+.lo-heatmap__cell--level-1 {
+  fill: rgba(109, 255, 199, 0.35);
+}
+
+.lo-heatmap__cell--level-2 {
+  fill: rgba(109, 255, 199, 0.6);
+}
+
+.lo-heatmap__cell--level-3 {
+  fill: rgba(244, 154, 229, 0.6);
+}
+
+.lo-heatmap__cell--level-4 {
+  fill: rgba(244, 154, 229, 0.9);
+}
+
+.lo-heatmap__cell--active {
+  stroke: #f6ff8f;
+  stroke-width: 2;
+}
+
+.lo-heatmap__legend {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--lo-muted);
+}
+
+.lo-heatmap__legend-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.lo-heatmap__swatch {
+  width: 12px;
+  height: 12px;
+  border: 1px solid rgba(0, 0, 0, 0.8);
+  display: inline-block;
+}
+
+.lo-heatmap__peak {
+  margin-top: 6px;
+}
+
+.lo-trend__line {
+  fill: none;
+  stroke: #f49ae5;
+  stroke-width: 2;
+  filter: drop-shadow(0 0 6px rgba(244, 154, 229, 0.45));
+}
+
+.lo-trend__point {
+  fill: #6df28c;
+  stroke: #0c0c0c;
+  stroke-width: 1;
+}
+
+.lo-trend__point--active {
+  fill: #f6ff8f;
+  stroke: #fff4c2;
 }
 
 .lo-history__meta {


### PR DESCRIPTION
### Motivation
- Reduce visual clutter for long history windows by offering alternate timeline views (heatmap, bars, trend) with sensible defaults.
- Make the timeline and YOY visuals printable and reliable in PDF exports by addressing canvas cloning limitations.
- Surface a compact summary (“Report Card”) so readers can quickly spot totals, active days, peak, and top providers.
- Preserve the retro CRT theme and avoid new external JS dependencies by using vanilla JS and SVG.

### Description
- Added persistent view mode state (`HISTORY_CHART_MODE_KEY`) and utilities `formatShortDate`, `buildDailySeries`, `buildTimelineMeta`, `resolveHistoryChartMode`, and `persistHistoryChartMode`.
- Implemented `buildTimelineSection` (UI toggle), `buildTimelineChart` (cleaner bars with limited ticks/labels), `buildCalendarHeatmap` (SVG weekly grid, discrete intensity classes, tooltips, legend, peak callout), and `buildTrendChart` (7-day rolling average as SVG polyline and points).
- Added `buildHistoryReportCard` to render a compact summary and top-5 providers table above charts, and wired it into `renderHistoryCharts`.
- Fixed `exportPDF()` to rasterize any canvases into `<img>` using `canvas.toDataURL('image/png')`, and added print-friendly CSS for charts, heatmap, trend, and report card in the JS print stylesheet and updated component CSS.

### Testing
- No automated tests were executed in this rollout (no test runner invoked).
- Manual code changes were committed and basic smoke checks were performed by inspecting generated DOM-building logic and CSS updates (non-automated).
- PDF export code attempts to gracefully ignore canvas export failures; no automated verification was run.
- Existing CSV export remains unchanged and was not modified by automated tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aab86f16c832ea09a52b19535d1d9)