### PR TITLE
Improve Bio opening crawl start position and typography consistency

### DIFF
--- a/style.css
+++ b/style.css
@@ -3189,38 +3189,65 @@ body.page-template-page-bio .bio-crawl-wrap,
   border-radius: 16px;
 }
 
+.bio-crawl-wrap::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 2;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.03) 0%, rgba(0, 0, 0, 0) 30%, rgba(0, 0, 0, 0.55) 100%);
+}
+
 .bio-crawl {
   position: absolute;
+  z-index: 1;
   left: 50%;
-  bottom: -35%;
+  bottom: 6%;
   width: min(680px, 88%);
-  transform: translateX(-50%) perspective(900px) rotateX(18deg);
+  transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(20%);
   transform-origin: 50% 100%;
   text-align: justify;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  line-height: 1.65;
-  color: #f5d24a; /* warm “crawl” yellow */
+  font-size: clamp(18px, 1.6vw, 24px);
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  line-height: 1.75;
+  color: #f5d24a;
   text-shadow: 0 2px 10px rgba(0,0,0,0.6);
   animation: bioCrawl 55s linear 1 both;
+}
+
+.bio-crawl,
+.bio-crawl * {
+  color: #f5d24a !important;
 }
 
 .bio-crawl-title {
   text-align: center;
   letter-spacing: 0.12em;
   margin: 0 0 8px 0;
-  font-size: clamp(26px, 3.2vw, 40px);
+  font-size: clamp(34px, 3.6vw, 52px);
 }
 
 .bio-crawl-subtitle {
   text-align: center;
   margin: 0 0 20px 0;
-  font-size: clamp(14px, 1.6vw, 18px);
+  font-size: clamp(20px, 2vw, 30px);
   opacity: 0.95;
 }
 
 .bio-crawl p {
   margin: 0 0 16px 0;
+}
+
+.bio-crawl a {
+  text-decoration: underline;
+  text-underline-offset: 0.14em;
+  transition: color 180ms ease;
+}
+
+.bio-crawl a:hover,
+.bio-crawl a:focus-visible {
+  color: #ffe37a !important;
 }
 
 .bio-crawl-bandcamp {
@@ -3229,8 +3256,8 @@ body.page-template-page-bio .bio-crawl-wrap,
 }
 
 @keyframes bioCrawl {
-  0%   { transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(0); }
-  100% { transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(-210%); }
+  0%   { transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(20%); }
+  100% { transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(-220%); }
 }
 
 /* Reduced motion: no animation, no tilt, keep readable */
@@ -3239,6 +3266,11 @@ body.page-template-page-bio .bio-crawl-wrap,
     height: auto;
     overflow: visible;
   }
+
+  .bio-crawl-wrap::before {
+    display: none;
+  }
+
   .bio-crawl {
     position: static;
     width: min(680px, 92%);


### PR DESCRIPTION
### Motivation
- The bio opening-crawl began off-screen and theme styles were overriding the intended large yellow crawl, so the crawl needs to start with the title visible and present a consistent large yellow opening-crawl look while still respecting reduced-motion.

### Description
- Start the crawl nearer the visible area by setting `.bio-crawl { bottom: 6%; transform: ... translateY(20%); }` and update `@keyframes bioCrawl` to animate from `translateY(20%)` to `translateY(-220%)` so the title/subtitle appear immediately and the crawl travels upward smoothly.
- Increase and normalize typography by adding `font-size: clamp(18px, 1.6vw, 24px)`, `line-height: 1.75`, `font-weight: 700`, and larger title/subtitle clamps (`.bio-crawl-title` and `.bio-crawl-subtitle`).
- Force the crawl color to the warm yellow with `.bio-crawl, .bio-crawl * { color: #f5d24a !important; }` and keep links readable with underline and a hover/focus color shift so theme colors do not bleed in.
- Add a non-interactive vignette overlay on the crawl container via `.bio-crawl-wrap::before` for a subtle top fade and hide that overlay in `prefers-reduced-motion`, and preserve reduced-motion by disabling the animation and tilt and falling back to a static readable layout.

### Testing
- Ran `git diff --check` which returned clean results for the edited CSS.
- Executed a Playwright-based screenshot attempt against local `/bio/` endpoints, but the navigation failed with `ERR_EMPTY_RESPONSE` so visual verification could not be captured in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a67cccccf8832ea39274bbb381999f)