### PR TITLE
Tighten desktop hero fold height and Galaga playfield sizing

### DIFF
--- a/js/hero-galaga.js
+++ b/js/hero-galaga.js
@@ -95,7 +95,7 @@
 
       const maxX = state.playfield.x + state.playfield.w - state.player.w;
       state.player.x = Math.max(state.playfield.x, Math.min(maxX, state.player.x));
-      state.player.y = state.playfield.y + state.playfield.h - 64;
+      state.player.y = state.playfield.y + state.playfield.h - state.player.h - 18;
     }
 
     function positionOverlayUI() {
@@ -122,13 +122,14 @@
       const height = Math.max(1, heroGrid.clientHeight);
       const heroGridRect = heroGrid.getBoundingClientRect();
       const mainRect = heroMain ? heroMain.getBoundingClientRect() : heroGridRect;
+      const visibleH = Math.min(mainRect.height, window.innerHeight - mainRect.top - 16);
       state.width = width;
       state.height = height;
       state.playfield = {
         x: Math.max(0, Math.round(mainRect.left - heroGridRect.left)),
         y: Math.max(0, Math.round(mainRect.top - heroGridRect.top)),
         w: Math.min(state.width, Math.max(1, Math.round(mainRect.width))),
-        h: Math.min(state.height, Math.max(1, Math.round(mainRect.height))),
+        h: Math.min(state.height, Math.max(260, Math.round(visibleH))),
       };
       canvas.width = Math.round(width * state.dpr);
       canvas.height = Math.round(height * state.dpr);
@@ -204,7 +205,7 @@
         w: 24,
         h: 14,
         x: state.playfield.x + state.playfield.w / 2 - 12,
-        y: state.playfield.y + state.playfield.h - 64,
+        y: state.playfield.y + state.playfield.h - 14 - 18,
         speed: 300,
       };
       spawnWave();
@@ -218,7 +219,7 @@
         w: 24,
         h: 14,
         x: state.playfield.x + state.playfield.w / 2 - 12,
-        y: state.playfield.y + state.playfield.h - 64,
+        y: state.playfield.y + state.playfield.h - 14 - 18,
         speed: 300,
       };
       spawnWave({ cols: 5, rows: 2, gapX: 16, gapY: 12, startY: 86 });

--- a/style.css
+++ b/style.css
@@ -2882,13 +2882,40 @@ body {
 
 @media (min-width: 860px) {
   .hero-grid {
-    grid-template-columns: minmax(0, 2.4fr) minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr) clamp(260px, 28vw, 340px);
     align-items: stretch;
   }
 
   /* Shift the main hero block toward the photo card on desktop while keeping its content centered. */
   .hero-main {
     justify-self: end;
+  }
+
+  .hero-photo-card {
+    padding: 1.25rem;
+  }
+
+  .hero-photo-frame {
+    padding: 0.6rem;
+    max-height: clamp(260px, 46vh, 420px);
+    aspect-ratio: 3 / 4;
+  }
+
+  .hero-photo {
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+@media (min-width: 860px) and (max-height: 820px) {
+  .hero-section {
+    padding-top: clamp(16px, 3vh, 30px);
+    padding-bottom: clamp(12px, 2.4vh, 24px);
+  }
+
+  .hero-grid {
+    gap: 1.5rem;
+    margin-bottom: 1.5rem;
   }
 }
 


### PR DESCRIPTION
### Motivation
- The homepage hero was taller than typical laptop viewports so the Galaga player ship could be pushed below the fold at 100% zoom.
- The right-hand About/photo card was visually dominating the hero height on desktop and needed a shorter, cropped presentation.
- Changes must be desktop-only so mobile/tablet layout remains unchanged.

### Description
- Narrowed the hero columns on desktop by changing the grid to `grid-template-columns: minmax(0, 1fr) clamp(260px, 28vw, 340px)` so the left playfield gets more room. 
- Reduced About card vertical footprint by lowering `.hero-photo-card` padding to `1.25rem`, shrinking `.hero-photo-frame` padding, and constraining the frame with `max-height: clamp(260px, 46vh, 420px)` and `aspect-ratio: 3 / 4`. 
- Ensured the photo fills and crops cleanly by setting `.hero-photo { height: 100%; object-fit: cover; }`.
- Added a height-aware desktop media query `@media (min-width: 860px) and (max-height: 820px)` to reduce `.hero-section` top/bottom padding and `.hero-grid` gap so the hero is more above-the-fold on shorter screens.
- Made Galaga sizing resilient by capping the playfield height in `sizeCanvas()` using a visible-height calculation (`visibleH = Math.min(mainRect.height, window.innerHeight - mainRect.top - 16)`) and applying a floor (`Math.max(260, Math.round(visibleH))`), and by anchoring the player Y using `state.player.h` so the ship stays inside the visible playfield bottom.

### Testing
- `node --check js/hero-galaga.js` ran successfully with no syntax errors. 
- `php -l page-home.php` reported no syntax errors. 
- A Playwright screenshot run against `http://127.0.0.1:8080` failed with `ERR_EMPTY_RESPONSE` because no local web server was available in the environment (visual/manual QA recommended on a running site at 1366×768 / 1440×900 at 100% zoom).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b3d35d9c832e98c47e71a3acb8a9)