### PR TITLE
Add draggable homepage hero spaceship with desktop particle trail

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -46,6 +46,16 @@ function retro_game_music_theme_scripts() {
         wp_enqueue_script('game-init', get_template_directory_uri() . '/js/game-init.js', [], '1.0.0', true);
         wp_enqueue_script('title-color', get_template_directory_uri() . '/js/title-color.js', [], '1.0.0', true);
     }
+
+    if ( is_front_page() || is_page_template( 'page-home.php' ) ) {
+        wp_enqueue_script(
+            'hero-ship-drag',
+            get_template_directory_uri() . '/js/hero-ship-drag.js',
+            array(),
+            filemtime( get_template_directory() . '/js/hero-ship-drag.js' ),
+            true
+        );
+    }
 }
 add_action('wp_enqueue_scripts', 'retro_game_music_theme_scripts');
 

--- a/js/hero-ship-drag.js
+++ b/js/hero-ship-drag.js
@@ -1,0 +1,241 @@
+(function () {
+  const ship = document.querySelector('.hero-ship');
+  const heroGrid = document.querySelector('.hero-grid');
+  const desktopQuery = window.matchMedia('(min-width: 860px)');
+  const reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+  if (!ship || !heroGrid || !desktopQuery.matches) {
+    return;
+  }
+
+  const canvas = document.createElement('canvas');
+  canvas.className = 'hero-ship-trail';
+  canvas.setAttribute('aria-hidden', 'true');
+  heroGrid.insertBefore(canvas, ship);
+
+  const ctx = canvas.getContext('2d', { alpha: true });
+  const particles = [];
+  const margin = 12;
+  let dpr = Math.max(1, window.devicePixelRatio || 1);
+  let rafId = 0;
+  let dragging = false;
+  let pointerId = null;
+  let offsetX = 0;
+  let offsetY = 0;
+  let prevX = null;
+  let prevY = null;
+  let resumeTimeout = 0;
+
+  const getReducedMotion = () => reducedMotionQuery.matches;
+
+  function resizeCanvas() {
+    dpr = Math.max(1, window.devicePixelRatio || 1);
+    const width = heroGrid.clientWidth;
+    const height = heroGrid.clientHeight;
+    canvas.width = Math.max(1, Math.round(width * dpr));
+    canvas.height = Math.max(1, Math.round(height * dpr));
+    canvas.style.width = width + 'px';
+    canvas.style.height = height + 'px';
+
+    const left = parseFloat(ship.style.left);
+    const top = parseFloat(ship.style.top);
+    if (!Number.isNaN(left) && !Number.isNaN(top)) {
+      setShipPosition(clampX(left), clampY(top));
+    }
+  }
+
+  function clampX(x) {
+    return Math.min(heroGrid.clientWidth - margin, Math.max(margin, x));
+  }
+
+  function clampY(y) {
+    return Math.min(heroGrid.clientHeight - margin, Math.max(margin, y));
+  }
+
+  function setShipPosition(x, y) {
+    ship.style.left = x + 'px';
+    ship.style.top = y + 'px';
+  }
+
+  function getLocalPointerPosition(event) {
+    const rect = heroGrid.getBoundingClientRect();
+    return {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top,
+    };
+  }
+
+  function spawnTrail(x, y, dx, dy) {
+    if (getReducedMotion()) {
+      return;
+    }
+
+    const speed = Math.hypot(dx, dy);
+    if (speed < 0.8) {
+      return;
+    }
+
+    const nx = dx / speed;
+    const ny = dy / speed;
+    const thrusterX = x;
+    const thrusterY = y + ship.offsetHeight * 0.35;
+    const count = Math.min(8, 2 + Math.floor(speed / 3));
+
+    for (let i = 0; i < count; i += 1) {
+      const jitter = (Math.random() - 0.5) * 0.6;
+      const spread = (Math.random() - 0.5) * 1.2;
+      const size = 1 + Math.floor(Math.random() * 3);
+      const life = 10 + Math.random() * 10;
+      particles.push({
+        x: thrusterX + spread * 10,
+        y: thrusterY + spread * 6,
+        vx: (-nx + jitter) * (0.9 + Math.random() * 1.1),
+        vy: (-ny + jitter * 0.7) * (0.9 + Math.random() * 1.1) + 0.2,
+        life,
+        maxLife: life,
+        size,
+        color: Math.random() > 0.45 ? '#9dfff8' : '#57f5ff',
+      });
+    }
+  }
+
+  function draw() {
+    if (!ctx) {
+      return;
+    }
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    for (let i = particles.length - 1; i >= 0; i -= 1) {
+      const p = particles[i];
+      p.x += p.vx;
+      p.y += p.vy;
+      p.vx *= 0.96;
+      p.vy *= 0.96;
+      p.life -= 1;
+
+      if (p.life <= 0) {
+        particles.splice(i, 1);
+        continue;
+      }
+
+      const alpha = p.life / p.maxLife;
+      ctx.globalAlpha = alpha;
+      ctx.fillStyle = p.color;
+      ctx.fillRect(Math.round(p.x * dpr), Math.round(p.y * dpr), Math.max(1, Math.round(p.size * dpr)), Math.max(1, Math.round(p.size * dpr)));
+    }
+
+    ctx.globalAlpha = 1;
+
+    if (dragging || particles.length) {
+      rafId = window.requestAnimationFrame(draw);
+    } else {
+      rafId = 0;
+    }
+  }
+
+  function startLoopIfNeeded() {
+    if (!rafId && (dragging || particles.length)) {
+      rafId = window.requestAnimationFrame(draw);
+    }
+  }
+
+  function onPointerMove(event) {
+    if (!dragging || event.pointerId !== pointerId) {
+      return;
+    }
+
+    const local = getLocalPointerPosition(event);
+    const x = clampX(local.x + offsetX);
+    const y = clampY(local.y + offsetY);
+
+    const dx = prevX === null ? 0 : x - prevX;
+    const dy = prevY === null ? 0 : y - prevY;
+
+    setShipPosition(x, y);
+    spawnTrail(x, y, dx, dy);
+    prevX = x;
+    prevY = y;
+    startLoopIfNeeded();
+  }
+
+  function endDrag(event) {
+    if (!dragging || event.pointerId !== pointerId) {
+      return;
+    }
+
+    dragging = false;
+    ship.classList.remove('is-dragging');
+
+    if (ship.hasPointerCapture(pointerId)) {
+      ship.releasePointerCapture(pointerId);
+    }
+
+    pointerId = null;
+    prevX = null;
+    prevY = null;
+
+    window.clearTimeout(resumeTimeout);
+    if (!getReducedMotion()) {
+      resumeTimeout = window.setTimeout(function () {
+        ship.classList.add('hero-ship--autopilot');
+        ship.style.left = '';
+        ship.style.top = '';
+      }, 1200);
+    }
+
+    startLoopIfNeeded();
+  }
+
+  ship.addEventListener('pointerdown', function (event) {
+    if (event.button !== 0 && event.pointerType !== 'touch' && event.pointerType !== 'pen') {
+      return;
+    }
+
+    event.preventDefault();
+    window.clearTimeout(resumeTimeout);
+    ship.classList.remove('hero-ship--autopilot');
+    ship.classList.add('is-dragging');
+
+    dragging = true;
+    pointerId = event.pointerId;
+
+    const rect = ship.getBoundingClientRect();
+    offsetX = rect.left + rect.width / 2 - event.clientX;
+    offsetY = rect.top + rect.height / 2 - event.clientY;
+
+    ship.setPointerCapture(pointerId);
+
+    const local = getLocalPointerPosition(event);
+    prevX = clampX(local.x + offsetX);
+    prevY = clampY(local.y + offsetY);
+    setShipPosition(prevX, prevY);
+    startLoopIfNeeded();
+  });
+
+  ship.addEventListener('pointermove', onPointerMove);
+  ship.addEventListener('pointerup', endDrag);
+  ship.addEventListener('pointercancel', endDrag);
+
+  window.addEventListener('resize', resizeCanvas, { passive: true });
+  desktopQuery.addEventListener('change', function (event) {
+    if (!event.matches) {
+      window.clearTimeout(resumeTimeout);
+      dragging = false;
+      particles.length = 0;
+      ship.classList.remove('is-dragging');
+      ship.classList.add('hero-ship--autopilot');
+      ship.style.left = '';
+      ship.style.top = '';
+      if (rafId) {
+        window.cancelAnimationFrame(rafId);
+        rafId = 0;
+      }
+      if (ctx) {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+      }
+    }
+  });
+
+  resizeCanvas();
+})();

--- a/page-home.php
+++ b/page-home.php
@@ -35,7 +35,7 @@ get_header();
                 </div>
                 <p class="hero-copy"><?php echo esc_html($hero_copy); ?></p>
             </div>
-            <div class="hero-deco hero-ship" aria-hidden="true"></div>
+            <button class="hero-deco hero-ship hero-ship--autopilot" type="button" aria-label="Drag the spaceship" title="Drag me" tabindex="0"></button>
             <div class="hero-side hero-photo-card">
                 <p class="hero-side-header">
                     <a class="hero-photo-link" href="<?php echo esc_url(home_url('/bio/')); ?>">

--- a/style.css
+++ b/style.css
@@ -2540,7 +2540,6 @@ body {
   .page-template-page-home-php .hero-ship,
   .home .hero-ship,
   .front-page .hero-ship {
-    /* Retro ship decal: visual-only layer behind hero copy/photo, never interactive. */
     display: block;
     position: absolute;
     left: clamp(52%, 58%, 64%);
@@ -2551,9 +2550,15 @@ body {
     transform: translate(-50%, -50%);
     transform-origin: 50% 50%;
     z-index: 1;
-    pointer-events: none;
     overflow: visible;
-    animation: heroShipPatrol 10.5s linear infinite;
+    border: 0;
+    padding: 0;
+    background: transparent;
+    cursor: grab;
+    touch-action: none;
+    user-select: none;
+    -webkit-user-select: none;
+    animation: none;
   }
 
   .page-template-page-home-php .hero-ship::before,
@@ -2584,6 +2589,31 @@ body {
     opacity: 0.44;
     animation: heroShipThruster 380ms steps(3, end) infinite;
   }
+
+  .page-template-page-home-php .hero-ship.hero-ship--autopilot,
+  .home .hero-ship.hero-ship--autopilot,
+  .front-page .hero-ship.hero-ship--autopilot {
+    animation: heroShipPatrol 10.5s linear infinite;
+  }
+
+  .page-template-page-home-php .hero-ship.is-dragging,
+  .home .hero-ship.is-dragging,
+  .front-page .hero-ship.is-dragging {
+    cursor: grabbing;
+    animation: none !important;
+    transform: translate(-50%, -50%);
+  }
+}
+
+.page-template-page-home-php .hero-ship-trail,
+.home .hero-ship-trail,
+.front-page .hero-ship-trail {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1;
+  pointer-events: none;
 }
 
 @media (max-width: 859px) {
@@ -2606,7 +2636,10 @@ body {
   .front-page .hero-ship::after,
   .page-template-page-home-php .hero-grid::before,
   .home .hero-grid::before,
-  .front-page .hero-grid::before {
+  .front-page .hero-grid::before,
+  .page-template-page-home-php .hero-ship-trail,
+  .home .hero-ship-trail,
+  .front-page .hero-ship-trail {
     animation: none !important;
   }
 }


### PR DESCRIPTION
### Motivation

- Make the decorative homepage spaceship interactive on desktop (>= 860px) so users can click/touch and drag it inside the `.hero-grid` while preserving the existing autopatrol behavior and respecting accessibility and reduced-motion preferences.  

### Description

- Replace the decorative ship markup in `page-home.php` with an accessible interactive element: a focusable `<button class="hero-deco hero-ship hero-ship--autopilot" ...>` that carries an `aria-label` and `title`.  
- Enqueue a new lightweight script `js/hero-ship-drag.js` only for homepage contexts (`is_front_page()` OR `is_page_template('page-home.php')`) via the existing enqueue flow in `functions.php` with `filemtime()` versioning and footer loading.  
- Update `style.css` to enable desktop drag interaction by removing `pointer-events: none`, adding `cursor: grab`, `touch-action: none`, `user-select: none`, keep the ship behind hero content (`z-index: 1`), scope the autopatrol animation to `.hero-ship--autopilot`, add `.is-dragging` state to pause animation, and add `.hero-ship-trail` canvas layer styles; include `prefers-reduced-motion` handling for animations.  
- Add `js/hero-ship-drag.js` implementing desktop-only guards, insertion of a DPR-aware `<canvas class="hero-ship-trail">` into `.hero-grid`, pointer-events API-based dragging with `setPointerCapture`, clamped movement within the hero playfield, a small performant particle system (pixel squares) that spawns thruster-style entrails during drag, and a delayed (1.2s) return to autopilot after release; script respects `prefers-reduced-motion` by disabling particles and avoiding continuous animations while still allowing position updates.  

### Testing

- Ran `php -l functions.php` and it reported no syntax errors.  
- Ran `php -l page-home.php` and it reported no syntax errors.  
- Ran `node --check js/hero-ship-drag.js` and the JS parsed cleanly.  
- Attempted a Playwright screenshot of `http://localhost` but the environment had no local web server available and the capture failed with `ERR_EMPTY_RESPONSE` (no browser validation possible in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d2dffb41c832ebb8d597a3986e6d1)