### PR TITLE
Update homepage copy: hero, Music/Tools, and ‘Jam With Me’ replacement

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -56,25 +56,25 @@ get_header();
         <h2 class="retro-title glow-lite">Musician &amp; Creative Technologist</h2>
         <section class="pixel-intro hero-intro">
             <p class="hero-headline pixel-font">Hi, I’m Suzy Easton — musician and creative technologist.</p>
-            <p class="hero-subhead">Vancouver-born, generalist by nature. I make indie rock, small tools, and creative experiments — the kind that (hopefully) make life feel a bit more grounded.</p>
-            <p class="hero-microproof">I’ve toured, landed on MuchMusic, and recorded in Chicago with Steve Albini. These days I’m building Track Analyzer, making short AI film experiments with BC + AI Film Club, and writing new songs.</p>
+            <p class="hero-subhead">Vancouver-born and generalist by nature, I build things that make noise — sometimes guitars, sometimes dashboards. My background spans classical training, bass-heavy grunge, jazz curiosity, and five years behind the counter at HMV talking records and discovering new sounds.</p>
+            <p class="hero-microproof">I’ve toured across Canada, appeared on MuchMusic, and recorded in Chicago with Steve Albini. These days, I’m building Track Analyzer, experimenting with short AI films through BC + AI Film Club, and writing whatever songs show up next.</p>
             <div class="hero-lanes">
                 <div class="hero-lane">
                     <p class="hero-lane-title pixel-font">Music</p>
-                    <p>Indie rock, covers, originals. Always down to jam. New stuff always loading.</p>
+                    <p>Classical roots. Indie and grunge instincts. Jazz influence. Originals, covers, collaborations — always evolving.</p>
                 </div>
                 <div class="hero-lane">
                     <p class="hero-lane-title pixel-font">Tools</p>
-                    <p>Track Analyzer, Lousy Outages, AI Film Club shorts, and other experiments.</p>
+                    <p>Track Analyzer, Lousy Outages, AI film experiments, and other projects that blend creativity with infrastructure.</p>
                 </div>
                 <div class="hero-lane">
-                    <p class="hero-lane-title pixel-font">Work with me</p>
-                    <p>QA, automation, reliability. Help for teams who want fewer WTF just happened afternoons.</p>
+                    <p class="hero-lane-title pixel-font">Jam With Me</p>
+                    <p>Whether it’s music, automation, QA, or building reliable systems, I’m always open to collaboration. If you’re into fewer “what just happened?” afternoons — or louder guitars — we’ll get along.</p>
                 </div>
             </div>
             <div class="hero-cta-group">
-                <a href="/suzys-track-analyzer/" class="pixel-button hero-primary-cta">Start here: Track Analyzer</a>
-                <a href="/lousy-outages/" class="pixel-button hero-secondary-cta">Open Lousy Outages</a>
+                <a href="/suzys-track-analyzer/" class="pixel-button hero-primary-cta">Start with: Track Analyzer</a>
+                <a href="/lousy-outages/" class="pixel-button hero-secondary-cta">Or explore: Lousy Outages</a>
                 <a href="/bio/" class="pixel-button hero-bio-button">Read full bio</a>
             </div>
         </section>


### PR DESCRIPTION
### Motivation
- Refresh the homepage hero copy to better reflect a multi-genre musical background and creative-technology work while keeping a cohesive, professional tone.
- Clarify the short lane summaries for `Music` and `Tools` to reflect current projects and influences.
- Replace the collaboration lane with a more playful but credible `Jam With Me` invitation without changing layout or classes.

### Description
- Updated `page-home.php` hero headline and two intro paragraphs to the new copy reflecting classical training, bass-heavy grunge, jazz, HMV experience, touring, MuchMusic, and current projects. 
- Replaced the `Music` lane text with: "Classical roots. Indie and grunge instincts. Jazz influence. Originals, covers, collaborations — always evolving." in `page-home.php`.
- Updated the `Tools` lane text to: "Track Analyzer, Lousy Outages, AI film experiments, and other projects that blend creativity with infrastructure." in `page-home.php`.
- Replaced the `Work with me` lane with `Jam With Me` and the requested collaboration copy, and adjusted CTA labels to `Start with: Track Analyzer` and `Or explore: Lousy Outages`, preserving all HTML structure, class names, and PHP.

### Testing
- Ran `php -l page-home.php` and received `No syntax errors detected in page-home.php`, so PHP syntax is valid. 
- Attempted a Playwright screenshot of a local dev server but the server was not reachable and the check failed with `ERR_EMPTY_RESPONSE`, indicating no running local web server to validate rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c0a9aedf8832e9ea4516b32c92b06)