### PR TITLE
Add opt-in desktop Galaga mini-game to homepage hero

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -55,6 +55,13 @@ function retro_game_music_theme_scripts() {
             filemtime( get_template_directory() . '/js/hero-ship-drag.js' ),
             true
         );
+        wp_enqueue_script(
+            'hero-galaga',
+            get_template_directory_uri() . '/js/hero-galaga.js',
+            array( 'hero-ship-drag' ),
+            filemtime( get_template_directory() . '/js/hero-galaga.js' ),
+            true
+        );
     }
 }
 add_action('wp_enqueue_scripts', 'retro_game_music_theme_scripts');

--- a/js/hero-galaga.js
+++ b/js/hero-galaga.js
@@ -1,0 +1,510 @@
+(function () {
+  function initHeroGalaga() {
+    const heroGrid = document.querySelector('.hero-grid');
+    const desktopQuery = window.matchMedia('(min-width: 860px)');
+    const reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+    window.__SE_GALAGA_ACTIVE = false;
+
+    if (!heroGrid || !desktopQuery.matches) {
+    return;
+  }
+
+  const rootStyles = window.getComputedStyle(document.documentElement);
+  const colors = {
+    primary: (rootStyles.getPropertyValue('--primary-color') || '#00ff00').trim(),
+    secondary: (rootStyles.getPropertyValue('--secondary-color') || '#e60073').trim(),
+    accent: (rootStyles.getPropertyValue('--accent-color') || '#ffff00').trim(),
+  };
+
+  const canvas = document.createElement('canvas');
+  canvas.className = 'hero-galaga-canvas';
+  canvas.setAttribute('aria-hidden', 'true');
+
+  const ui = document.createElement('div');
+  ui.className = 'hero-galaga-ui';
+  ui.innerHTML = '<p class="hero-galaga-status">Score: <span data-galaga-score>0</span> · Lives: <span data-galaga-lives>3</span> · Wave: <span data-galaga-wave>1</span></p><p class="hero-galaga-help">Move: ←/→ or A/D · Shoot: Space · Esc: Quit</p><div class="hero-galaga-gameover" data-galaga-gameover hidden></div>';
+
+  const hint = document.createElement('div');
+  hint.className = 'hero-galaga-hint';
+  hint.textContent = reducedMotionQuery.matches ? 'Press G to play (manual motion)' : 'Press G to play';
+
+  heroGrid.appendChild(canvas);
+  heroGrid.appendChild(ui);
+  heroGrid.appendChild(hint);
+
+  const ctx = canvas.getContext('2d', { alpha: true });
+  if (!ctx) {
+    return;
+  }
+
+  ctx.imageSmoothingEnabled = false;
+
+  const scoreEl = ui.querySelector('[data-galaga-score]');
+  const livesEl = ui.querySelector('[data-galaga-lives]');
+  const waveEl = ui.querySelector('[data-galaga-wave]');
+  const gameOverEl = ui.querySelector('[data-galaga-gameover]');
+
+  const state = {
+    active: false,
+    running: false,
+    gameOver: false,
+    width: 1,
+    height: 1,
+    dpr: Math.max(1, window.devicePixelRatio || 1),
+    rafId: 0,
+    score: 0,
+    lives: 3,
+    wave: 1,
+    player: null,
+    playerBullets: [],
+    enemyBullets: [],
+    enemies: [],
+    enemyDir: 1,
+    enemyStepTimer: 0,
+    enemyFireTimer: 0,
+    keys: {
+      left: false,
+      right: false,
+      fire: false,
+    },
+    lastShotAt: 0,
+    lastFrame: 0,
+  };
+
+  function sizeCanvas() {
+    state.dpr = Math.max(1, window.devicePixelRatio || 1);
+    const width = Math.max(1, heroGrid.clientWidth);
+    const height = Math.max(1, heroGrid.clientHeight);
+    state.width = width;
+    state.height = height;
+    canvas.width = Math.round(width * state.dpr);
+    canvas.height = Math.round(height * state.dpr);
+    canvas.style.width = width + 'px';
+    canvas.style.height = height + 'px';
+    ctx.setTransform(state.dpr, 0, 0, state.dpr, 0, 0);
+    ctx.imageSmoothingEnabled = false;
+
+    if (state.player) {
+      state.player.x = Math.min(state.width - state.player.w, Math.max(0, state.player.x));
+      state.player.y = state.height - 64;
+    }
+  }
+
+  function updateUI() {
+    scoreEl.textContent = String(state.score);
+    livesEl.textContent = String(state.lives);
+    waveEl.textContent = String(state.wave);
+  }
+
+  function spawnWave() {
+    const cols = 8;
+    const rows = 4;
+    const enemyW = 22;
+    const enemyH = 16;
+    const gapX = 18;
+    const gapY = 14;
+    const totalW = cols * enemyW + (cols - 1) * gapX;
+    const startX = Math.max(20, (state.width - totalW) / 2);
+    const startY = 56;
+
+    state.enemies = [];
+    for (let row = 0; row < rows; row += 1) {
+      for (let col = 0; col < cols; col += 1) {
+        state.enemies.push({
+          x: startX + col * (enemyW + gapX),
+          y: startY + row * (enemyH + gapY),
+          w: enemyW,
+          h: enemyH,
+          alive: true,
+        });
+      }
+    }
+
+    state.enemyDir = 1;
+    state.enemyStepTimer = 0;
+    state.enemyFireTimer = 0;
+  }
+
+  function resetGame() {
+    state.score = 0;
+    state.lives = 3;
+    state.wave = 1;
+    state.gameOver = false;
+    state.playerBullets = [];
+    state.enemyBullets = [];
+    state.player = {
+      w: 24,
+      h: 14,
+      x: state.width / 2 - 12,
+      y: state.height - 64,
+      speed: 300,
+    };
+
+    spawnWave();
+    updateUI();
+    gameOverEl.hidden = true;
+    gameOverEl.textContent = '';
+  }
+
+  function startGame() {
+    if (state.active || !desktopQuery.matches) {
+      return;
+    }
+
+    state.active = true;
+    state.running = true;
+    window.__SE_GALAGA_ACTIVE = true;
+    heroGrid.classList.add('is-galaga');
+    resetGame();
+    state.lastFrame = performance.now();
+    state.rafId = window.requestAnimationFrame(loop);
+  }
+
+  function stopGame() {
+    state.active = false;
+    state.running = false;
+    state.gameOver = false;
+    state.keys.left = false;
+    state.keys.right = false;
+    state.keys.fire = false;
+    window.__SE_GALAGA_ACTIVE = false;
+    heroGrid.classList.remove('is-galaga');
+    if (state.rafId) {
+      window.cancelAnimationFrame(state.rafId);
+      state.rafId = 0;
+    }
+    ctx.clearRect(0, 0, state.width, state.height);
+    gameOverEl.hidden = true;
+    gameOverEl.textContent = '';
+  }
+
+  function intersects(a, b) {
+    return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
+  }
+
+  function handleKeys(dt, now) {
+    if (!state.player) {
+      return;
+    }
+
+    const dir = (state.keys.right ? 1 : 0) - (state.keys.left ? 1 : 0);
+    state.player.x += dir * state.player.speed * dt;
+    state.player.x = Math.max(0, Math.min(state.width - state.player.w, state.player.x));
+
+    if (state.keys.fire && now - state.lastShotAt > 180) {
+      state.playerBullets.push({ x: state.player.x + state.player.w / 2 - 2, y: state.player.y - 8, w: 4, h: 10, vy: -430 });
+      state.lastShotAt = now;
+    }
+  }
+
+  function updateEnemies(dt) {
+    if (!state.enemies.length) {
+      return;
+    }
+
+    const stepInterval = Math.max(0.14, 0.5 - (state.wave - 1) * 0.04);
+    state.enemyStepTimer += dt;
+
+    if (state.enemyStepTimer >= stepInterval) {
+      state.enemyStepTimer = 0;
+      const stepX = 14 + state.wave * 1.2;
+      const stepY = 14;
+
+      let nextMinX = Infinity;
+      let nextMaxX = -Infinity;
+      state.enemies.forEach(function (enemy) {
+        if (!enemy.alive) {
+          return;
+        }
+        const nextX = enemy.x + stepX * state.enemyDir;
+        nextMinX = Math.min(nextMinX, nextX);
+        nextMaxX = Math.max(nextMaxX, nextX + enemy.w);
+      });
+
+      const hitEdge = nextMinX <= 8 || nextMaxX >= state.width - 8;
+
+      state.enemies.forEach(function (enemy) {
+        if (!enemy.alive) {
+          return;
+        }
+        if (hitEdge) {
+          enemy.y += stepY;
+        } else {
+          enemy.x += stepX * state.enemyDir;
+        }
+      });
+
+      if (hitEdge) {
+        state.enemyDir *= -1;
+      }
+    }
+
+    state.enemyFireTimer += dt;
+    const fireInterval = Math.max(0.45, 1.2 - (state.wave - 1) * 0.08);
+    if (state.enemyFireTimer >= fireInterval) {
+      state.enemyFireTimer = 0;
+      const aliveEnemies = state.enemies.filter(function (enemy) {
+        return enemy.alive;
+      });
+      if (aliveEnemies.length) {
+        const shooter = aliveEnemies[Math.floor(Math.random() * aliveEnemies.length)];
+        state.enemyBullets.push({
+          x: shooter.x + shooter.w / 2 - 2,
+          y: shooter.y + shooter.h,
+          w: 4,
+          h: 10,
+          vy: 240 + state.wave * 22,
+        });
+      }
+    }
+  }
+
+  function updateBullets(dt) {
+    state.playerBullets.forEach(function (bullet) {
+      bullet.y += bullet.vy * dt;
+    });
+    state.enemyBullets.forEach(function (bullet) {
+      bullet.y += bullet.vy * dt;
+    });
+
+    state.playerBullets = state.playerBullets.filter(function (bullet) {
+      return bullet.y + bullet.h > 0;
+    });
+    state.enemyBullets = state.enemyBullets.filter(function (bullet) {
+      return bullet.y < state.height + bullet.h;
+    });
+  }
+
+  function resolveCollisions() {
+    state.playerBullets = state.playerBullets.filter(function (bullet) {
+      let hit = false;
+      state.enemies.forEach(function (enemy) {
+        if (enemy.alive && intersects(bullet, enemy)) {
+          enemy.alive = false;
+          hit = true;
+          state.score += 100;
+        }
+      });
+      return !hit;
+    });
+
+    if (state.player) {
+      state.enemyBullets = state.enemyBullets.filter(function (bullet) {
+        if (intersects(bullet, state.player)) {
+          state.lives -= 1;
+          return false;
+        }
+        return true;
+      });
+    }
+
+    if (state.lives <= 0 && !state.gameOver) {
+      state.running = false;
+      state.gameOver = true;
+      gameOverEl.hidden = false;
+      gameOverEl.textContent = 'Game Over · Score ' + state.score + ' · Press Enter to restart or Esc to quit';
+    }
+
+    const aliveCount = state.enemies.filter(function (enemy) {
+      return enemy.alive;
+    }).length;
+
+    if (aliveCount === 0 && !state.gameOver) {
+      state.wave += 1;
+      state.playerBullets = [];
+      state.enemyBullets = [];
+      spawnWave();
+    }
+
+    const invaded = state.enemies.some(function (enemy) {
+      return enemy.alive && enemy.y + enemy.h >= state.height - 56;
+    });
+
+    if (invaded && !state.gameOver) {
+      state.lives = 0;
+      state.running = false;
+      state.gameOver = true;
+      gameOverEl.hidden = false;
+      gameOverEl.textContent = 'Game Over · Invaded! · Press Enter to restart or Esc to quit';
+    }
+
+    updateUI();
+  }
+
+  function drawPlayer() {
+    if (!state.player) {
+      return;
+    }
+
+    const p = state.player;
+    ctx.fillStyle = colors.primary;
+    ctx.fillRect(Math.round(p.x + 10), Math.round(p.y), 4, 3);
+    ctx.fillRect(Math.round(p.x + 7), Math.round(p.y + 3), 10, 4);
+    ctx.fillRect(Math.round(p.x + 3), Math.round(p.y + 7), 18, 4);
+    ctx.fillRect(Math.round(p.x), Math.round(p.y + 11), 24, 3);
+    ctx.fillStyle = colors.accent;
+    ctx.fillRect(Math.round(p.x + 11), Math.round(p.y + 5), 2, 4);
+  }
+
+  function drawEnemy(enemy) {
+    ctx.fillStyle = colors.secondary;
+    ctx.fillRect(Math.round(enemy.x + 2), Math.round(enemy.y), enemy.w - 4, 3);
+    ctx.fillRect(Math.round(enemy.x), Math.round(enemy.y + 3), enemy.w, 5);
+    ctx.fillRect(Math.round(enemy.x + 4), Math.round(enemy.y + 8), enemy.w - 8, 3);
+    ctx.fillStyle = colors.accent;
+    ctx.fillRect(Math.round(enemy.x + 5), Math.round(enemy.y + 4), 2, 2);
+    ctx.fillRect(Math.round(enemy.x + enemy.w - 7), Math.round(enemy.y + 4), 2, 2);
+  }
+
+  function drawBullets() {
+    ctx.fillStyle = colors.accent;
+    state.playerBullets.forEach(function (bullet) {
+      ctx.fillRect(Math.round(bullet.x), Math.round(bullet.y), bullet.w, bullet.h);
+    });
+
+    ctx.fillStyle = colors.primary;
+    state.enemyBullets.forEach(function (bullet) {
+      ctx.fillRect(Math.round(bullet.x), Math.round(bullet.y), bullet.w, bullet.h);
+    });
+  }
+
+  function render() {
+    ctx.clearRect(0, 0, state.width, state.height);
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.72)';
+    ctx.fillRect(0, 0, state.width, state.height);
+
+    drawPlayer();
+
+    state.enemies.forEach(function (enemy) {
+      if (enemy.alive) {
+        drawEnemy(enemy);
+      }
+    });
+
+    drawBullets();
+
+    if (!state.running && !state.gameOver) {
+      ctx.fillStyle = colors.primary;
+      ctx.font = '12px "Press Start 2P", monospace';
+      ctx.textAlign = 'center';
+      ctx.fillText('Press G to Start', state.width / 2, state.height / 2);
+    }
+  }
+
+  function loop(now) {
+    const dt = Math.min(0.033, (now - state.lastFrame) / 1000 || 0.016);
+    state.lastFrame = now;
+
+    if (state.active && state.running) {
+      handleKeys(dt, now);
+      updateEnemies(dt);
+      updateBullets(dt);
+      resolveCollisions();
+    }
+
+    render();
+
+    if (state.active) {
+      state.rafId = window.requestAnimationFrame(loop);
+    }
+  }
+
+  function isTypingTarget(target) {
+    if (!target) {
+      return false;
+    }
+    const tag = target.tagName;
+    return target.isContentEditable || tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+  }
+
+  window.addEventListener('keydown', function (event) {
+    const key = event.key.toLowerCase();
+    const typing = isTypingTarget(event.target);
+
+    if (!state.active && !typing && key === 'g') {
+      startGame();
+      event.preventDefault();
+      return;
+    }
+
+    if (!state.active) {
+      return;
+    }
+
+    if (key === 'escape') {
+      stopGame();
+      event.preventDefault();
+      return;
+    }
+
+    if (state.gameOver && key === 'enter') {
+      resetGame();
+      state.running = true;
+      state.lastFrame = performance.now();
+      event.preventDefault();
+      return;
+    }
+
+    if (key === 'arrowleft' || key === 'a') {
+      state.keys.left = true;
+      event.preventDefault();
+    }
+    if (key === 'arrowright' || key === 'd') {
+      state.keys.right = true;
+      event.preventDefault();
+    }
+    if (key === ' ' || key === 'spacebar') {
+      state.keys.fire = true;
+      event.preventDefault();
+    }
+  });
+
+  window.addEventListener('keyup', function (event) {
+    if (!state.active) {
+      return;
+    }
+
+    const key = event.key.toLowerCase();
+    if (key === 'arrowleft' || key === 'a') {
+      state.keys.left = false;
+      event.preventDefault();
+    }
+    if (key === 'arrowright' || key === 'd') {
+      state.keys.right = false;
+      event.preventDefault();
+    }
+    if (key === ' ' || key === 'spacebar') {
+      state.keys.fire = false;
+      event.preventDefault();
+    }
+  });
+
+  desktopQuery.addEventListener('change', function (event) {
+    if (!event.matches && state.active) {
+      stopGame();
+    }
+  });
+
+  const resizeObserver = 'ResizeObserver' in window
+    ? new ResizeObserver(function () {
+      sizeCanvas();
+    })
+    : null;
+
+  if (resizeObserver) {
+    resizeObserver.observe(heroGrid);
+  } else {
+    window.addEventListener('resize', sizeCanvas, { passive: true });
+  }
+
+  sizeCanvas();
+  updateUI();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initHeroGalaga, { once: true });
+  } else {
+    initHeroGalaga();
+  }
+})();

--- a/js/hero-ship-drag.js
+++ b/js/hero-ship-drag.js
@@ -28,6 +28,10 @@
 
   const getReducedMotion = () => reducedMotionQuery.matches;
 
+  function isGalagaActive() {
+    return Boolean(window.__SE_GALAGA_ACTIVE);
+  }
+
   function resizeCanvas() {
     dpr = Math.max(1, window.devicePixelRatio || 1);
     const width = heroGrid.clientWidth;
@@ -141,7 +145,7 @@
   }
 
   function onPointerMove(event) {
-    if (!dragging || event.pointerId !== pointerId) {
+    if (isGalagaActive() || !dragging || event.pointerId !== pointerId) {
       return;
     }
 
@@ -160,7 +164,7 @@
   }
 
   function endDrag(event) {
-    if (!dragging || event.pointerId !== pointerId) {
+    if (isGalagaActive() || !dragging || event.pointerId !== pointerId) {
       return;
     }
 
@@ -188,6 +192,10 @@
   }
 
   ship.addEventListener('pointerdown', function (event) {
+    if (isGalagaActive()) {
+      return;
+    }
+
     if (event.button !== 0 && event.pointerType !== 'touch' && event.pointerType !== 'pen') {
       return;
     }

--- a/style.css
+++ b/style.css
@@ -2616,6 +2616,100 @@ body {
   pointer-events: none;
 }
 
+
+.page-template-page-home-php .hero-galaga-canvas,
+.home .hero-galaga-canvas,
+.front-page .hero-galaga-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  z-index: 4;
+  pointer-events: auto;
+}
+
+.page-template-page-home-php .hero-galaga-ui,
+.home .hero-galaga-ui,
+.front-page .hero-galaga-ui {
+  position: absolute;
+  inset: 12px 12px auto;
+  display: none;
+  z-index: 5;
+  pointer-events: none;
+  font-size: 0.55rem;
+  line-height: 1.55;
+  color: var(--primary-color);
+  text-shadow: 0 0 6px rgba(0, 0, 0, 0.7);
+}
+
+.page-template-page-home-php .hero-galaga-status,
+.page-template-page-home-php .hero-galaga-help,
+.home .hero-galaga-status,
+.home .hero-galaga-help,
+.front-page .hero-galaga-status,
+.front-page .hero-galaga-help {
+  margin: 0;
+  background: rgba(0, 0, 0, 0.68);
+  border: 1px solid rgba(128, 225, 255, 0.44);
+  padding: 7px 10px;
+}
+
+.page-template-page-home-php .hero-galaga-help,
+.home .hero-galaga-help,
+.front-page .hero-galaga-help {
+  margin-top: 6px;
+  color: var(--accent-color);
+}
+
+.page-template-page-home-php .hero-galaga-gameover,
+.home .hero-galaga-gameover,
+.front-page .hero-galaga-gameover {
+  margin-top: 10px;
+  max-width: min(90%, 560px);
+  background: rgba(10, 10, 10, 0.84);
+  border: 2px solid var(--secondary-color);
+  color: var(--accent-color);
+  padding: 10px;
+}
+
+.page-template-page-home-php .hero-galaga-hint,
+.home .hero-galaga-hint,
+.front-page .hero-galaga-hint {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 4;
+  padding: 6px 10px;
+  font-size: 0.52rem;
+  letter-spacing: 0.04em;
+  color: var(--accent-color);
+  border: 1px solid rgba(128, 225, 255, 0.35);
+  background: rgba(0, 0, 0, 0.62);
+  pointer-events: none;
+}
+
+.page-template-page-home-php .hero-grid.is-galaga .hero-galaga-canvas,
+.page-template-page-home-php .hero-grid.is-galaga .hero-galaga-ui,
+.home .hero-grid.is-galaga .hero-galaga-canvas,
+.home .hero-grid.is-galaga .hero-galaga-ui,
+.front-page .hero-grid.is-galaga .hero-galaga-canvas,
+.front-page .hero-grid.is-galaga .hero-galaga-ui {
+  display: block;
+}
+
+.page-template-page-home-php .hero-grid.is-galaga .hero-galaga-hint,
+.home .hero-grid.is-galaga .hero-galaga-hint,
+.front-page .hero-grid.is-galaga .hero-galaga-hint,
+.page-template-page-home-php .hero-grid.is-galaga .hero-ship,
+.page-template-page-home-php .hero-grid.is-galaga .hero-ship-trail,
+.home .hero-grid.is-galaga .hero-ship,
+.home .hero-grid.is-galaga .hero-ship-trail,
+.front-page .hero-grid.is-galaga .hero-ship,
+.front-page .hero-grid.is-galaga .hero-ship-trail {
+  display: none;
+}
+
 @media (max-width: 859px) {
   .page-template-page-home-php .hero-ship,
   .home .hero-ship,


### PR DESCRIPTION
### Motivation
- Provide a fun, non-destructive, opt‑in arcade mode for the homepage hero that runs only on desktop and only when the visitor explicitly starts it.
- Preserve existing homepage UX (drag/autopilot, CTAs, links) and respect reduced motion preferences while preventing accidental hijack of inputs.

### Description
- Added a new script `js/hero-galaga.js` which initializes only on desktop (`matchMedia('(min-width: 860px)')`), injects `canvas.hero-galaga-canvas`, `div.hero-galaga-ui`, and `div.hero-galaga-hint`, reads theme CSS variables for colors, supports DPR via `devicePixelRatio`, and uses `ResizeObserver` to resize the canvas; the animation loop only starts after the user presses `G` and `window.__SE_GALAGA_ACTIVE` is set while playing.
- Implemented a compact Galaga‑style MVP inside the new script with left/right movement (`ArrowLeft`/`ArrowRight` + `A`/`D`), `Space` to shoot, enemy grid movement (step left/right, descend on edge), enemy firing, bullet/enemy collision, score/lives tracking, wave progression, and a Game Over overlay with `Enter` to restart and `Esc` to quit.
- Updated `js/hero-ship-drag.js` to add a simple guard (`window.__SE_GALAGA_ACTIVE`) so drag/pointer logic bails out while Arcade Mode is active and does not capture input during play.
- Added hero-scoped CSS in `style.css` to style `.hero-galaga-canvas`, `.hero-galaga-ui`, and `.hero-galaga-hint`, and added an `.hero-grid.is-galaga` active state that shows the canvas/ui and hides the decorative ship/trail without affecting layout.
- Enqueued `js/hero-galaga.js` from `functions.php` for front page / `page-home.php` with `filemtime` cache-busting and declared it dependent on `hero-ship-drag` and loaded in the footer.

### Testing
- Ran `php -l functions.php` to lint the PHP and it succeeded.
- Ran `node --check js/hero-galaga.js` and `node --check js/hero-ship-drag.js` for JS syntax validation and both succeeded.
- Attempted to run a local PHP dev server (`php -S ...`) and automated page capture via Playwright; the server started but a request to the repo root failed because the full WordPress runtime is not available in this environment, so the visual in‑browser validation must be performed inside a proper WP environment; Playwright still produced a screenshot artifact but the page returned a 500 from the missing WP bootstrap.

Files changed/added
- Added: `js/hero-galaga.js` (new game logic and UI insertion)
- Modified: `js/hero-ship-drag.js` (guard to disable dragging during arcade mode)
- Modified: `style.css` (hero-scoped canvas/UI/hint styles and active state)
- Modified: `functions.php` (enqueue `hero-galaga.js` on front page/home template)

Controls / quick test instructions
- On desktop (≥ 860px) load the homepage and confirm the hint “Press G to play” appears, press `G` to start, use `←/→` or `A/D` to move, `Space` to shoot, `Esc` to quit, and `Enter` to restart on Game Over.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3a51a91d0832e9ef490e9c1dba4d6)