### PR TITLE
Refine bio crawl opener framing and horizon fade

### DIFF
--- a/js/bio-crawl.js
+++ b/js/bio-crawl.js
@@ -42,12 +42,26 @@ document.addEventListener('DOMContentLoaded', () => {
     const wrapHeight = Math.ceil(wrap.clientHeight);
     const contentHeight = Math.ceil(crawlContent.scrollHeight);
 
-    // Place opening frame in the lower third/lower quarter like a classic crawl.
-    const startRatio = window.innerWidth <= 700 ? 0.75 : 0.72;
-    const start = Math.round(wrapHeight * startRatio);
+    const title = crawlContent.querySelector('.bio-crawl-title');
+    const subtitle = crawlContent.querySelector('.bio-crawl-subtitle');
+    const firstParagraph = crawlContent.querySelector('p');
 
-    // Extra travel so the final paragraphs clear the top fade completely.
-    const fadeClearance = Math.ceil(wrapHeight * 0.32);
+    const titleHeight = Math.ceil(title ? title.getBoundingClientRect().height : 0);
+    const subtitleHeight = Math.ceil(subtitle ? subtitle.getBoundingClientRect().height : 0);
+    const firstParagraphHeight = Math.ceil(firstParagraph ? firstParagraph.getBoundingClientRect().height : 0);
+    const titleBlockHeight = titleHeight + subtitleHeight;
+
+    // Explicitly anchor opener: title block starts around lower quarter/lower third,
+    // with subtitle + first paragraph intro visible on frame one.
+    const openerTargetY = Math.round(wrapHeight * (window.innerWidth <= 700 ? 0.68 : 0.64));
+    const introVisibility = Math.round(firstParagraphHeight * 0.46);
+    const baseStart = openerTargetY - titleBlockHeight;
+    const minStart = Math.round(wrapHeight * 0.4);
+    const maxStart = Math.round(wrapHeight * 0.8);
+    const start = Math.max(minStart, Math.min(maxStart, baseStart - introVisibility));
+
+    // Ensure enough upward travel to fully clear the horizon fade.
+    const fadeClearance = Math.ceil(wrapHeight * 0.24);
     const travel = contentHeight + start + fadeClearance;
 
     wrap.style.setProperty('--crawl-start', `${start}px`);

--- a/style.css
+++ b/style.css
@@ -3178,7 +3178,7 @@ body.page-template-page-bio-php .bio-content {
 
 .bio-crawl-wrap {
   --crawl-duration: 52s;
-  --crawl-start: 72%;
+  --crawl-start: 62%;
   --crawl-travel: 1900px;
   position: relative;
   overflow: hidden;
@@ -3320,29 +3320,28 @@ body.page-template-page-bio-php .bio-content {
 
 .bio-crawl-wrap::before {
   top: 0;
-  height: 72%;
+  height: 34%;
   background: linear-gradient(
     to bottom,
-    rgba(0, 0, 0, 1) 0%,
-    rgba(0, 0, 0, 0.995) 12%,
-    rgba(0, 0, 0, 0.95) 28%,
-    rgba(0, 0, 0, 0.72) 48%,
-    rgba(0, 0, 0, 0.35) 66%,
-    rgba(0, 0, 0, 0.08) 84%,
+    rgba(0, 0, 0, 0.96) 0%,
+    rgba(0, 0, 0, 0.78) 10%,
+    rgba(0, 0, 0, 0.46) 28%,
+    rgba(0, 0, 0, 0.2) 52%,
+    rgba(0, 0, 0, 0.06) 76%,
     rgba(0, 0, 0, 0) 100%
   );
 }
 
 .bio-crawl-wrap::after {
   bottom: 0;
-  height: 104px;
-  background: linear-gradient(to top, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0));
+  height: 72px;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.24), rgba(0, 0, 0, 0));
 }
 
 @media (max-width: 700px) {
   .bio-crawl-wrap {
     --crawl-duration: 58s;
-    --crawl-start: 74%;
+    --crawl-start: 64%;
     height: min(80vh, 760px);
   }
 


### PR DESCRIPTION
### Motivation
- The top fade overlay previously acted like a curtain (covering ~72% of the crawl area) which could dim or swallow the opening frame and make the title/subtitle/first paragraph hard to read on load.  
- The opener placement relied on a loose percentage start ratio which produced inconsistent initial framing across viewports.  
- The goal is a simpler, more deterministic Star Wars–style opener: title near the lower third/quarter, subtitle second, and the start of the first paragraph visible, with the horizon fade only used to vanish distant text.

### Description
- Reduced the top overlay in `style.css` by shrinking `.bio-crawl-wrap::before` from `height: 72%` to `height: 34%` and moved the heaviest opacity values to the very top so the fade behaves as a horizon rather than a curtain.  
- Softened the bottom fade by changing `.bio-crawl-wrap::after` from `height: 104px` / 0.5 opacity to `height: 72px` / 0.24 opacity so the lower opening frame remains clear.  
- Replaced the broad ratio-only opener start in `js/bio-crawl.js` with measurement-driven logic that uses `getBoundingClientRect()` on `.bio-crawl-title`, `.bio-crawl-subtitle`, and the first `<p>` inside `.bio-crawl-content` plus the wrapper height to compute a deterministic `--crawl-start` (clamped between ~40% and ~80% of wrapper height) and a smaller `fadeClearance`.  
- Kept the simpler top-anchored geometry (`.bio-crawl-track` top-anchored, `--crawl-start`/`--crawl-travel` animation, and non-transformed `.bio-crawl-content`) and preserved the existing Tone.js toggle labels and transport/synth loop behavior exactly as `Suzy’s Music Bio Theme Song: Off` / `Suzy’s Music Bio Theme Song: On`.

### Testing
- Ran JavaScript syntax check with `node --check js/bio-crawl.js` and it passed.  
- Verified PHP templates with `php -l page-bio.php` and `php -l functions.php` and both reported no syntax errors.  
- Attempted an automated browser screenshot to validate visual framing but the local webserver returned `ERR_EMPTY_RESPONSE` for common localhost ports in this environment, so a live visual smoke test could not be captured here.  
- No console or syntax errors were observed in the static checks above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acd2d05da8832e80633e4aaacc4e56)