### PR TITLE
Restructure homepage and improve Lousy Outages teaser (REST-first, safer messaging)

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -60,13 +60,16 @@ get_header();
           <a class="btn-8bit" href="/lousy-outages/">OPEN THE LIVE DASHBOARD →</a>
         </section>
         <h2 class="retro-title glow-lite">Musician &amp; Creative Technologist</h2>
-        <section class="pixel-intro" style="max-width: 720px; margin: 0 auto; line-height: 1.8; font-size: 1.05rem;">
-    <p>I&rsquo;m a musician, technologist, and creative builder based in Vancouver.</p>
-
-    <p>Toured nationally as a bassist, recorded with Steve Albini in Chicago, and appeared on MuchMusic. Today, I keep creating, playing around with programming/coding and releasing new music at night while shipping infrastructure code by day hah!</p>
-
-    <p>i was going to run for vancouver city council in 2026, but instead i&rsquo;m going to focus on building weird/beautiful creative tools</p>
-</section>
+        <section class="pixel-intro hero-intro">
+            <p class="hero-tagline pixel-font">Vancouver-based musician + creative technologist.</p>
+            <p>By day I ship infrastructure work; by night I build weird, beautiful tools and release indie music.</p>
+            <ul class="hero-build-list">
+                <li>I build: playful music tech &amp; track tools.</li>
+                <li>I build: arcade-style dashboards for real-world systems.</li>
+                <li>I build: creative experiments that mix art, sound, and code.</li>
+            </ul>
+            <a href="/bio/" class="pixel-button hero-bio-button">Read full bio</a>
+        </section>
 
         <p class="arcade-subtext">Insert coin to explore</p>
         <div class="puck-icon" role="img" aria-label="retro hockey puck icon">🏒</div>
@@ -125,6 +128,7 @@ get_header();
                 <h3 class="group-title">🎮 Games &amp; Tools</h3>
                 <div class="group-buttons">
                     <a href="/riff-generator" class="pixel-button">Riff Generator</a>
+                    <a href="/suzys-track-analyzer/" class="pixel-button">Track Analyzer</a>
                     <a href="/arcade" class="pixel-button">Canucks Game</a>
                     <a href="/canucks-stats" class="pixel-button">Canucks Stats</a>
                     <a href="/albini-qa" class="pixel-button">Albini Q&amp;A</a>
@@ -161,8 +165,6 @@ get_header();
         </div>
     </section>
 
-    <?php get_template_part('parts/lousy-outages-teaser'); ?>
-
     <?php
     $grimes_note = apply_filters(
         'se_home_grimes_note',
@@ -181,8 +183,10 @@ get_header();
     <section class="track-analyzer-feature">
         <h2 class="pixel-font">Track Analyzer</h2>
         <p class="pixel-font">Upload an MP3 and get instant feedback on your mix.</p>
-        <a href="/suzys-track-analyzer" class="pixel-button analyzer-cta">Analyze Your Track</a>
+        <a href="/suzys-track-analyzer/" class="pixel-button analyzer-cta">Analyze Your Track</a>
     </section>
+
+    <?php get_template_part('parts/lousy-outages-teaser'); ?>
 
     <section class="party-announcement crt-block">
         <h2>Grunge &amp; Rock Video Party (Instagram)</h2>

--- a/parts/lousy-outages-teaser.php
+++ b/parts/lousy-outages-teaser.php
@@ -15,10 +15,10 @@ if ( class_exists( '\\LousyOutages\\I18n' ) ) {
     $teaser_strings = array_merge( $teaser_strings, array_intersect_key( $localized, $teaser_strings ) );
 }
 
-$teaser_data  = function_exists( 'get_lousy_outages_home_teaser_from_feed' )
-    ? get_lousy_outages_home_teaser_from_feed()
+$teaser_data  = function_exists( 'get_lousy_outages_home_teaser_data' )
+    ? get_lousy_outages_home_teaser_data()
     : [
-        'headline' => 'All clear: no active incidents right now.',
+        'headline' => 'All clear — no active outages right now.',
         'href'     => home_url( '/lousy-outages/' ),
         'status'   => 'clear',
         'footnote' => '',
@@ -26,7 +26,9 @@ $teaser_data  = function_exists( 'get_lousy_outages_home_teaser_from_feed' )
     ];
 $teaser_href  = $teaser_data['href'] ?? home_url( '/lousy-outages/' );
 $feed_url     = $teaser_data['feed_url'] ?? $feed_url;
-$status_class = ( $teaser_data['status'] ?? 'clear' ) === 'outage' ? '' : ' lo-home-pacman-alert--clear';
+$status       = $teaser_data['status'] ?? 'clear';
+$status_class = 'clear' === $status ? ' lo-home-pacman-alert--clear' : ' lo-home-pacman-alert--outage';
+$footnote     = $teaser_data['footnote'] ?? '';
 ?>
 <section id="lousy-outages-teaser" class="lo-home-teaser" aria-live="polite">
     <h2 class="lo-home-heading">Lousy Outages</h2>
@@ -39,8 +41,8 @@ $status_class = ( $teaser_data['status'] ?? 'clear' ) === 'outage' ? '' : ' lo-h
         </span>
     </p>
 
-    <?php if ( ! empty( $teaser_data['footnote'] ) ) : ?>
-        <p class="lo-home-footnote"><?php echo esc_html( $teaser_data['footnote'] ); ?></p>
+    <?php if ( ! empty( $footnote ) ) : ?>
+        <p class="lo-home-footnote"><?php echo wp_kses_post( $footnote ); ?></p>
     <?php endif; ?>
 
     <p class="caption"><?php echo esc_html( $teaser_strings['teaserCaption'] ); ?></p>

--- a/style.css
+++ b/style.css
@@ -1404,6 +1404,35 @@ footer,
   margin-bottom: 1.5rem;
 }
 
+.hero-section .hero-intro {
+  max-width: 720px;
+  margin: 0 auto;
+  line-height: 1.8;
+  font-size: 1.05rem;
+  text-align: center;
+}
+
+.hero-section .hero-tagline {
+  margin-bottom: 0.75rem;
+  color: #9bffc6;
+}
+
+.hero-section .hero-build-list {
+  max-width: 560px;
+  margin: 1rem auto 0;
+  padding-left: 1.4rem;
+  text-align: left;
+}
+
+.hero-section .hero-build-list li {
+  margin-bottom: 0.5rem;
+}
+
+.hero-section .hero-bio-button {
+  margin-top: 0.75rem;
+  display: inline-flex;
+}
+
 .lousy-outages-page {
   max-width: 900px;
   margin: 0 auto;
@@ -1454,6 +1483,10 @@ footer,
   color: #9bffc6;
 }
 
+.lo-home-pacman-alert--outage {
+  color: #ff7a7a;
+}
+
 .lo-home-pacman-alert--signal {
   color: #ffe48a;
 }
@@ -1462,6 +1495,11 @@ footer,
   margin: 0;
   font-size: 0.75rem;
   color: rgba(229, 249, 255, 0.7);
+}
+
+.lo-home-footnote a {
+  color: #9bffc6;
+  text-decoration: underline;
 }
 
 .lo-home-teaser .lo-actions {


### PR DESCRIPTION
### Motivation
- Make the homepage copy tighter and more intentional while preserving the CRT/arcade styling.
- Surface the new `Track Analyzer` feature in the home button grid and ensure its CTA is consistent.
- Move the Lousy Outages teaser lower on the page and ensure it never implies an outage when none exists.
- Use the live REST summary as the primary data source for the teaser and degrade gracefully to RSS when needed.

### Description
- Updated `page-home.php` to tighten the hero into a single tagline, a compact paragraph, a 3-item build list, a `Read full bio` CTA, added `Track Analyzer` to the Games & Tools grid, and moved the Lousy Outages teaser to appear after the Track Analyzer block.
- Reworked the teaser include `parts/lousy-outages-teaser.php` to expect `get_lousy_outages_home_teaser_data()` and to map status to clear/outage classes and render a sanitized footnote with links.
- Added REST-first teaser logic to `functions.php`: `get_lousy_outages_home_teaser_data()` now attempts a `wp_remote_get()` to `'/wp-json/lousy-outages/v1/summary'` with a 3s timeout, safely parses `summary_meta`/`meta`, uses `outage_count`, `signal_count`, `unverified_count`, and formats `generated_at`, selects the top provider by `tile_kind === 'outage'` (or outage-like status) and lowest `sort_key`, and only shows provider names when `outage_count > 0`.
- Kept an RSS fallback via the existing `fetch_feed()` logic (exposed as `get_lousy_outages_home_teaser_from_feed()`), tightened fallback behavior so RSS items will not promote signals to main outage headlines (only explicit recent `[OUTAGE]` items within the configured window are treated as outages), and reduced the homepage outage window to 1 hour via `LOUSY_OUTAGES_HOME_OUTAGE_WINDOW_HOURS` to avoid stale headlines.
- Styling updates in `style.css` to add hero intro styles and distinguish calm (`--clear`) vs urgent (`--outage`) teaser colors while keeping existing CRT theme and spacing.
- All changes are backwards-compatible and degrade gracefully when the plugin is disabled or the REST call fails (REST failure returns `null` and the code falls back to RSS).

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695abdc5fa88832eba19bbac1250006d)