### PR TITLE
Reduce desktop hero gap by aligning .hero-main toward photo card

### DIFF
--- a/style.css
+++ b/style.css
@@ -2496,6 +2496,11 @@ body {
     grid-template-columns: minmax(0, 2.4fr) minmax(0, 1fr);
     align-items: stretch;
   }
+
+  /* Shift the main hero block toward the photo card on desktop while keeping its content centered. */
+  .hero-main {
+    justify-self: end;
+  }
 }
 
 .hero-main {


### PR DESCRIPTION
### Motivation
- On desktop (>= 860px) the `.hero-main` block was centered inside a very wide grid column, producing a large empty gap between the centered wordmark/copy and the About photo card; the goal is to move the block closer to the photo card while keeping the copy visually centered and preserving mobile/tablet behavior.

### Description
- Added a desktop-only override in `style.css` inside `@media (min-width: 860px)` to set `.hero-main { justify-self: end; }` with a one-line comment explaining the intent, while leaving `text-align: center` and all mobile rules unchanged so the wordmark/copy remain centered internally.

### Testing
- Ran a diff/whitespace check (`git diff --check`) with no issues reported.
- Attempted an automated Playwright screenshot of `http://localhost:8080` but it failed with `ERR_EMPTY_RESPONSE` because no local server was available in this environment, so visual verification could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d1550e670832ea9595b1a56974ecd)