### PR TITLE
Enhance bio crawl depth perspective and top fade

### DIFF
--- a/style.css
+++ b/style.css
@@ -3191,8 +3191,8 @@ body.page-template-page-bio-php .bio-content {
 .bio-crawl-camera {
   position: absolute;
   inset: 0;
-  perspective: 920px;
-  perspective-origin: 50% 14%;
+  perspective: 700px;
+  perspective-origin: 50% 16%;
   overflow: hidden;
 }
 
@@ -3200,7 +3200,7 @@ body.page-template-page-bio-php .bio-content {
   position: absolute;
   top: 0;
   left: 50%;
-  width: min(560px, 72vw);
+  width: min(520px, 68vw);
   transform: translate(-50%, var(--crawl-start));
   animation: seBioCrawlTrack var(--crawl-duration) linear 1 both;
   animation-play-state: paused;
@@ -3223,7 +3223,7 @@ body.page-template-page-bio-php .bio-content {
 
 .bio-crawl {
   margin: 0;
-  transform: rotateX(24deg);
+  transform: rotateX(31deg);
   transform-origin: 50% 0;
   text-align: left;
   font-weight: 700;
@@ -3311,14 +3311,21 @@ body.page-template-page-bio-php .bio-content {
 
 .bio-crawl-wrap::before {
   top: 0;
-  height: 22px;
-  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.32), rgba(0, 0, 0, 0));
+  height: 50%;
+  background: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 1) 0%,
+    rgba(0, 0, 0, 0.95) 14%,
+    rgba(0, 0, 0, 0.72) 32%,
+    rgba(0, 0, 0, 0.24) 58%,
+    rgba(0, 0, 0, 0) 100%
+  );
 }
 
 .bio-crawl-wrap::after {
   bottom: 0;
-  height: 120px;
-  background: linear-gradient(to top, rgba(0, 0, 0, 0.88), rgba(0, 0, 0, 0));
+  height: 104px;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.78), rgba(0, 0, 0, 0));
 }
 
 @media (max-width: 700px) {
@@ -3328,7 +3335,7 @@ body.page-template-page-bio-php .bio-content {
   }
 
   .bio-crawl-track {
-    width: min(88vw, 520px);
+    width: min(84vw, 490px);
   }
 
   .bio-crawl {


### PR DESCRIPTION
### Motivation
- Increase the perceived depth of the bio opening crawl by strengthening perspective and tilt, tightening the receding plane, and making the top fade much stronger so the crawl convincingly recedes into darkness.
- Tune desktop and mobile crawl widths and vanishing point so the upper receding plane appears narrower and more focused while keeping the text readable.

### Description
- Updated `style.css` to set `perspective` from `920px` to `700px` and move the vanishing point with `perspective-origin: 50% 16%` to deepen the receding effect.
- Narrowed the crawl track by changing `width: min(560px, 72vw)` to `width: min(520px, 68vw)` on desktop and `min(88vw, 520px)` to `min(84vw, 490px)` in the mobile media query to make the upper plane appear tighter.
- Increased the tilt by changing `transform: rotateX(24deg)` to `rotateX(31deg)` to strengthen the perspective foreshortening while keeping text styling unchanged.
- Reworked the top/bottom masks by replacing the subtle top overlay with a more pronounced top-to-transparent gradient (`::before` height now `50%` with stepped opacity stops) and slightly reducing the bottom overlay height/opacity to keep the top-weighted fade.

### Testing
- Committed the change and verified with `git status` and a successful `git commit` showing one file modified (`style.css`).
- Started a local PHP dev server (`php -S 0.0.0.0:8000 -t /workspace/suzyeastonca`) to host the page for visual checks, which started successfully.
- Attempted an automated screenshot with Playwright to validate the visual result, but Chromium crashed with a `SIGSEGV` during launch so the screenshot could not be captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acc50cf91c832eadfb1577001565d5)