### PR TITLE
Add weekday to Vancouver Tech Events date headers

### DIFF
--- a/inc/vancouver-tech-events.php
+++ b/inc/vancouver-tech-events.php
@@ -1212,7 +1212,8 @@ function suzy_render_vancouver_tech_events_html( ?array $events = null ): string
                     $timezone = wp_timezone();
                     $date_dt  = DateTime::createFromFormat( 'Y-m-d H:i:s', $date_key . ' 12:00:00', $timezone );
                     $date_ts  = $date_dt ? $date_dt->getTimestamp() : (int) ( $date_events[0]['start'] ?? time() );
-                    echo esc_html( wp_date( get_option( 'date_format' ), $date_ts ) );
+                    $format = 'l, ' . get_option( 'date_format' );
+                    echo esc_html( wp_date( $format, $date_ts ) );
                     ?>
                 </h2>
                 <ul class="vte-event-list">


### PR DESCRIPTION
### Motivation
- Date headers on the Vancouver Tech Events page should include the weekday name (e.g. "Monday, January 11, 2026").
- Preserve the existing timezone-safe timestamp calculation to avoid reintroducing off-by-one date errors.
- Keep event grouping and sorting behavior unchanged while adjusting only the displayed header format.

### Description
- Updated `inc/vancouver-tech-events.php` to prepend the weekday to the displayed date by using `$format = 'l, ' . get_option( 'date_format' );` and `echo esc_html( wp_date( $format, $date_ts ) );`.
- Left the timezone-safe timestamp creation (`$date_dt`, `$date_ts`) exactly as-is to preserve the previous off-by-one fix.
- No other event grouping, sorting, or display logic was modified.

### Testing
- No automated tests were run for this change.
- The change was committed and the file `inc/vancouver-tech-events.php` was updated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69642a9f3f60832e9448ff1325a30e80)