### PR TITLE
Replace Bio opening crawl animation with scroll-driven crawl

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -63,6 +63,16 @@ function retro_game_music_theme_scripts() {
             true
         );
     }
+
+    if ( is_page_template( 'page-bio.php' ) || is_page( 'bio' ) ) {
+        wp_enqueue_script(
+            'bio-crawl',
+            get_template_directory_uri() . '/js/bio-crawl.js',
+            array(),
+            filemtime( get_template_directory() . '/js/bio-crawl.js' ),
+            true
+        );
+    }
 }
 add_action('wp_enqueue_scripts', 'retro_game_music_theme_scripts');
 

--- a/js/bio-crawl.js
+++ b/js/bio-crawl.js
@@ -1,0 +1,163 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const wrap = document.querySelector('.bio-crawl-wrap');
+  if (!wrap) {
+    return;
+  }
+
+  window.scrollTo(0, 0);
+  wrap.scrollTop = 0;
+
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const holdMs = 1800;
+  const speed = 18; // px/sec
+  const resumeDelayMs = 900;
+  const dragThreshold = 6;
+
+  let rafId = null;
+  let lastTime = null;
+  let holdUntil = performance.now() + holdMs;
+  let autoScrollEnabled = !prefersReducedMotion;
+
+  let isPointerDown = false;
+  let isDragging = false;
+  let activePointerId = null;
+  let startY = 0;
+  let startScrollTop = 0;
+  let maxMovement = 0;
+  let suppressClick = false;
+  let resumeTimer = null;
+
+  const maxScrollTop = () => wrap.scrollHeight - wrap.clientHeight;
+
+  const pauseAutoScroll = () => {
+    autoScrollEnabled = false;
+  };
+
+  const resumeAutoScroll = (delay = 0) => {
+    if (prefersReducedMotion) {
+      return;
+    }
+
+    window.clearTimeout(resumeTimer);
+    resumeTimer = window.setTimeout(() => {
+      autoScrollEnabled = true;
+      holdUntil = performance.now();
+      if (!rafId) {
+        rafId = requestAnimationFrame(step);
+      }
+    }, delay);
+  };
+
+  const step = (now) => {
+    if (lastTime === null) {
+      lastTime = now;
+    }
+
+    const deltaSeconds = Math.max(0, now - lastTime) / 1000;
+    lastTime = now;
+
+    if (autoScrollEnabled && !isDragging && now >= holdUntil) {
+      const nextScrollTop = Math.min(maxScrollTop(), wrap.scrollTop + speed * deltaSeconds);
+      wrap.scrollTop = nextScrollTop;
+
+      if (wrap.scrollTop >= maxScrollTop() - 2) {
+        rafId = null;
+        return;
+      }
+    }
+
+    rafId = requestAnimationFrame(step);
+  };
+
+  const endDrag = () => {
+    if (!isPointerDown) {
+      return;
+    }
+
+    isPointerDown = false;
+    activePointerId = null;
+    wrap.classList.remove('is-dragging');
+
+    if (isDragging) {
+      suppressClick = true;
+      window.setTimeout(() => {
+        suppressClick = false;
+      }, 0);
+    }
+
+    isDragging = false;
+    resumeAutoScroll(resumeDelayMs);
+  };
+
+  wrap.addEventListener('pointerdown', (event) => {
+    if (event.button !== 0) {
+      return;
+    }
+
+    if (event.target.closest('a')) {
+      return;
+    }
+
+    window.clearTimeout(resumeTimer);
+    pauseAutoScroll();
+
+    isPointerDown = true;
+    isDragging = false;
+    activePointerId = event.pointerId;
+    startY = event.clientY;
+    startScrollTop = wrap.scrollTop;
+    maxMovement = 0;
+
+    wrap.setPointerCapture(event.pointerId);
+  });
+
+  wrap.addEventListener('pointermove', (event) => {
+    if (!isPointerDown || event.pointerId !== activePointerId) {
+      return;
+    }
+
+    const movement = Math.abs(event.clientY - startY);
+    maxMovement = Math.max(maxMovement, movement);
+
+    if (movement >= dragThreshold) {
+      isDragging = true;
+      wrap.classList.add('is-dragging');
+    }
+
+    if (isDragging) {
+      event.preventDefault();
+      wrap.scrollTop = startScrollTop - (event.clientY - startY);
+    }
+  });
+
+  wrap.addEventListener('pointerup', (event) => {
+    if (event.pointerId !== activePointerId) {
+      return;
+    }
+
+    if (wrap.hasPointerCapture(event.pointerId)) {
+      wrap.releasePointerCapture(event.pointerId);
+    }
+
+    endDrag();
+  });
+
+  wrap.addEventListener('pointercancel', endDrag);
+  wrap.addEventListener('lostpointercapture', endDrag);
+
+  wrap.addEventListener('click', (event) => {
+    if (!suppressClick) {
+      return;
+    }
+
+    const link = event.target.closest('a');
+    if (link && maxMovement >= dragThreshold) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  }, true);
+
+  if (!prefersReducedMotion) {
+    rafId = requestAnimationFrame(step);
+  }
+});

--- a/style.css
+++ b/style.css
@@ -3169,51 +3169,38 @@ body {
   }
 }
 
-/* Bio page: opening-crawl vibe (desktop-first, respects reduced motion) */
-body.page-template-page-bio .bio-crawl-wrap,
-.bio-page .bio-crawl-wrap,
-.page-bio .bio-crawl-wrap {
+/* Bio crawl: scroll-based (no CSS animation) */
+.bio-crawl-wrap {
   position: relative;
-  overflow: hidden;
+  overflow: auto;
   height: min(78vh, 780px);
-  padding: 24px 0;
+  padding: 0;
   border-radius: 16px;
+  scroll-behavior: auto;
+  cursor: grab;
+  -webkit-overflow-scrolling: touch;
 }
 
-/* Fallback in case no body class exists: scope via .bio-content parent */
-.bio-content .bio-crawl-wrap {
-  position: relative;
-  overflow: hidden;
-  height: min(78vh, 780px);
-  padding: 24px 0;
-  border-radius: 16px;
-}
+/* Hide scrollbar (still scrollable) */
+.bio-crawl-wrap::-webkit-scrollbar { width: 0; height: 0; }
+.bio-crawl-wrap { scrollbar-width: none; }
 
-.bio-crawl-wrap::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  z-index: 2;
-  background: linear-gradient(to top, rgba(0, 0, 0, 0.03) 0%, rgba(0, 0, 0, 0) 30%, rgba(0, 0, 0, 0.55) 100%);
-}
+.bio-crawl-wrap.is-dragging { cursor: grabbing; }
 
 .bio-crawl {
-  position: absolute;
-  z-index: 1;
-  left: 50%;
-  bottom: 0;
-  width: min(680px, 88%);
+  width: min(720px, 90%);
+  margin: 0 auto;
+  padding-top: clamp(180px, 34vh, 360px);
+  padding-bottom: clamp(260px, 40vh, 520px);
+  transform: perspective(900px) rotateX(18deg);
   transform-origin: 50% 100%;
   text-align: justify;
-  font-size: clamp(18px, 1.6vw, 24px);
-  font-weight: 700;
+  font-weight: 800;
   letter-spacing: 0.03em;
-  line-height: 1.75;
+  line-height: 1.8;
+  font-size: clamp(18px, 1.6vw, 24px);
   color: #f5d24a;
   text-shadow: 0 2px 10px rgba(0,0,0,0.6);
-  animation: bioCrawl 80s linear 1 both;
-  will-change: transform;
 }
 
 .bio-crawl,
@@ -3223,16 +3210,15 @@ body.page-template-page-bio .bio-crawl-wrap,
 
 .bio-crawl-title {
   text-align: center;
-  letter-spacing: 0.12em;
-  margin: 0 0 8px 0;
-  font-size: clamp(34px, 3.6vw, 52px);
+  letter-spacing: 0.14em;
+  margin: 0 0 10px 0;
+  font-size: clamp(36px, 4vw, 56px);
 }
 
 .bio-crawl-subtitle {
   text-align: center;
-  margin: 0 0 20px 0;
-  font-size: clamp(20px, 2vw, 30px);
-  opacity: 0.95;
+  margin: 0 0 26px 0;
+  font-size: clamp(16px, 1.8vw, 22px);
 }
 
 .bio-crawl p {
@@ -3255,29 +3241,32 @@ body.page-template-page-bio .bio-crawl-wrap,
   margin-top: 22px;
 }
 
-@keyframes bioCrawl {
-  0%   { transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(48%); }
-  12%  { transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(48%); }
-  100% { transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(-240%); }
+/* Vignette fade (top and bottom) */
+.bio-crawl-wrap::before,
+.bio-crawl-wrap::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 90px;
+  pointer-events: none;
+  z-index: 2;
 }
 
-/* Reduced motion: no animation, no tilt, keep readable */
+.bio-crawl-wrap::before {
+  top: 0;
+  background: linear-gradient(to bottom, rgba(0,0,0,0.9), rgba(0,0,0,0));
+}
+
+.bio-crawl-wrap::after {
+  bottom: 0;
+  background: linear-gradient(to top, rgba(0,0,0,0.9), rgba(0,0,0,0));
+}
+
+/* Reduced motion: remove tilt for readability, still scrollable */
 @media (prefers-reduced-motion: reduce) {
-  .bio-crawl-wrap {
-    height: auto;
-    overflow: visible;
-  }
-
-  .bio-crawl-wrap::before {
-    display: none;
-  }
-
   .bio-crawl {
-    position: static;
-    width: min(680px, 92%);
     transform: none;
-    animation: none;
-    margin: 0 auto;
     text-align: left;
   }
 }


### PR DESCRIPTION
### Motivation
- The existing CSS `@keyframes` crawl started mid-text because the animation ran before the user saw the page, and it prevented direct user scrubbing.  
- Replace the animated, absolutely-positioned approach with a scroll-driven container so the title/subtitle are visible immediately and the user can control progress.  
- Respect accessibility by disabling auto-scroll when `prefers-reduced-motion: reduce` while keeping manual scrolling/drag working.  

### Description
- Removed the animated absolute-layout rules and `@keyframes bioCrawl` and replaced them with a scroll container in `style.css` (new `.bio-crawl-wrap` rules, hidden scrollbar, vignette overlays, drag cursor states, and a reduced-motion fallback).  
- Reworked `.bio-crawl` styles to be a centered, perspective-tilted block with top/bottom padding so the title/subtitle are visible at load.  
- Added `js/bio-crawl.js` implementing: initial `window.scrollTo(0,0)` + `wrap.scrollTop = 0`, a `1800ms` intro hold, time-based auto-scroll at `18px/s` via `requestAnimationFrame`, pointer drag scrub (click+drag), pause/resume behavior, and click-safe link handling that prevents accidental link activation after a drag.  
- Enqueued the new script only for the Bio page/template (`page-bio.php` or page slug `bio`) using `filemtime(...)` for cache busting and loading in the footer in `functions.php`.  

### Testing
- Ran `php -l functions.php` to validate PHP syntax and it reported no syntax errors.  
- Ran `node --check js/bio-crawl.js` to validate the script and it returned successfully.  
- Started a local PHP server and captured a Playwright screenshot of `/bio/` to visually validate the crawl begins at the top; the capture completed.  
- Files changed and committed: `style.css`, `js/bio-crawl.js`, and `functions.php`; automated checks above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6814e6fc4832e866a3167841fb29c)