### PR TITLE
Fix Galaga Arcade Mode activation and add desktop Play button

### DIFF
--- a/js/hero-galaga.js
+++ b/js/hero-galaga.js
@@ -6,6 +6,11 @@
 
     window.__SE_GALAGA_ACTIVE = false;
 
+    if (heroGrid) {
+      heroGrid.dataset.galagaReady = 'true';
+      heroGrid.dataset.galagaActive = 'false';
+    }
+
     if (!heroGrid || !desktopQuery.matches) {
     return;
   }
@@ -27,7 +32,9 @@
 
   const hint = document.createElement('div');
   hint.className = 'hero-galaga-hint';
-  hint.textContent = reducedMotionQuery.matches ? 'Press G to play (manual motion)' : 'Press G to play';
+  hint.innerHTML = '<span class="hero-galaga-hint-text">'
+    + (reducedMotionQuery.matches ? 'Press G to play (manual motion)' : 'Press G to play')
+    + '</span><button type="button" class="hero-galaga-start">Play</button>';
 
   heroGrid.appendChild(canvas);
   heroGrid.appendChild(ui);
@@ -44,6 +51,7 @@
   const livesEl = ui.querySelector('[data-galaga-lives]');
   const waveEl = ui.querySelector('[data-galaga-wave]');
   const gameOverEl = ui.querySelector('[data-galaga-gameover]');
+  const startButton = hint.querySelector('.hero-galaga-start');
 
   const state = {
     active: false,
@@ -152,11 +160,14 @@
       return;
     }
 
+    canvas.tabIndex = 0;
     state.active = true;
     state.running = true;
     window.__SE_GALAGA_ACTIVE = true;
+    heroGrid.dataset.galagaActive = 'true';
     heroGrid.classList.add('is-galaga');
     resetGame();
+    canvas.focus({ preventScroll: true });
     state.lastFrame = performance.now();
     state.rafId = window.requestAnimationFrame(loop);
   }
@@ -169,6 +180,7 @@
     state.keys.right = false;
     state.keys.fire = false;
     window.__SE_GALAGA_ACTIVE = false;
+    heroGrid.dataset.galagaActive = 'false';
     heroGrid.classList.remove('is-galaga');
     if (state.rafId) {
       window.cancelAnimationFrame(state.rafId);
@@ -418,13 +430,32 @@
     return target.isContentEditable || tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
   }
 
+  function shouldBlockGameplayEvent(event) {
+    if (!state.active) {
+      return false;
+    }
+
+    const code = event.code;
+    return code === 'ArrowLeft' || code === 'ArrowRight' || code === 'KeyA' || code === 'KeyD' || code === 'Space';
+  }
+
+  if (startButton) {
+    startButton.addEventListener('click', function (event) {
+      event.preventDefault();
+      event.stopPropagation();
+      startGame();
+      canvas.focus({ preventScroll: true });
+    });
+  }
+
   window.addEventListener('keydown', function (event) {
-    const key = event.key.toLowerCase();
+    const code = event.code;
     const typing = isTypingTarget(event.target);
 
-    if (!state.active && !typing && key === 'g') {
+    if (!state.active && !typing && code === 'KeyG') {
       startGame();
       event.preventDefault();
+      event.stopPropagation();
       return;
     }
 
@@ -432,53 +463,67 @@
       return;
     }
 
-    if (key === 'escape') {
-      stopGame();
-      event.preventDefault();
+    if (typing) {
       return;
     }
 
-    if (state.gameOver && key === 'enter') {
+    if (code === 'Escape') {
+      stopGame();
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    if (state.gameOver && code === 'Enter') {
       resetGame();
       state.running = true;
       state.lastFrame = performance.now();
       event.preventDefault();
+      event.stopPropagation();
       return;
     }
 
-    if (key === 'arrowleft' || key === 'a') {
+    if (code === 'ArrowLeft' || code === 'KeyA') {
       state.keys.left = true;
-      event.preventDefault();
     }
-    if (key === 'arrowright' || key === 'd') {
+    if (code === 'ArrowRight' || code === 'KeyD') {
       state.keys.right = true;
-      event.preventDefault();
     }
-    if (key === ' ' || key === 'spacebar') {
+    if (code === 'Space') {
       state.keys.fire = true;
-      event.preventDefault();
     }
-  });
+
+    if (shouldBlockGameplayEvent(event)) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  }, { capture: true });
 
   window.addEventListener('keyup', function (event) {
     if (!state.active) {
       return;
     }
 
-    const key = event.key.toLowerCase();
-    if (key === 'arrowleft' || key === 'a') {
+    if (isTypingTarget(event.target)) {
+      return;
+    }
+
+    const code = event.code;
+    if (code === 'ArrowLeft' || code === 'KeyA') {
       state.keys.left = false;
-      event.preventDefault();
     }
-    if (key === 'arrowright' || key === 'd') {
+    if (code === 'ArrowRight' || code === 'KeyD') {
       state.keys.right = false;
-      event.preventDefault();
     }
-    if (key === ' ' || key === 'spacebar') {
+    if (code === 'Space') {
       state.keys.fire = false;
-      event.preventDefault();
     }
-  });
+
+    if (shouldBlockGameplayEvent(event)) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  }, { capture: true });
 
   desktopQuery.addEventListener('change', function (event) {
     if (!event.matches && state.active) {

--- a/style.css
+++ b/style.css
@@ -2686,7 +2686,36 @@ body {
   color: var(--accent-color);
   border: 1px solid rgba(128, 225, 255, 0.35);
   background: rgba(0, 0, 0, 0.62);
-  pointer-events: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  pointer-events: auto;
+}
+
+.page-template-page-home-php .hero-galaga-start,
+.home .hero-galaga-start,
+.front-page .hero-galaga-start {
+  appearance: none;
+  border: 1px solid var(--primary-color);
+  background: rgba(0, 0, 0, 0.75);
+  color: var(--primary-color);
+  font: inherit;
+  font-size: 0.5rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 4px 8px;
+  line-height: 1.1;
+  cursor: pointer;
+}
+
+.page-template-page-home-php .hero-galaga-start:hover,
+.page-template-page-home-php .hero-galaga-start:focus-visible,
+.home .hero-galaga-start:hover,
+.home .hero-galaga-start:focus-visible,
+.front-page .hero-galaga-start:hover,
+.front-page .hero-galaga-start:focus-visible {
+  border-color: var(--accent-color);
+  color: var(--accent-color);
 }
 
 .page-template-page-home-php .hero-grid.is-galaga .hero-galaga-canvas,


### PR DESCRIPTION
### Motivation
- Ensure Arcade Mode reliably activates on desktop when `startGame` was previously not triggered by blocked key events or variable `event.key` values. 
- Provide an obvious desktop-only opt-in so the homepage isn’t hijacked and users can start the game without relying solely on keyboard events. 
- Make input/focus behavior robust so gameplay keys don’t cause page scroll or get swallowed by other handlers. 
- Add a minimal, inspectable debug flag to verify the script is initialized and active without console logs.

### Description
- Updated `js/hero-galaga.js` to use `KeyboardEvent.code` for controls (`KeyG`, `Escape`, `Enter`, `ArrowLeft`/`ArrowRight`, `KeyA`/`KeyD`, `Space`) and moved `keydown`/`keyup` listeners to the capture phase (`{ capture: true }`) to avoid other scripts stopping propagation. 
- Added a clickable desktop start control: the hint now contains a `<button class="hero-galaga-start">Play</button>` and a click handler that calls `startGame()`, focuses the canvas, and prevents dragging. 
- Improved focus/input robustness by setting `canvas.tabIndex = 0`, calling `canvas.focus({ preventScroll: true })` on start, and suppressing movement/fire key events with `preventDefault()` + `stopPropagation()` while the game is active; typing targets (`INPUT`, `TEXTAREA`, `SELECT`, `contentEditable`) are still ignored. 
- Added lightweight debug dataset flags on `.hero-grid`: set `data-galaga-ready="true"` on init and toggle `data-galaga-active` to `"true"` / `"false"` on start/stop. 
- Updated `style.css` to make the hint clickable on desktop (`pointer-events: auto`), display it as an inline-flex container, and added styles for `.hero-galaga-start` (visual and focus/hover states). 
- Files changed: `js/hero-galaga.js`, `style.css` (no changes to `js/hero-ship-drag.js`).

### Testing
- Ran `node --check js/hero-galaga.js` which succeeded. 
- Started a local PHP server (`php -S 0.0.0.0:8000 -t .`) and attempted an automated Playwright screenshot run to validate UI, but Chromium crashed with SIGSEGV in this environment so no screenshot artifact was produced. 
- All automated checks listed above are included; the Playwright run failed due to environment/browser instability rather than code errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a5a3dd44832eaa59b0ee09775fc4)