### PR TITLE
Improve bio opening crawl visibility and readability

### DIFF
--- a/js/bio-crawl.js
+++ b/js/bio-crawl.js
@@ -9,19 +9,16 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   window.scrollTo(0, 0);
+  wrap.classList.add('is-crawl-ready');
 
-  const restartCrawl = () => {
+  window.addEventListener('pageshow', (event) => {
+    if (!event.persisted) {
+      return;
+    }
+
     window.scrollTo(0, 0);
     wrap.classList.remove('is-crawl-ready');
     void wrap.offsetWidth;
-    queueMicrotask(() => {
-      wrap.classList.add('is-crawl-ready');
-    });
-  };
-
-  restartCrawl();
-
-  window.addEventListener('pageshow', () => {
-    restartCrawl();
+    wrap.classList.add('is-crawl-ready');
   });
 });

--- a/style.css
+++ b/style.css
@@ -3189,17 +3189,17 @@ body.page-template-page-bio-php .bio-content {
   left: 50%;
   width: min(720px, 90%);
   margin: 0;
-  transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(34vh);
+  transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(8vh);
   opacity: 1;
   transform-origin: 50% 100%;
   text-align: justify;
   font-weight: 800;
   letter-spacing: 0.03em;
-  line-height: 1.8;
-  font-size: clamp(18px, 1.6vw, 24px);
+  line-height: 1.85;
+  font-size: clamp(22px, 2.1vw, 30px);
   color: #f5d24a;
   text-shadow: 0 2px 10px rgba(0, 0, 0, 0.6);
-  animation: seBioCrawl 55s linear 1 both;
+  animation: seBioCrawl 44s linear 1 both;
   animation-play-state: paused;
   will-change: transform;
   z-index: 1;
@@ -3210,9 +3210,8 @@ body.page-template-page-bio-php .bio-content {
 }
 
 @keyframes seBioCrawl {
-  0%,
-  3% {
-    transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(34vh);
+  0% {
+    transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(8vh);
   }
 
   100% {
@@ -3230,13 +3229,13 @@ body.page-template-page-bio-php .bio-content {
   text-align: center;
   letter-spacing: 0.14em;
   margin: 0 0 10px 0;
-  font-size: clamp(36px, 4vw, 56px);
+  font-size: clamp(42px, 5vw, 68px);
 }
 
 .bio-crawl-subtitle {
   text-align: center;
   margin: 0 0 26px 0;
-  font-size: clamp(16px, 1.8vw, 22px);
+  font-size: clamp(20px, 2.2vw, 30px);
 }
 
 .bio-crawl p {


### PR DESCRIPTION
### Motivation
- The crawl started visually off-screen due to `transform: ... translateY(34vh)` and an initial keyframe hold, producing a long empty black lead-in before text appeared.
- The animation duration (`55s`) and the initial keyframe pause made the motion feel sluggish on first paint.
- Crawl typography was too small for comfortable reading, especially the title and subtitle.
- The JS startup flow performed an unnecessary restart/microtask cycle that could delay the first visible render.

### Description
- Adjusted the crawl starting position by changing the CSS `transform` start from `translateY(34vh)` to `translateY(8vh)` so the title/subtitle are in-frame on load.
- Removed the extra keyframe hold and shortened the animation from `55s` to `44s` by updating `@keyframes seBioCrawl` and the `animation` declaration so motion begins immediately.
- Increased typography for readability by changing body `font-size` to `clamp(22px, 2.1vw, 30px)`, title to `clamp(42px, 5vw, 68px)`, and subtitle to `clamp(20px, 2.2vw, 30px)`, and slightly adjusted `line-height` to `1.85`.
- Simplified `js/bio-crawl.js` startup: mark the crawl `is-crawl-ready` immediately on `DOMContentLoaded` and retain a minimal `pageshow` handler that only resets the animation when `event.persisted` is true to support BFCache without delaying first paint.
- Preserved the yellow color, perspective/rotateX look, vignette fades, and the `prefers-reduced-motion` fallback.

### Testing
- Ran `node -c js/bio-crawl.js` with no syntax errors (succeeded).
- Ran `php -l page-bio.php` with no syntax errors (succeeded).
- Attempted an automated Playwright screenshot of `http://localhost:8080/bio/`, but the local server returned `net::ERR_EMPTY_RESPONSE` so the visual snapshot step failed in this environment (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac887fe324832eb349f112b5162b48)