### PR TITLE
Top-anchor bio opening crawl + Tone.js synthesized Sound toggle

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -66,9 +66,16 @@ function retro_game_music_theme_scripts() {
 
     if ( is_page_template( 'page-bio.php' ) || is_page( 'bio' ) ) {
         wp_enqueue_script(
+            'tone-js',
+            'https://unpkg.com/tone@14.7.77/build/Tone.js',
+            array(),
+            '14.7.77',
+            true
+        );
+        wp_enqueue_script(
             'bio-crawl',
             get_template_directory_uri() . '/js/bio-crawl.js',
-            array(),
+            array( 'tone-js' ),
             filemtime( get_template_directory() . '/js/bio-crawl.js' ),
             true
         );

--- a/js/bio-crawl.js
+++ b/js/bio-crawl.js
@@ -7,77 +7,174 @@ document.addEventListener('DOMContentLoaded', () => {
   const track = wrap.querySelector('.bio-crawl-track');
   const crawl = wrap.querySelector('.bio-crawl');
   const soundToggle = wrap.querySelector('.bio-crawl-sound-toggle');
-  const audio = wrap.querySelector('.bio-crawl-audio');
+  const reduceMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
 
-  const setCrawlTravel = () => {
+  const state = {
+    loop: null,
+    bassLoop: null,
+    leadSynth: null,
+    bassSynth: null,
+    fxNodes: [],
+    isSoundOn: false,
+    isTransportSetup: false
+  };
+
+  const setToggleState = (isOn) => {
+    if (!soundToggle) {
+      return;
+    }
+
+    soundToggle.setAttribute('aria-pressed', isOn ? 'true' : 'false');
+    soundToggle.textContent = isOn ? 'Sound: On' : 'Sound: Off';
+  };
+
+  const updateCrawlMetrics = () => {
     if (!track || !crawl) {
       return;
     }
 
-    const crawlRect = crawl.getBoundingClientRect();
     const wrapRect = wrap.getBoundingClientRect();
+    const crawlRect = crawl.getBoundingClientRect();
+    const wrapHeight = Math.ceil(wrapRect.height);
     const crawlHeight = Math.ceil(crawlRect.height);
-    const viewportHeight = Math.ceil(wrapRect.height);
-    const extraDistance = Math.ceil(viewportHeight * 0.72);
-    const travel = Math.max(crawlHeight + viewportHeight + extraDistance, viewportHeight);
 
+    const start = Math.round(wrapHeight * 0.66);
+    const extraDistance = Math.ceil(wrapHeight * 0.26);
+    const travel = Math.max(crawlHeight + start + extraDistance, wrapHeight + start);
+
+    wrap.style.setProperty('--crawl-start', `${start}px`);
     wrap.style.setProperty('--crawl-travel', `${travel}px`);
   };
 
-  const setupAudioToggle = () => {
-    if (!soundToggle || !audio) {
-      return;
-    }
-
-    const audioSrc = audio.dataset.audioSrc ? audio.dataset.audioSrc.trim() : '';
-    if (!audioSrc) {
-      soundToggle.hidden = true;
-      soundToggle.disabled = true;
-      return;
-    }
-
-    audio.src = audioSrc;
-    audio.loop = true;
-    soundToggle.hidden = false;
-
-    const setToggleState = (isPlaying) => {
-      soundToggle.setAttribute('aria-pressed', isPlaying ? 'true' : 'false');
-      soundToggle.textContent = isPlaying ? 'Sound: On' : 'Sound: Off';
-    };
-
-    setToggleState(false);
-
-    soundToggle.addEventListener('click', async () => {
-      if (audio.paused) {
-        try {
-          await audio.play();
-          setToggleState(true);
-        } catch (error) {
-          setToggleState(false);
-        }
-        return;
-      }
-
-      audio.pause();
-      setToggleState(false);
-    });
-
-    audio.addEventListener('pause', () => {
-      if (!audio.ended) {
-        setToggleState(false);
-      }
-    });
-
-    audio.addEventListener('play', () => {
-      setToggleState(true);
-    });
-  };
-
   const refreshCrawl = () => {
-    setCrawlTravel();
+    if (reduceMotionQuery.matches) {
+      wrap.classList.remove('is-crawl-ready');
+      return;
+    }
+
+    updateCrawlMetrics();
     wrap.classList.remove('is-crawl-ready');
     void wrap.offsetWidth;
     wrap.classList.add('is-crawl-ready');
+  };
+
+  const disposeSound = () => {
+    if (state.loop) {
+      state.loop.stop(0);
+      state.loop.dispose();
+      state.loop = null;
+    }
+
+    if (state.bassLoop) {
+      state.bassLoop.stop(0);
+      state.bassLoop.dispose();
+      state.bassLoop = null;
+    }
+
+    if (state.leadSynth) {
+      state.leadSynth.dispose();
+      state.leadSynth = null;
+    }
+
+    if (state.bassSynth) {
+      state.bassSynth.dispose();
+      state.bassSynth = null;
+    }
+
+    state.fxNodes.forEach((node) => node.dispose());
+    state.fxNodes = [];
+    state.isTransportSetup = false;
+  };
+
+  const buildSoundLoop = () => {
+    if (typeof Tone === 'undefined' || state.isTransportSetup) {
+      return;
+    }
+
+    const leadDelay = new Tone.FeedbackDelay('8n', 0.2);
+    const leadReverb = new Tone.Reverb({ decay: 1.4, wet: 0.23 });
+    const leadGain = new Tone.Gain(0.16).toDestination();
+
+    state.leadSynth = new Tone.PolySynth(Tone.Synth, {
+      oscillator: { type: 'square8' },
+      envelope: { attack: 0.005, decay: 0.22, sustain: 0.35, release: 0.45 }
+    });
+    state.leadSynth.chain(leadDelay, leadReverb, leadGain);
+
+    const bassGain = new Tone.Gain(0.12).toDestination();
+    state.bassSynth = new Tone.MonoSynth({
+      oscillator: { type: 'pulse' },
+      filter: { Q: 1.2, type: 'lowpass', rolloff: -24 },
+      envelope: { attack: 0.01, decay: 0.2, sustain: 0.5, release: 0.35 },
+      filterEnvelope: { attack: 0.01, decay: 0.12, sustain: 0.2, release: 0.3, baseFrequency: 90, octaves: 2 }
+    }).connect(bassGain);
+
+    state.fxNodes = [leadDelay, leadReverb, leadGain, bassGain];
+
+    const fanfare = [
+      ['C5', 'E5', 'G5'],
+      ['D5', 'F5', 'A5'],
+      ['E5', 'G5', 'B5'],
+      ['G5', 'B5', 'D6'],
+      ['F5', 'A5', 'C6'],
+      ['E5', 'G5', 'B5'],
+      ['D5', 'F5', 'A5'],
+      ['G4', 'D5', 'G5']
+    ];
+
+    const bassline = ['C2', 'C2', 'D2', 'E2', 'F2', 'E2', 'D2', 'G1'];
+
+    state.loop = new Tone.Sequence((time, chord) => {
+      state.leadSynth.triggerAttackRelease(chord, '8n', time, 0.9);
+    }, fanfare, '8n');
+
+    state.bassLoop = new Tone.Sequence((time, note) => {
+      state.bassSynth.triggerAttackRelease(note, '8n', time, 0.75);
+    }, bassline, '8n');
+
+    Tone.Transport.bpm.value = 126;
+    Tone.Transport.loop = true;
+    Tone.Transport.loopStart = 0;
+    Tone.Transport.loopEnd = '2m';
+
+    state.loop.start(0);
+    state.bassLoop.start(0);
+    state.isTransportSetup = true;
+  };
+
+  const setupSoundToggle = () => {
+    if (!soundToggle) {
+      return;
+    }
+
+    soundToggle.hidden = false;
+    setToggleState(false);
+
+    soundToggle.addEventListener('click', async () => {
+      if (typeof Tone === 'undefined') {
+        return;
+      }
+
+      try {
+        await Tone.start();
+        buildSoundLoop();
+
+        if (!state.isSoundOn) {
+          Tone.Transport.start('+0.05');
+          state.isSoundOn = true;
+          setToggleState(true);
+          return;
+        }
+
+        Tone.Transport.stop();
+        state.isSoundOn = false;
+        setToggleState(false);
+      } catch (error) {
+        console.error('Bio crawl sound toggle failed', error);
+        state.isSoundOn = false;
+        setToggleState(false);
+      }
+    });
   };
 
   if ('scrollRestoration' in history) {
@@ -85,11 +182,16 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   window.scrollTo(0, 0);
-  setCrawlTravel();
-  setupAudioToggle();
-  wrap.classList.add('is-crawl-ready');
+  setupSoundToggle();
+  refreshCrawl();
 
-  window.addEventListener('resize', setCrawlTravel);
+  window.addEventListener('resize', updateCrawlMetrics);
+
+  if (reduceMotionQuery.addEventListener) {
+    reduceMotionQuery.addEventListener('change', refreshCrawl);
+  } else if (reduceMotionQuery.addListener) {
+    reduceMotionQuery.addListener(refreshCrawl);
+  }
 
   if (document.fonts && document.fonts.ready) {
     document.fonts.ready.then(() => {
@@ -104,5 +206,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
     window.scrollTo(0, 0);
     refreshCrawl();
+  });
+
+  window.addEventListener('beforeunload', () => {
+    if (typeof Tone !== 'undefined') {
+      Tone.Transport.stop();
+      Tone.Transport.cancel();
+    }
+    disposeSound();
   });
 });

--- a/page-bio.php
+++ b/page-bio.php
@@ -8,20 +8,12 @@ get_header();
 <main id="main-content">
     <section class="page-content">
         <div class="bio-content">
-<?php
-$bio_audio_fallback_path = '/assets/audio/bio-crawl-theme.mp3';
-$bio_audio_fallback_src  = file_exists( get_template_directory() . $bio_audio_fallback_path )
-    ? get_template_directory_uri() . $bio_audio_fallback_path
-    : '';
-$bio_audio_src = apply_filters( 'se_bio_crawl_audio_src', $bio_audio_fallback_src );
-?>
 <div class="bio-crawl-wrap" aria-label="Bio opening crawl">
   <button
     class="bio-crawl-sound-toggle"
     type="button"
     aria-pressed="false"
     aria-label="Toggle crawl sound"
-    hidden
   >Sound: Off</button>
   <div class="bio-crawl-camera">
     <div class="bio-crawl-track">
@@ -45,7 +37,6 @@ $bio_audio_src = apply_filters( 'se_bio_crawl_audio_src', $bio_audio_fallback_sr
       </div>
     </div>
   </div>
-  <audio class="bio-crawl-audio" preload="none" data-audio-src="<?php echo esc_attr( $bio_audio_src ); ?>"></audio>
 </div>
         </div>
     </section>

--- a/style.css
+++ b/style.css
@@ -3177,30 +3177,31 @@ body.page-template-page-bio-php .bio-content {
 }
 
 .bio-crawl-wrap {
-  --crawl-duration: 50s;
-  --crawl-travel: 1400px;
+  --crawl-duration: 52s;
+  --crawl-start: 66%;
+  --crawl-travel: 1600px;
   position: relative;
   overflow: hidden;
   height: min(82vh, 860px);
   border-radius: 16px;
   padding: 0;
-  background: radial-gradient(circle at 50% -40%, rgba(20, 20, 20, 0.45), rgba(0, 0, 0, 0.98) 68%);
+  background: radial-gradient(circle at 50% -30%, rgba(24, 24, 24, 0.55), rgba(0, 0, 0, 0.98) 66%);
 }
 
 .bio-crawl-camera {
   position: absolute;
   inset: 0;
-  perspective: 840px;
+  perspective: 920px;
   perspective-origin: 50% 14%;
   overflow: hidden;
 }
 
 .bio-crawl-track {
   position: absolute;
+  top: 0;
   left: 50%;
-  bottom: -16%;
-  width: min(630px, 78vw);
-  transform: translateX(-50%) translateY(0);
+  width: min(560px, 72vw);
+  transform: translate(-50%, var(--crawl-start));
   animation: seBioCrawlTrack var(--crawl-duration) linear 1 both;
   animation-play-state: paused;
   will-change: transform;
@@ -3212,23 +3213,23 @@ body.page-template-page-bio-php .bio-content {
 
 @keyframes seBioCrawlTrack {
   from {
-    transform: translateX(-50%) translateY(0);
+    transform: translate(-50%, var(--crawl-start));
   }
 
   to {
-    transform: translateX(-50%) translateY(calc(-1 * var(--crawl-travel)));
+    transform: translate(-50%, calc(-1 * var(--crawl-travel)));
   }
 }
 
 .bio-crawl {
   margin: 0;
   transform: rotateX(24deg);
-  transform-origin: 50% 100%;
+  transform-origin: 50% 0;
   text-align: left;
   font-weight: 700;
-  letter-spacing: 0.012em;
-  line-height: 1.58;
-  font-size: clamp(16px, 1.55vw, 20px);
+  letter-spacing: 0.01em;
+  line-height: 1.56;
+  font-size: clamp(15px, 1.35vw, 19px);
   color: #f5d24a;
   text-shadow: 0 2px 8px rgba(0, 0, 0, 0.56);
 }
@@ -3244,14 +3245,14 @@ body.page-template-page-bio-php .bio-content {
   text-align: center;
   letter-spacing: 0.11em;
   margin: 0 0 10px 0;
-  font-size: clamp(28px, 3.5vw, 44px);
+  font-size: clamp(28px, 3.3vw, 42px);
   line-height: 1.15;
 }
 
 .bio-crawl-subtitle {
   text-align: center;
   margin: 0 0 30px 0;
-  font-size: clamp(13px, 1.45vw, 18px);
+  font-size: clamp(12px, 1.3vw, 17px);
   line-height: 1.35;
 }
 
@@ -3292,10 +3293,6 @@ body.page-template-page-bio-php .bio-content {
   cursor: pointer;
 }
 
-.bio-crawl-sound-toggle[hidden] {
-  display: none;
-}
-
 .bio-crawl-sound-toggle:focus-visible,
 .bio-crawl-sound-toggle:hover {
   border-color: #ffe37a;
@@ -3314,38 +3311,37 @@ body.page-template-page-bio-php .bio-content {
 
 .bio-crawl-wrap::before {
   top: 0;
-  height: 34px;
-  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.42), rgba(0, 0, 0, 0));
+  height: 22px;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.32), rgba(0, 0, 0, 0));
 }
 
 .bio-crawl-wrap::after {
   bottom: 0;
-  height: 130px;
-  background: linear-gradient(to top, rgba(0, 0, 0, 0.92), rgba(0, 0, 0, 0));
+  height: 120px;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.88), rgba(0, 0, 0, 0));
 }
 
 @media (max-width: 700px) {
   .bio-crawl-wrap {
-    --crawl-duration: 56s;
+    --crawl-duration: 58s;
     height: min(78vh, 760px);
   }
 
   .bio-crawl-track {
-    width: min(94vw, 560px);
-    bottom: -18%;
+    width: min(88vw, 520px);
   }
 
   .bio-crawl {
-    font-size: clamp(14px, 3.3vw, 18px);
+    font-size: clamp(14px, 3.3vw, 17px);
     line-height: 1.54;
   }
 
   .bio-crawl-title {
-    font-size: clamp(24px, 8.2vw, 34px);
+    font-size: clamp(24px, 8vw, 34px);
   }
 
   .bio-crawl-subtitle {
-    font-size: clamp(12px, 3.8vw, 16px);
+    font-size: clamp(12px, 3.8vw, 15px);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Fix the core bug where the crawl showed the end first by replacing bottom-anchoring with a top-anchored motion so the title and opening lines appear first. 
- Remove the page’s dependency on an MP3 fallback and provide a small original synthesized fanfare that can be toggled by the user. 
- Preserve an accessible, static layout when `prefers-reduced-motion: reduce` is set.

### Description
- CSS: replaced bottom-anchored `.bio-crawl-track` with a top-anchored track and added `--crawl-start`/`--crawl-travel` vars, moved perspective to `.bio-crawl-camera`, motion to `.bio-crawl-track`, and tilt to `.bio-crawl` so the camera, movement, and text plane are separated. 
- JS: added measurements that compute `--crawl-start` (~66% of wrapper height) and `--crawl-travel` (crawl height + start + extra distance) after fonts are ready and on resize, then animate from `translate(-50%, var(--crawl-start))` to `translate(-50%, calc(-1 * var(--crawl-travel)))` so the TOP of content is visible first and the whole crawl exits the viewport. 
- Audio: removed the audio-element MP3 fallback from the template, enqueued `Tone.js` only on the bio page via `functions.php`, and implemented a visible `Sound: Off / Sound: On` toggle that initializes a lightweight synthesized loop (lead poly synth + bass mono synth + sequences) with `Tone.start()` on user interaction and starts/stops `Tone.Transport` without autoplay. 
- Reduced motion: `prefers-reduced-motion: reduce` disables perspective, masks, and animations and renders a readable static column, and JS avoids starting the animated state when reduced-motion is active.

### Testing
- Ran `php -l page-bio.php` and it reported no syntax errors. (passed)
- Ran `php -l functions.php` and it reported no syntax errors. (passed)
- Ran `node --check js/bio-crawl.js` for a basic JS syntax check and it passed. (passed)
- Attempted a Playwright page capture (`page.goto('http://127.0.0.1:8080/bio/')`) but the local PHP route returned `ERR_EMPTY_RESPONSE` in this environment so a runtime visual screenshot could not be produced; functionality should be validated in a running WordPress instance. (not executed here)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acc169e9c4832ea36b367bf1cdc877)