### PR TITLE
Refine homepage hero ship patrol animation

### DIFF
--- a/style.css
+++ b/style.css
@@ -2515,22 +2515,45 @@ body {
 }
 
 @media (min-width: 860px) {
+  /* Decorative wireframe horizon for homepage hero only. */
+  .page-template-page-home-php .hero-grid::before,
+  .home .hero-grid::before,
+  .front-page .hero-grid::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -10px;
+    height: clamp(90px, 16vh, 160px);
+    z-index: 0;
+    pointer-events: none;
+    background:
+      repeating-linear-gradient(90deg, rgba(128, 225, 255, 0.16) 0 1px, transparent 1px 28px),
+      repeating-linear-gradient(0deg, rgba(128, 225, 255, 0.2) 0 1px, transparent 1px 30px);
+    transform: perspective(500px) rotateX(60deg);
+    transform-origin: bottom;
+    mask-image: linear-gradient(to top, rgba(0, 0, 0, 0.55) 0%, rgba(0, 0, 0, 0) 84%);
+    opacity: 0.34;
+    animation: heroTerrainScroll 18s linear infinite;
+  }
+
   .page-template-page-home-php .hero-ship,
   .home .hero-ship,
   .front-page .hero-ship {
     /* Retro ship decal: visual-only layer behind hero copy/photo, never interactive. */
     display: block;
     position: absolute;
-    left: clamp(56%, 62%, 70%);
+    left: clamp(52%, 58%, 64%);
     top: clamp(260px, 70%, 520px);
-    width: clamp(140px, 18vw, 240px);
+    width: clamp(72px, 9vw, 140px);
+    --ship-travel: clamp(160px, 18vw, 320px);
     aspect-ratio: 1 / 1;
     transform: translate(-50%, -50%);
     transform-origin: 50% 50%;
     z-index: 1;
     pointer-events: none;
     overflow: visible;
-    animation: heroShipDrift 14s ease-in-out infinite;
+    animation: heroShipPatrol 10.5s linear infinite;
   }
 
   .page-template-page-home-php .hero-ship::before,
@@ -2552,13 +2575,13 @@ body {
     position: absolute;
     left: 50%;
     top: 92%;
-    width: 20%;
-    height: 26%;
+    width: 16%;
+    height: 22%;
     transform: translate(-50%, -50%);
     border-radius: 999px;
-    background: radial-gradient(circle at 50% 28%, rgba(157, 255, 248, 0.88) 0%, rgba(90, 255, 235, 0.44) 45%, rgba(21, 186, 168, 0) 100%);
-    filter: blur(1px);
-    opacity: 0.52;
+    background: radial-gradient(circle at 50% 24%, rgba(157, 255, 248, 0.72) 0%, rgba(90, 255, 235, 0.34) 44%, rgba(21, 186, 168, 0) 100%);
+    filter: blur(0.6px);
+    opacity: 0.44;
     animation: heroShipThruster 380ms steps(3, end) infinite;
   }
 }
@@ -2580,41 +2603,61 @@ body {
   .home .hero-ship::after,
   .front-page .hero-ship,
   .front-page .hero-ship::before,
-  .front-page .hero-ship::after {
+  .front-page .hero-ship::after,
+  .page-template-page-home-php .hero-grid::before,
+  .home .hero-grid::before,
+  .front-page .hero-grid::before {
     animation: none !important;
   }
 }
 
-@keyframes heroShipDrift {
-  0%,
+@keyframes heroShipPatrol {
+  0% {
+    transform: translate(-50%, -50%) translateX(calc(-1 * var(--ship-travel))) translateY(-2px);
+    opacity: 0;
+  }
+  10% {
+    opacity: 0.96;
+  }
+  50% {
+    transform: translate(-50%, -50%) translateX(0) translateY(2px);
+    opacity: 1;
+  }
+  90% {
+    opacity: 0.96;
+  }
   100% {
-    transform: translate(-50%, -50%) translate(-10px, -10px);
-  }
-  40% {
-    transform: translate(-50%, -50%) translate(12px, 8px);
-  }
-  70% {
-    transform: translate(-50%, -50%) translate(4px, 14px);
+    transform: translate(-50%, -50%) translateX(var(--ship-travel)) translateY(-1px);
+    opacity: 0;
   }
 }
 
 @keyframes heroShipBob {
   0%,
   100% {
-    transform: translateY(-3px);
+    transform: translateY(-2px);
   }
   50% {
-    transform: translateY(4px);
+    transform: translateY(2px);
   }
 }
 
 @keyframes heroShipBank {
   0%,
   100% {
-    rotate: -2.5deg;
+    rotate: -1.6deg;
   }
   50% {
-    rotate: 2.5deg;
+    rotate: 1.6deg;
+  }
+}
+
+@keyframes heroTerrainScroll {
+  from {
+    background-position: 0 0, 0 0;
+  }
+  to {
+    background-position: 28px 0, 0 30px;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Make the homepage-only desktop ship read as a small, passing sprite rather than a parked decorative icon while keeping it non-interactive and visually behind hero content. 
- Add an optional, subtle wireframe horizon to fill the lower starfield pocket without cluttering the hero or blocking clicks. 

### Description
- Resize and reposition `.hero-ship` for desktop and introduce `--ship-travel` while replacing `heroShipDrift` with a new `heroShipPatrol` animation that translates across the pocket and fades at edges. 
- Soften sprite layer motion by reducing bob amplitude and bank angle in `heroShipBob` and `heroShipBank`, and slim down the thruster (`::after`) size/blur/opacity while keeping the `steps()` flicker. 
- Add a homepage-scoped `.hero-grid::before` pseudo-element that renders a low-opacity, perspective wireframe horizon with a very subtle `heroTerrainScroll` background animation. 
- Respect `prefers-reduced-motion` by disabling the ship, sprite, thruster, and terrain animations in the homepage contexts. 

### Testing
- Searched for relevant selectors and keyframes with `rg -n "hero-ship|Homepage hero-only decorative filler|heroShip" style.css` and found expected matches. 
- Reviewed the edited CSS region with `sed -n '2470,2675p' style.css` to verify placement and values of the new rules. 
- Inspected the generated diff for `style.css` to confirm the insertions and removals match the design intent. 
- Attempted an automated visual capture with Playwright, but Chromium crashed (SIGSEGV) in this environment so live screenshot verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d1eabe174832e971dfd4753c0605c)