### PR TITLE
Fix Vancouver Tech Events date headers timezone handling

### DIFF
--- a/inc/vancouver-tech-events.php
+++ b/inc/vancouver-tech-events.php
@@ -1208,7 +1208,12 @@ function suzy_render_vancouver_tech_events_html( ?array $events = null ): string
 
             <?php foreach ( $events_by_date as $date_key => $date_events ) : ?>
                 <h2 class="vte-date">
-                    <?php echo esc_html( wp_date( get_option( 'date_format' ), strtotime( $date_key ) ) ); ?>
+                    <?php
+                    $timezone = wp_timezone();
+                    $date_dt  = DateTime::createFromFormat( 'Y-m-d H:i:s', $date_key . ' 12:00:00', $timezone );
+                    $date_ts  = $date_dt ? $date_dt->getTimestamp() : (int) ( $date_events[0]['start'] ?? time() );
+                    echo esc_html( wp_date( get_option( 'date_format' ), $date_ts ) );
+                    ?>
                 </h2>
                 <ul class="vte-event-list">
                     <?php foreach ( $date_events as $event ) : ?>


### PR DESCRIPTION
### Motivation
- Date headers on the Vancouver Tech Events page could be off by one because the header used `strtotime($date_key)` which interprets midnight in the server/PHP timezone while `wp_date` formats in the WordPress timezone. 
- Events were already grouped by `wp_date('Y-m-d', $start)`, so the header rendering needed to be computed in the WP timezone to match grouping. 
- Building the header timestamp at midday avoids midnight/DST edge cases that can shift the displayed calendar date.

### Description
- Replace the header rendering `wp_date( get_option('date_format'), strtotime( $date_key ) )` with a WP-timezone `DateTime` built via `DateTime::createFromFormat('Y-m-d H:i:s', $date_key . ' 12:00:00', $timezone)`. 
- Use the `DateTime` timestamp or fall back to the first event `start` (or `time()`) and then call `wp_date` to format the header. 
- The change is implemented in `inc/vancouver-tech-events.php` inside `suzy_render_vancouver_tech_events_html()` and preserves existing grouping and sorting logic.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696428355e84832e98e2d3e9e2b01caf)