### PR TITLE
Fix atom self links for custom lousy-outages feeds

### DIFF
--- a/lousy-outages/includes/Feed.php
+++ b/lousy-outages/includes/Feed.php
@@ -33,7 +33,8 @@ class Feed {
             self::render_incidents_feed($charset);
             return;
         }
-        $self = esc_url(get_feed_link($feedName ?: 'lousy-outages'));
+        // Use the current request URL to avoid mismatch between query-string and pretty permalinks.
+        $self = esc_url(function_exists('get_self_link') ? get_self_link() : home_url(add_query_arg(null, null)));
 
         $store  = new Store();
         $states = $store->get_all();
@@ -89,7 +90,8 @@ class Feed {
     private static function render_incidents_feed(string $charset = 'UTF-8'): void {
         $items       = self::collect_recent_incident_items(2, 30, true);
         $lastUpdated = !empty($items[0]['pubDate']) ? $items[0]['pubDate'] : self::format_rss_date(gmdate('c'));
-        $self        = esc_url(get_feed_link('lousy-outages-incidents'));
+        // Use the current request URL to avoid mismatch between query-string and pretty permalinks.
+        $self        = esc_url(function_exists('get_self_link') ? get_self_link() : home_url(add_query_arg(null, null)));
 
         echo '<?xml version="1.0" encoding="' . esc_attr($charset ?: 'UTF-8') . '"?>';
         ?>

--- a/lousy-outages/includes/Feeds.php
+++ b/lousy-outages/includes/Feeds.php
@@ -53,11 +53,12 @@ class Feeds {
 
         [$items, $last_updated] = self::collect_incident_items();
 
-        $feed_link = function_exists('get_feed_link')
-            ? get_feed_link(self::FEED_NAME)
-            : home_url('/?feed=' . self::FEED_NAME);
+        // Use the current request URL so query-string vs pretty permalink access matches validator expectations.
+        $feed_link = function_exists('get_self_link')
+            ? get_self_link()
+            : home_url(add_query_arg(null, null));
         if (! $feed_link) {
-            $feed_link = home_url('/?feed=' . self::FEED_NAME);
+            $feed_link = home_url(add_query_arg(null, null));
         }
 
         echo '<?xml version="1.0" encoding="' . esc_attr($charset ?: 'UTF-8') . '"?>' . "\n";


### PR DESCRIPTION
### Motivation
- RSS validators reported “Self reference doesn't match document location” because the feed `atom:link` was built with `get_feed_link()` or hardcoded URLs that could differ from the actual request URL. 
- The goal is to make the `<atom:link rel="self">` match the exact URL used to fetch the feed for both query-string and pretty-permalink access.

### Description
- Replaced `get_feed_link()` usage with `get_self_link()` (preferred) and a fallback to `home_url(add_query_arg(null, null))` in `lousy-outages/includes/Feeds.php` and `lousy-outages/includes/Feed.php` so the atom self link matches the request URL. 
- Added short inline comments explaining why `get_self_link()` is used to avoid query-string vs pretty-permalink mismatches. 
- Left the `<link>` element (dashboard URL) and all item formatting/content unchanged. 
- Changes are minimal and confined to `lousy-outages/includes/Feeds.php` and `lousy-outages/includes/Feed.php` only.

### Testing
- No automated tests were executed for this change.
- (Manual verification recommended: request the feed via both `/?feed=lousy_outages_status` and `/feed/lousy_outages_status/` and confirm the `<atom:link>` `href` exactly matches the requested URL.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e83032198832eab60e427c1fbebd0)