### PR TITLE
Distinguish outages vs degraded signals in Lousy Outages teaser

### DIFF
--- a/parts/lousy-outages-teaser.php
+++ b/parts/lousy-outages-teaser.php
@@ -16,12 +16,14 @@ if ( class_exists( '\\LousyOutages\\I18n' ) ) {
 }
 
 $latest_incident = null;
+$latest_signal = null;
 $relative_started = '';
 $teaser_href = home_url( '/lousy-outages/' );
 
 if ( class_exists( '\\LousyOutages\\Summary' ) ) {
     $current = Summary::current();
-    if ( ! empty( $current['hasIncident'] ) ) {
+    $kind = $current['kind'] ?? ( ! empty( $current['hasIncident'] ) ? 'outage' : 'clear' );
+    if ( 'outage' === $kind ) {
         $latest_incident = (object) [
             'provider'   => $current['provider'] ?? '',
             'title'      => $current['title'] ?? '',
@@ -29,6 +31,17 @@ if ( class_exists( '\\LousyOutages\\Summary' ) ) {
             'started_at' => $current['started_at'] ?? '',
         ];
         $relative_started = $latest_incident->relative;
+        if ( ! empty( $current['href'] ) ) {
+            $teaser_href = $current['href'];
+        }
+    } elseif ( 'signal' === $kind ) {
+        $latest_signal = (object) [
+            'provider'   => $current['provider'] ?? '',
+            'status'     => $current['status'] ?? '',
+            'relative'   => $current['relative'] ?? '',
+            'started_at' => $current['started_at'] ?? '',
+        ];
+        $relative_started = $latest_signal->relative;
         if ( ! empty( $current['href'] ) ) {
             $teaser_href = $current['href'];
         }
@@ -48,6 +61,20 @@ if ( class_exists( '\\LousyOutages\\Summary' ) ) {
                 — <?php echo esc_html( $latest_incident->title ); ?>
                 <?php if ( $relative_started ) : ?>
                     (started <?php echo esc_html( $relative_started ); ?>)
+                <?php endif; ?>
+            </span>
+        </p>
+    <?php elseif ( $latest_signal ) : ?>
+        <p class="lo-home-pacman-alert lo-home-pacman-alert--signal" data-signal-start="<?php echo esc_attr( $latest_signal->started_at ); ?>" data-relative="<?php echo esc_attr( $relative_started ); ?>">
+            <span class="lo-pacman" aria-hidden="true"></span>
+            <span class="lo-pacman-dots" aria-hidden="true"></span>
+            <span class="lo-alert-text">
+                Signal detected:
+                <strong><?php echo esc_html( $latest_signal->provider ); ?></strong>
+                — <?php echo esc_html( $latest_signal->status ); ?>.
+                No active incident posted yet.
+                <?php if ( $relative_started ) : ?>
+                    (checked <?php echo esc_html( $relative_started ); ?>)
                 <?php endif; ?>
             </span>
         </p>

--- a/style.css
+++ b/style.css
@@ -1454,6 +1454,10 @@ footer,
   color: #9bffc6;
 }
 
+.lo-home-pacman-alert--signal {
+  color: #ffe48a;
+}
+
 .lo-pacman {
   width: 1.6rem;
   height: 1.6rem;


### PR DESCRIPTION
### Motivation
- The homepage was showing “Outage detected” whenever a provider reported a degraded status indicator even if no unresolved incident was posted. 
- Statuspage-like APIs expose both a status indicator and a separate unresolved-incident list, so an isolated degraded indicator should be treated as a "signal" rather than an outage. 
- The teaser copy should clearly show `Outage detected` only for real unresolved incidents, `Signal detected` for degraded indicators without unresolved incidents, and `All clear` otherwise.

### Description
- Updated `Summary::current()` to return a `kind` (`outage`|`signal`|`clear`) and added `hasSignal`, `outageCount`, and `signalCount` while keeping `hasIncident` true only for `outage`. 
- Replaced the old degraded fallback with `latest_signal_provider()` and added helper methods `is_unresolved_incident()`, `has_unresolved_incident()`, `count_outages()`, and `count_signals()` to separate unresolved incidents from mere signals. 
- Adjusted `parts/lousy-outages-teaser.php` to render `Outage detected`, `Signal detected` (with message "No active incident posted yet"), or `All clear` depending on the new `kind`, and added a new CSS class `lo-home-pacman-alert--signal`. 
- Minor styling change in `style.css` to give signals a distinct neutral/yellow color via `.lo-home-pacman-alert--signal`.

### Testing
- No automated unit tests were executed against these changes. 
- An automated Playwright page load was attempted to `http://localhost:8000` but failed because no local server was available, so runtime verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ab00f0a74832ea43137729732600e)