### PR TITLE
Fix bio opening crawl to start near bottom with top-anchored Star Wars motion

### DIFF
--- a/js/bio-crawl.js
+++ b/js/bio-crawl.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const track = wrap.querySelector('.bio-crawl-track');
   const crawl = wrap.querySelector('.bio-crawl');
+  const crawlContent = wrap.querySelector('.bio-crawl-content');
   const soundToggle = wrap.querySelector('.bio-crawl-sound-toggle');
   const reduceMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
 
@@ -34,19 +35,20 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   const updateCrawlMetrics = () => {
-    if (!track || !crawl) {
+    if (!track || !crawl || !crawlContent) {
       return;
     }
 
-    const wrapRect = wrap.getBoundingClientRect();
-    const crawlRect = crawl.getBoundingClientRect();
-    const wrapHeight = Math.ceil(wrapRect.height);
-    const crawlHeight = Math.ceil(crawlRect.height);
+    const wrapHeight = Math.ceil(wrap.clientHeight);
+    const contentHeight = Math.ceil(crawlContent.scrollHeight);
 
-    const baseStartRatio = window.innerWidth <= 700 ? 0.66 : 0.62;
-    const start = Math.round(wrapHeight * baseStartRatio);
-    const farFadeExit = Math.ceil(wrapHeight * 0.28);
-    const travel = Math.max(crawlHeight + start + farFadeExit, wrapHeight + start + farFadeExit);
+    // Place opening frame in the lower third/lower quarter like a classic crawl.
+    const startRatio = window.innerWidth <= 700 ? 0.75 : 0.72;
+    const start = Math.round(wrapHeight * startRatio);
+
+    // Extra travel so the final paragraphs clear the top fade completely.
+    const fadeClearance = Math.ceil(wrapHeight * 0.32);
+    const travel = contentHeight + start + fadeClearance;
 
     wrap.style.setProperty('--crawl-start', `${start}px`);
     wrap.style.setProperty('--crawl-travel', `${travel}px`);

--- a/page-bio.php
+++ b/page-bio.php
@@ -18,22 +18,24 @@ get_header();
   <div class="bio-crawl-camera">
     <div class="bio-crawl-track">
       <div class="bio-crawl">
-        <h1 class="bio-crawl-title">SUZY EASTON</h1>
-        <h2 class="bio-crawl-subtitle">Vancouver born and raised</h2>
+        <div class="bio-crawl-content">
+          <h1 class="bio-crawl-title">SUZY EASTON</h1>
+          <h2 class="bio-crawl-subtitle">Vancouver born and raised</h2>
 
-        <p>Hello. I’m Suzy Easton, a musician and creative technologist. I started with piano lessons, moved into open mics, studied classical music and recording arts, and later played in the psychedelic rock band Seafoam and on bass for The Smokes/Minto. We toured across Canada and recorded in Chicago with Steve Albini.</p>
+          <p>Hello. I’m Suzy Easton, a musician and creative technologist. I started with piano lessons, moved into open mics, studied classical music and recording arts, and later played in the psychedelic rock band Seafoam and on bass for The Smokes/Minto. We toured across Canada and recorded in Chicago with Steve Albini.</p>
 
-        <p>Alongside music, I work in Senior IT Ops with a focus on reliability, automation, and software operations. I like building systems that hold up under pressure, and tools that feel intentional, modern, and fun to use.</p>
+          <p>Alongside music, I work in Senior IT Ops with a focus on reliability, automation, and software operations. I like building systems that hold up under pressure, and tools that feel intentional, modern, and fun to use.</p>
 
-        <p>Lately I have been diving deep into AI. I use it for creative workflows, automation, and interactive experiments where art meets infrastructure. I am drawn to work that is practical, innovative, and a little unexpected.</p>
+          <p>Lately I have been diving deep into AI. I use it for creative workflows, automation, and interactive experiments where art meets infrastructure. I am drawn to work that is practical, innovative, and a little unexpected.</p>
 
-        <p>Recent projects include new music, lessons and sessions, and <em>Lousy Outages</em>, an arcade-style outage and status dashboard built for public awareness. It is a playful format for a serious topic, especially in a world where status pages often tell only part of the story.</p>
+          <p>Recent projects include new music, lessons and sessions, and <em>Lousy Outages</em>, an arcade-style outage and status dashboard built for public awareness. It is a playful format for a serious topic, especially in a world where status pages often tell only part of the story.</p>
 
-        <p>Coffee for Builders (Vancouver) should get lit one of these days.</p>
+          <p>Coffee for Builders (Vancouver) should get lit one of these days.</p>
 
-        <p>Reach me at <a href="mailto:suzyeaston@icloud.com">suzyeaston@icloud.com</a>.</p>
+          <p>Reach me at <a href="mailto:suzyeaston@icloud.com">suzyeaston@icloud.com</a>.</p>
 
-        <p class="bio-crawl-bandcamp">🎶 <a href="https://suzyeaston.bandcamp.com" target="_blank" rel="noopener">Support on Bandcamp</a></p>
+          <p class="bio-crawl-bandcamp">🎶 <a href="https://suzyeaston.bandcamp.com" target="_blank" rel="noopener">Support on Bandcamp</a></p>
+        </div>
       </div>
     </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -3178,7 +3178,7 @@ body.page-template-page-bio-php .bio-content {
 
 .bio-crawl-wrap {
   --crawl-duration: 52s;
-  --crawl-start: 62%;
+  --crawl-start: 72%;
   --crawl-travel: 1900px;
   position: relative;
   overflow: hidden;
@@ -3192,19 +3192,19 @@ body.page-template-page-bio-php .bio-content {
 .bio-crawl-camera {
   position: absolute;
   inset: 0;
-  perspective: 980px;
-  perspective-origin: 50% 18%;
+  perspective: 900px;
+  perspective-origin: 50% 24%;
   overflow: hidden;
 }
 
 .bio-crawl-track {
   position: absolute;
   left: 50%;
-  bottom: 0;
+  top: 0;
   width: min(880px, 90vw);
   margin: 0;
-  transform-origin: 50% 100%;
-  transform: translate(-50%, var(--crawl-start));
+  transform-origin: 50% 0%;
+  transform: translate3d(-50%, var(--crawl-start), 0);
   animation: seBioCrawlTrack var(--crawl-duration) linear 1 both;
   animation-play-state: paused;
   will-change: transform;
@@ -3216,11 +3216,11 @@ body.page-template-page-bio-php .bio-content {
 
 @keyframes seBioCrawlTrack {
   from {
-    transform: translate(-50%, var(--crawl-start));
+    transform: translate3d(-50%, var(--crawl-start), 0);
   }
 
   to {
-    transform: translate(-50%, calc(-1 * var(--crawl-travel)));
+    transform: translate3d(-50%, calc(-1 * var(--crawl-travel)), 0);
   }
 }
 
@@ -3234,8 +3234,8 @@ body.page-template-page-bio-php .bio-content {
   color: #f5d24a;
   text-shadow: 0 2px 10px rgba(0, 0, 0, 0.58);
   background: transparent;
-  transform-origin: 50% 100%;
-  transform: rotateX(24deg);
+  transform-origin: 50% 0%;
+  transform: rotateX(19deg);
 }
 
 .bio-crawl,
@@ -3261,6 +3261,10 @@ body.page-template-page-bio-php .bio-content {
   line-height: 1.35;
 }
 
+
+.bio-crawl-content {
+  display: block;
+}
 .bio-crawl p {
   margin: 0 0 16px 0;
   text-align: left;
@@ -3338,7 +3342,7 @@ body.page-template-page-bio-php .bio-content {
 @media (max-width: 700px) {
   .bio-crawl-wrap {
     --crawl-duration: 58s;
-    --crawl-start: 66%;
+    --crawl-start: 74%;
     height: min(80vh, 760px);
   }
 
@@ -3349,7 +3353,7 @@ body.page-template-page-bio-php .bio-content {
   .bio-crawl {
     font-size: clamp(16px, 4.05vw, 21px);
     line-height: 1.54;
-    transform: rotateX(21deg);
+    transform: rotateX(16deg);
   }
 
   .bio-crawl-title {


### PR DESCRIPTION
### Motivation
- Ensure the bio page opens with the title block visible near the lower portion of the viewport so the first frame shows `SUZY EASTON`, `Vancouver born and raised`, and the start of the first paragraph. 
- Prevent the existing bug that showed the middle of the bio first by fixing the travel/geometry math and anchoring behavior. 
- Use a simple, readable Star Wars–style crawl (large/readable near the bottom, receding upward) while preserving the existing music toggle and reduced-motion behavior.

### Description
- Added a non-transformed wrapper `.bio-crawl-content` inside `.bio-crawl` and used that element as the canonical height source for travel calculations (measured via `crawlContent.scrollHeight`) in `js/bio-crawl.js`.
- Re-anchored the animated track to the top by changing `.bio-crawl-track` to `top: 0` and using a top-origin transform (`transform-origin: 50% 0%`) so the animation runs from an explicit start position upward instead of bottom-anchoring.
- Replaced transformed `getBoundingClientRect()` math with non-transformed measurements and explicit start ratios: `startRatio` = `0.72` on desktop and `0.75` on small screens, and compute `--crawl-travel` = `contentHeight + start + fadeClearance` to ensure full clearance of the bio.
- Tuned CSS geometry for readability: modestly reduced perspective and `rotateX` values, switched to `translate3d()` for smoother transforms, added `.bio-crawl-content { display: block; }`, and kept `prefers-reduced-motion` rules intact.
- Preserved Tone.js music behavior and exact toggle labels (`Suzy’s Music Bio Theme Song: Off` / `Suzy’s Music Bio Theme Song: On`) and left sound setup logic unchanged in `js/bio-crawl.js`.

### Testing
- Ran `php -l page-bio.php` and it returned no syntax errors (passed). 
- Ran `php -l functions.php` and it returned no syntax errors (passed). 
- Ran `node --check js/bio-crawl.js` and the script is syntactically valid (passed). 
- Attempted a headless browser screenshot via Playwright to validate rendering, but the local web server was unreachable (`ERR_EMPTY_RESPONSE`), so a visual capture could not be produced in this environment (manual/CI visual check recommended).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acce5ab934832e825d684f2ec9aefc)