### PR TITLE
Anchor .bio-crawl to top and adjust keyframes so crawl is visible on first paint

### DIFF
--- a/style.css
+++ b/style.css
@@ -3186,12 +3186,13 @@ body.page-template-page-bio-php .bio-content {
 
 .bio-crawl {
   position: absolute;
+  top: 0;
   left: 50%;
   width: min(720px, 90%);
   margin: 0;
-  transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(8vh);
+  transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(0);
   opacity: 1;
-  transform-origin: 50% 100%;
+  transform-origin: 50% 0;
   text-align: justify;
   font-weight: 800;
   letter-spacing: 0.03em;
@@ -3211,11 +3212,11 @@ body.page-template-page-bio-php .bio-content {
 
 @keyframes seBioCrawl {
   0% {
-    transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(8vh);
+    transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(0);
   }
 
   100% {
-    transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(-260vh);
+    transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(-240vh);
   }
 }
 
@@ -3293,5 +3294,10 @@ body.page-template-page-bio-php .bio-content {
     transform: none;
     animation: none;
     text-align: left;
+  }
+
+  .bio-crawl-wrap::before,
+  .bio-crawl-wrap::after {
+    display: none;
   }
 }


### PR DESCRIPTION
### Motivation
- Fix a layout/anchoring bug where the Star Wars-style crawl was rendered below the visible `.bio-crawl-wrap` because the absolutely positioned element had no explicit vertical anchor. This change makes the initial frame deterministic so the title/subtitle are visible immediately.
- Preserve the larger yellow typography and the perspective `rotateX` effect, keep `prefers-reduced-motion` behavior, and avoid JS timing/delay hacks; the solution is CSS-first positioning and animation.

### Description
- Anchored the absolutely positioned crawl by adding `top: 0` to `.bio-crawl` so it is pinned to the top edge of `.bio-crawl-wrap` on initial layout. (`style.css`).
- Changed the baseline transform to start from `translateY(0)` and updated the `@keyframes seBioCrawl` `0%` to `translateY(0)` so the title/subtitle are in-view on first paint, and adjusted the final frame to `translateY(-240vh)` to maintain the upward travel. (`style.css`).
- Updated `transform-origin` from `50% 100%` to `50% 0` to align perspective with the new top-anchored start. (`style.css`).
- Improved reduced-motion readability by hiding the vignette overlays in the reduced-motion media query while keeping the crawl in normal document flow for `prefers-reduced-motion: reduce`. (`style.css`).
- Left `js/bio-crawl.js` unchanged except for its existing BFCache/pageshow reset behavior so no JS delay hacks were added.

### Testing
- Inspected the modified CSS in `style.css` and confirmed that `top: 0`, `translateY(0)`, the updated `transform-origin`, and updated `@keyframes seBioCrawl` are present (static inspection succeeded).
- Printed the relevant file region to confirm line edits were applied and the reduced-motion overlay rule was added (file content verification succeeded).
- Ran a headless browser navigation to `http://127.0.0.1:8000/bio/` and attempted a screenshot; the environment returned `404` for that route so full runtime visual verification of the WordPress page could not be completed in this container (runtime validation limited).
- Observed a console/network `404` when attempting to load the page in the test environment, so no additional automated runtime assertions were possible here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac8bd1e108832eb39b281fca0006c9)