### PR TITLE
Refine homepage hero ship placement, sprite and CSS-only animations

### DIFF
--- a/assets/brand/hero-ship.svg
+++ b/assets/brand/hero-ship.svg
@@ -1,35 +1,49 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 120" role="img" aria-hidden="true" shape-rendering="crispEdges">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-hidden="true" shape-rendering="crispEdges">
   <title>Retro hero ship decal</title>
-  <rect width="160" height="120" fill="none"/>
+  <rect width="96" height="96" fill="none"/>
 
-  <!-- Thruster rail (rear) -->
-  <rect x="14" y="56" width="8" height="8" fill="#73fff4"/>
-  <rect x="22" y="54" width="8" height="12" fill="#12d6ca"/>
+  <!-- Outer silhouette -->
+  <rect x="44" y="10" width="8" height="6" fill="#00b85f"/>
+  <rect x="40" y="16" width="16" height="4" fill="#00b85f"/>
+  <rect x="36" y="20" width="24" height="4" fill="#00b85f"/>
+  <rect x="30" y="24" width="36" height="4" fill="#00b85f"/>
+  <rect x="24" y="28" width="48" height="4" fill="#00b85f"/>
+  <rect x="18" y="32" width="60" height="4" fill="#00b85f"/>
+  <rect x="14" y="36" width="68" height="4" fill="#00b85f"/>
+  <rect x="12" y="40" width="72" height="8" fill="#00b85f"/>
+  <rect x="16" y="48" width="64" height="8" fill="#00b85f"/>
+  <rect x="20" y="56" width="56" height="8" fill="#00b85f"/>
+  <rect x="24" y="64" width="20" height="8" fill="#00b85f"/>
+  <rect x="52" y="64" width="20" height="8" fill="#00b85f"/>
+  <rect x="28" y="72" width="12" height="8" fill="#00b85f"/>
+  <rect x="56" y="72" width="12" height="8" fill="#00b85f"/>
 
-  <!-- Wing tips -->
-  <rect x="44" y="44" width="10" height="8" fill="#00ff66"/>
-  <rect x="44" y="68" width="10" height="8" fill="#00ff66"/>
-  <rect x="54" y="40" width="10" height="12" fill="#7dffc7"/>
-  <rect x="54" y="68" width="10" height="12" fill="#7dffc7"/>
+  <!-- Wing plates -->
+  <rect x="22" y="34" width="16" height="8" fill="#00ff66"/>
+  <rect x="58" y="34" width="16" height="8" fill="#00ff66"/>
+  <rect x="18" y="42" width="22" height="8" fill="#00ff88"/>
+  <rect x="56" y="42" width="22" height="8" fill="#00ff88"/>
+  <rect x="22" y="50" width="18" height="8" fill="#7dffc7"/>
+  <rect x="56" y="50" width="18" height="8" fill="#7dffc7"/>
 
-  <!-- Hull -->
-  <rect x="32" y="52" width="68" height="16" fill="#00ff88"/>
-  <rect x="64" y="48" width="56" height="24" fill="#00ffa2"/>
-  <rect x="96" y="52" width="30" height="16" fill="#2afed0"/>
+  <!-- Core fuselage -->
+  <rect x="34" y="24" width="28" height="8" fill="#00ffa2"/>
+  <rect x="30" y="32" width="36" height="8" fill="#2afed0"/>
+  <rect x="28" y="40" width="40" height="16" fill="#00ffa2"/>
+  <rect x="32" y="56" width="32" height="12" fill="#12d6ca"/>
 
   <!-- Cockpit and nose -->
-  <rect x="76" y="54" width="20" height="12" fill="#072f2d"/>
-  <rect x="100" y="54" width="8" height="12" fill="#b5fff3"/>
-  <rect x="120" y="56" width="12" height="8" fill="#d5fff9"/>
-  <rect x="132" y="58" width="8" height="4" fill="#efffff"/>
+  <rect x="42" y="20" width="12" height="16" fill="#072f2d"/>
+  <rect x="44" y="22" width="8" height="10" fill="#b5fff3"/>
+  <rect x="46" y="12" width="4" height="8" fill="#d5fff9"/>
 
-  <!-- Scanline accents -->
-  <rect x="40" y="58" width="54" height="2" fill="#03221f" opacity="0.45"/>
-  <rect x="44" y="62" width="50" height="2" fill="#03221f" opacity="0.35"/>
+  <!-- Engine pods -->
+  <rect x="30" y="74" width="8" height="10" fill="#73fff4"/>
+  <rect x="58" y="74" width="8" height="10" fill="#73fff4"/>
+  <rect x="32" y="84" width="4" height="4" fill="#12d6ca"/>
+  <rect x="60" y="84" width="4" height="4" fill="#12d6ca"/>
 
-  <!-- Outline pass -->
-  <rect x="30" y="50" width="2" height="20" fill="#00b85f"/>
-  <rect x="32" y="50" width="94" height="2" fill="#00b85f"/>
-  <rect x="32" y="68" width="94" height="2" fill="#00b85f"/>
-  <rect x="126" y="54" width="2" height="12" fill="#00b85f"/>
+  <!-- Accent scanlines -->
+  <rect x="24" y="46" width="48" height="2" fill="#03221f" opacity="0.4"/>
+  <rect x="28" y="54" width="40" height="2" fill="#03221f" opacity="0.32"/>
 </svg>

--- a/style.css
+++ b/style.css
@@ -2521,17 +2521,28 @@ body {
     /* Retro ship decal: visual-only layer behind hero copy/photo, never interactive. */
     display: block;
     position: absolute;
-    left: clamp(52%, 58%, 64%);
-    top: clamp(90px, 20vh, 180px);
+    left: clamp(56%, 62%, 70%);
+    top: clamp(260px, 70%, 520px);
     width: clamp(140px, 18vw, 240px);
-    aspect-ratio: 4 / 3;
+    aspect-ratio: 1 / 1;
     transform: translate(-50%, -50%);
-    transform-origin: center;
+    transform-origin: 50% 50%;
     z-index: 1;
     pointer-events: none;
+    overflow: visible;
+    animation: heroShipDrift 14s ease-in-out infinite;
+  }
+
+  .page-template-page-home-php .hero-ship::before,
+  .home .hero-ship::before,
+  .front-page .hero-ship::before {
+    content: "";
+    position: absolute;
+    inset: 0;
     background: url('assets/brand/hero-ship.svg') center / contain no-repeat;
-    filter: drop-shadow(0 0 10px rgba(73, 255, 173, 0.35)) drop-shadow(0 0 22px rgba(40, 220, 255, 0.2));
-    animation: heroShipFloat 14s ease-in-out infinite;
+    filter: drop-shadow(0 0 10px rgba(73, 255, 173, 0.35)) drop-shadow(0 0 24px rgba(40, 220, 255, 0.22));
+    transform-origin: 50% 60%;
+    animation: heroShipBob 3.6s ease-in-out infinite, heroShipBank 2.4s ease-in-out infinite, heroShipGlow 4.8s ease-in-out infinite;
   }
 
   .page-template-page-home-php .hero-ship::after,
@@ -2539,15 +2550,15 @@ body {
   .front-page .hero-ship::after {
     content: "";
     position: absolute;
-    left: 7%;
-    top: 50%;
+    left: 50%;
+    top: 92%;
     width: 20%;
-    height: 34%;
-    transform: translate(-60%, -50%);
+    height: 26%;
+    transform: translate(-50%, -50%);
     border-radius: 999px;
-    background: radial-gradient(circle at 65% 50%, rgba(157, 255, 248, 0.9) 0%, rgba(90, 255, 235, 0.42) 42%, rgba(21, 186, 168, 0) 100%);
+    background: radial-gradient(circle at 50% 28%, rgba(157, 255, 248, 0.88) 0%, rgba(90, 255, 235, 0.44) 45%, rgba(21, 186, 168, 0) 100%);
     filter: blur(1px);
-    opacity: 0.58;
+    opacity: 0.52;
     animation: heroShipThruster 380ms steps(3, end) infinite;
   }
 }
@@ -2562,22 +2573,60 @@ body {
 
 @media (prefers-reduced-motion: reduce) {
   .page-template-page-home-php .hero-ship,
+  .page-template-page-home-php .hero-ship::before,
   .page-template-page-home-php .hero-ship::after,
   .home .hero-ship,
+  .home .hero-ship::before,
   .home .hero-ship::after,
   .front-page .hero-ship,
+  .front-page .hero-ship::before,
   .front-page .hero-ship::after {
     animation: none !important;
   }
 }
 
-@keyframes heroShipFloat {
+@keyframes heroShipDrift {
   0%,
   100% {
-    transform: translate(-50%, -50%) translate(-18px, -6px);
+    transform: translate(-50%, -50%) translate(-10px, -10px);
+  }
+  40% {
+    transform: translate(-50%, -50%) translate(12px, 8px);
+  }
+  70% {
+    transform: translate(-50%, -50%) translate(4px, 14px);
+  }
+}
+
+@keyframes heroShipBob {
+  0%,
+  100% {
+    transform: translateY(-3px);
   }
   50% {
-    transform: translate(-50%, -50%) translate(18px, 6px);
+    transform: translateY(4px);
+  }
+}
+
+@keyframes heroShipBank {
+  0%,
+  100% {
+    rotate: -2.5deg;
+  }
+  50% {
+    rotate: 2.5deg;
+  }
+}
+
+@keyframes heroShipGlow {
+  0%,
+  100% {
+    opacity: 0.92;
+    filter: drop-shadow(0 0 8px rgba(73, 255, 173, 0.28)) drop-shadow(0 0 18px rgba(40, 220, 255, 0.16));
+  }
+  45% {
+    opacity: 1;
+    filter: drop-shadow(0 0 12px rgba(73, 255, 173, 0.4)) drop-shadow(0 0 26px rgba(40, 220, 255, 0.25));
   }
 }
 
@@ -2585,15 +2634,15 @@ body {
   0%,
   100% {
     opacity: 0.45;
-    transform: translate(-60%, -50%) scale(0.9, 0.85);
+    transform: translate(-50%, -50%) scale(0.82, 0.78);
   }
   40% {
     opacity: 0.75;
-    transform: translate(-60%, -50%) scale(1.06, 1.1);
+    transform: translate(-50%, -50%) scale(1.02, 1.08);
   }
   70% {
     opacity: 0.55;
-    transform: translate(-60%, -50%) scale(0.95, 0.95);
+    transform: translate(-50%, -50%) scale(0.9, 0.9);
   }
 }
 


### PR DESCRIPTION
### Motivation
- The decorative ship floated too high near the wordmark on desktop, so it must live in the mid/lower starfield pocket behind the hero copy and left of the About card. 
- The sprite needed to read more like a classic Galaga-style fighter and have richer but lightweight animation without JS. 
- Animations must be layered so transforms don’t fight, remain purely CSS-driven for performance, and fully respect `prefers-reduced-motion`. 

### Description
- Repositioned the homepage-only desktop ship by changing `left`/`top` to `left: clamp(56%, 62%, 70%)` and `top: clamp(260px, 70%, 520px)` and updated the aspect to `aspect-ratio: 1 / 1` in `style.css`. 
- Split layout vs sprite: `.hero-ship` is now the positioned container with `animation: heroShipDrift` and `overflow: visible`, while `.hero-ship::before` renders the SVG sprite (`background: url('assets/brand/hero-ship.svg')`) and owns bob/bank/glow animations, and `.hero-ship::after` remains the thruster flicker with adjusted position/size. 
- Added keyframes `heroShipDrift`, `heroShipBob`, `heroShipBank`, and `heroShipGlow` and tuned `heroShipThruster` for a gentle attract-mode feel; all animations are CSS-only. 
- Broadened reduced-motion handling so `@media (prefers-reduced-motion: reduce)` disables `.hero-ship`, `.hero-ship::before`, `.hero-ship::after` animations. 
- Replaced `assets/brand/hero-ship.svg` with a square (96×96) pixel-rect SVG that is symmetric, nose-up, cockpit + engine pods, and uses the existing neon green/teal palette to read as a Galaga-style sprite. 
- Kept this homepage-only and desktop-only behavior, made the deco non-interactive (`pointer-events: none`), preserved `.hero-grid { isolation: isolate; position: relative; }`, and skipped adding optional laser markup to keep the diff minimal. 

### Testing
- Ran `git diff --check` with no issues reported (succeeds). 
- Captured a visual preview by serving the repo via `python3 -m http.server 4173` and taking a Playwright screenshot of a local preview page, which produced the artifact screenshot (saved during the rollout). 
- Committed the changes (`git commit`) and verified modified files `style.css` and `assets/brand/hero-ship.svg` are updated as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d1bd8e694832e8e25231124e40afe)