### PR TITLE
Refactor bio crawl into receding surface and update theme-song toggle labels

### DIFF
--- a/js/bio-crawl.js
+++ b/js/bio-crawl.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
     return;
   }
 
+  const surface = wrap.querySelector('.bio-crawl-surface');
   const track = wrap.querySelector('.bio-crawl-track');
   const crawl = wrap.querySelector('.bio-crawl');
   const soundToggle = wrap.querySelector('.bio-crawl-sound-toggle');
@@ -24,23 +25,30 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
+    const label = isOn
+      ? 'Suzy’s Music Bio Theme Song: On'
+      : 'Suzy’s Music Bio Theme Song: Off';
+
     soundToggle.setAttribute('aria-pressed', isOn ? 'true' : 'false');
-    soundToggle.textContent = isOn ? 'Sound: On' : 'Sound: Off';
+    soundToggle.setAttribute('aria-label', label);
+    soundToggle.textContent = label;
   };
 
   const updateCrawlMetrics = () => {
-    if (!track || !crawl) {
+    if (!surface || !track || !crawl) {
       return;
     }
 
     const wrapRect = wrap.getBoundingClientRect();
+    const surfaceRect = surface.getBoundingClientRect();
     const crawlRect = crawl.getBoundingClientRect();
     const wrapHeight = Math.ceil(wrapRect.height);
+    const surfaceHeight = Math.ceil(surfaceRect.height);
     const crawlHeight = Math.ceil(crawlRect.height);
 
-    const start = Math.round(wrapHeight * 0.66);
-    const extraDistance = Math.ceil(wrapHeight * 0.26);
-    const travel = Math.max(crawlHeight + start + extraDistance, wrapHeight + start);
+    const start = Math.round(wrapHeight * 0.58);
+    const farFadeExit = Math.ceil(surfaceHeight * 0.22);
+    const travel = Math.max(crawlHeight + start + farFadeExit, surfaceHeight + start);
 
     wrap.style.setProperty('--crawl-start', `${start}px`);
     wrap.style.setProperty('--crawl-travel', `${travel}px`);

--- a/page-bio.php
+++ b/page-bio.php
@@ -13,27 +13,29 @@ get_header();
     class="bio-crawl-sound-toggle"
     type="button"
     aria-pressed="false"
-    aria-label="Toggle crawl sound"
-  >Sound: Off</button>
+    aria-label="Suzy’s Music Bio Theme Song: Off"
+  >Suzy’s Music Bio Theme Song: Off</button>
   <div class="bio-crawl-camera">
-    <div class="bio-crawl-track">
-      <div class="bio-crawl">
-        <h1 class="bio-crawl-title">SUZY EASTON</h1>
-        <h2 class="bio-crawl-subtitle">Vancouver born and raised</h2>
+    <div class="bio-crawl-surface">
+      <div class="bio-crawl-track">
+        <div class="bio-crawl">
+          <h1 class="bio-crawl-title">SUZY EASTON</h1>
+          <h2 class="bio-crawl-subtitle">Vancouver born and raised</h2>
 
-        <p>Hello. I’m Suzy Easton, a musician and creative technologist. I started with piano lessons, moved into open mics, studied classical music and recording arts, and later played in the psychedelic rock band Seafoam and on bass for The Smokes/Minto. We toured across Canada and recorded in Chicago with Steve Albini.</p>
+          <p>Hello. I’m Suzy Easton, a musician and creative technologist. I started with piano lessons, moved into open mics, studied classical music and recording arts, and later played in the psychedelic rock band Seafoam and on bass for The Smokes/Minto. We toured across Canada and recorded in Chicago with Steve Albini.</p>
 
-        <p>Alongside music, I work in Senior IT Ops with a focus on reliability, automation, and software operations. I like building systems that hold up under pressure, and tools that feel intentional, modern, and fun to use.</p>
+          <p>Alongside music, I work in Senior IT Ops with a focus on reliability, automation, and software operations. I like building systems that hold up under pressure, and tools that feel intentional, modern, and fun to use.</p>
 
-        <p>Lately I have been diving deep into AI. I use it for creative workflows, automation, and interactive experiments where art meets infrastructure. I am drawn to work that is practical, innovative, and a little unexpected.</p>
+          <p>Lately I have been diving deep into AI. I use it for creative workflows, automation, and interactive experiments where art meets infrastructure. I am drawn to work that is practical, innovative, and a little unexpected.</p>
 
-        <p>Recent projects include new music, lessons and sessions, and <em>Lousy Outages</em>, an arcade-style outage and status dashboard built for public awareness. It is a playful format for a serious topic, especially in a world where status pages often tell only part of the story.</p>
+          <p>Recent projects include new music, lessons and sessions, and <em>Lousy Outages</em>, an arcade-style outage and status dashboard built for public awareness. It is a playful format for a serious topic, especially in a world where status pages often tell only part of the story.</p>
 
-        <p>Coffee for Builders (Vancouver) should get lit one of these days.</p>
+          <p>Coffee for Builders (Vancouver) should get lit one of these days.</p>
 
-        <p>Reach me at <a href="mailto:suzyeaston@icloud.com">suzyeaston@icloud.com</a>.</p>
+          <p>Reach me at <a href="mailto:suzyeaston@icloud.com">suzyeaston@icloud.com</a>.</p>
 
-        <p class="bio-crawl-bandcamp">🎶 <a href="https://suzyeaston.bandcamp.com" target="_blank" rel="noopener">Support on Bandcamp</a></p>
+          <p class="bio-crawl-bandcamp">🎶 <a href="https://suzyeaston.bandcamp.com" target="_blank" rel="noopener">Support on Bandcamp</a></p>
+        </div>
       </div>
     </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -3178,30 +3178,44 @@ body.page-template-page-bio-php .bio-content {
 
 .bio-crawl-wrap {
   --crawl-duration: 52s;
-  --crawl-start: 66%;
-  --crawl-travel: 1600px;
+  --crawl-start: 58%;
+  --crawl-travel: 1900px;
+  --crawl-surface-height: 240%;
   position: relative;
   overflow: hidden;
-  height: min(82vh, 860px);
+  height: min(84vh, 900px);
   border-radius: 16px;
   padding: 0;
-  background: radial-gradient(circle at 50% -30%, rgba(24, 24, 24, 0.55), rgba(0, 0, 0, 0.98) 66%);
+  isolation: isolate;
+  background: radial-gradient(circle at 50% -36%, rgba(26, 26, 26, 0.45), rgba(0, 0, 0, 0.98) 62%);
 }
 
 .bio-crawl-camera {
   position: absolute;
   inset: 0;
-  perspective: 700px;
-  perspective-origin: 50% 16%;
+  perspective: 560px;
+  perspective-origin: 50% 100%;
+  overflow: hidden;
+}
+
+.bio-crawl-surface {
+  position: absolute;
+  left: 50%;
+  bottom: -5%;
+  width: min(1120px, 128vw);
+  height: var(--crawl-surface-height);
+  transform-origin: 50% 100%;
+  transform: translateX(-50%) rotateX(65deg);
+  clip-path: polygon(0% 100%, 100% 100%, 62% 0%, 38% 0%);
   overflow: hidden;
 }
 
 .bio-crawl-track {
   position: absolute;
-  top: 0;
-  left: 50%;
-  width: min(520px, 68vw);
-  transform: translate(-50%, var(--crawl-start));
+  inset: 0;
+  width: min(760px, 58vw);
+  margin: 0 auto;
+  transform: translateY(var(--crawl-start));
   animation: seBioCrawlTrack var(--crawl-duration) linear 1 both;
   animation-play-state: paused;
   will-change: transform;
@@ -3213,25 +3227,24 @@ body.page-template-page-bio-php .bio-content {
 
 @keyframes seBioCrawlTrack {
   from {
-    transform: translate(-50%, var(--crawl-start));
+    transform: translateY(var(--crawl-start));
   }
 
   to {
-    transform: translate(-50%, calc(-1 * var(--crawl-travel)));
+    transform: translateY(calc(-1 * var(--crawl-travel)));
   }
 }
 
 .bio-crawl {
   margin: 0;
-  transform: rotateX(31deg);
-  transform-origin: 50% 0;
   text-align: left;
   font-weight: 700;
   letter-spacing: 0.01em;
-  line-height: 1.56;
-  font-size: clamp(15px, 1.35vw, 19px);
+  line-height: 1.58;
+  font-size: clamp(16px, 1.52vw, 20px);
   color: #f5d24a;
-  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.56);
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.58);
+  background: transparent;
 }
 
 .bio-crawl,
@@ -3239,20 +3252,21 @@ body.page-template-page-bio-php .bio-content {
   color: #f5d24a !important;
   white-space: normal;
   word-spacing: normal;
+  background: transparent !important;
 }
 
 .bio-crawl-title {
   text-align: center;
-  letter-spacing: 0.11em;
+  letter-spacing: 0.12em;
   margin: 0 0 10px 0;
-  font-size: clamp(28px, 3.3vw, 42px);
-  line-height: 1.15;
+  font-size: clamp(30px, 4.1vw, 52px);
+  line-height: 1.1;
 }
 
 .bio-crawl-subtitle {
   text-align: center;
-  margin: 0 0 30px 0;
-  font-size: clamp(12px, 1.3vw, 17px);
+  margin: 0 0 34px 0;
+  font-size: clamp(12px, 1.48vw, 18px);
   line-height: 1.35;
 }
 
@@ -3274,22 +3288,22 @@ body.page-template-page-bio-php .bio-content {
 
 .bio-crawl-bandcamp {
   text-align: center;
-  margin-top: 20px;
+  margin-top: 24px;
 }
 
 .bio-crawl-sound-toggle {
   position: absolute;
   top: 14px;
   right: 14px;
-  z-index: 3;
+  z-index: 5;
   border: 1px solid rgba(245, 210, 74, 0.75);
   border-radius: 999px;
-  padding: 6px 11px;
+  padding: 7px 12px;
   background: rgba(0, 0, 0, 0.72);
   color: #f5d24a;
   font-size: 0.62rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  text-transform: none;
   cursor: pointer;
 }
 
@@ -3306,36 +3320,44 @@ body.page-template-page-bio-php .bio-content {
   left: 0;
   right: 0;
   pointer-events: none;
-  z-index: 2;
+  z-index: 4;
 }
 
 .bio-crawl-wrap::before {
   top: 0;
-  height: 50%;
+  height: 68%;
   background: linear-gradient(
     to bottom,
     rgba(0, 0, 0, 1) 0%,
-    rgba(0, 0, 0, 0.95) 14%,
-    rgba(0, 0, 0, 0.72) 32%,
-    rgba(0, 0, 0, 0.24) 58%,
+    rgba(0, 0, 0, 0.99) 12%,
+    rgba(0, 0, 0, 0.88) 30%,
+    rgba(0, 0, 0, 0.52) 50%,
+    rgba(0, 0, 0, 0.14) 70%,
     rgba(0, 0, 0, 0) 100%
   );
 }
 
 .bio-crawl-wrap::after {
   bottom: 0;
-  height: 104px;
+  height: 128px;
   background: linear-gradient(to top, rgba(0, 0, 0, 0.78), rgba(0, 0, 0, 0));
 }
 
 @media (max-width: 700px) {
   .bio-crawl-wrap {
     --crawl-duration: 58s;
-    height: min(78vh, 760px);
+    --crawl-surface-height: 266%;
+    height: min(80vh, 760px);
+  }
+
+  .bio-crawl-surface {
+    width: min(960px, 176vw);
+    transform: translateX(-50%) rotateX(63deg);
+    clip-path: polygon(0% 100%, 100% 100%, 68% 0%, 32% 0%);
   }
 
   .bio-crawl-track {
-    width: min(84vw, 490px);
+    width: min(620px, 74vw);
   }
 
   .bio-crawl {
@@ -3357,12 +3379,18 @@ body.page-template-page-bio-php .bio-content {
     height: auto;
     overflow: visible;
     background: transparent;
+    border-radius: 0;
   }
 
-  .bio-crawl-camera {
+  .bio-crawl-camera,
+  .bio-crawl-surface {
     position: static;
     perspective: none;
+    transform: none;
+    clip-path: none;
     overflow: visible;
+    width: auto;
+    height: auto;
   }
 
   .bio-crawl-track {


### PR DESCRIPTION
### Motivation
- Turn the flat, tilted-rectangle crawl into a believable bottom-anchored receding plane so the text narrows toward a vanishing point and dissolves naturally into the horizon.  
- Remove the visible rectangular text box effect and keep the crawl feeling like floating yellow text over the starfield.  
- Replace generic `Sound: Off/On` copy with the requested site-specific labels and keep the existing Tone.js synth music behavior.  

### Description
- Refactored markup in `page-bio.php` to the requested hierarchy by adding an explicit `.bio-crawl-surface` between `.bio-crawl-camera` and `.bio-crawl-track` so the animated content rides a tilted, bottom-anchored surface.  
- Reworked CSS in `style.css` to move perspective to `.bio-crawl-camera`, make `.bio-crawl-surface` tall and pivot from `transform-origin: 50% 100%`, apply a trapezoid `clip-path` to taper the plane, and strengthen the top horizon fade while removing any background from `.bio-crawl` so no rectangular box shows behind the text.  
- Adjusted animation geometry variables and sizing (`--crawl-start`, `--crawl-travel`, `--crawl-surface-height`, perspective, durations and responsive tweaks) to produce a wider-near / narrower-far crawl plane and keep the title/subtitle visible at start.  
- Updated JS in `js/bio-crawl.js` to measure the `surface` along with `wrap` and `crawl` (`surfaceRect`, `surfaceHeight`) and compute `--crawl-start`/`--crawl-travel` using wrapper + surface + content so the track moves up the tilted plane correctly.  
- Replaced sound toggle copy in three places: initial markup `page-bio.php` (now `Suzy’s Music Bio Theme Song: Off`), runtime JS label swapping and `aria-label` in `js/bio-crawl.js` (toggling `Suzy’s Music Bio Theme Song: Off/On`), and ensured `aria-pressed` updates remain.  
- Preserved the existing Tone.js synth implementation and reduced-motion handling so `prefers-reduced-motion` disables perspective/clip/masking and renders a static readable layout.  

### Testing
- Ran `php -l page-bio.php` and it returned no syntax errors.  
- Ran `php -l functions.php` and it returned no syntax errors.  
- Ran `node --check js/bio-crawl.js` and the JS passed a syntax check.  
- Attempted visual/browser validation via a Playwright screenshot of `/bio/`, but the local WordPress endpoint was unreachable in this environment (`ERR_EMPTY_RESPONSE`), so full runtime visual verification could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acc8158b74832eacbe821867d5e6c1)