### PR TITLE
Refactor bio opening crawl structure and improve readability/travel

### DIFF
--- a/js/bio-crawl.js
+++ b/js/bio-crawl.js
@@ -4,12 +4,73 @@ document.addEventListener('DOMContentLoaded', () => {
     return;
   }
 
+  const stage = wrap.querySelector('.bio-crawl-stage');
+  const crawl = wrap.querySelector('.bio-crawl');
+  const soundToggle = wrap.querySelector('.bio-crawl-sound-toggle');
+  const audio = wrap.querySelector('.bio-crawl-audio');
+
+  const setCrawlTravel = () => {
+    if (!stage || !crawl) {
+      return;
+    }
+
+    const crawlHeight = Math.ceil(crawl.scrollHeight);
+    stage.style.height = `${crawlHeight}px`;
+  };
+
+  const setupAudioToggle = () => {
+    if (!soundToggle || !audio) {
+      return;
+    }
+
+    const audioSrc = audio.dataset.audioSrc ? audio.dataset.audioSrc.trim() : '';
+    if (!audioSrc) {
+      soundToggle.hidden = true;
+      soundToggle.disabled = true;
+      return;
+    }
+
+    audio.src = audioSrc;
+    audio.loop = true;
+    soundToggle.hidden = false;
+
+    const setToggleState = (isPlaying) => {
+      soundToggle.setAttribute('aria-pressed', isPlaying ? 'true' : 'false');
+      soundToggle.textContent = isPlaying ? 'Sound: On' : 'Sound: Off';
+    };
+
+    setToggleState(false);
+
+    soundToggle.addEventListener('click', async () => {
+      if (audio.paused) {
+        try {
+          await audio.play();
+          setToggleState(true);
+        } catch (error) {
+          setToggleState(false);
+        }
+        return;
+      }
+
+      audio.pause();
+      setToggleState(false);
+    });
+
+    audio.addEventListener('ended', () => {
+      setToggleState(false);
+    });
+  };
+
   if ('scrollRestoration' in history) {
     history.scrollRestoration = 'manual';
   }
 
   window.scrollTo(0, 0);
+  setCrawlTravel();
+  setupAudioToggle();
   wrap.classList.add('is-crawl-ready');
+
+  window.addEventListener('resize', setCrawlTravel);
 
   window.addEventListener('pageshow', (event) => {
     if (!event.persisted) {
@@ -17,6 +78,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     window.scrollTo(0, 0);
+    setCrawlTravel();
     wrap.classList.remove('is-crawl-ready');
     void wrap.offsetWidth;
     wrap.classList.add('is-crawl-ready');

--- a/page-bio.php
+++ b/page-bio.php
@@ -8,25 +8,36 @@ get_header();
 <main id="main-content">
     <section class="page-content">
         <div class="bio-content">
+<?php $bio_audio_src = apply_filters( 'se_bio_crawl_audio_src', '' ); ?>
 <div class="bio-crawl-wrap" aria-label="Bio opening crawl">
-  <div class="bio-crawl">
-    <h1 class="bio-crawl-title">SUZY EASTON</h1>
-    <h2 class="bio-crawl-subtitle">Vancouver born and raised</h2>
+  <button
+    class="bio-crawl-sound-toggle"
+    type="button"
+    aria-pressed="false"
+    aria-label="Toggle crawl sound"
+    hidden
+  >Sound: Off</button>
+  <div class="bio-crawl-stage">
+    <div class="bio-crawl">
+      <h1 class="bio-crawl-title">SUZY EASTON</h1>
+      <h2 class="bio-crawl-subtitle">Vancouver born and raised</h2>
 
-    <p>Hello. I’m Suzy Easton, a musician and creative technologist. I started with piano lessons, moved into open mics, studied classical music and recording arts, and later played in the psychedelic rock band Seafoam and on bass for The Smokes/Minto. We toured across Canada and recorded in Chicago with Steve Albini.</p>
+      <p>Hello. I’m Suzy Easton, a musician and creative technologist. I started with piano lessons, moved into open mics, studied classical music and recording arts, and later played in the psychedelic rock band Seafoam and on bass for The Smokes/Minto. We toured across Canada and recorded in Chicago with Steve Albini.</p>
 
-    <p>Alongside music, I work in Senior IT Ops with a focus on reliability, automation, and software operations. I like building systems that hold up under pressure, and tools that feel intentional, modern, and fun to use.</p>
+      <p>Alongside music, I work in Senior IT Ops with a focus on reliability, automation, and software operations. I like building systems that hold up under pressure, and tools that feel intentional, modern, and fun to use.</p>
 
-    <p>Lately I have been diving deep into AI. I use it for creative workflows, automation, and interactive experiments where art meets infrastructure. I am drawn to work that is practical, innovative, and a little unexpected.</p>
+      <p>Lately I have been diving deep into AI. I use it for creative workflows, automation, and interactive experiments where art meets infrastructure. I am drawn to work that is practical, innovative, and a little unexpected.</p>
 
-    <p>Recent projects include new music, lessons and sessions, and <em>Lousy Outages</em>, an arcade-style outage and status dashboard built for public awareness. It is a playful format for a serious topic, especially in a world where status pages often tell only part of the story.</p>
+      <p>Recent projects include new music, lessons and sessions, and <em>Lousy Outages</em>, an arcade-style outage and status dashboard built for public awareness. It is a playful format for a serious topic, especially in a world where status pages often tell only part of the story.</p>
 
-    <p>Coffee for Builders (Vancouver) should get lit one of these days.</p>
+      <p>Coffee for Builders (Vancouver) should get lit one of these days.</p>
 
-    <p>Reach me at <a href="mailto:suzyeaston@icloud.com">suzyeaston@icloud.com</a>.</p>
+      <p>Reach me at <a href="mailto:suzyeaston@icloud.com">suzyeaston@icloud.com</a>.</p>
 
-    <p class="bio-crawl-bandcamp">🎶 <a href="https://suzyeaston.bandcamp.com" target="_blank" rel="noopener">Support on Bandcamp</a></p>
+      <p class="bio-crawl-bandcamp">🎶 <a href="https://suzyeaston.bandcamp.com" target="_blank" rel="noopener">Support on Bandcamp</a></p>
+    </div>
   </div>
+  <audio class="bio-crawl-audio" preload="none" data-audio-src="<?php echo esc_attr( $bio_audio_src ); ?>"></audio>
 </div>
         </div>
     </section>

--- a/style.css
+++ b/style.css
@@ -3177,47 +3177,55 @@ body.page-template-page-bio-php .bio-content {
 }
 
 .bio-crawl-wrap {
+  --crawl-duration: 48s;
+  --crawl-start-offset: 20%;
+  --crawl-end-offset: 38vh;
   position: relative;
   overflow: hidden;
-  height: min(78vh, 780px);
+  height: min(80vh, 820px);
   border-radius: 16px;
   padding: 0;
 }
 
-.bio-crawl {
+.bio-crawl-stage {
   position: absolute;
-  top: 0;
-  left: 50%;
-  width: min(720px, 90%);
-  margin: 0;
-  transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(0);
-  opacity: 1;
-  transform-origin: 50% 0;
-  text-align: justify;
-  font-weight: 800;
-  letter-spacing: 0.03em;
-  line-height: 1.85;
-  font-size: clamp(22px, 2.1vw, 30px);
-  color: #f5d24a;
-  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.6);
-  animation: seBioCrawl 44s linear 1 both;
+  inset: 0;
+  transform: translateY(var(--crawl-start-offset));
+  animation: seBioCrawlStage var(--crawl-duration) linear 1 both;
   animation-play-state: paused;
   will-change: transform;
   z-index: 1;
 }
 
-.bio-crawl-wrap.is-crawl-ready .bio-crawl {
+.bio-crawl-wrap.is-crawl-ready .bio-crawl-stage {
   animation-play-state: running;
 }
 
-@keyframes seBioCrawl {
+@keyframes seBioCrawlStage {
   0% {
-    transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(0);
+    transform: translateY(var(--crawl-start-offset));
   }
 
   100% {
-    transform: translateX(-50%) perspective(900px) rotateX(18deg) translateY(-240vh);
+    transform: translateY(calc(-100% - var(--crawl-end-offset)));
   }
+}
+
+.bio-crawl {
+  position: absolute;
+  left: 50%;
+  top: 0;
+  width: min(690px, 90%);
+  margin: 0;
+  transform: translateX(-50%) perspective(950px) rotateX(20deg);
+  transform-origin: 50% 0;
+  text-align: left;
+  font-weight: 700;
+  letter-spacing: 0.018em;
+  line-height: 1.62;
+  font-size: clamp(19px, 1.9vw, 24px);
+  color: #f5d24a;
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.62);
 }
 
 .bio-crawl,
@@ -3228,19 +3236,21 @@ body.page-template-page-bio-php .bio-content {
 
 .bio-crawl-title {
   text-align: center;
-  letter-spacing: 0.14em;
-  margin: 0 0 10px 0;
-  font-size: clamp(42px, 5vw, 68px);
+  letter-spacing: 0.12em;
+  margin: 0 0 8px 0;
+  font-size: clamp(36px, 4.6vw, 56px);
+  line-height: 1.15;
 }
 
 .bio-crawl-subtitle {
   text-align: center;
-  margin: 0 0 26px 0;
-  font-size: clamp(20px, 2.2vw, 30px);
+  margin: 0 0 24px 0;
+  font-size: clamp(16px, 1.8vw, 22px);
+  line-height: 1.35;
 }
 
 .bio-crawl p {
-  margin: 0 0 16px 0;
+  margin: 0 0 14px 0;
 }
 
 .bio-crawl a {
@@ -3256,7 +3266,33 @@ body.page-template-page-bio-php .bio-content {
 
 .bio-crawl-bandcamp {
   text-align: center;
-  margin-top: 22px;
+  margin-top: 18px;
+}
+
+.bio-crawl-sound-toggle {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  z-index: 3;
+  border: 1px solid rgba(245, 210, 74, 0.75);
+  border-radius: 999px;
+  padding: 6px 11px;
+  background: rgba(0, 0, 0, 0.72);
+  color: #f5d24a;
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.bio-crawl-sound-toggle[hidden] {
+  display: none;
+}
+
+.bio-crawl-sound-toggle:focus-visible,
+.bio-crawl-sound-toggle:hover {
+  border-color: #ffe37a;
+  color: #ffe37a;
 }
 
 /* Vignette fade (top and bottom) */
@@ -3266,19 +3302,43 @@ body.page-template-page-bio-php .bio-content {
   position: absolute;
   left: 0;
   right: 0;
-  height: 90px;
   pointer-events: none;
   z-index: 2;
 }
 
 .bio-crawl-wrap::before {
   top: 0;
-  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.9), rgba(0, 0, 0, 0));
+  height: 56px;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.58), rgba(0, 0, 0, 0));
 }
 
 .bio-crawl-wrap::after {
   bottom: 0;
-  background: linear-gradient(to top, rgba(0, 0, 0, 0.9), rgba(0, 0, 0, 0));
+  height: 110px;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.88), rgba(0, 0, 0, 0));
+}
+
+@media (max-width: 700px) {
+  .bio-crawl-wrap {
+    --crawl-duration: 54s;
+    --crawl-start-offset: 16%;
+    --crawl-end-offset: 34vh;
+    height: min(78vh, 760px);
+  }
+
+  .bio-crawl {
+    width: min(92%, 640px);
+    font-size: clamp(17px, 4vw, 21px);
+    line-height: 1.58;
+  }
+
+  .bio-crawl-title {
+    font-size: clamp(30px, 9vw, 42px);
+  }
+
+  .bio-crawl-subtitle {
+    font-size: clamp(14px, 4.5vw, 18px);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -3287,13 +3347,19 @@ body.page-template-page-bio-php .bio-content {
     overflow: visible;
   }
 
-  .bio-crawl {
+  .bio-crawl-stage {
     position: static;
-    width: min(720px, 90%);
-    margin: 0 auto;
     transform: none;
     animation: none;
+  }
+
+  .bio-crawl {
+    position: static;
+    width: min(720px, 92%);
+    margin: 0 auto;
+    transform: none;
     text-align: left;
+    text-shadow: none;
   }
 
   .bio-crawl-wrap::before,


### PR DESCRIPTION
### Motivation
- Fix unreliable title visibility, ugly word-spacing, oversized text, and the crawl stopping short while preserving the classic yellow opening-crawl feel. 
- Separate layout, perspective and motion so typography and animation behave predictably under transform and across viewport sizes. 
- Offer an optional unobtrusive sound toggle that uses a user-provided audio source and degrades gracefully when none is available. 

### Description
- Reworked markup to a three-layer structure by updating `page-bio.php` to include ` .bio-crawl-wrap` (viewport), ` .bio-crawl-stage` (vertical travel) and ` .bio-crawl` (perspective/typography), and added a hidden `button.bio-crawl-sound-toggle` plus `audio.bio-crawl-audio` driven by the `se_bio_crawl_audio_src` filter. 
- Removed `text-align: justify` and tuned typography in `style.css` (smaller font, lighter weight, reduced letter-spacing and line-height) to eliminate the exaggerated word gaps caused by justification applied to a transformed/perspective block. 
- Moved the vertical animation from the transformed element to the stage and replaced the fixed `translateY(-240vh)` approach with a content-aware end state using `translateY(calc(-100% - var(--crawl-end-offset)))` so the crawl continues until the entire content leaves the viewport. 
- Implemented JS in `js/bio-crawl.js` to measure the crawl content height and set the stage height, to initialize the optional audio button only when `data-audio-src` (populated via `se_bio_crawl_audio_src`) is present, and to provide play/pause toggle behavior without autoplay or timing hacks. 
- Explanation of specific items: the spacing looked broken because `text-align: justify` on a transformed/perspective element forces uneven word spacing; the fixed `-240vh` end distance failed when content height changed because it was not based on actual content length; animation/perspective were separated by keeping perspective/rotateX on `.bio-crawl` while animating `translateY` on `.bio-crawl-stage`; first-frame title visibility was improved by starting the stage lower (`--crawl-start-offset`) and reducing the top vignette so the title/subtitle are visible on first paint; the optional sound toggle reads a user-supplied path via the `se_bio_crawl_audio_src` filter, remains off/hidden by default, only plays on user click, loops while active, and is hidden/disabled if no audio is provided. 

### Testing
- Ran PHP lint: `php -l page-bio.php` which succeeded. 
- Validated the crawl script parse with Node: `node -e "new Function(require('fs').readFileSync('js/bio-crawl.js','utf8')); console.log('js ok')"` which printed `js ok`. 
- Attempted a browser screenshot via Playwright, but the Chromium process crashed with a SIGSEGV in this environment so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac8fc65d80832eb4606bd3b93a1ffb)