### PR TITLE
Improve hero Galaga attract mode and HUD/hint layout

### DIFF
--- a/js/hero-galaga.js
+++ b/js/hero-galaga.js
@@ -12,539 +12,634 @@
     }
 
     if (!heroGrid || !desktopQuery.matches) {
-    return;
-  }
-
-  const rootStyles = window.getComputedStyle(document.documentElement);
-  const colors = {
-    primary: (rootStyles.getPropertyValue('--primary-color') || '#00ff00').trim(),
-    secondary: (rootStyles.getPropertyValue('--secondary-color') || '#e60073').trim(),
-    accent: (rootStyles.getPropertyValue('--accent-color') || '#ffff00').trim(),
-  };
-
-  const canvas = document.createElement('canvas');
-  canvas.className = 'hero-galaga-canvas';
-  canvas.setAttribute('aria-hidden', 'true');
-
-  const ui = document.createElement('div');
-  ui.className = 'hero-galaga-ui';
-  ui.innerHTML = '<p class="hero-galaga-status">Score: <span data-galaga-score>0</span> · Lives: <span data-galaga-lives>3</span> · Wave: <span data-galaga-wave>1</span></p><p class="hero-galaga-help">Move: ←/→ or A/D · Shoot: Space · Esc: Quit</p><div class="hero-galaga-gameover" data-galaga-gameover hidden></div>';
-
-  const hint = document.createElement('div');
-  hint.className = 'hero-galaga-hint';
-  hint.innerHTML = '<span class="hero-galaga-hint-text">'
-    + (reducedMotionQuery.matches ? 'Press G to play (manual motion)' : 'Press G to play')
-    + '</span><button type="button" class="hero-galaga-start">Play</button>';
-
-  heroGrid.appendChild(canvas);
-  heroGrid.appendChild(ui);
-  heroGrid.appendChild(hint);
-
-  const ctx = canvas.getContext('2d', { alpha: true });
-  if (!ctx) {
-    return;
-  }
-
-  ctx.imageSmoothingEnabled = false;
-
-  const scoreEl = ui.querySelector('[data-galaga-score]');
-  const livesEl = ui.querySelector('[data-galaga-lives]');
-  const waveEl = ui.querySelector('[data-galaga-wave]');
-  const gameOverEl = ui.querySelector('[data-galaga-gameover]');
-  const startButton = hint.querySelector('.hero-galaga-start');
-
-  const state = {
-    active: false,
-    running: false,
-    gameOver: false,
-    width: 1,
-    height: 1,
-    dpr: Math.max(1, window.devicePixelRatio || 1),
-    rafId: 0,
-    score: 0,
-    lives: 3,
-    wave: 1,
-    player: null,
-    playerBullets: [],
-    enemyBullets: [],
-    enemies: [],
-    enemyDir: 1,
-    enemyStepTimer: 0,
-    enemyFireTimer: 0,
-    keys: {
-      left: false,
-      right: false,
-      fire: false,
-    },
-    lastShotAt: 0,
-    lastFrame: 0,
-  };
-
-  function sizeCanvas() {
-    state.dpr = Math.max(1, window.devicePixelRatio || 1);
-    const width = Math.max(1, heroGrid.clientWidth);
-    const height = Math.max(1, heroGrid.clientHeight);
-    state.width = width;
-    state.height = height;
-    canvas.width = Math.round(width * state.dpr);
-    canvas.height = Math.round(height * state.dpr);
-    canvas.style.width = width + 'px';
-    canvas.style.height = height + 'px';
-    ctx.setTransform(state.dpr, 0, 0, state.dpr, 0, 0);
-    ctx.imageSmoothingEnabled = false;
-
-    if (state.player) {
-      state.player.x = Math.min(state.width - state.player.w, Math.max(0, state.player.x));
-      state.player.y = state.height - 64;
-    }
-  }
-
-  function updateUI() {
-    scoreEl.textContent = String(state.score);
-    livesEl.textContent = String(state.lives);
-    waveEl.textContent = String(state.wave);
-  }
-
-  function spawnWave() {
-    const cols = 8;
-    const rows = 4;
-    const enemyW = 22;
-    const enemyH = 16;
-    const gapX = 18;
-    const gapY = 14;
-    const totalW = cols * enemyW + (cols - 1) * gapX;
-    const startX = Math.max(20, (state.width - totalW) / 2);
-    const startY = 56;
-
-    state.enemies = [];
-    for (let row = 0; row < rows; row += 1) {
-      for (let col = 0; col < cols; col += 1) {
-        state.enemies.push({
-          x: startX + col * (enemyW + gapX),
-          y: startY + row * (enemyH + gapY),
-          w: enemyW,
-          h: enemyH,
-          alive: true,
-        });
-      }
+      return;
     }
 
-    state.enemyDir = 1;
-    state.enemyStepTimer = 0;
-    state.enemyFireTimer = 0;
-  }
-
-  function resetGame() {
-    state.score = 0;
-    state.lives = 3;
-    state.wave = 1;
-    state.gameOver = false;
-    state.playerBullets = [];
-    state.enemyBullets = [];
-    state.player = {
-      w: 24,
-      h: 14,
-      x: state.width / 2 - 12,
-      y: state.height - 64,
-      speed: 300,
+    const rootStyles = window.getComputedStyle(document.documentElement);
+    const colors = {
+      primary: (rootStyles.getPropertyValue('--primary-color') || '#00ff00').trim(),
+      secondary: (rootStyles.getPropertyValue('--secondary-color') || '#e60073').trim(),
+      accent: (rootStyles.getPropertyValue('--accent-color') || '#ffff00').trim(),
     };
 
-    spawnWave();
-    updateUI();
-    gameOverEl.hidden = true;
-    gameOverEl.textContent = '';
-  }
+    const canvas = document.createElement('canvas');
+    canvas.className = 'hero-galaga-canvas';
+    canvas.setAttribute('aria-hidden', 'true');
 
-  function startGame() {
-    if (state.active || !desktopQuery.matches) {
+    const ui = document.createElement('div');
+    ui.className = 'hero-galaga-ui';
+    ui.innerHTML = '<p class="hero-galaga-status">Score: <span data-galaga-score>0</span> · Lives: <span data-galaga-lives>3</span> · Wave: <span data-galaga-wave>1</span></p><p class="hero-galaga-help">Move: ←/→ or A/D · Shoot: Space · Esc: Quit</p><div class="hero-galaga-gameover" data-galaga-gameover hidden></div>';
+
+    const hint = document.createElement('div');
+    hint.className = 'hero-galaga-hint';
+    hint.innerHTML = '<span class="hero-galaga-hint-text" data-galaga-hint-text></span><button type="button" class="hero-galaga-start">Play</button>';
+
+    heroGrid.appendChild(canvas);
+    heroGrid.appendChild(ui);
+    heroGrid.appendChild(hint);
+
+    const ctx = canvas.getContext('2d', { alpha: true });
+    if (!ctx) {
       return;
     }
 
-    canvas.tabIndex = 0;
-    state.active = true;
-    state.running = true;
-    window.__SE_GALAGA_ACTIVE = true;
-    heroGrid.dataset.galagaActive = 'true';
-    heroGrid.classList.add('is-galaga');
-    resetGame();
-    canvas.focus({ preventScroll: true });
-    state.lastFrame = performance.now();
-    state.rafId = window.requestAnimationFrame(loop);
-  }
+    ctx.imageSmoothingEnabled = false;
 
-  function stopGame() {
-    state.active = false;
-    state.running = false;
-    state.gameOver = false;
-    state.keys.left = false;
-    state.keys.right = false;
-    state.keys.fire = false;
-    window.__SE_GALAGA_ACTIVE = false;
-    heroGrid.dataset.galagaActive = 'false';
-    heroGrid.classList.remove('is-galaga');
-    if (state.rafId) {
-      window.cancelAnimationFrame(state.rafId);
-      state.rafId = 0;
-    }
-    ctx.clearRect(0, 0, state.width, state.height);
-    gameOverEl.hidden = true;
-    gameOverEl.textContent = '';
-  }
+    const scoreEl = ui.querySelector('[data-galaga-score]');
+    const livesEl = ui.querySelector('[data-galaga-lives]');
+    const waveEl = ui.querySelector('[data-galaga-wave]');
+    const gameOverEl = ui.querySelector('[data-galaga-gameover]');
+    const startButton = hint.querySelector('.hero-galaga-start');
+    const hintTextEl = hint.querySelector('[data-galaga-hint-text]');
 
-  function intersects(a, b) {
-    return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
-  }
+    const state = {
+      mode: 'idle',
+      running: false,
+      gameOver: false,
+      width: 1,
+      height: 1,
+      dpr: Math.max(1, window.devicePixelRatio || 1),
+      rafId: 0,
+      score: 0,
+      lives: 3,
+      wave: 1,
+      player: null,
+      playerBullets: [],
+      enemyBullets: [],
+      enemies: [],
+      enemyDir: 1,
+      enemyStepTimer: 0,
+      enemyFireTimer: 0,
+      keys: {
+        left: false,
+        right: false,
+        fire: false,
+      },
+      lastShotAt: 0,
+      lastFrame: 0,
+      idleTick: 0,
+    };
 
-  function handleKeys(dt, now) {
-    if (!state.player) {
-      return;
-    }
-
-    const dir = (state.keys.right ? 1 : 0) - (state.keys.left ? 1 : 0);
-    state.player.x += dir * state.player.speed * dt;
-    state.player.x = Math.max(0, Math.min(state.width - state.player.w, state.player.x));
-
-    if (state.keys.fire && now - state.lastShotAt > 180) {
-      state.playerBullets.push({ x: state.player.x + state.player.w / 2 - 2, y: state.player.y - 8, w: 4, h: 10, vy: -430 });
-      state.lastShotAt = now;
-    }
-  }
-
-  function updateEnemies(dt) {
-    if (!state.enemies.length) {
-      return;
+    function isActiveMode() {
+      return state.mode === 'active';
     }
 
-    const stepInterval = Math.max(0.14, 0.5 - (state.wave - 1) * 0.04);
-    state.enemyStepTimer += dt;
+    function shouldAnimateIdle() {
+      return !reducedMotionQuery.matches && desktopQuery.matches && state.mode === 'idle';
+    }
 
-    if (state.enemyStepTimer >= stepInterval) {
+    function sizeCanvas() {
+      state.dpr = Math.max(1, window.devicePixelRatio || 1);
+      const width = Math.max(1, heroGrid.clientWidth);
+      const height = Math.max(1, heroGrid.clientHeight);
+      state.width = width;
+      state.height = height;
+      canvas.width = Math.round(width * state.dpr);
+      canvas.height = Math.round(height * state.dpr);
+      canvas.style.width = width + 'px';
+      canvas.style.height = height + 'px';
+      ctx.setTransform(state.dpr, 0, 0, state.dpr, 0, 0);
+      ctx.imageSmoothingEnabled = false;
+
+      if (state.player) {
+        state.player.x = Math.min(state.width - state.player.w, Math.max(0, state.player.x));
+        state.player.y = state.height - 64;
+      }
+
+      if (!isActiveMode()) {
+        render();
+      }
+    }
+
+    function updateUI() {
+      scoreEl.textContent = String(state.score);
+      livesEl.textContent = String(state.lives);
+      waveEl.textContent = String(state.wave);
+    }
+
+    function updateHint() {
+      if (!hintTextEl || !startButton) {
+        return;
+      }
+
+      if (isActiveMode()) {
+        hintTextEl.textContent = 'Esc to quit';
+        startButton.hidden = true;
+      } else {
+        hintTextEl.textContent = reducedMotionQuery.matches
+          ? 'Press G to play (manual motion)'
+          : 'Press G to play';
+        startButton.hidden = false;
+      }
+    }
+
+    function spawnWave() {
+      const cols = 8;
+      const rows = 4;
+      const enemyW = 22;
+      const enemyH = 16;
+      const gapX = 18;
+      const gapY = 14;
+      const totalW = cols * enemyW + (cols - 1) * gapX;
+      const startX = Math.max(20, (state.width - totalW) / 2);
+      const startY = 56;
+
+      state.enemies = [];
+      for (let row = 0; row < rows; row += 1) {
+        for (let col = 0; col < cols; col += 1) {
+          state.enemies.push({
+            x: startX + col * (enemyW + gapX),
+            y: startY + row * (enemyH + gapY),
+            w: enemyW,
+            h: enemyH,
+            alive: true,
+          });
+        }
+      }
+
+      state.enemyDir = 1;
       state.enemyStepTimer = 0;
-      const stepX = 14 + state.wave * 1.2;
-      const stepY = 14;
-
-      let nextMinX = Infinity;
-      let nextMaxX = -Infinity;
-      state.enemies.forEach(function (enemy) {
-        if (!enemy.alive) {
-          return;
-        }
-        const nextX = enemy.x + stepX * state.enemyDir;
-        nextMinX = Math.min(nextMinX, nextX);
-        nextMaxX = Math.max(nextMaxX, nextX + enemy.w);
-      });
-
-      const hitEdge = nextMinX <= 8 || nextMaxX >= state.width - 8;
-
-      state.enemies.forEach(function (enemy) {
-        if (!enemy.alive) {
-          return;
-        }
-        if (hitEdge) {
-          enemy.y += stepY;
-        } else {
-          enemy.x += stepX * state.enemyDir;
-        }
-      });
-
-      if (hitEdge) {
-        state.enemyDir *= -1;
-      }
-    }
-
-    state.enemyFireTimer += dt;
-    const fireInterval = Math.max(0.45, 1.2 - (state.wave - 1) * 0.08);
-    if (state.enemyFireTimer >= fireInterval) {
       state.enemyFireTimer = 0;
-      const aliveEnemies = state.enemies.filter(function (enemy) {
-        return enemy.alive;
-      });
-      if (aliveEnemies.length) {
-        const shooter = aliveEnemies[Math.floor(Math.random() * aliveEnemies.length)];
-        state.enemyBullets.push({
-          x: shooter.x + shooter.w / 2 - 2,
-          y: shooter.y + shooter.h,
-          w: 4,
-          h: 10,
-          vy: 240 + state.wave * 22,
-        });
-      }
-    }
-  }
-
-  function updateBullets(dt) {
-    state.playerBullets.forEach(function (bullet) {
-      bullet.y += bullet.vy * dt;
-    });
-    state.enemyBullets.forEach(function (bullet) {
-      bullet.y += bullet.vy * dt;
-    });
-
-    state.playerBullets = state.playerBullets.filter(function (bullet) {
-      return bullet.y + bullet.h > 0;
-    });
-    state.enemyBullets = state.enemyBullets.filter(function (bullet) {
-      return bullet.y < state.height + bullet.h;
-    });
-  }
-
-  function resolveCollisions() {
-    state.playerBullets = state.playerBullets.filter(function (bullet) {
-      let hit = false;
-      state.enemies.forEach(function (enemy) {
-        if (enemy.alive && intersects(bullet, enemy)) {
-          enemy.alive = false;
-          hit = true;
-          state.score += 100;
-        }
-      });
-      return !hit;
-    });
-
-    if (state.player) {
-      state.enemyBullets = state.enemyBullets.filter(function (bullet) {
-        if (intersects(bullet, state.player)) {
-          state.lives -= 1;
-          return false;
-        }
-        return true;
-      });
     }
 
-    if (state.lives <= 0 && !state.gameOver) {
-      state.running = false;
-      state.gameOver = true;
-      gameOverEl.hidden = false;
-      gameOverEl.textContent = 'Game Over · Score ' + state.score + ' · Press Enter to restart or Esc to quit';
-    }
-
-    const aliveCount = state.enemies.filter(function (enemy) {
-      return enemy.alive;
-    }).length;
-
-    if (aliveCount === 0 && !state.gameOver) {
-      state.wave += 1;
+    function initScene() {
       state.playerBullets = [];
       state.enemyBullets = [];
+      state.player = {
+        w: 24,
+        h: 14,
+        x: state.width / 2 - 12,
+        y: state.height - 64,
+        speed: 300,
+      };
       spawnWave();
     }
 
-    const invaded = state.enemies.some(function (enemy) {
-      return enemy.alive && enemy.y + enemy.h >= state.height - 56;
-    });
+    function resetGame() {
+      state.score = 0;
+      state.lives = 3;
+      state.wave = 1;
+      state.gameOver = false;
+      state.lastShotAt = 0;
+      initScene();
+      updateUI();
+      gameOverEl.hidden = true;
+      gameOverEl.textContent = '';
+    }
 
-    if (invaded && !state.gameOver) {
-      state.lives = 0;
+    function ensureLoopRunning() {
+      if (state.rafId || (!isActiveMode() && !shouldAnimateIdle())) {
+        return;
+      }
+      state.lastFrame = performance.now();
+      state.rafId = window.requestAnimationFrame(loop);
+    }
+
+    function stopLoop() {
+      if (state.rafId) {
+        window.cancelAnimationFrame(state.rafId);
+        state.rafId = 0;
+      }
+    }
+
+    function enterIdleMode() {
+      state.mode = 'idle';
       state.running = false;
-      state.gameOver = true;
-      gameOverEl.hidden = false;
-      gameOverEl.textContent = 'Game Over · Invaded! · Press Enter to restart or Esc to quit';
+      state.gameOver = false;
+      state.keys.left = false;
+      state.keys.right = false;
+      state.keys.fire = false;
+      state.playerBullets = [];
+      state.enemyBullets = [];
+      state.idleTick = 0;
+
+      window.__SE_GALAGA_ACTIVE = false;
+      heroGrid.dataset.galagaActive = 'false';
+      heroGrid.classList.remove('is-galaga');
+      canvas.style.pointerEvents = 'none';
+      gameOverEl.hidden = true;
+      gameOverEl.textContent = '';
+
+      updateHint();
+      render();
+      if (shouldAnimateIdle()) {
+        ensureLoopRunning();
+      } else {
+        stopLoop();
+      }
     }
 
-    updateUI();
-  }
+    function startGame() {
+      if (!desktopQuery.matches || isActiveMode()) {
+        return;
+      }
 
-  function drawPlayer() {
-    if (!state.player) {
-      return;
+      stopLoop();
+      canvas.tabIndex = 0;
+      state.mode = 'active';
+      state.running = true;
+      window.__SE_GALAGA_ACTIVE = true;
+      heroGrid.dataset.galagaActive = 'true';
+      heroGrid.classList.add('is-galaga');
+      canvas.style.pointerEvents = 'auto';
+
+      resetGame();
+      updateHint();
+      canvas.focus({ preventScroll: true });
+      ensureLoopRunning();
     }
 
-    const p = state.player;
-    ctx.fillStyle = colors.primary;
-    ctx.fillRect(Math.round(p.x + 10), Math.round(p.y), 4, 3);
-    ctx.fillRect(Math.round(p.x + 7), Math.round(p.y + 3), 10, 4);
-    ctx.fillRect(Math.round(p.x + 3), Math.round(p.y + 7), 18, 4);
-    ctx.fillRect(Math.round(p.x), Math.round(p.y + 11), 24, 3);
-    ctx.fillStyle = colors.accent;
-    ctx.fillRect(Math.round(p.x + 11), Math.round(p.y + 5), 2, 4);
-  }
+    function stopGame() {
+      if (!isActiveMode()) {
+        return;
+      }
+      enterIdleMode();
+    }
 
-  function drawEnemy(enemy) {
-    ctx.fillStyle = colors.secondary;
-    ctx.fillRect(Math.round(enemy.x + 2), Math.round(enemy.y), enemy.w - 4, 3);
-    ctx.fillRect(Math.round(enemy.x), Math.round(enemy.y + 3), enemy.w, 5);
-    ctx.fillRect(Math.round(enemy.x + 4), Math.round(enemy.y + 8), enemy.w - 8, 3);
-    ctx.fillStyle = colors.accent;
-    ctx.fillRect(Math.round(enemy.x + 5), Math.round(enemy.y + 4), 2, 2);
-    ctx.fillRect(Math.round(enemy.x + enemy.w - 7), Math.round(enemy.y + 4), 2, 2);
-  }
+    function intersects(a, b) {
+      return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
+    }
 
-  function drawBullets() {
-    ctx.fillStyle = colors.accent;
-    state.playerBullets.forEach(function (bullet) {
-      ctx.fillRect(Math.round(bullet.x), Math.round(bullet.y), bullet.w, bullet.h);
-    });
+    function handleKeys(dt, now) {
+      if (!state.player) {
+        return;
+      }
 
-    ctx.fillStyle = colors.primary;
-    state.enemyBullets.forEach(function (bullet) {
-      ctx.fillRect(Math.round(bullet.x), Math.round(bullet.y), bullet.w, bullet.h);
-    });
-  }
+      const dir = (state.keys.right ? 1 : 0) - (state.keys.left ? 1 : 0);
+      state.player.x += dir * state.player.speed * dt;
+      state.player.x = Math.max(0, Math.min(state.width - state.player.w, state.player.x));
 
-  function render() {
-    ctx.clearRect(0, 0, state.width, state.height);
-    ctx.fillStyle = 'rgba(0, 0, 0, 0.72)';
-    ctx.fillRect(0, 0, state.width, state.height);
+      if (state.keys.fire && now - state.lastShotAt > 180) {
+        state.playerBullets.push({ x: state.player.x + state.player.w / 2 - 2, y: state.player.y - 8, w: 4, h: 10, vy: -430 });
+        state.lastShotAt = now;
+      }
+    }
 
-    drawPlayer();
+    function updateEnemies(dt) {
+      if (!state.enemies.length) {
+        return;
+      }
 
-    state.enemies.forEach(function (enemy) {
-      if (enemy.alive) {
-        drawEnemy(enemy);
+      const stepInterval = Math.max(0.14, 0.5 - (state.wave - 1) * 0.04);
+      state.enemyStepTimer += dt;
+
+      if (state.enemyStepTimer >= stepInterval) {
+        state.enemyStepTimer = 0;
+        const stepX = 14 + state.wave * 1.2;
+        const stepY = 14;
+
+        let nextMinX = Infinity;
+        let nextMaxX = -Infinity;
+        state.enemies.forEach(function (enemy) {
+          if (!enemy.alive) {
+            return;
+          }
+          const nextX = enemy.x + stepX * state.enemyDir;
+          nextMinX = Math.min(nextMinX, nextX);
+          nextMaxX = Math.max(nextMaxX, nextX + enemy.w);
+        });
+
+        const hitEdge = nextMinX <= 8 || nextMaxX >= state.width - 8;
+
+        state.enemies.forEach(function (enemy) {
+          if (!enemy.alive) {
+            return;
+          }
+          if (hitEdge) {
+            enemy.y += stepY;
+          } else {
+            enemy.x += stepX * state.enemyDir;
+          }
+        });
+
+        if (hitEdge) {
+          state.enemyDir *= -1;
+        }
+      }
+
+      state.enemyFireTimer += dt;
+      const fireInterval = Math.max(0.45, 1.2 - (state.wave - 1) * 0.08);
+      if (state.enemyFireTimer >= fireInterval) {
+        state.enemyFireTimer = 0;
+        const aliveEnemies = state.enemies.filter(function (enemy) {
+          return enemy.alive;
+        });
+        if (aliveEnemies.length) {
+          const shooter = aliveEnemies[Math.floor(Math.random() * aliveEnemies.length)];
+          state.enemyBullets.push({
+            x: shooter.x + shooter.w / 2 - 2,
+            y: shooter.y + shooter.h,
+            w: 4,
+            h: 10,
+            vy: 240 + state.wave * 22,
+          });
+        }
+      }
+    }
+
+    function updateBullets(dt) {
+      state.playerBullets.forEach(function (bullet) {
+        bullet.y += bullet.vy * dt;
+      });
+      state.enemyBullets.forEach(function (bullet) {
+        bullet.y += bullet.vy * dt;
+      });
+
+      state.playerBullets = state.playerBullets.filter(function (bullet) {
+        return bullet.y + bullet.h > 0;
+      });
+      state.enemyBullets = state.enemyBullets.filter(function (bullet) {
+        return bullet.y < state.height + bullet.h;
+      });
+    }
+
+    function resolveCollisions() {
+      state.playerBullets = state.playerBullets.filter(function (bullet) {
+        let hit = false;
+        state.enemies.forEach(function (enemy) {
+          if (enemy.alive && intersects(bullet, enemy)) {
+            enemy.alive = false;
+            hit = true;
+            state.score += 100;
+          }
+        });
+        return !hit;
+      });
+
+      if (state.player) {
+        state.enemyBullets = state.enemyBullets.filter(function (bullet) {
+          if (intersects(bullet, state.player)) {
+            state.lives -= 1;
+            return false;
+          }
+          return true;
+        });
+      }
+
+      if (state.lives <= 0 && !state.gameOver) {
+        state.running = false;
+        state.gameOver = true;
+        gameOverEl.hidden = false;
+        gameOverEl.textContent = 'Game Over · Score ' + state.score + ' · Press Enter to restart or Esc to quit';
+      }
+
+      const aliveCount = state.enemies.filter(function (enemy) {
+        return enemy.alive;
+      }).length;
+
+      if (aliveCount === 0 && !state.gameOver) {
+        state.wave += 1;
+        state.playerBullets = [];
+        state.enemyBullets = [];
+        spawnWave();
+      }
+
+      const invaded = state.enemies.some(function (enemy) {
+        return enemy.alive && enemy.y + enemy.h >= state.height - 56;
+      });
+
+      if (invaded && !state.gameOver) {
+        state.lives = 0;
+        state.running = false;
+        state.gameOver = true;
+        gameOverEl.hidden = false;
+        gameOverEl.textContent = 'Game Over · Invaded! · Press Enter to restart or Esc to quit';
+      }
+
+      updateUI();
+    }
+
+    function drawPlayer() {
+      if (!state.player) {
+        return;
+      }
+
+      const p = state.player;
+      ctx.fillStyle = colors.primary;
+      ctx.fillRect(Math.round(p.x + 10), Math.round(p.y), 4, 3);
+      ctx.fillRect(Math.round(p.x + 7), Math.round(p.y + 3), 10, 4);
+      ctx.fillRect(Math.round(p.x + 3), Math.round(p.y + 7), 18, 4);
+      ctx.fillRect(Math.round(p.x), Math.round(p.y + 11), 24, 3);
+      ctx.fillStyle = colors.accent;
+      ctx.fillRect(Math.round(p.x + 11), Math.round(p.y + 5), 2, 4);
+    }
+
+    function drawEnemy(enemy, yOffset) {
+      const drawY = enemy.y + (yOffset || 0);
+      ctx.fillStyle = colors.secondary;
+      ctx.fillRect(Math.round(enemy.x + 2), Math.round(drawY), enemy.w - 4, 3);
+      ctx.fillRect(Math.round(enemy.x), Math.round(drawY + 3), enemy.w, 5);
+      ctx.fillRect(Math.round(enemy.x + 4), Math.round(drawY + 8), enemy.w - 8, 3);
+      ctx.fillStyle = colors.accent;
+      ctx.fillRect(Math.round(enemy.x + 5), Math.round(drawY + 4), 2, 2);
+      ctx.fillRect(Math.round(enemy.x + enemy.w - 7), Math.round(drawY + 4), 2, 2);
+    }
+
+    function drawBullets() {
+      ctx.fillStyle = colors.accent;
+      state.playerBullets.forEach(function (bullet) {
+        ctx.fillRect(Math.round(bullet.x), Math.round(bullet.y), bullet.w, bullet.h);
+      });
+
+      ctx.fillStyle = colors.primary;
+      state.enemyBullets.forEach(function (bullet) {
+        ctx.fillRect(Math.round(bullet.x), Math.round(bullet.y), bullet.w, bullet.h);
+      });
+    }
+
+    function render() {
+      ctx.clearRect(0, 0, state.width, state.height);
+      ctx.fillStyle = 'rgba(0, 0, 0, 0.58)';
+      ctx.fillRect(0, 0, state.width, state.height);
+
+      drawPlayer();
+
+      const idleBob = isActiveMode() ? 0 : Math.sin(state.idleTick * 1.35) * 3;
+      state.enemies.forEach(function (enemy, index) {
+        if (enemy.alive) {
+          const offset = isActiveMode() ? 0 : idleBob + Math.sin(index * 0.7 + state.idleTick) * 1.25;
+          drawEnemy(enemy, offset);
+        }
+      });
+
+      drawBullets();
+
+      if (!isActiveMode()) {
+        ctx.fillStyle = 'rgba(0, 0, 0, 0.42)';
+        ctx.fillRect(0, state.height - 74, state.width, 74);
+      }
+    }
+
+    function loop(now) {
+      const dt = Math.min(0.033, (now - state.lastFrame) / 1000 || 0.016);
+      state.lastFrame = now;
+
+      if (isActiveMode() && state.running) {
+        handleKeys(dt, now);
+        updateEnemies(dt);
+        updateBullets(dt);
+        resolveCollisions();
+      } else if (state.mode === 'idle') {
+        state.idleTick += dt;
+      }
+
+      render();
+
+      if (isActiveMode() || shouldAnimateIdle()) {
+        state.rafId = window.requestAnimationFrame(loop);
+      } else {
+        state.rafId = 0;
+      }
+    }
+
+    function isTypingTarget(target) {
+      if (!target) {
+        return false;
+      }
+      const tag = target.tagName;
+      return target.isContentEditable || tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+    }
+
+    function shouldBlockGameplayEvent(event) {
+      if (!isActiveMode()) {
+        return false;
+      }
+
+      const code = event.code;
+      return code === 'ArrowLeft' || code === 'ArrowRight' || code === 'KeyA' || code === 'KeyD' || code === 'Space';
+    }
+
+    if (startButton) {
+      startButton.addEventListener('click', function (event) {
+        event.preventDefault();
+        event.stopPropagation();
+        startGame();
+      });
+    }
+
+    window.addEventListener('keydown', function (event) {
+      const code = event.code;
+      const typing = isTypingTarget(event.target);
+
+      if (!isActiveMode() && !typing && code === 'KeyG') {
+        startGame();
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+
+      if (!isActiveMode()) {
+        return;
+      }
+
+      if (typing) {
+        return;
+      }
+
+      if (code === 'Escape') {
+        stopGame();
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+
+      if (state.gameOver && code === 'Enter') {
+        resetGame();
+        state.running = true;
+        state.lastFrame = performance.now();
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+
+      if (code === 'ArrowLeft' || code === 'KeyA') {
+        state.keys.left = true;
+      }
+      if (code === 'ArrowRight' || code === 'KeyD') {
+        state.keys.right = true;
+      }
+      if (code === 'Space') {
+        state.keys.fire = true;
+      }
+
+      if (shouldBlockGameplayEvent(event)) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    }, { capture: true });
+
+    window.addEventListener('keyup', function (event) {
+      if (!isActiveMode()) {
+        return;
+      }
+
+      if (isTypingTarget(event.target)) {
+        return;
+      }
+
+      const code = event.code;
+      if (code === 'ArrowLeft' || code === 'KeyA') {
+        state.keys.left = false;
+      }
+      if (code === 'ArrowRight' || code === 'KeyD') {
+        state.keys.right = false;
+      }
+      if (code === 'Space') {
+        state.keys.fire = false;
+      }
+
+      if (shouldBlockGameplayEvent(event)) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    }, { capture: true });
+
+    desktopQuery.addEventListener('change', function (event) {
+      if (!event.matches) {
+        stopLoop();
+        window.__SE_GALAGA_ACTIVE = false;
+        heroGrid.classList.remove('is-galaga');
+        heroGrid.classList.remove('has-galaga');
+        heroGrid.dataset.galagaActive = 'false';
+        return;
+      }
+
+      heroGrid.classList.add('has-galaga');
+      if (!isActiveMode()) {
+        enterIdleMode();
       }
     });
 
-    drawBullets();
-
-    if (!state.running && !state.gameOver) {
-      ctx.fillStyle = colors.primary;
-      ctx.font = '12px "Press Start 2P", monospace';
-      ctx.textAlign = 'center';
-      ctx.fillText('Press G to Start', state.width / 2, state.height / 2);
-    }
-  }
-
-  function loop(now) {
-    const dt = Math.min(0.033, (now - state.lastFrame) / 1000 || 0.016);
-    state.lastFrame = now;
-
-    if (state.active && state.running) {
-      handleKeys(dt, now);
-      updateEnemies(dt);
-      updateBullets(dt);
-      resolveCollisions();
-    }
-
-    render();
-
-    if (state.active) {
-      state.rafId = window.requestAnimationFrame(loop);
-    }
-  }
-
-  function isTypingTarget(target) {
-    if (!target) {
-      return false;
-    }
-    const tag = target.tagName;
-    return target.isContentEditable || tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
-  }
-
-  function shouldBlockGameplayEvent(event) {
-    if (!state.active) {
-      return false;
-    }
-
-    const code = event.code;
-    return code === 'ArrowLeft' || code === 'ArrowRight' || code === 'KeyA' || code === 'KeyD' || code === 'Space';
-  }
-
-  if (startButton) {
-    startButton.addEventListener('click', function (event) {
-      event.preventDefault();
-      event.stopPropagation();
-      startGame();
-      canvas.focus({ preventScroll: true });
+    reducedMotionQuery.addEventListener('change', function () {
+      updateHint();
+      if (isActiveMode()) {
+        return;
+      }
+      if (shouldAnimateIdle()) {
+        ensureLoopRunning();
+      } else {
+        stopLoop();
+        render();
+      }
     });
-  }
 
-  window.addEventListener('keydown', function (event) {
-    const code = event.code;
-    const typing = isTypingTarget(event.target);
+    const resizeObserver = 'ResizeObserver' in window
+      ? new ResizeObserver(function () {
+        sizeCanvas();
+      })
+      : null;
 
-    if (!state.active && !typing && code === 'KeyG') {
-      startGame();
-      event.preventDefault();
-      event.stopPropagation();
-      return;
+    if (resizeObserver) {
+      resizeObserver.observe(heroGrid);
+    } else {
+      window.addEventListener('resize', sizeCanvas, { passive: true });
     }
 
-    if (!state.active) {
-      return;
-    }
-
-    if (typing) {
-      return;
-    }
-
-    if (code === 'Escape') {
-      stopGame();
-      event.preventDefault();
-      event.stopPropagation();
-      return;
-    }
-
-    if (state.gameOver && code === 'Enter') {
-      resetGame();
-      state.running = true;
-      state.lastFrame = performance.now();
-      event.preventDefault();
-      event.stopPropagation();
-      return;
-    }
-
-    if (code === 'ArrowLeft' || code === 'KeyA') {
-      state.keys.left = true;
-    }
-    if (code === 'ArrowRight' || code === 'KeyD') {
-      state.keys.right = true;
-    }
-    if (code === 'Space') {
-      state.keys.fire = true;
-    }
-
-    if (shouldBlockGameplayEvent(event)) {
-      event.preventDefault();
-      event.stopPropagation();
-    }
-  }, { capture: true });
-
-  window.addEventListener('keyup', function (event) {
-    if (!state.active) {
-      return;
-    }
-
-    if (isTypingTarget(event.target)) {
-      return;
-    }
-
-    const code = event.code;
-    if (code === 'ArrowLeft' || code === 'KeyA') {
-      state.keys.left = false;
-    }
-    if (code === 'ArrowRight' || code === 'KeyD') {
-      state.keys.right = false;
-    }
-    if (code === 'Space') {
-      state.keys.fire = false;
-    }
-
-    if (shouldBlockGameplayEvent(event)) {
-      event.preventDefault();
-      event.stopPropagation();
-    }
-  }, { capture: true });
-
-  desktopQuery.addEventListener('change', function (event) {
-    if (!event.matches && state.active) {
-      stopGame();
-    }
-  });
-
-  const resizeObserver = 'ResizeObserver' in window
-    ? new ResizeObserver(function () {
-      sizeCanvas();
-    })
-    : null;
-
-  if (resizeObserver) {
-    resizeObserver.observe(heroGrid);
-  } else {
-    window.addEventListener('resize', sizeCanvas, { passive: true });
-  }
-
-  sizeCanvas();
-  updateUI();
+    heroGrid.classList.add('has-galaga');
+    sizeCanvas();
+    updateUI();
+    initScene();
+    enterIdleMode();
   }
 
   if (document.readyState === 'loading') {

--- a/style.css
+++ b/style.css
@@ -2626,19 +2626,23 @@ body {
   height: 100%;
   display: none;
   z-index: 4;
-  pointer-events: auto;
+  pointer-events: none;
 }
 
 .page-template-page-home-php .hero-galaga-ui,
 .home .hero-galaga-ui,
 .front-page .hero-galaga-ui {
   position: absolute;
-  inset: 12px 12px auto;
+  top: 12px;
+  left: 12px;
+  right: auto;
+  width: max-content;
+  max-width: calc(100% - 24px);
   display: none;
   z-index: 5;
   pointer-events: none;
   font-size: 0.55rem;
-  line-height: 1.55;
+  line-height: 1.3;
   color: var(--primary-color);
   text-shadow: 0 0 6px rgba(0, 0, 0, 0.7);
 }
@@ -2652,13 +2656,13 @@ body {
   margin: 0;
   background: rgba(0, 0, 0, 0.68);
   border: 1px solid rgba(128, 225, 255, 0.44);
-  padding: 7px 10px;
+  padding: 5px 8px;
 }
 
 .page-template-page-home-php .hero-galaga-help,
 .home .hero-galaga-help,
 .front-page .hero-galaga-help {
-  margin-top: 6px;
+  margin-top: 4px;
   color: var(--accent-color);
 }
 
@@ -2677,8 +2681,10 @@ body {
 .home .hero-galaga-hint,
 .front-page .hero-galaga-hint {
   position: absolute;
-  top: 12px;
-  right: 12px;
+  bottom: 12px;
+  left: 12px;
+  top: auto;
+  right: auto;
   z-index: 4;
   padding: 6px 10px;
   font-size: 0.52rem;
@@ -2690,6 +2696,12 @@ body {
   align-items: center;
   gap: 8px;
   pointer-events: auto;
+}
+
+.page-template-page-home-php .hero-galaga-hint-text,
+.home .hero-galaga-hint-text,
+.front-page .hero-galaga-hint-text {
+  line-height: 1.2;
 }
 
 .page-template-page-home-php .hero-galaga-start,
@@ -2718,6 +2730,15 @@ body {
   color: var(--accent-color);
 }
 
+.page-template-page-home-php .hero-grid.has-galaga .hero-galaga-canvas,
+.page-template-page-home-php .hero-grid.has-galaga .hero-galaga-hint,
+.home .hero-grid.has-galaga .hero-galaga-canvas,
+.home .hero-grid.has-galaga .hero-galaga-hint,
+.front-page .hero-grid.has-galaga .hero-galaga-canvas,
+.front-page .hero-grid.has-galaga .hero-galaga-hint {
+  display: block;
+}
+
 .page-template-page-home-php .hero-grid.is-galaga .hero-galaga-canvas,
 .page-template-page-home-php .hero-grid.is-galaga .hero-galaga-ui,
 .home .hero-grid.is-galaga .hero-galaga-canvas,
@@ -2727,15 +2748,18 @@ body {
   display: block;
 }
 
-.page-template-page-home-php .hero-grid.is-galaga .hero-galaga-hint,
-.home .hero-grid.is-galaga .hero-galaga-hint,
-.front-page .hero-grid.is-galaga .hero-galaga-hint,
 .page-template-page-home-php .hero-grid.is-galaga .hero-ship,
 .page-template-page-home-php .hero-grid.is-galaga .hero-ship-trail,
 .home .hero-grid.is-galaga .hero-ship,
 .home .hero-grid.is-galaga .hero-ship-trail,
 .front-page .hero-grid.is-galaga .hero-ship,
 .front-page .hero-grid.is-galaga .hero-ship-trail {
+  display: none;
+}
+
+.page-template-page-home-php .hero-grid.is-galaga .hero-galaga-start,
+.home .hero-grid.is-galaga .hero-galaga-start,
+.front-page .hero-grid.is-galaga .hero-galaga-start {
   display: none;
 }
 


### PR DESCRIPTION
### Motivation
- Make the Galaga overlay feel like an optional on-hero experience (visible player/enemies) without hijacking homepage interactions until the user opts in.
- Ensure the HUD is compact and the start hint doesn't overlap the Support/CTA area.
- Provide a desktop "Attract Mode" that runs only when appropriate and respects `prefers-reduced-motion`.

### Description
- Refactored `js/hero-galaga.js` to introduce explicit `mode` (`idle` / `active`) with an attract-mode idle scene on desktop and explicit opt-in via `G` or the Play button, and `Esc` returning to idle instead of removing the overlay.
- In idle mode the canvas uses `pointer-events: none`, key capture/blocking is disabled, `window.__SE_GALAGA_ACTIVE` remains `false`, and a lightweight idle animation runs only when `prefers-reduced-motion` is not set; active mode enables pointer events, key blocking, and gameplay state.
- Updated UI/hint behavior so the hint text updates (`Press G to play` vs `Esc to quit`) and the Play button is hidden while active, while CTAs/About card remain clickable during idle by using `.has-galaga` for attract display and `.is-galaga` for active gameplay.
- Modified `style.css` to make the HUD compact (`top:12px; left:12px; width: max-content; max-width: calc(100% - 24px)`), tightened padding/line-height, and moved the start hint to bottom-left to avoid overlap with the Support button, plus rules to show canvas+hint in attract mode while keeping full UI only during active play.

### Testing
- Ran `node --check js/hero-galaga.js` which succeeded to validate the script syntax.
- Attempted an automated browser screenshot via Playwright to visually validate layout, but Chromium failed to launch in this environment (SIGSEGV) so the screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4ab8f5cf8832ebbfc565f85445072)