### PR TITLE
Remove Buy Me a Coffee widget embeds and standardize single Support link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A custom WordPress theme powering [suzyeaston.ca](https://suzyeaston.ca), comple
 - Downtown Eastside advocacy section and notes on Suzy's possible 2026 city council run
 - Custom REST endpoints for Canucks news and betting odds
 - **Lousy Outages** arcade‑style status board with homepage teaser
-- "Buy Me a Coffee" buttons to support Suzy's work
+- A single Support link (header + homepage About group) for supporting Suzy's work
 - Mobile friendly with drag & tap controls
 
 ## Lousy Outages refresh

--- a/assets/css/buttons.css
+++ b/assets/css/buttons.css
@@ -1,17 +1,1 @@
-.btn-bmc {
-  display: inline-block;
-  padding: 0.5rem 1rem;
-  border: 3px solid #0f0;
-  background: #111;
-  color: #0f0;
-  text-decoration: none;
-  font-family: 'Press Start 2P', monospace;
-  font-size: 0.75rem;
-  box-shadow: 0 0 8px #0f0, inset 0 0 8px #0f0;
-}
-.btn-bmc:hover,
-.btn-bmc:focus {
-  background: #0f0;
-  color: #111;
-  box-shadow: 0 0 12px #0f0, inset 0 0 4px #0f0;
-}
+/* .btn-bmc styles removed; support uses shared .pixel-button links. */

--- a/header.php
+++ b/header.php
@@ -131,7 +131,13 @@
     </a>
   </div>
   <div class="header-actions">
-    <?php get_template_part( 'parts/bmc-button' ); ?>
+    <a class="pixel-button header-support-link"
+       href="https://buymeacoffee.com/wi0amge"
+       target="_blank"
+       rel="noopener noreferrer"
+       aria-label="Support Suzy">
+       Support
+    </a>
   </div>
 </header>
 

--- a/page-home.php
+++ b/page-home.php
@@ -120,7 +120,7 @@ get_header();
                 <h3 class="group-title">📚 About &amp; Info</h3>
                 <div class="group-buttons">
                     <a href="/bio" class="pixel-button">About Suzy</a>
-                    <a href="/coffee-for-builders" class="pixel-button">Coffee for Builders</a>
+                    <a href="https://buymeacoffee.com/wi0amge" class="pixel-button" target="_blank" rel="noopener noreferrer">Support</a>
                 </div>
             </div>
 
@@ -189,12 +189,7 @@ get_header();
     </section>
 
 
-    <section class="support-section">
-        <h2 class="pixel-font">Support My Creative Journey</h2>
-        <p class="pixel-font">For collaborations or just to chat, reach out at <a href="mailto:suzyeaston@icloud.com" class="support-link">suzyeaston@icloud.com</a></p>
-        <p style="text-align:center;">🎶 <a href="https://suzyeaston.bandcamp.com" target="_blank">Support my music on Bandcamp</a></p>
-        <p style="text-align:center;">New demo drops this weekend. Stay noisy.</p>
-    </section>
+    
 </main>
 
     <script>

--- a/page-lousy-outages.php
+++ b/page-lousy-outages.php
@@ -162,11 +162,7 @@ if ($unsub_success) {
     </section>
     <footer class="lo-support">
       <p class="lo-support__lead">If this dashboard makes your on-call a little less lousy, you can help keep it running:</p>
-      <ul class="lo-support__links">
-        <li>☕ <a class="lo-link" href="https://buymeacoffee.com/wi0amge" target="_blank" rel="noopener">Buy Me a Coffee</a></li>
-        <li>💖 <a class="lo-link" href="https://paypal.me/suzyeaston" target="_blank" rel="noopener">Donate via PayPal</a></li>
-        <li>🎵 <a class="lo-link" href="https://suzyeaston.bandcamp.com/" target="_blank" rel="noopener">Listen on Bandcamp (new release coming soon!)</a></li>
-      </ul>
+      <p><a class="lo-link" href="https://buymeacoffee.com/wi0amge" target="_blank" rel="noopener noreferrer">Support this project</a></p>
       <p class="lo-support__note">Thanks for fueling the retro outage radar.</p>
     </footer>
   </div>

--- a/parts/bmc-button.php
+++ b/parts/bmc-button.php
@@ -1,4 +1,1 @@
-<div class="bmc-container">
-  <a class="btn-bmc" href="https://buymeacoffee.com/wi0amge" target="_blank" rel="noopener" aria-label="Support Suzy on Buy Me a Coffee">☕ Buy me a coffee</a>
-  <script data-name="BMC-Widget" data-cfasync="false" src="https://cdnjs.buymeacoffee.com/1.0.0/widget.prod.min.js" data-id="wi0amge" data-description="Support me on Buy Me a Coffee!" data-message="Thanks for visiting" data-color="#00ff00" data-position="Right" data-x_margin="18" data-y_margin="18"></script>
-</div>
+<?php // BMC widget removed. Keep support as a simple link in header/homepage.


### PR DESCRIPTION
### Motivation
- Remove the site-wide Buy Me a Coffee (BMC) widget and duplicate support clutter while keeping a single, simple external Support link for visitors.

### Description
- Replaced the global `parts/bmc-button` include in `header.php` with a plain header Support link to `https://buymeacoffee.com/wi0amge` that uses `target="_blank"` and `rel="noopener noreferrer"`.
- Cleared the BMC widget/embed from `parts/bmc-button.php` and replaced the markup with a short comment so no widget script is output anywhere.
- Updated `page-home.php` to replace the “Coffee for Builders” button with a direct external Support link and removed the bottom `support-section` block to eliminate duplicate donation copy.
- Simplified `page-lousy-outages.php` footer by replacing the multi-item support list (Buy Me a Coffee, PayPal, Bandcamp) with a single `Support this project` link to Buy Me a Coffee while preserving the lead sentence and closing note.
- Removed the `.btn-bmc` rules from `assets/css/buttons.css` and added a short comment indicating the styles were removed since support now uses shared `.pixel-button` links.
- Updated `README.md` to reflect the single Support link instead of claiming Buy Me a Coffee buttons/widgets.

Files changed: `header.php`, `parts/bmc-button.php`, `page-home.php`, `page-lousy-outages.php`, `assets/css/buttons.css`, `README.md`.

### Testing
- Ran PHP lint on modified templates with `php -l header.php`, `php -l page-home.php`, `php -l page-lousy-outages.php`, and `php -l parts/bmc-button.php`, and all files reported no syntax errors.
- Searched the PHP files for remaining BMC widget references with `rg -n "widget.prod.min.js|data-name=\"BMC-Widget\"|btn-bmc|get_template_part\( 'parts/bmc-button' \)" -g '*.php'` and found no remaining widget script or legacy BMC classes.
- Attempted a headless browser snapshot to validate runtime UI, but the environment had no web server reachable at `localhost`/`127.0.0.1` on ports `80`, `8080`, or `3000`, so no live screenshot could be captured.
- Verified CSS cleanup by confirming the `.btn-bmc` rules were removed and replaced with a small comment in `assets/css/buttons.css`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69950a1cef58832e8f1d5be2545b8ea9)