### PR TITLE
Simplify bio crawl geometry to restore readable cinematic opening

### DIFF
--- a/js/bio-crawl.js
+++ b/js/bio-crawl.js
@@ -4,7 +4,6 @@ document.addEventListener('DOMContentLoaded', () => {
     return;
   }
 
-  const surface = wrap.querySelector('.bio-crawl-surface');
   const track = wrap.querySelector('.bio-crawl-track');
   const crawl = wrap.querySelector('.bio-crawl');
   const soundToggle = wrap.querySelector('.bio-crawl-sound-toggle');
@@ -35,20 +34,19 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   const updateCrawlMetrics = () => {
-    if (!surface || !track || !crawl) {
+    if (!track || !crawl) {
       return;
     }
 
     const wrapRect = wrap.getBoundingClientRect();
-    const surfaceRect = surface.getBoundingClientRect();
     const crawlRect = crawl.getBoundingClientRect();
     const wrapHeight = Math.ceil(wrapRect.height);
-    const surfaceHeight = Math.ceil(surfaceRect.height);
     const crawlHeight = Math.ceil(crawlRect.height);
 
-    const start = Math.round(wrapHeight * 0.58);
-    const farFadeExit = Math.ceil(surfaceHeight * 0.22);
-    const travel = Math.max(crawlHeight + start + farFadeExit, surfaceHeight + start);
+    const baseStartRatio = window.innerWidth <= 700 ? 0.66 : 0.62;
+    const start = Math.round(wrapHeight * baseStartRatio);
+    const farFadeExit = Math.ceil(wrapHeight * 0.28);
+    const travel = Math.max(crawlHeight + start + farFadeExit, wrapHeight + start + farFadeExit);
 
     wrap.style.setProperty('--crawl-start', `${start}px`);
     wrap.style.setProperty('--crawl-travel', `${travel}px`);

--- a/page-bio.php
+++ b/page-bio.php
@@ -16,26 +16,24 @@ get_header();
     aria-label="Suzy’s Music Bio Theme Song: Off"
   >Suzy’s Music Bio Theme Song: Off</button>
   <div class="bio-crawl-camera">
-    <div class="bio-crawl-surface">
-      <div class="bio-crawl-track">
-        <div class="bio-crawl">
-          <h1 class="bio-crawl-title">SUZY EASTON</h1>
-          <h2 class="bio-crawl-subtitle">Vancouver born and raised</h2>
+    <div class="bio-crawl-track">
+      <div class="bio-crawl">
+        <h1 class="bio-crawl-title">SUZY EASTON</h1>
+        <h2 class="bio-crawl-subtitle">Vancouver born and raised</h2>
 
-          <p>Hello. I’m Suzy Easton, a musician and creative technologist. I started with piano lessons, moved into open mics, studied classical music and recording arts, and later played in the psychedelic rock band Seafoam and on bass for The Smokes/Minto. We toured across Canada and recorded in Chicago with Steve Albini.</p>
+        <p>Hello. I’m Suzy Easton, a musician and creative technologist. I started with piano lessons, moved into open mics, studied classical music and recording arts, and later played in the psychedelic rock band Seafoam and on bass for The Smokes/Minto. We toured across Canada and recorded in Chicago with Steve Albini.</p>
 
-          <p>Alongside music, I work in Senior IT Ops with a focus on reliability, automation, and software operations. I like building systems that hold up under pressure, and tools that feel intentional, modern, and fun to use.</p>
+        <p>Alongside music, I work in Senior IT Ops with a focus on reliability, automation, and software operations. I like building systems that hold up under pressure, and tools that feel intentional, modern, and fun to use.</p>
 
-          <p>Lately I have been diving deep into AI. I use it for creative workflows, automation, and interactive experiments where art meets infrastructure. I am drawn to work that is practical, innovative, and a little unexpected.</p>
+        <p>Lately I have been diving deep into AI. I use it for creative workflows, automation, and interactive experiments where art meets infrastructure. I am drawn to work that is practical, innovative, and a little unexpected.</p>
 
-          <p>Recent projects include new music, lessons and sessions, and <em>Lousy Outages</em>, an arcade-style outage and status dashboard built for public awareness. It is a playful format for a serious topic, especially in a world where status pages often tell only part of the story.</p>
+        <p>Recent projects include new music, lessons and sessions, and <em>Lousy Outages</em>, an arcade-style outage and status dashboard built for public awareness. It is a playful format for a serious topic, especially in a world where status pages often tell only part of the story.</p>
 
-          <p>Coffee for Builders (Vancouver) should get lit one of these days.</p>
+        <p>Coffee for Builders (Vancouver) should get lit one of these days.</p>
 
-          <p>Reach me at <a href="mailto:suzyeaston@icloud.com">suzyeaston@icloud.com</a>.</p>
+        <p>Reach me at <a href="mailto:suzyeaston@icloud.com">suzyeaston@icloud.com</a>.</p>
 
-          <p class="bio-crawl-bandcamp">🎶 <a href="https://suzyeaston.bandcamp.com" target="_blank" rel="noopener">Support on Bandcamp</a></p>
-        </div>
+        <p class="bio-crawl-bandcamp">🎶 <a href="https://suzyeaston.bandcamp.com" target="_blank" rel="noopener">Support on Bandcamp</a></p>
       </div>
     </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -3178,44 +3178,33 @@ body.page-template-page-bio-php .bio-content {
 
 .bio-crawl-wrap {
   --crawl-duration: 52s;
-  --crawl-start: 58%;
+  --crawl-start: 62%;
   --crawl-travel: 1900px;
-  --crawl-surface-height: 240%;
   position: relative;
   overflow: hidden;
   height: min(84vh, 900px);
   border-radius: 16px;
   padding: 0;
   isolation: isolate;
-  background: radial-gradient(circle at 50% -36%, rgba(26, 26, 26, 0.45), rgba(0, 0, 0, 0.98) 62%);
+  background: radial-gradient(circle at 50% -32%, rgba(26, 26, 26, 0.42), rgba(0, 0, 0, 0.985) 64%);
 }
 
 .bio-crawl-camera {
   position: absolute;
   inset: 0;
-  perspective: 560px;
-  perspective-origin: 50% 100%;
-  overflow: hidden;
-}
-
-.bio-crawl-surface {
-  position: absolute;
-  left: 50%;
-  bottom: -5%;
-  width: min(1120px, 128vw);
-  height: var(--crawl-surface-height);
-  transform-origin: 50% 100%;
-  transform: translateX(-50%) rotateX(65deg);
-  clip-path: polygon(0% 100%, 100% 100%, 62% 0%, 38% 0%);
+  perspective: 980px;
+  perspective-origin: 50% 18%;
   overflow: hidden;
 }
 
 .bio-crawl-track {
   position: absolute;
-  inset: 0;
-  width: min(760px, 58vw);
-  margin: 0 auto;
-  transform: translateY(var(--crawl-start));
+  left: 50%;
+  bottom: 0;
+  width: min(880px, 90vw);
+  margin: 0;
+  transform-origin: 50% 100%;
+  transform: translate(-50%, var(--crawl-start));
   animation: seBioCrawlTrack var(--crawl-duration) linear 1 both;
   animation-play-state: paused;
   will-change: transform;
@@ -3227,11 +3216,11 @@ body.page-template-page-bio-php .bio-content {
 
 @keyframes seBioCrawlTrack {
   from {
-    transform: translateY(var(--crawl-start));
+    transform: translate(-50%, var(--crawl-start));
   }
 
   to {
-    transform: translateY(calc(-1 * var(--crawl-travel)));
+    transform: translate(-50%, calc(-1 * var(--crawl-travel)));
   }
 }
 
@@ -3241,10 +3230,12 @@ body.page-template-page-bio-php .bio-content {
   font-weight: 700;
   letter-spacing: 0.01em;
   line-height: 1.58;
-  font-size: clamp(16px, 1.52vw, 20px);
+  font-size: clamp(19px, 2.05vw, 31px);
   color: #f5d24a;
   text-shadow: 0 2px 10px rgba(0, 0, 0, 0.58);
   background: transparent;
+  transform-origin: 50% 100%;
+  transform: rotateX(24deg);
 }
 
 .bio-crawl,
@@ -3259,14 +3250,14 @@ body.page-template-page-bio-php .bio-content {
   text-align: center;
   letter-spacing: 0.12em;
   margin: 0 0 10px 0;
-  font-size: clamp(30px, 4.1vw, 52px);
+  font-size: clamp(40px, 5.2vw, 78px);
   line-height: 1.1;
 }
 
 .bio-crawl-subtitle {
   text-align: center;
   margin: 0 0 34px 0;
-  font-size: clamp(12px, 1.48vw, 18px);
+  font-size: clamp(15px, 2vw, 26px);
   line-height: 1.35;
 }
 
@@ -3325,52 +3316,48 @@ body.page-template-page-bio-php .bio-content {
 
 .bio-crawl-wrap::before {
   top: 0;
-  height: 68%;
+  height: 72%;
   background: linear-gradient(
     to bottom,
     rgba(0, 0, 0, 1) 0%,
-    rgba(0, 0, 0, 0.99) 12%,
-    rgba(0, 0, 0, 0.88) 30%,
-    rgba(0, 0, 0, 0.52) 50%,
-    rgba(0, 0, 0, 0.14) 70%,
+    rgba(0, 0, 0, 0.995) 12%,
+    rgba(0, 0, 0, 0.95) 28%,
+    rgba(0, 0, 0, 0.72) 48%,
+    rgba(0, 0, 0, 0.35) 66%,
+    rgba(0, 0, 0, 0.08) 84%,
     rgba(0, 0, 0, 0) 100%
   );
 }
 
 .bio-crawl-wrap::after {
   bottom: 0;
-  height: 128px;
-  background: linear-gradient(to top, rgba(0, 0, 0, 0.78), rgba(0, 0, 0, 0));
+  height: 104px;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0));
 }
 
 @media (max-width: 700px) {
   .bio-crawl-wrap {
     --crawl-duration: 58s;
-    --crawl-surface-height: 266%;
+    --crawl-start: 66%;
     height: min(80vh, 760px);
   }
 
-  .bio-crawl-surface {
-    width: min(960px, 176vw);
-    transform: translateX(-50%) rotateX(63deg);
-    clip-path: polygon(0% 100%, 100% 100%, 68% 0%, 32% 0%);
-  }
-
   .bio-crawl-track {
-    width: min(620px, 74vw);
+    width: min(700px, 94vw);
   }
 
   .bio-crawl {
-    font-size: clamp(14px, 3.3vw, 17px);
+    font-size: clamp(16px, 4.05vw, 21px);
     line-height: 1.54;
+    transform: rotateX(21deg);
   }
 
   .bio-crawl-title {
-    font-size: clamp(24px, 8vw, 34px);
+    font-size: clamp(32px, 9.2vw, 46px);
   }
 
   .bio-crawl-subtitle {
-    font-size: clamp(12px, 3.8vw, 15px);
+    font-size: clamp(13px, 4.2vw, 18px);
   }
 }
 
@@ -3382,12 +3369,10 @@ body.page-template-page-bio-php .bio-content {
     border-radius: 0;
   }
 
-  .bio-crawl-camera,
-  .bio-crawl-surface {
+  .bio-crawl-camera {
     position: static;
     perspective: none;
     transform: none;
-    clip-path: none;
     overflow: visible;
     width: auto;
     height: auto;


### PR DESCRIPTION
### Motivation
- The crawl had become a tiny distant wedge because an over-engineered tilted surface (`rotateX(65deg)`) plus a severe `clip-path` and a low vanishing point caused immediate width compression and a faraway start. 
- The goal is a classic readable opening crawl that starts large near the lower viewport and gradually recedes into the upper-center vanishing point without feeling crushed. 
- Keep the corrected music toggle labeling and existing Tone.js synthesized theme behavior intact while simplifying geometry.

### Description
- Removed the extra `.bio-crawl-surface` wrapper from `page-bio.php` and placed the animated track directly under the camera so the crawl is no longer forced into a clipped runway. 
- Reworked CSS in `style.css` to use a simpler camera → track → crawl setup by increasing `perspective`, moving `perspective-origin` toward upper-center (`50% 18%`), reducing text tilt to a modest `rotateX(24deg)` (and `21deg` on small screens), widening the track and increasing title/body sizes for a readable opening frame. 
- Simplified JS in `js/bio-crawl.js` by removing references to the removed surface, and updated `updateCrawlMetrics()` to compute `--crawl-start`/`--crawl-travel` from wrapper and crawl sizes with a more conservative start ratio so the title appears large near the lower-middle viewport. 
- Tuned overlay fades so the top fade handles horizon disappearance (stronger top fade, softer bottom fade), and preserved the `Suzy’s Music Bio Theme Song: Off/On` toggle text and existing Tone.js setup/behavior.

### Testing
- Ran `node --check js/bio-crawl.js` which completed without syntax errors. 
- Ran `php -l page-bio.php` which reported no syntax errors. 
- Verified presence of the preserved music toggle labels with `rg -n "Suzy’s Music Bio Theme Song" page-bio.php js/bio-crawl.js` which returned expected matches. 
- Attempted automated visual capture via Playwright of `http://localhost:/bio/` but local WordPress endpoints were not responding (`ERR_EMPTY_RESPONSE`/navigation errors), so runtime visual screenshot validation could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69accabc6ba4832e88ef594994986ce8)