### PR TITLE
Fix /bio/ crawl blank-start regression and interaction polish

### DIFF
--- a/js/bio-crawl.js
+++ b/js/bio-crawl.js
@@ -1,11 +1,12 @@
 document.addEventListener('DOMContentLoaded', () => {
+  if ('scrollRestoration' in history) {
+    history.scrollRestoration = 'manual';
+  }
+
   const wrap = document.querySelector('.bio-crawl-wrap');
   if (!wrap) {
     return;
   }
-
-  window.scrollTo(0, 0);
-  wrap.scrollTop = 0;
 
   const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   const holdMs = 1800;
@@ -26,6 +27,54 @@ document.addEventListener('DOMContentLoaded', () => {
   let maxMovement = 0;
   let suppressClick = false;
   let resumeTimer = null;
+  let hintTimer = null;
+  let pointerHintShown = false;
+
+  const hint = document.createElement('div');
+  hint.className = 'bio-crawl-hint';
+  hint.textContent = 'Drag / Scroll';
+  wrap.appendChild(hint);
+
+  const resetToStart = () => {
+    wrap.scrollTop = 0;
+    window.scrollTo(0, 0);
+  };
+
+  const ensureTitleVisible = () => {
+    const title = wrap.querySelector('.bio-crawl-title');
+    if (!title) {
+      return;
+    }
+
+    const titleRect = title.getBoundingClientRect();
+    const wrapRect = wrap.getBoundingClientRect();
+    if (titleRect.top > wrapRect.bottom - 40) {
+      wrap.scrollTop = Math.max(0, title.offsetTop - Math.round(wrap.clientHeight * 0.35));
+    }
+  };
+
+  const resetAndReveal = () => {
+    resetToStart();
+    ensureTitleVisible();
+  };
+
+  const showHintBriefly = (duration = 2500) => {
+    hint.classList.remove('is-hidden');
+    window.clearTimeout(hintTimer);
+    hintTimer = window.setTimeout(() => {
+      hint.classList.add('is-hidden');
+    }, duration);
+  };
+
+  resetAndReveal();
+  requestAnimationFrame(() => {
+    resetAndReveal();
+    requestAnimationFrame(resetAndReveal);
+  });
+  window.setTimeout(resetAndReveal, 50);
+  window.setTimeout(resetAndReveal, 250);
+  window.addEventListener('pageshow', resetAndReveal);
+  showHintBriefly();
 
   const maxScrollTop = () => wrap.scrollHeight - wrap.clientHeight;
 
@@ -79,7 +128,7 @@ document.addEventListener('DOMContentLoaded', () => {
     wrap.classList.remove('is-dragging');
 
     if (isDragging) {
-      suppressClick = true;
+      suppressClick = maxMovement >= dragThreshold;
       window.setTimeout(() => {
         suppressClick = false;
       }, 0);
@@ -96,6 +145,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (event.target.closest('a')) {
       return;
+    }
+
+    if (!pointerHintShown) {
+      pointerHintShown = true;
+      showHintBriefly(1200);
     }
 
     window.clearTimeout(resumeTimer);
@@ -144,6 +198,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
   wrap.addEventListener('pointercancel', endDrag);
   wrap.addEventListener('lostpointercapture', endDrag);
+
+  wrap.addEventListener('wheel', () => {
+    window.clearTimeout(resumeTimer);
+    pauseAutoScroll();
+    resumeAutoScroll(resumeDelayMs);
+  }, { passive: true });
 
   wrap.addEventListener('click', (event) => {
     if (!suppressClick) {

--- a/style.css
+++ b/style.css
@@ -3190,8 +3190,8 @@ body {
 .bio-crawl {
   width: min(720px, 90%);
   margin: 0 auto;
-  padding-top: clamp(180px, 34vh, 360px);
-  padding-bottom: clamp(260px, 40vh, 520px);
+  padding-top: clamp(36px, 10vh, 120px);
+  padding-bottom: clamp(220px, 30vh, 520px);
   transform: perspective(900px) rotateX(18deg);
   transform-origin: 50% 100%;
   text-align: justify;
@@ -3206,6 +3206,26 @@ body {
 .bio-crawl,
 .bio-crawl * {
   color: #f5d24a !important;
+  white-space: normal;
+}
+
+.bio-crawl-hint {
+  position: absolute;
+  left: 14px;
+  bottom: 12px;
+  z-index: 3;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(245, 210, 74, 0.9);
+  text-shadow: 0 1px 8px rgba(0, 0, 0, 0.85);
+  pointer-events: none;
+  opacity: 0.92;
+  transition: opacity 260ms ease;
+}
+
+.bio-crawl-hint.is-hidden {
+  opacity: 0;
 }
 
 .bio-crawl-title {


### PR DESCRIPTION
### Motivation
- The Star Wars-style crawl on `/bio/` could start scrolled into a blank black area because of excessive top padding and browser scroll restoration behavior. 
- Global `white-space: pre-wrap` on `.bio-content` introduced odd spacing inside the crawl. 
- Interaction felt broken when the pointer cursor remained over an empty area and auto-scroll could begin from an off-screen position. 

### Description
- Reduce crawl runway by changing `.bio-crawl` padding to `padding-top: clamp(36px, 10vh, 120px)` and `padding-bottom: clamp(220px, 30vh, 520px)` in `style.css` and add `white-space: normal` for `.bio-crawl, .bio-crawl *` to avoid `pre-wrap` artifacts. 
- Add a subtle CSS-only hint overlay `.bio-crawl-hint` that fades out to guide users to `Drag / Scroll`. 
- Harden startup behavior in `js/bio-crawl.js` by disabling `history.scrollRestoration`, adding `resetToStart()` with repeated calls (immediate, double `requestAnimationFrame`, 50ms/250ms timeouts) and a `pageshow` handler, and adding `ensureTitleVisible()` to nudge the wrap so the title/subtitle are visible. 
- Improve interaction: wheel/trackpad pauses auto-scroll and resumes after `900ms`, drag click suppression only blocks clicks when movement >= threshold, hint briefly re-shows on first pointerdown, and `prefers-reduced-motion` still disables auto-scroll while preserving manual drag/wheel. 
- Files changed: `style.css` and `js/bio-crawl.js`.
- Quick manual validation steps: reload `/bio/` repeatedly and confirm title/subtitle are visible on load; click+drag to scrub and verify `grabbing` cursor only when dragging and links remain clickable when not dragging; use mouse wheel/trackpad to confirm auto-scroll pauses and resumes; enable `prefers-reduced-motion` to confirm no auto-scroll. 

### Testing
- Ran `node --check js/bio-crawl.js` which succeeded with no syntax errors. 
- Attempted an automated Playwright screenshot run against `http://127.0.0.1/bio/` but the local web server did not respond so browser-based verification could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a69256d104832e9b1366c275082d2e)