### PR TITLE
Refine bio opening crawl start timing and hold behavior

### DIFF
--- a/style.css
+++ b/style.css
@@ -3175,7 +3175,7 @@ body.page-template-page-bio .bio-crawl-wrap,
 .page-bio .bio-crawl-wrap {
   position: relative;
   overflow: hidden;
-  height: min(70vh, 720px);
+  height: min(78vh, 780px);
   padding: 24px 0;
   border-radius: 16px;
 }
@@ -3184,7 +3184,7 @@ body.page-template-page-bio .bio-crawl-wrap,
 .bio-content .bio-crawl-wrap {
   position: relative;
   overflow: hidden;
-  height: min(70vh, 720px);
+  height: min(78vh, 780px);
   padding: 24px 0;
   border-radius: 16px;
 }
@@ -3202,9 +3202,8 @@ body.page-template-page-bio .bio-crawl-wrap,
   position: absolute;
   z-index: 1;
   left: 50%;
-  bottom: 6%;
+  bottom: 0;
   width: min(680px, 88%);
-  transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(20%);
   transform-origin: 50% 100%;
   text-align: justify;
   font-size: clamp(18px, 1.6vw, 24px);
@@ -3213,7 +3212,8 @@ body.page-template-page-bio .bio-crawl-wrap,
   line-height: 1.75;
   color: #f5d24a;
   text-shadow: 0 2px 10px rgba(0,0,0,0.6);
-  animation: bioCrawl 55s linear 1 both;
+  animation: bioCrawl 80s linear 1 both;
+  will-change: transform;
 }
 
 .bio-crawl,
@@ -3256,8 +3256,9 @@ body.page-template-page-bio .bio-crawl-wrap,
 }
 
 @keyframes bioCrawl {
-  0%   { transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(20%); }
-  100% { transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(-220%); }
+  0%   { transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(48%); }
+  12%  { transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(48%); }
+  100% { transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(-240%); }
 }
 
 /* Reduced motion: no animation, no tilt, keep readable */


### PR DESCRIPTION
### Motivation
- The bio opening crawl started its scroll too early so the title/subtitle weren’t visible immediately; the goal is to present the title/subtitle on load and hold briefly before scrolling.
- Maintain the large yellow typography and preserve `prefers-reduced-motion` behavior so users who request reduced motion see a static, readable layout.

### Description
- Increased the crawl container height by setting `.bio-crawl-wrap` to `height: min(78vh, 780px);` for both page-scoped and fallback selectors to give the crawl more vertical room.
- Repositioned `.bio-crawl` with `bottom: 0`, removed the selector-level start `translateY(...)`, kept `left: 50%`, perspective/rotateX tilt, and `width: min(680px, 88%);`.
- Set the animation to `animation: bioCrawl 80s linear 1 both;` and added `will-change: transform;` to `.bio-crawl` for smoother transforms.
- Replaced `@keyframes bioCrawl` with a hold-then-scroll sequence so the crawl holds at `translateY(48%)` from `0%` to `12%` and then scrolls to `translateY(-240%)` at `100%`.
- Preserved forced yellow typography (`color: #f5d24a !important;`) and left `@media (prefers-reduced-motion: reduce)` overrides intact (`transform: none; animation: none; position: static;`).

### Testing
- Ran `git diff -- style.css` to verify the CSS changes were applied, which showed the expected edits.
- Ran `git status --short` to confirm the working tree included the modified `style.css` file, which succeeded.
- Attempted an automated Playwright capture of `http://localhost:8080/bio/` to validate the visual result, which failed due to `net::ERR_EMPTY_RESPONSE` from the local server so a runtime screenshot could not be obtained.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a67e91e444832e92b16c81116d2ee3)