### PR TITLE
Separate OpenAI JSON body from HTTP transport and improve error handling

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -558,7 +558,9 @@ function albini_handle_query( WP_REST_Request $req ) {
             'model'       => 'gpt-4o',
             'max_tokens'  => 350,
             'temperature' => 0.4,
-            'timeout'     => 15,
+        ),
+        array(
+            'timeout' => 15,
         )
     );
 
@@ -630,7 +632,9 @@ function se_handle_riff_tip( WP_REST_Request $req ) {
         array(
             'temperature' => 0.8,
             'max_tokens'  => 80,
-            'timeout'     => 15,
+        ),
+        array(
+            'timeout' => 15,
         )
     );
 


### PR DESCRIPTION
### Motivation
- Fix broken OpenAI requests where transport-only options (e.g. `timeout`) were being merged into the JSON body and rejected by OpenAI. 
- Ensure HTTP timeouts still control `wp_remote_post` duration without being sent to the API. 
- Avoid leaking raw API responses while surfacing useful diagnostics for site administrators. 
- Preserve existing defaults for `model`, `temperature`, and `max_tokens` while tightening accepted request fields.

### Description
- Refactor `se_openai_chat` to accept an optional third parameter ` $http_options` and extract any `timeout` into a local `$http_timeout` used for `wp_remote_post` instead of the JSON body. 
- Implement a whitelist of allowed OpenAI chat-completions body keys and build the request body with `array_intersect_key` so transport options are never serialized into the OpenAI payload. 
- Improve error handling by sanitizing and trimming error messages, logging details with `error_log`, and returning `WP_Error` values that include HTTP status and a short sanitized message. 
- Update call sites in `page-track-analyzer.php` and `functions.php` to pass timeouts via the new HTTP options parameter and change Track Analyzer UX to show detailed `WP_Error` output only when `?ta_debug=1` and the current user can `manage_options`.

### Testing
- No automated tests were executed as part of this change (no CI/unit tests were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ab82d7774832eaf67bfd6d80f7034)