### PR TITLE
Homepage: use Lousy Outages RSS for teaser headline and stabilize feed GUIDs

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -144,8 +144,6 @@ get_header();
 
     </div>
 
-    <?php get_template_part('parts/lousy-outages-teaser'); ?>
-
     <section class="now-listening">
         <h2 class="pixel-font">Now Listening</h2>
         <div class="now-listening-item">
@@ -162,6 +160,8 @@ get_header();
             <iframe width="100%" height="360" src="https://www.youtube.com/embed/71cIYDnDZUk?autoplay=0" title="Willie Nelson — Hands on the Wheel" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
     </section>
+
+    <?php get_template_part('parts/lousy-outages-teaser'); ?>
 
     <?php
     $grimes_note = apply_filters(

--- a/parts/lousy-outages-teaser.php
+++ b/parts/lousy-outages-teaser.php
@@ -1,13 +1,13 @@
 <?php
 use LousyOutages\I18n;
-use LousyOutages\Summary;
 
 $teaser_strings = [
     'teaserCaption' => 'Check if your favourite services are up. Insert coin to refresh.',
-    'viewDashboard' => 'View Full Dashboard →',
+    'viewDashboard' => 'View full dashboard',
+    'subscribeRss'  => 'Subscribe (RSS)',
 ];
 
-$feed_url     = home_url( '/?feed=lousy_outages_status' ); // Pretty /feed/lousy_outages_status/ works after a permalink flush, but the query form is more reliable.
+$feed_url = home_url( '/?feed=lousy_outages_status' ); // Pretty /feed/lousy_outages_status/ works after a permalink flush, but the query form is more reliable.
 
 if ( class_exists( '\\LousyOutages\\I18n' ) ) {
     $locale         = I18n::determine_locale();
@@ -15,89 +15,45 @@ if ( class_exists( '\\LousyOutages\\I18n' ) ) {
     $teaser_strings = array_merge( $teaser_strings, array_intersect_key( $localized, $teaser_strings ) );
 }
 
-$latest_incident = null;
-$latest_signal = null;
-$relative_started = '';
-$teaser_href = home_url( '/lousy-outages/' );
-
-if ( class_exists( '\\LousyOutages\\Summary' ) ) {
-    $current = Summary::current();
-    $kind = $current['kind'] ?? ( ! empty( $current['hasIncident'] ) ? 'outage' : 'clear' );
-    if ( 'outage' === $kind ) {
-        $latest_incident = (object) [
-            'provider'   => $current['provider'] ?? '',
-            'title'      => $current['title'] ?? '',
-            'relative'   => $current['relative'] ?? '',
-            'started_at' => $current['started_at'] ?? '',
-        ];
-        $relative_started = $latest_incident->relative;
-        if ( ! empty( $current['href'] ) ) {
-            $teaser_href = $current['href'];
-        }
-    } elseif ( 'signal' === $kind ) {
-        $latest_signal = (object) [
-            'provider'   => $current['provider'] ?? '',
-            'status'     => $current['status'] ?? '',
-            'relative'   => $current['relative'] ?? '',
-            'started_at' => $current['started_at'] ?? '',
-        ];
-        $relative_started = $latest_signal->relative;
-        if ( ! empty( $current['href'] ) ) {
-            $teaser_href = $current['href'];
-        }
-    }
-}
+$teaser_data  = function_exists( 'get_lousy_outages_home_teaser_from_feed' )
+    ? get_lousy_outages_home_teaser_from_feed()
+    : [
+        'headline' => 'All clear: no active incidents right now.',
+        'href'     => home_url( '/lousy-outages/' ),
+        'status'   => 'clear',
+        'footnote' => '',
+        'feed_url' => $feed_url,
+    ];
+$teaser_href  = $teaser_data['href'] ?? home_url( '/lousy-outages/' );
+$feed_url     = $teaser_data['feed_url'] ?? $feed_url;
+$status_class = ( $teaser_data['status'] ?? 'clear' ) === 'outage' ? '' : ' lo-home-pacman-alert--clear';
 ?>
 <section id="lousy-outages-teaser" class="lo-home-teaser" aria-live="polite">
     <h2 class="lo-home-heading">Lousy Outages</h2>
 
-    <?php if ( $latest_incident ) : ?>
-        <p class="lo-home-pacman-alert" data-incident-start="<?php echo esc_attr( $latest_incident->started_at ); ?>" data-relative="<?php echo esc_attr( $relative_started ); ?>">
-            <span class="lo-pacman" aria-hidden="true"></span>
-            <span class="lo-pacman-dots" aria-hidden="true"></span>
-            <span class="lo-alert-text">
-                Outage detected:
-                <strong><?php echo esc_html( $latest_incident->provider ); ?></strong>
-                — <?php echo esc_html( $latest_incident->title ); ?>
-                <?php if ( $relative_started ) : ?>
-                    (started <?php echo esc_html( $relative_started ); ?>)
-                <?php endif; ?>
-            </span>
-        </p>
-    <?php elseif ( $latest_signal ) : ?>
-        <p class="lo-home-pacman-alert lo-home-pacman-alert--signal" data-signal-start="<?php echo esc_attr( $latest_signal->started_at ); ?>" data-relative="<?php echo esc_attr( $relative_started ); ?>">
-            <span class="lo-pacman" aria-hidden="true"></span>
-            <span class="lo-pacman-dots" aria-hidden="true"></span>
-            <span class="lo-alert-text">
-                Signal detected:
-                <strong><?php echo esc_html( $latest_signal->provider ); ?></strong>
-                — <?php echo esc_html( $latest_signal->status ); ?>.
-                No active incident posted yet.
-                <?php if ( $relative_started ) : ?>
-                    (checked <?php echo esc_html( $relative_started ); ?>)
-                <?php endif; ?>
-            </span>
-        </p>
-    <?php else : ?>
-        <p class="lo-home-pacman-alert lo-home-pacman-alert--clear">
-            <span class="lo-pacman" aria-hidden="true"></span>
-            <span class="lo-pacman-dots" aria-hidden="true"></span>
-            <span class="lo-alert-text">
-                All clear: no active incidents right now. Insert coin to refresh.
-            </span>
-        </p>
+    <p class="lo-home-pacman-alert<?php echo esc_attr( $status_class ); ?>">
+        <span class="lo-pacman" aria-hidden="true"></span>
+        <span class="lo-pacman-dots" aria-hidden="true"></span>
+        <span class="lo-alert-text">
+            <?php echo esc_html( $teaser_data['headline'] ?? '' ); ?>
+        </span>
+    </p>
+
+    <?php if ( ! empty( $teaser_data['footnote'] ) ) : ?>
+        <p class="lo-home-footnote"><?php echo esc_html( $teaser_data['footnote'] ); ?></p>
     <?php endif; ?>
 
     <p class="caption"><?php echo esc_html( $teaser_strings['teaserCaption'] ); ?></p>
 
-    <a class="lo-home-teaser-link" href="<?php echo esc_url( $teaser_href ); ?>"><?php echo esc_html( $teaser_strings['viewDashboard'] ); ?></a>
-
     <div class="lo-actions lo-actions--rss">
-      <a class="lo-link" href="<?php echo esc_url( $feed_url ); ?>" target="_blank" rel="noopener">
-        <svg class="lo-icon" viewBox="0 0 24 24" aria-hidden="true">
-          <path fill="currentColor" d="M6 17a2 2 0 11.001 3.999A2 2 0 016 17zm-2-7v3a8 8 0 018 8h3c0-6.075-4.925-11-11-11zm0-5v3c9.389 0 17 7.611 17 17h3C24 13.85 10.15 0 4 0z"/>
-        </svg>
-        Subscribe (RSS)
-      </a>
+        <a class="lo-link" href="<?php echo esc_url( $teaser_href ); ?>">
+            <?php echo esc_html( $teaser_strings['viewDashboard'] ); ?>
+        </a>
+        <a class="lo-link" href="<?php echo esc_url( $feed_url ); ?>" target="_blank" rel="noopener">
+            <svg class="lo-icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path fill="currentColor" d="M6 17a2 2 0 11.001 3.999A2 2 0 016 17zm-2-7v3a8 8 0 018 8h3c0-6.075-4.925-11-11-11zm0-5v3c9.389 0 17 7.611 17 17h3C24 13.85 10.15 0 4 0z"/>
+            </svg>
+            <?php echo esc_html( $teaser_strings['subscribeRss'] ); ?>
+        </a>
     </div>
 </section>

--- a/style.css
+++ b/style.css
@@ -1458,6 +1458,34 @@ footer,
   color: #ffe48a;
 }
 
+.lo-home-footnote {
+  margin: 0;
+  font-size: 0.75rem;
+  color: rgba(229, 249, 255, 0.7);
+}
+
+.lo-home-teaser .lo-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.lo-home-teaser .lo-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--arcade-neon-green, #39ff14);
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.8rem;
+  color: var(--arcade-neon-green, #39ff14);
+  background: rgba(57, 255, 20, 0.05);
+}
+
 .lo-pacman {
   width: 1.6rem;
   height: 1.6rem;


### PR DESCRIPTION
### Motivation
- Prevent the homepage teaser from surfacing confusing “Signal detected / Degraded” as the primary headline by relying on the site’s own Lousy Outages RSS intent markers.
- Use the feed prefixes ([OUTAGE], [DEGRADED], [COMMUNITY REPORT]) to reflect editorial intent and only escalate to an outage headline for recent [OUTAGE] items.
- Stop duplicate items in the generated RSS by stabilizing GUIDs per incident so readers don’t get repeated items for the same incident.
- Ensure the teaser is visually placed below the homepage dashboard/hero so it is not the first major panel.

### Description
- Added `get_lousy_outages_home_teaser_from_feed()` (in `functions.php`) which reads `/?feed=lousy_outages_status` via `fetch_feed()`, applies a 5-minute cache TTL via `wp_feed_cache_transient_lifetime`, de-dupes items defensively, and selects an outage headline only when a recent `[OUTAGE]` item is present (configurable windows via `LOUSY_OUTAGES_HOME_*_WINDOW_HOURS`).
- Updated the teaser template (`parts/lousy-outages-teaser.php`) to consume the RSS-derived headline, render an optional small footnote for recent `[DEGRADED]` or community reports, and show two CTAs: “View full dashboard” and “Subscribe (RSS)”.
- Moved the teaser include in `page-home.php` so it renders below the hero/dashboard area instead of appearing first on the page.
- Stabilized and de-duplicated the plugin feed generation in `lousy-outages/includes/Feeds.php` by introducing `build_incident_key()` and changing GUID construction to a stable key per incident, and by collecting items keyed by incident to avoid emitting duplicates; also adjusted styles in `style.css` for footnote and teaser actions.
- Feed URL used: `/?feed=lousy_outages_status`; cache TTL: 5 minutes.

### Testing
- No automated tests were executed as part of this change.
- PHP linter or runtime checks were not run in this environment.
- Manual code inspection was performed during the change to ensure integration points (`fetch_feed`, template include) align with existing theme/plugin patterns.
- Further automated or staging validation is recommended to confirm runtime feed parsing and frontend rendering under WP environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ab2dd3894832e8626ee6bb36b04ad)