### PR TITLE
Bio crawl: refactor to camera/track layout and add audio fallback

### DIFF
--- a/js/bio-crawl.js
+++ b/js/bio-crawl.js
@@ -4,18 +4,24 @@ document.addEventListener('DOMContentLoaded', () => {
     return;
   }
 
-  const stage = wrap.querySelector('.bio-crawl-stage');
+  const track = wrap.querySelector('.bio-crawl-track');
   const crawl = wrap.querySelector('.bio-crawl');
   const soundToggle = wrap.querySelector('.bio-crawl-sound-toggle');
   const audio = wrap.querySelector('.bio-crawl-audio');
 
   const setCrawlTravel = () => {
-    if (!stage || !crawl) {
+    if (!track || !crawl) {
       return;
     }
 
-    const crawlHeight = Math.ceil(crawl.scrollHeight);
-    stage.style.height = `${crawlHeight}px`;
+    const crawlRect = crawl.getBoundingClientRect();
+    const wrapRect = wrap.getBoundingClientRect();
+    const crawlHeight = Math.ceil(crawlRect.height);
+    const viewportHeight = Math.ceil(wrapRect.height);
+    const extraDistance = Math.ceil(viewportHeight * 0.72);
+    const travel = Math.max(crawlHeight + viewportHeight + extraDistance, viewportHeight);
+
+    wrap.style.setProperty('--crawl-travel', `${travel}px`);
   };
 
   const setupAudioToggle = () => {
@@ -56,9 +62,22 @@ document.addEventListener('DOMContentLoaded', () => {
       setToggleState(false);
     });
 
-    audio.addEventListener('ended', () => {
-      setToggleState(false);
+    audio.addEventListener('pause', () => {
+      if (!audio.ended) {
+        setToggleState(false);
+      }
     });
+
+    audio.addEventListener('play', () => {
+      setToggleState(true);
+    });
+  };
+
+  const refreshCrawl = () => {
+    setCrawlTravel();
+    wrap.classList.remove('is-crawl-ready');
+    void wrap.offsetWidth;
+    wrap.classList.add('is-crawl-ready');
   };
 
   if ('scrollRestoration' in history) {
@@ -72,15 +91,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
   window.addEventListener('resize', setCrawlTravel);
 
+  if (document.fonts && document.fonts.ready) {
+    document.fonts.ready.then(() => {
+      refreshCrawl();
+    });
+  }
+
   window.addEventListener('pageshow', (event) => {
     if (!event.persisted) {
       return;
     }
 
     window.scrollTo(0, 0);
-    setCrawlTravel();
-    wrap.classList.remove('is-crawl-ready');
-    void wrap.offsetWidth;
-    wrap.classList.add('is-crawl-ready');
+    refreshCrawl();
   });
 });

--- a/page-bio.php
+++ b/page-bio.php
@@ -8,7 +8,13 @@ get_header();
 <main id="main-content">
     <section class="page-content">
         <div class="bio-content">
-<?php $bio_audio_src = apply_filters( 'se_bio_crawl_audio_src', '' ); ?>
+<?php
+$bio_audio_fallback_path = '/assets/audio/bio-crawl-theme.mp3';
+$bio_audio_fallback_src  = file_exists( get_template_directory() . $bio_audio_fallback_path )
+    ? get_template_directory_uri() . $bio_audio_fallback_path
+    : '';
+$bio_audio_src = apply_filters( 'se_bio_crawl_audio_src', $bio_audio_fallback_src );
+?>
 <div class="bio-crawl-wrap" aria-label="Bio opening crawl">
   <button
     class="bio-crawl-sound-toggle"
@@ -17,24 +23,26 @@ get_header();
     aria-label="Toggle crawl sound"
     hidden
   >Sound: Off</button>
-  <div class="bio-crawl-stage">
-    <div class="bio-crawl">
-      <h1 class="bio-crawl-title">SUZY EASTON</h1>
-      <h2 class="bio-crawl-subtitle">Vancouver born and raised</h2>
+  <div class="bio-crawl-camera">
+    <div class="bio-crawl-track">
+      <div class="bio-crawl">
+        <h1 class="bio-crawl-title">SUZY EASTON</h1>
+        <h2 class="bio-crawl-subtitle">Vancouver born and raised</h2>
 
-      <p>Hello. I’m Suzy Easton, a musician and creative technologist. I started with piano lessons, moved into open mics, studied classical music and recording arts, and later played in the psychedelic rock band Seafoam and on bass for The Smokes/Minto. We toured across Canada and recorded in Chicago with Steve Albini.</p>
+        <p>Hello. I’m Suzy Easton, a musician and creative technologist. I started with piano lessons, moved into open mics, studied classical music and recording arts, and later played in the psychedelic rock band Seafoam and on bass for The Smokes/Minto. We toured across Canada and recorded in Chicago with Steve Albini.</p>
 
-      <p>Alongside music, I work in Senior IT Ops with a focus on reliability, automation, and software operations. I like building systems that hold up under pressure, and tools that feel intentional, modern, and fun to use.</p>
+        <p>Alongside music, I work in Senior IT Ops with a focus on reliability, automation, and software operations. I like building systems that hold up under pressure, and tools that feel intentional, modern, and fun to use.</p>
 
-      <p>Lately I have been diving deep into AI. I use it for creative workflows, automation, and interactive experiments where art meets infrastructure. I am drawn to work that is practical, innovative, and a little unexpected.</p>
+        <p>Lately I have been diving deep into AI. I use it for creative workflows, automation, and interactive experiments where art meets infrastructure. I am drawn to work that is practical, innovative, and a little unexpected.</p>
 
-      <p>Recent projects include new music, lessons and sessions, and <em>Lousy Outages</em>, an arcade-style outage and status dashboard built for public awareness. It is a playful format for a serious topic, especially in a world where status pages often tell only part of the story.</p>
+        <p>Recent projects include new music, lessons and sessions, and <em>Lousy Outages</em>, an arcade-style outage and status dashboard built for public awareness. It is a playful format for a serious topic, especially in a world where status pages often tell only part of the story.</p>
 
-      <p>Coffee for Builders (Vancouver) should get lit one of these days.</p>
+        <p>Coffee for Builders (Vancouver) should get lit one of these days.</p>
 
-      <p>Reach me at <a href="mailto:suzyeaston@icloud.com">suzyeaston@icloud.com</a>.</p>
+        <p>Reach me at <a href="mailto:suzyeaston@icloud.com">suzyeaston@icloud.com</a>.</p>
 
-      <p class="bio-crawl-bandcamp">🎶 <a href="https://suzyeaston.bandcamp.com" target="_blank" rel="noopener">Support on Bandcamp</a></p>
+        <p class="bio-crawl-bandcamp">🎶 <a href="https://suzyeaston.bandcamp.com" target="_blank" rel="noopener">Support on Bandcamp</a></p>
+      </div>
     </div>
   </div>
   <audio class="bio-crawl-audio" preload="none" data-audio-src="<?php echo esc_attr( $bio_audio_src ); ?>"></audio>

--- a/style.css
+++ b/style.css
@@ -3177,80 +3177,87 @@ body.page-template-page-bio-php .bio-content {
 }
 
 .bio-crawl-wrap {
-  --crawl-duration: 48s;
-  --crawl-start-offset: 20%;
-  --crawl-end-offset: 38vh;
+  --crawl-duration: 50s;
+  --crawl-travel: 1400px;
   position: relative;
   overflow: hidden;
-  height: min(80vh, 820px);
+  height: min(82vh, 860px);
   border-radius: 16px;
   padding: 0;
+  background: radial-gradient(circle at 50% -40%, rgba(20, 20, 20, 0.45), rgba(0, 0, 0, 0.98) 68%);
 }
 
-.bio-crawl-stage {
+.bio-crawl-camera {
   position: absolute;
   inset: 0;
-  transform: translateY(var(--crawl-start-offset));
-  animation: seBioCrawlStage var(--crawl-duration) linear 1 both;
-  animation-play-state: paused;
-  will-change: transform;
-  z-index: 1;
+  perspective: 840px;
+  perspective-origin: 50% 14%;
+  overflow: hidden;
 }
 
-.bio-crawl-wrap.is-crawl-ready .bio-crawl-stage {
+.bio-crawl-track {
+  position: absolute;
+  left: 50%;
+  bottom: -16%;
+  width: min(630px, 78vw);
+  transform: translateX(-50%) translateY(0);
+  animation: seBioCrawlTrack var(--crawl-duration) linear 1 both;
+  animation-play-state: paused;
+  will-change: transform;
+}
+
+.bio-crawl-wrap.is-crawl-ready .bio-crawl-track {
   animation-play-state: running;
 }
 
-@keyframes seBioCrawlStage {
-  0% {
-    transform: translateY(var(--crawl-start-offset));
+@keyframes seBioCrawlTrack {
+  from {
+    transform: translateX(-50%) translateY(0);
   }
 
-  100% {
-    transform: translateY(calc(-100% - var(--crawl-end-offset)));
+  to {
+    transform: translateX(-50%) translateY(calc(-1 * var(--crawl-travel)));
   }
 }
 
 .bio-crawl {
-  position: absolute;
-  left: 50%;
-  top: 0;
-  width: min(690px, 90%);
   margin: 0;
-  transform: translateX(-50%) perspective(950px) rotateX(20deg);
-  transform-origin: 50% 0;
+  transform: rotateX(24deg);
+  transform-origin: 50% 100%;
   text-align: left;
   font-weight: 700;
-  letter-spacing: 0.018em;
-  line-height: 1.62;
-  font-size: clamp(19px, 1.9vw, 24px);
+  letter-spacing: 0.012em;
+  line-height: 1.58;
+  font-size: clamp(16px, 1.55vw, 20px);
   color: #f5d24a;
-  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.62);
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.56);
 }
 
 .bio-crawl,
 .bio-crawl * {
   color: #f5d24a !important;
   white-space: normal;
+  word-spacing: normal;
 }
 
 .bio-crawl-title {
   text-align: center;
-  letter-spacing: 0.12em;
-  margin: 0 0 8px 0;
-  font-size: clamp(36px, 4.6vw, 56px);
+  letter-spacing: 0.11em;
+  margin: 0 0 10px 0;
+  font-size: clamp(28px, 3.5vw, 44px);
   line-height: 1.15;
 }
 
 .bio-crawl-subtitle {
   text-align: center;
-  margin: 0 0 24px 0;
-  font-size: clamp(16px, 1.8vw, 22px);
+  margin: 0 0 30px 0;
+  font-size: clamp(13px, 1.45vw, 18px);
   line-height: 1.35;
 }
 
 .bio-crawl p {
-  margin: 0 0 14px 0;
+  margin: 0 0 16px 0;
+  text-align: left;
 }
 
 .bio-crawl a {
@@ -3266,7 +3273,7 @@ body.page-template-page-bio-php .bio-content {
 
 .bio-crawl-bandcamp {
   text-align: center;
-  margin-top: 18px;
+  margin-top: 20px;
 }
 
 .bio-crawl-sound-toggle {
@@ -3295,7 +3302,6 @@ body.page-template-page-bio-php .bio-content {
   color: #ffe37a;
 }
 
-/* Vignette fade (top and bottom) */
 .bio-crawl-wrap::before,
 .bio-crawl-wrap::after {
   content: "";
@@ -3308,36 +3314,38 @@ body.page-template-page-bio-php .bio-content {
 
 .bio-crawl-wrap::before {
   top: 0;
-  height: 56px;
-  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.58), rgba(0, 0, 0, 0));
+  height: 34px;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.42), rgba(0, 0, 0, 0));
 }
 
 .bio-crawl-wrap::after {
   bottom: 0;
-  height: 110px;
-  background: linear-gradient(to top, rgba(0, 0, 0, 0.88), rgba(0, 0, 0, 0));
+  height: 130px;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.92), rgba(0, 0, 0, 0));
 }
 
 @media (max-width: 700px) {
   .bio-crawl-wrap {
-    --crawl-duration: 54s;
-    --crawl-start-offset: 16%;
-    --crawl-end-offset: 34vh;
+    --crawl-duration: 56s;
     height: min(78vh, 760px);
   }
 
+  .bio-crawl-track {
+    width: min(94vw, 560px);
+    bottom: -18%;
+  }
+
   .bio-crawl {
-    width: min(92%, 640px);
-    font-size: clamp(17px, 4vw, 21px);
-    line-height: 1.58;
+    font-size: clamp(14px, 3.3vw, 18px);
+    line-height: 1.54;
   }
 
   .bio-crawl-title {
-    font-size: clamp(30px, 9vw, 42px);
+    font-size: clamp(24px, 8.2vw, 34px);
   }
 
   .bio-crawl-subtitle {
-    font-size: clamp(14px, 4.5vw, 18px);
+    font-size: clamp(12px, 3.8vw, 16px);
   }
 }
 
@@ -3345,18 +3353,24 @@ body.page-template-page-bio-php .bio-content {
   .bio-crawl-wrap {
     height: auto;
     overflow: visible;
+    background: transparent;
   }
 
-  .bio-crawl-stage {
+  .bio-crawl-camera {
     position: static;
-    transform: none;
-    animation: none;
+    perspective: none;
+    overflow: visible;
   }
 
-  .bio-crawl {
+  .bio-crawl-track {
     position: static;
     width: min(720px, 92%);
     margin: 0 auto;
+    animation: none;
+    transform: none;
+  }
+
+  .bio-crawl {
     transform: none;
     text-align: left;
     text-shadow: none;


### PR DESCRIPTION
### Motivation
- The crawl looked like a single oversized, tilted text block because perspective and animation were applied directly to the content block instead of a camera viewing a moving track. 
- The sound toggle was hidden when no filter-provided source existed because there was no sensible theme fallback for the audio URL. 
- The travel distance was previously a viewport-only tune and could stop the crawl before the content fully disappeared. 

### Description
- Reorganized DOM in `page-bio.php` to layered markup (`.bio-crawl-wrap` → `.bio-crawl-camera` → `.bio-crawl-track` → `.bio-crawl`) and added a fallback audio path `/assets/audio/bio-crawl-theme.mp3` that is used unless a filter (`se_bio_crawl_audio_src`) overrides it. 
- Moved perspective to the camera layer and made the crawl a tilted content surface only, added a bottom-anchored `.bio-crawl-track` to animate upward so the title/subtitle are visible as the opening frame and the text visually narrows toward a vanishing point (`style.css`). 
- Rewrote motion to compute travel from real rendered dimensions using `getBoundingClientRect()` and set `--crawl-travel` dynamically, recalc on `resize` and after `document.fonts.ready`, and safely restart the animation on BFCache `pageshow` (`js/bio-crawl.js`). 
- Tuned typography and fades: reduced body font size and width, kept yellow retro styling, softened top fade so the title is not clipped, and preserved a clear `prefers-reduced-motion` static presentation. 

### Testing
- Ran `php -l page-bio.php` with no syntax errors. 
- Ran `node --check js/bio-crawl.js` with no syntax errors. 
- Ran `git diff --check` (lint/githooks) with no reported issues. 
- Attempted an automated browser capture of `/bio/` but the local site was not reachable in this environment (`net::ERR_EMPTY_RESPONSE`), so no live visual screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac93fbf79c832e9fb06a55558d89dc)