### PR TITLE
Adjust homepage hero z-index so spaceship is draggable on desktop

### DIFF
--- a/style.css
+++ b/style.css
@@ -2549,7 +2549,7 @@ body {
     aspect-ratio: 1 / 1;
     transform: translate(-50%, -50%);
     transform-origin: 50% 50%;
-    z-index: 1;
+    z-index: 3;
     overflow: visible;
     border: 0;
     padding: 0;
@@ -2612,7 +2612,7 @@ body {
   inset: 0;
   width: 100%;
   height: 100%;
-  z-index: 1;
+  z-index: 2;
   pointer-events: none;
 }
 


### PR DESCRIPTION
### Motivation
- Pointer events on the homepage ship were intercepted by overlapping hero content because `.hero-ship` was behind `.hero-main`/`.hero-side`; this change makes pointerdown reliably hit the ship without altering visuals or behavior.

### Description
- Increase `.hero-ship` stacking order to `z-index: 3` inside the homepage `@media (min-width: 860px)` rules so the button is above `.hero-main`/`.hero-side` (which remain at `z-index: 2`).
- Raise `.hero-ship-trail` to `z-index: 2` so the trail stays visible beneath the ship while keeping `pointer-events: none` unchanged.
- This is a CSS-only, homepage-scoped change and preserves existing JS drag/autopilot logic and reduced-motion behavior.

### Testing
- Verified the `style.css` changes and selector locations to confirm the cascade now places ` .hero-ship` above hero blocks and the trail between them.
- Attempted an automated visual check with Playwright, but the local site was not reachable (`ERR_EMPTY_RESPONSE`), so visual runtime verification could not be captured in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3a28dcb90832ea9fc24e1df19a65d)