### PR TITLE
Scope Lousy Outages mail overrides and align envelope sender for DMARC

### DIFF
--- a/lousy-outages/README.md
+++ b/lousy-outages/README.md
@@ -41,6 +41,14 @@ Use the **Poll Now** button in the debug panel to run an immediate poll. The pan
 
 Place `[lousy_outages]` in any page or post to render the status table. A page titled *Lousy Outages* is created automatically on activation.
 
+
+## Deliverability checklist
+
+- DMARC passes when either DKIM passes with alignment **or** SPF passes with an envelope-from (Return-Path / MAIL FROM) aligned to the visible From domain.
+- Lousy Outages mail now sets PHPMailer `Sender` and sendmail `-f` to align envelope-from with the `suzyeaston.ca` From domain.
+- In Gmail, open an alert email, choose **Show original**, and verify `dmarc=pass` in Authentication-Results.
+- DNS still matters: SPF, DKIM, and DMARC records must be correctly configured for full deliverability.
+
 ## Filters & Actions
 
 - `lousy_outages_providers` – filter the provider array before polling.

--- a/lousy-outages/includes/MailTransport.php
+++ b/lousy-outages/includes/MailTransport.php
@@ -10,6 +10,9 @@ class MailTransport
 {
     private const SENDMAIL_PATH = '/usr/sbin/sendmail';
 
+    private static bool $active = false;
+    /** @var array<string,mixed> */
+    private static array $context = [];
     private static bool $forceMail = false;
     private static string $transport = 'mail';
     private static bool $fallbackAttempted = false;
@@ -22,27 +25,60 @@ class MailTransport
         add_filter('wp_mail_from_name', [self::class, 'fromName']);
     }
 
+    /**
+     * @param array<string,mixed> $context
+     */
+    public static function begin(array $context = []): void
+    {
+        self::$active = true;
+        self::$context = $context;
+        self::$fallbackAttempted = false;
+    }
+
+    public static function end(): void
+    {
+        self::$active = false;
+        self::$context = [];
+        self::$forceMail = false;
+        self::$fallbackAttempted = false;
+        self::$transport = 'mail';
+    }
+
+    public static function isActive(): bool
+    {
+        return self::$active;
+    }
+
     public static function configure($phpmailer): void
     {
-        if (! $phpmailer instanceof PHPMailer) {
+        if (! self::isActive() || ! $phpmailer instanceof PHPMailer) {
             return;
         }
 
-        self::$fallbackAttempted = false;
+        $fromAddress = self::resolveFromAddress();
+        $envelopeSender = (string) apply_filters('lousy_outages_envelope_from', $fromAddress);
+        $envelopeSender = self::cleanAddress($envelopeSender);
+        if (! is_email($envelopeSender)) {
+            $envelopeSender = $fromAddress;
+        }
+
+        $phpmailer->Sender = $envelopeSender;
 
         if (self::$forceMail) {
             $phpmailer->isMail();
             $phpmailer->Mailer = 'mail';
             self::$transport = 'mail';
             self::$forceMail = false;
+            self::addDebugHeaders($phpmailer, $envelopeSender, $fromAddress);
             return;
         }
 
         $sendmailPath = self::SENDMAIL_PATH;
         if (is_string($sendmailPath) && is_executable($sendmailPath)) {
             $phpmailer->isSendmail();
-            $phpmailer->Sendmail = $sendmailPath . ' -t -i';
+            $phpmailer->Sendmail = $sendmailPath . ' -t -i -f ' . escapeshellarg($envelopeSender);
             self::$transport = 'sendmail';
+            self::addDebugHeaders($phpmailer, $envelopeSender, $fromAddress);
             return;
         }
 
@@ -53,24 +89,49 @@ class MailTransport
         $phpmailer->SMTPAutoTLS = false;
         $phpmailer->SMTPKeepAlive = false;
         self::$transport = 'smtp';
+        self::addDebugHeaders($phpmailer, $envelopeSender, $fromAddress);
     }
 
     public static function fromAddress(string $address = ''): string
     {
+        if (! self::isActive()) {
+            return $address;
+        }
+
         $desired = sanitize_email('noreply@suzyeaston.ca');
+        if (isset(self::$context['from_address'])) {
+            $contextAddress = self::cleanAddress((string) self::$context['from_address']);
+            if (is_email($contextAddress)) {
+                $desired = $contextAddress;
+            }
+        }
 
         return $desired ?: $address;
     }
 
     public static function fromName(string $name = ''): string
     {
+        if (! self::isActive()) {
+            return $name;
+        }
+
         $desired = sanitize_text_field('Lousy Outages');
+        if (isset(self::$context['from_name'])) {
+            $contextName = trim(preg_replace('/[\r\n]+/', ' ', (string) self::$context['from_name']));
+            if ('' !== $contextName) {
+                $desired = sanitize_text_field($contextName);
+            }
+        }
 
         return $desired ?: $name;
     }
 
     public static function handleFailure(WP_Error $error): void
     {
+        if (! self::isActive()) {
+            return;
+        }
+
         self::logFailure($error);
 
         if ('smtp' !== self::$transport || self::$fallbackAttempted) {
@@ -115,5 +176,32 @@ class MailTransport
 
         $target = trailingslashit(WP_CONTENT_DIR) . 'uploads/lo-mail.log';
         error_log($logMessage, 3, $target);
+    }
+
+    private static function resolveFromAddress(): string
+    {
+        $fromAddress = 'noreply@suzyeaston.ca';
+        if (isset(self::$context['from_address'])) {
+            $fromAddress = (string) self::$context['from_address'];
+        }
+
+        $fromAddress = self::cleanAddress((string) sanitize_email($fromAddress));
+        if (! is_email($fromAddress)) {
+            $fromAddress = 'noreply@suzyeaston.ca';
+        }
+
+        return $fromAddress;
+    }
+
+    private static function cleanAddress(string $value): string
+    {
+        return trim(str_replace(["\r", "\n"], '', $value));
+    }
+
+    private static function addDebugHeaders(PHPMailer $phpmailer, string $envelopeSender, string $fromAddress): void
+    {
+        $phpmailer->addCustomHeader('X-Lousy-Outages-Transport', self::$transport);
+        $phpmailer->addCustomHeader('X-Lousy-Outages-Envelope-From', $envelopeSender);
+        $phpmailer->addCustomHeader('X-Lousy-Outages-From', $fromAddress);
     }
 }

--- a/lousy-outages/includes/Mailer.php
+++ b/lousy-outages/includes/Mailer.php
@@ -16,17 +16,10 @@ class Mailer {
             return false;
         }
 
-        $from_email = get_option('admin_email');
-        if (!is_email($from_email)) {
-            $host = wp_parse_url(home_url(), PHP_URL_HOST);
-            if (!is_string($host) || '' === $host) {
-                $host = 'example.com';
-            }
-            $from_email = 'no-reply@' . ltrim($host, '@');
-        }
+        $from_email = 'noreply@suzyeaston.ca';
         $from_email = (string) apply_filters('lousy_outages_mail_from_email', $from_email, $email);
         if (!is_email($from_email)) {
-            $from_email = $email;
+            $from_email = 'noreply@suzyeaston.ca';
         }
 
         $from_name = wp_specialchars_decode(get_bloginfo('name', 'display'), ENT_QUOTES);
@@ -74,10 +67,17 @@ class Mailer {
         };
 
         add_action('phpmailer_init', $alt_body_callback);
+        MailTransport::begin([
+            'from_address' => $from_email,
+            'from_name' => $from_name,
+        ]);
 
-        $sent = wp_mail($email, $subject, $html_body, $headers);
-
-        remove_action('phpmailer_init', $alt_body_callback);
+        try {
+            $sent = wp_mail($email, $subject, $html_body, $headers);
+        } finally {
+            MailTransport::end();
+            remove_action('phpmailer_init', $alt_body_callback);
+        }
 
         if (! $sent && defined('WP_DEBUG') && WP_DEBUG) {
             error_log(sprintf('[lousy_outages] mail_send_failed recipient=%s subject=%s', $email, $subject));


### PR DESCRIPTION
### Motivation

- Prevent global mail hooks from affecting unrelated site emails and improve DMARC outcomes for Lousy Outages alerts. 
- Ensure the envelope sender (Return-Path / MAIL FROM) is aligned with the visible From domain so SPF can satisfy DMARC when DKIM fails.

### Description

- Added `MailTransport::begin(array $context = [])`, `MailTransport::end()`, and `MailTransport::isActive()` and guarded `configure()`, `fromAddress()`, `fromName()`, and `handleFailure()` so the transport hooks are NO-OP unless the transport is active. 
- Updated `Mailer::send()` to default the From email to `noreply@suzyeaston.ca`, call `MailTransport::begin()` before `wp_mail()` and `MailTransport::end()` in a `try/finally` to guarantee cleanup.
- In `MailTransport::configure()` set a sanitized/validated envelope sender from `lousy_outages_envelope_from` (defaults to the resolved Lousy Outages from address), assign it to `PHPMailer->Sender`, and for sendmail include `-f` using `escapeshellarg()` to avoid sendmail arg injection.
- Strip CR/LF from addresses to prevent header injection and validate envelope sender with `is_email()`; fall back to `noreply@suzyeaston.ca` when invalid.
- Add active-only debug headers to outgoing Lousy Outages messages: `X-Lousy-Outages-Transport`, `X-Lousy-Outages-Envelope-From`, and `X-Lousy-Outages-From`.
- Preserve existing SMTP→mail fallback retry behavior but restrict it to active Lousy Outages sends so other plugins/themes are not affected.
- Added a short Deliverability checklist to `lousy-outages/README.md` documenting DMARC/SPF/DKIM alignment and how the code sets `Sender`/`-f`.

### Testing

- Confirmed `MailTransport::begin()` is only invoked from the Lousy Outages send path by searching `wp_mail(` and `MailTransport::begin` in the repo and verifying `Mailer::send()` wraps `wp_mail()`; other `wp_mail()` callers are unaffected. (Found `MailTransport::begin` usage in `lousy-outages/includes/Mailer.php` only.)
- Ran PHP lint on changed files with `php -l` and both modified PHP files reported no syntax errors. 
- Ran `npm test`; JS integration tests in the repository currently show unrelated failures (5 failing, 4 passing) in existing frontend tests (`anchor.parentNode.insertBefore is not a function`), which are unrelated to the mail transport changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7cb8ef4f0832eb1faf90a34f02433)