### PR TITLE
Add desktop-only retro spaceship decal to homepage hero gap

### DIFF
--- a/assets/brand/hero-ship.svg
+++ b/assets/brand/hero-ship.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 120" role="img" aria-hidden="true" shape-rendering="crispEdges">
+  <title>Retro hero ship decal</title>
+  <rect width="160" height="120" fill="none"/>
+
+  <!-- Thruster rail (rear) -->
+  <rect x="14" y="56" width="8" height="8" fill="#73fff4"/>
+  <rect x="22" y="54" width="8" height="12" fill="#12d6ca"/>
+
+  <!-- Wing tips -->
+  <rect x="44" y="44" width="10" height="8" fill="#00ff66"/>
+  <rect x="44" y="68" width="10" height="8" fill="#00ff66"/>
+  <rect x="54" y="40" width="10" height="12" fill="#7dffc7"/>
+  <rect x="54" y="68" width="10" height="12" fill="#7dffc7"/>
+
+  <!-- Hull -->
+  <rect x="32" y="52" width="68" height="16" fill="#00ff88"/>
+  <rect x="64" y="48" width="56" height="24" fill="#00ffa2"/>
+  <rect x="96" y="52" width="30" height="16" fill="#2afed0"/>
+
+  <!-- Cockpit and nose -->
+  <rect x="76" y="54" width="20" height="12" fill="#072f2d"/>
+  <rect x="100" y="54" width="8" height="12" fill="#b5fff3"/>
+  <rect x="120" y="56" width="12" height="8" fill="#d5fff9"/>
+  <rect x="132" y="58" width="8" height="4" fill="#efffff"/>
+
+  <!-- Scanline accents -->
+  <rect x="40" y="58" width="54" height="2" fill="#03221f" opacity="0.45"/>
+  <rect x="44" y="62" width="50" height="2" fill="#03221f" opacity="0.35"/>
+
+  <!-- Outline pass -->
+  <rect x="30" y="50" width="2" height="20" fill="#00b85f"/>
+  <rect x="32" y="50" width="94" height="2" fill="#00b85f"/>
+  <rect x="32" y="68" width="94" height="2" fill="#00b85f"/>
+  <rect x="126" y="54" width="2" height="12" fill="#00b85f"/>
+</svg>

--- a/page-home.php
+++ b/page-home.php
@@ -35,6 +35,7 @@ get_header();
                 </div>
                 <p class="hero-copy"><?php echo esc_html($hero_copy); ?></p>
             </div>
+            <div class="hero-deco hero-ship" aria-hidden="true"></div>
             <div class="hero-side hero-photo-card">
                 <p class="hero-side-header">
                     <a class="hero-photo-link" href="<?php echo esc_url(home_url('/bio/')); ?>">

--- a/style.css
+++ b/style.css
@@ -2491,6 +2491,112 @@ body {
   z-index: 1;
 }
 
+/* Homepage hero-only decorative filler to make the starfield gap intentional on desktop. */
+.page-template-page-home-php .hero-grid,
+.home .hero-grid,
+.front-page .hero-grid {
+  isolation: isolate;
+}
+
+.page-template-page-home-php .hero-main,
+.page-template-page-home-php .hero-side,
+.home .hero-main,
+.home .hero-side,
+.front-page .hero-main,
+.front-page .hero-side {
+  position: relative;
+  z-index: 2;
+}
+
+.page-template-page-home-php .hero-ship,
+.home .hero-ship,
+.front-page .hero-ship {
+  display: none;
+}
+
+@media (min-width: 860px) {
+  .page-template-page-home-php .hero-ship,
+  .home .hero-ship,
+  .front-page .hero-ship {
+    /* Retro ship decal: visual-only layer behind hero copy/photo, never interactive. */
+    display: block;
+    position: absolute;
+    left: clamp(52%, 58%, 64%);
+    top: clamp(90px, 20vh, 180px);
+    width: clamp(140px, 18vw, 240px);
+    aspect-ratio: 4 / 3;
+    transform: translate(-50%, -50%);
+    transform-origin: center;
+    z-index: 1;
+    pointer-events: none;
+    background: url('assets/brand/hero-ship.svg') center / contain no-repeat;
+    filter: drop-shadow(0 0 10px rgba(73, 255, 173, 0.35)) drop-shadow(0 0 22px rgba(40, 220, 255, 0.2));
+    animation: heroShipFloat 14s ease-in-out infinite;
+  }
+
+  .page-template-page-home-php .hero-ship::after,
+  .home .hero-ship::after,
+  .front-page .hero-ship::after {
+    content: "";
+    position: absolute;
+    left: 7%;
+    top: 50%;
+    width: 20%;
+    height: 34%;
+    transform: translate(-60%, -50%);
+    border-radius: 999px;
+    background: radial-gradient(circle at 65% 50%, rgba(157, 255, 248, 0.9) 0%, rgba(90, 255, 235, 0.42) 42%, rgba(21, 186, 168, 0) 100%);
+    filter: blur(1px);
+    opacity: 0.58;
+    animation: heroShipThruster 380ms steps(3, end) infinite;
+  }
+}
+
+@media (max-width: 859px) {
+  .page-template-page-home-php .hero-ship,
+  .home .hero-ship,
+  .front-page .hero-ship {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page-template-page-home-php .hero-ship,
+  .page-template-page-home-php .hero-ship::after,
+  .home .hero-ship,
+  .home .hero-ship::after,
+  .front-page .hero-ship,
+  .front-page .hero-ship::after {
+    animation: none !important;
+  }
+}
+
+@keyframes heroShipFloat {
+  0%,
+  100% {
+    transform: translate(-50%, -50%) translate(-18px, -6px);
+  }
+  50% {
+    transform: translate(-50%, -50%) translate(18px, 6px);
+  }
+}
+
+@keyframes heroShipThruster {
+  0%,
+  100% {
+    opacity: 0.45;
+    transform: translate(-60%, -50%) scale(0.9, 0.85);
+  }
+  40% {
+    opacity: 0.75;
+    transform: translate(-60%, -50%) scale(1.06, 1.1);
+  }
+  70% {
+    opacity: 0.55;
+    transform: translate(-60%, -50%) scale(0.95, 0.95);
+  }
+}
+
 @media (min-width: 860px) {
   .hero-grid {
     grid-template-columns: minmax(0, 2.4fr) minmax(0, 1fr);


### PR DESCRIPTION
### Motivation
- Fill the large empty starfield gap in the homepage hero with a tasteful decorative element so the layout reads as an intentional retro arcade attract screen on desktop.
- Keep the decal purely decorative and non-interactive to avoid interfering with hero copy, photo card, or clicks.
- Respect accessibility and performance constraints by providing a CSS-driven animation and honoring `prefers-reduced-motion`.

### Description
- Added a decorative node in the homepage hero markup: `div.hero-deco.hero-ship` inserted between `.hero-main` and `.hero-side` in `page-home.php` so the element only appears in the homepage template.
- Created a pixel-art SVG asset at `assets/brand/hero-ship.svg` composed of `<rect>` blocks with a neon green/teal palette and a rear thruster zone for CSS glow/flicker effects.
- Added homepage-scoped CSS in `style.css` that isolates the hero grid, layers `.hero-ship` behind hero content (`z-index` + `pointer-events: none`), restricts visibility to desktop via `@media (min-width: 860px)`, sizes/positions the decal with `clamp()` and `aspect-ratio`, and applies a gentle float animation plus a thruster flicker via `::after`.
- Implemented reduced-motion support where animations are disabled under `@media (prefers-reduced-motion: reduce)`, and ensured the ship is hidden on widths below `860px`.

### Testing
- Ran PHP syntax check with `php -l page-home.php`, which succeeded.
- Parsed the new SVG with Python's XML parser using `xml.etree.ElementTree` (`ET.parse('assets/brand/hero-ship.svg')`), which succeeded.
- Attempted an automated browser screenshot test, but no local web server was reachable in the environment so a live-render screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d18b2cc24832ea727bd49e0078461)