### PR TITLE
Add ASMR Lab page, REST generation endpoint, and procedural 8‑bit foley engine

### DIFF
--- a/assets/css/asmr-lab.css
+++ b/assets/css/asmr-lab.css
@@ -1,0 +1,15 @@
+.asmr-lab-shell{max-width:980px;margin:2rem auto;padding:1.25rem;background:#0f1222;border:1px solid #31407a;border-radius:10px;color:#d7e2ff;box-shadow:0 0 24px rgba(66,120,255,.2)}
+.asmr-kicker{font-size:.75rem;letter-spacing:.12em;text-transform:uppercase;color:#7aa2ff}
+.asmr-title{font-family:'Press Start 2P',monospace;font-size:1.4rem;color:#b5cbff}
+.asmr-lab-form label{display:flex;flex-direction:column;gap:.35rem;font-size:.85rem}
+.asmr-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:.8rem}
+.asmr-grid input,.asmr-grid textarea{background:#0a0d1c;color:#e6ecff;border:1px solid #33437f;border-radius:6px;padding:.6rem}
+.asmr-actions,.asmr-audio-controls{display:flex;gap:.6rem;flex-wrap:wrap;margin-top:1rem}
+.pixel-button.secondary{opacity:.86}
+.asmr-status{min-height:1.2rem;color:#7df9c1}
+.asmr-error{color:#ff8ca0;background:#2a0e16;padding:.5rem .7rem;border-radius:6px;border:1px solid #7a2f44}
+.asmr-results{margin-top:1rem;display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:.9rem}
+.asmr-card{background:#131830;border:1px solid #2f3f73;border-radius:8px;padding:.8rem}
+.asmr-card h2{margin:.2rem 0 .5rem;font-size:1rem;color:#9ec0ff}
+.asmr-card pre{max-height:240px;overflow:auto;background:#090d1a;padding:.6rem;border-radius:6px}
+.pixel-button.tiny{font-size:.75rem;padding:.25rem .45rem}

--- a/functions.php
+++ b/functions.php
@@ -132,6 +132,47 @@ function se_enqueue_lousy_outages_page_styles() {
 }
 add_action( 'wp_enqueue_scripts', 'se_enqueue_lousy_outages_page_styles' );
 
+function se_enqueue_asmr_lab_assets() {
+    if ( ! is_page_template( 'page-asmr-lab.php' ) ) {
+        return;
+    }
+
+    $dir = get_stylesheet_directory();
+    $uri = get_stylesheet_directory_uri();
+
+    $css_path = '/assets/css/asmr-lab.css';
+    if ( file_exists( $dir . $css_path ) ) {
+        wp_enqueue_style( 'se-asmr-lab', $uri . $css_path, array(), filemtime( $dir . $css_path ) );
+    }
+
+    wp_enqueue_script(
+        'tone-js',
+        'https://unpkg.com/tone@14.7.77/build/Tone.js',
+        array(),
+        '14.7.77',
+        true
+    );
+
+    $engine_path = '/js/asmr-foley-engine.js';
+    if ( file_exists( $dir . $engine_path ) ) {
+        wp_enqueue_script( 'se-asmr-foley-engine', $uri . $engine_path, array( 'tone-js' ), filemtime( $dir . $engine_path ), true );
+    }
+
+    $app_path = '/js/asmr-lab.js';
+    if ( file_exists( $dir . $app_path ) ) {
+        wp_enqueue_script( 'se-asmr-lab', $uri . $app_path, array( 'se-asmr-foley-engine' ), filemtime( $dir . $app_path ), true );
+        wp_localize_script(
+            'se-asmr-lab',
+            'seAsmrLab',
+            array(
+                'endpoint' => esc_url_raw( rest_url( 'se/v1/asmr-generate' ) ),
+                'nonce'    => wp_create_nonce( 'wp_rest' ),
+            )
+        );
+    }
+}
+add_action( 'wp_enqueue_scripts', 'se_enqueue_asmr_lab_assets' );
+
 // Header tweak CSS for the Lousy Outages page/template.
 // Idempotent: safe if this file is included multiple times.
 if ( ! function_exists('se_enqueue_header_tweak_css') ) {
@@ -570,6 +611,12 @@ add_action('rest_api_init', function() {
         'callback'            => 'se_handle_riff_tip',
         'permission_callback' => '__return_true',
     ]);
+
+    register_rest_route('se/v1', '/asmr-generate', [
+        'methods'             => 'POST',
+        'callback'            => 'se_handle_asmr_generate',
+        'permission_callback' => '__return_true',
+    ]);
 });
 
 // =========================================
@@ -802,6 +849,187 @@ function se_handle_riff_tip( WP_REST_Request $req ) {
     }
 
     return rest_ensure_response( array( 'tip' => $tip ) );
+}
+
+function se_get_asmr_allowed_engines() {
+    return array(
+        'plastic_tap',
+        'paper_crinkle',
+        'soft_tear',
+        'adhesive_peel',
+        'rain_hiss',
+        'breath_pulse',
+        'ceramic_tick',
+        'ui_bloop',
+        'low_hum',
+        'fiber_brush',
+    );
+}
+
+function se_extract_json_object( $raw ) {
+    $raw = trim( (string) $raw );
+    if ( preg_match( '/```(?:json)?\s*(.+?)```/is', $raw, $matches ) ) {
+        $raw = trim( $matches[1] );
+    }
+    $start = strpos( $raw, '{' );
+    $end   = strrpos( $raw, '}' );
+    if ( false === $start || false === $end || $end <= $start ) {
+        return '';
+    }
+    return substr( $raw, $start, $end - $start + 1 );
+}
+
+function se_validate_asmr_response( $decoded ) {
+    if ( ! is_array( $decoded ) ) {
+        return new WP_Error( 'asmr_invalid_json', __( 'ASMR Lab returned malformed JSON. Please regenerate.', 'suzys-music-theme' ), array( 'status' => 500 ) );
+    }
+
+    $required = array(
+        'title',
+        'runtime_seconds',
+        'hook',
+        'concept_summary',
+        'sensory_palette',
+        'ai_usage_map',
+        'ai_edge_strategy',
+        'failure_modes_to_embrace',
+        'human_control_notes',
+        'beat_sheet',
+        'edit_notes',
+        'video_prompts',
+        'negative_prompts',
+        'presentation_note',
+        'sound_recipe',
+    );
+
+    $keys = array_keys( $decoded );
+    sort( $keys );
+    $required_sorted = $required;
+    sort( $required_sorted );
+    if ( $keys !== $required_sorted ) {
+        return new WP_Error( 'asmr_shape_error', __( 'ASMR Lab response shape was unexpected. Please regenerate.', 'suzys-music-theme' ), array( 'status' => 500 ) );
+    }
+
+    $decoded['runtime_seconds'] = max( 15, min( 30, absint( $decoded['runtime_seconds'] ) ) );
+
+    if ( ! is_array( $decoded['sound_recipe'] ) ) {
+        return new WP_Error( 'asmr_sound_recipe_invalid', __( 'Sound recipe was invalid. Please regenerate.', 'suzys-music-theme' ), array( 'status' => 500 ) );
+    }
+
+    $recipe = $decoded['sound_recipe'];
+    $recipe['bpm'] = max( 40, min( 220, absint( $recipe['bpm'] ?? 90 ) ) );
+    $recipe['master'] = is_array( $recipe['master'] ?? null ) ? $recipe['master'] : array();
+    $recipe['master'] = array(
+        'bitcrusher_bits' => max( 3, min( 16, absint( $recipe['master']['bitcrusher_bits'] ?? 8 ) ) ),
+        'downsample_factor' => max( 1, min( 12, absint( $recipe['master']['downsample_factor'] ?? 1 ) ) ),
+        'reverb_wet' => max( 0, min( 0.8, floatval( $recipe['master']['reverb_wet'] ?? 0.15 ) ) ),
+        'lowpass_hz' => max( 300, min( 18000, absint( $recipe['master']['lowpass_hz'] ?? 9000 ) ) ),
+    );
+
+    $events = is_array( $recipe['events'] ?? null ) ? $recipe['events'] : array();
+    $allowed_engines = se_get_asmr_allowed_engines();
+    $sanitized_events = array();
+    foreach ( $events as $event ) {
+        if ( ! is_array( $event ) ) {
+            continue;
+        }
+        $engine = sanitize_key( $event['engine'] ?? '' );
+        if ( ! in_array( $engine, $allowed_engines, true ) ) {
+            continue;
+        }
+        $sanitized_events[] = array(
+            'time' => max( 0, floatval( $event['time'] ?? 0 ) ),
+            'engine' => $engine,
+            'duration' => max( 0.03, min( 4, floatval( $event['duration'] ?? 0.2 ) ) ),
+            'params' => is_array( $event['params'] ?? null ) ? $event['params'] : array(),
+        );
+    }
+
+    if ( empty( $sanitized_events ) ) {
+        return new WP_Error( 'asmr_sound_events_missing', __( 'Sound recipe had no usable events. Try regenerate.', 'suzys-music-theme' ), array( 'status' => 500 ) );
+    }
+
+    $recipe['events'] = $sanitized_events;
+    $decoded['sound_recipe'] = $recipe;
+
+    return $decoded;
+}
+
+function se_handle_asmr_generate( WP_REST_Request $req ) {
+    $params = $req->get_json_params();
+    if ( ! is_array( $params ) ) {
+        $params = $req->get_params();
+    }
+
+    $payload = array(
+        'concept' => sanitize_text_field( $params['concept'] ?? '' ),
+        'object' => sanitize_text_field( $params['object'] ?? '' ),
+        'setting' => sanitize_text_field( $params['setting'] ?? '' ),
+        'mood' => sanitize_text_field( $params['mood'] ?? '' ),
+        'duration' => max( 15, min( 30, absint( $params['duration'] ?? 20 ) ) ),
+        'voice_style' => sanitize_text_field( $params['voice_style'] ?? '' ),
+        'weirdness' => max( 1, min( 10, absint( $params['weirdness'] ?? 6 ) ) ),
+        'creative_goal' => sanitize_textarea_field( $params['creative_goal'] ?? '' ),
+        'sound_only' => ! empty( $params['sound_only'] ),
+    );
+
+    if ( empty( $payload['concept'] ) || empty( $payload['object'] ) || empty( $payload['setting'] ) || empty( $payload['mood'] ) ) {
+        return new WP_Error( 'asmr_missing_fields', __( 'Please provide concept, object, setting, and mood.', 'suzys-music-theme' ), array( 'status' => 400 ) );
+    }
+
+    $allowed_engines = implode( ', ', se_get_asmr_allowed_engines() );
+    $system_prompt = 'You are ASMR Lab, a collaboration between human taste and machine excess. '
+        . 'Generate tactile, sonic, visual, and AI-process-aware output for a 15-30 second AI-film sensory ad concept. '
+        . 'Return ONE strict JSON object and no markdown. '
+        . 'Use exactly and only these top-level keys: title, runtime_seconds, hook, concept_summary, sensory_palette, ai_usage_map, ai_edge_strategy, failure_modes_to_embrace, human_control_notes, beat_sheet, edit_notes, video_prompts, negative_prompts, presentation_note, sound_recipe. '
+        . 'sound_recipe must include bpm, master(bitcrusher_bits, downsample_factor, reverb_wet, lowpass_hz), and events[]. '
+        . 'Each event object must have time, engine, duration, params. '
+        . 'Only use these engine names: ' . $allowed_engines . '. '
+        . 'Do not include prose outside JSON.';
+
+    if ( $payload['sound_only'] ) {
+        $system_prompt .= ' If sound_only is true, keep other fields concise but still present and focus creative detail in sound_recipe.';
+    }
+
+    $response = se_openai_chat(
+        array(
+            array(
+                'role'    => 'system',
+                'content' => $system_prompt,
+            ),
+            array(
+                'role'    => 'user',
+                'content' => wp_json_encode( $payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ),
+            ),
+        ),
+        array(
+            'model'       => 'gpt-4o',
+            'temperature' => 0.9,
+            'max_tokens'  => 1800,
+        ),
+        array(
+            'timeout' => 40,
+        )
+    );
+
+    if ( is_wp_error( $response ) ) {
+        $status = ( 'no_key' === $response->get_error_code() ) ? 503 : 500;
+        return new WP_Error( 'asmr_openai_error', $response->get_error_message(), array( 'status' => $status ) );
+    }
+
+    $raw = trim( $response['choices'][0]['message']['content'] ?? '' );
+    $json = se_extract_json_object( $raw );
+    $decoded = json_decode( $json, true );
+    if ( JSON_ERROR_NONE !== json_last_error() ) {
+        return new WP_Error( 'asmr_decode_error', __( 'The lab output was malformed. Please regenerate.', 'suzys-music-theme' ), array( 'status' => 500 ) );
+    }
+
+    $validated = se_validate_asmr_response( $decoded );
+    if ( is_wp_error( $validated ) ) {
+        return $validated;
+    }
+
+    return rest_ensure_response( $validated );
 }
 
 // =========================================

--- a/js/asmr-foley-engine.js
+++ b/js/asmr-foley-engine.js
@@ -1,0 +1,301 @@
+(function (window) {
+  'use strict';
+
+  const ENGINE_NAMES = [
+    'plastic_tap', 'paper_crinkle', 'soft_tear', 'adhesive_peel', 'rain_hiss',
+    'breath_pulse', 'ceramic_tick', 'ui_bloop', 'low_hum', 'fiber_brush'
+  ];
+
+  function clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
+  }
+
+  class AsmrFoleyEngine {
+    constructor() {
+      this.ctx = null;
+      this.masterNode = null;
+      this.nodes = [];
+      this.activeOscillators = [];
+      this.currentRecipe = null;
+      this.isPlaying = false;
+    }
+
+    async ensureContext() {
+      if (!window.AudioContext && !window.webkitAudioContext) {
+        throw new Error('Web Audio is unavailable in this browser.');
+      }
+      if (!this.ctx) {
+        const Ctx = window.AudioContext || window.webkitAudioContext;
+        this.ctx = new Ctx();
+      }
+      if (this.ctx.state === 'suspended') {
+        await this.ctx.resume();
+      }
+      return this.ctx;
+    }
+
+    setRecipe(recipe) {
+      this.currentRecipe = recipe || null;
+    }
+
+    clearActiveNodes() {
+      this.activeOscillators.forEach((osc) => {
+        try { osc.stop(); } catch (e) { }
+      });
+      this.activeOscillators = [];
+      this.nodes.forEach((node) => {
+        try { node.disconnect(); } catch (e) { }
+      });
+      this.nodes = [];
+    }
+
+    stop() {
+      this.clearActiveNodes();
+      this.isPlaying = false;
+    }
+
+    buildMasterChain(ctx, destination, master = {}) {
+      const input = ctx.createGain();
+      input.gain.value = 0.95;
+
+      const lowpass = ctx.createBiquadFilter();
+      lowpass.type = 'lowpass';
+      lowpass.frequency.value = clamp(Number(master.lowpass_hz || 12000), 600, 18000);
+
+      const drive = ctx.createWaveShaper();
+      drive.curve = this.makeSaturationCurve(25);
+      drive.oversample = '2x';
+
+      const wet = ctx.createGain();
+      wet.gain.value = clamp(Number(master.reverb_wet || 0.1), 0, 0.6);
+      const dry = ctx.createGain();
+      dry.gain.value = 1 - wet.gain.value;
+
+      const convolver = this.makeTinyReverb(ctx);
+      const bitNode = this.makeBitCrusherNode(ctx, {
+        bits: clamp(Number(master.bitcrusher_bits || 8), 3, 16),
+        normfreq: 1 / clamp(Number(master.downsample_factor || 1), 1, 12)
+      });
+
+      input.connect(lowpass);
+      lowpass.connect(drive);
+      drive.connect(dry);
+      drive.connect(convolver);
+      convolver.connect(wet);
+      dry.connect(bitNode);
+      wet.connect(bitNode);
+      bitNode.connect(destination);
+
+      this.nodes.push(input, lowpass, drive, dry, wet, convolver, bitNode);
+      return input;
+    }
+
+    makeBitCrusherNode(ctx, options) {
+      const bits = options.bits || 8;
+      const normfreq = options.normfreq || 1;
+      const node = ctx.createScriptProcessor(4096, 1, 1);
+      let phaser = 0;
+      let last = 0;
+      const step = Math.pow(0.5, bits);
+      node.onaudioprocess = function (e) {
+        const input = e.inputBuffer.getChannelData(0);
+        const output = e.outputBuffer.getChannelData(0);
+        for (let i = 0; i < input.length; i += 1) {
+          phaser += normfreq;
+          if (phaser >= 1.0) {
+            phaser -= 1.0;
+            last = step * Math.floor(input[i] / step + 0.5);
+          }
+          output[i] = last;
+        }
+      };
+      return node;
+    }
+
+    makeTinyReverb(ctx) {
+      const convolver = ctx.createConvolver();
+      const length = ctx.sampleRate * 0.4;
+      const impulse = ctx.createBuffer(2, length, ctx.sampleRate);
+      for (let ch = 0; ch < 2; ch += 1) {
+        const data = impulse.getChannelData(ch);
+        for (let i = 0; i < length; i += 1) {
+          data[i] = (Math.random() * 2 - 1) * Math.pow(1 - i / length, 2);
+        }
+      }
+      convolver.buffer = impulse;
+      return convolver;
+    }
+
+    makeSaturationCurve(amount) {
+      const k = typeof amount === 'number' ? amount : 50;
+      const n = 44100;
+      const curve = new Float32Array(n);
+      const deg = Math.PI / 180;
+      for (let i = 0; i < n; i += 1) {
+        const x = (i * 2) / n - 1;
+        curve[i] = ((3 + k) * x * 20 * deg) / (Math.PI + k * Math.abs(x));
+      }
+      return curve;
+    }
+
+    scheduleNoiseBurst(ctx, target, start, duration, opts = {}) {
+      const buffer = ctx.createBuffer(1, Math.floor(ctx.sampleRate * duration), ctx.sampleRate);
+      const data = buffer.getChannelData(0);
+      for (let i = 0; i < data.length; i += 1) {
+        data[i] = (Math.random() * 2 - 1) * (opts.color || 1);
+      }
+      const source = ctx.createBufferSource();
+      source.buffer = buffer;
+
+      const filter = ctx.createBiquadFilter();
+      filter.type = opts.filterType || 'bandpass';
+      filter.frequency.value = opts.freq || 1400;
+      filter.Q.value = opts.q || 1;
+
+      const gain = ctx.createGain();
+      gain.gain.setValueAtTime(0.0001, start);
+      gain.gain.exponentialRampToValueAtTime(opts.peak || 0.15, start + 0.01);
+      gain.gain.exponentialRampToValueAtTime(0.0001, start + duration);
+
+      source.connect(filter);
+      filter.connect(gain);
+      gain.connect(target);
+
+      source.start(start);
+      source.stop(start + duration + 0.02);
+
+      this.nodes.push(source, filter, gain);
+    }
+
+    scheduleTone(ctx, target, start, duration, opts = {}) {
+      const osc = ctx.createOscillator();
+      osc.type = opts.type || 'triangle';
+      osc.frequency.setValueAtTime(opts.from || 220, start);
+      if (opts.to) {
+        osc.frequency.exponentialRampToValueAtTime(Math.max(20, opts.to), start + duration);
+      }
+      const gain = ctx.createGain();
+      gain.gain.setValueAtTime(0.0001, start);
+      gain.gain.exponentialRampToValueAtTime(opts.peak || 0.2, start + 0.01);
+      gain.gain.exponentialRampToValueAtTime(0.0001, start + duration);
+      osc.connect(gain);
+      gain.connect(target);
+      osc.start(start);
+      osc.stop(start + duration + 0.03);
+      this.activeOscillators.push(osc);
+      this.nodes.push(osc, gain);
+    }
+
+    renderEvent(ctx, destination, event, atTime) {
+      const duration = clamp(Number(event.duration || 0.2), 0.03, 4);
+      const p = event.params || {};
+
+      switch (event.engine) {
+        case 'plastic_tap':
+          this.scheduleTone(ctx, destination, atTime, duration * 0.4, { from: p.pitch || 620, to: 280, peak: 0.18, type: 'square' });
+          this.scheduleNoiseBurst(ctx, destination, atTime, duration * 0.25, { freq: 1800, q: 6, peak: 0.07 });
+          break;
+        case 'paper_crinkle':
+          this.scheduleNoiseBurst(ctx, destination, atTime, duration, { freq: 2500, q: 0.8, peak: 0.12, filterType: 'highpass' });
+          break;
+        case 'soft_tear':
+          this.scheduleNoiseBurst(ctx, destination, atTime, duration, { freq: 1200, q: 1.5, peak: 0.14 });
+          this.scheduleTone(ctx, destination, atTime, duration * 0.5, { from: 180, to: 120, peak: 0.05 });
+          break;
+        case 'adhesive_peel':
+          this.scheduleNoiseBurst(ctx, destination, atTime, duration, { freq: 900, q: 2, peak: 0.1 });
+          this.scheduleTone(ctx, destination, atTime, duration, { from: 320, to: 90, peak: 0.08, type: 'sawtooth' });
+          break;
+        case 'rain_hiss':
+          this.scheduleNoiseBurst(ctx, destination, atTime, duration, { freq: 6000, q: 0.7, peak: 0.09, filterType: 'lowpass' });
+          break;
+        case 'breath_pulse':
+          this.scheduleNoiseBurst(ctx, destination, atTime, duration, { freq: 700, q: 0.9, peak: 0.1 });
+          break;
+        case 'ceramic_tick':
+          this.scheduleTone(ctx, destination, atTime, duration * 0.25, { from: p.pitch || 900, to: 300, peak: 0.12, type: 'triangle' });
+          break;
+        case 'ui_bloop':
+          this.scheduleTone(ctx, destination, atTime, duration, { from: p.from || 320, to: p.to || 560, peak: 0.16, type: 'square' });
+          break;
+        case 'low_hum':
+          this.scheduleTone(ctx, destination, atTime, duration, { from: p.freq || 70, to: p.freq || 70, peak: 0.15, type: 'sine' });
+          break;
+        case 'fiber_brush':
+          this.scheduleNoiseBurst(ctx, destination, atTime, duration, { freq: 1600, q: 1.1, peak: 0.08 });
+          break;
+        default:
+          break;
+      }
+    }
+
+    validateRecipe(recipe) {
+      if (!recipe || typeof recipe !== 'object') return false;
+      if (!Array.isArray(recipe.events)) return false;
+      return recipe.events.every((event) => ENGINE_NAMES.includes(event.engine));
+    }
+
+    async preview(recipe) {
+      await this.ensureContext();
+      if (!this.validateRecipe(recipe)) {
+        throw new Error('Sound recipe is invalid or uses unsupported engines.');
+      }
+      this.stop();
+      const now = this.ctx.currentTime + 0.05;
+      this.masterNode = this.buildMasterChain(this.ctx, this.ctx.destination, recipe.master || {});
+      recipe.events.forEach((event) => {
+        const timeOffset = Math.max(0, Number(event.time || 0));
+        this.renderEvent(this.ctx, this.masterNode, event, now + timeOffset);
+      });
+      const total = recipe.events.reduce((max, event) => {
+        const end = Number(event.time || 0) + Number(event.duration || 0.2);
+        return Math.max(max, end);
+      }, 0);
+      this.isPlaying = true;
+      setTimeout(() => { this.isPlaying = false; this.clearActiveNodes(); }, (total + 1.5) * 1000);
+    }
+
+    async exportWav(recipe) {
+      if (!this.validateRecipe(recipe)) {
+        throw new Error('Cannot export: invalid recipe.');
+      }
+      const lengthSec = Math.max(2, recipe.events.reduce((max, event) => Math.max(max, Number(event.time || 0) + Number(event.duration || 0.2)), 0) + 1);
+      const sr = 44100;
+      const offline = new OfflineAudioContext(1, Math.ceil(lengthSec * sr), sr);
+      const master = this.buildMasterChain(offline, offline.destination, recipe.master || {});
+      recipe.events.forEach((event) => {
+        this.renderEvent(offline, master, event, Math.max(0, Number(event.time || 0)));
+      });
+      const rendered = await offline.startRendering();
+      return this.audioBufferToWav(rendered);
+    }
+
+    audioBufferToWav(buffer) {
+      const channelData = buffer.getChannelData(0);
+      const bytes = 44 + channelData.length * 2;
+      const view = new DataView(new ArrayBuffer(bytes));
+      const writeString = (o, s) => { for (let i = 0; i < s.length; i += 1) view.setUint8(o + i, s.charCodeAt(i)); };
+      writeString(0, 'RIFF');
+      view.setUint32(4, 36 + channelData.length * 2, true);
+      writeString(8, 'WAVEfmt ');
+      view.setUint32(16, 16, true);
+      view.setUint16(20, 1, true);
+      view.setUint16(22, 1, true);
+      view.setUint32(24, buffer.sampleRate, true);
+      view.setUint32(28, buffer.sampleRate * 2, true);
+      view.setUint16(32, 2, true);
+      view.setUint16(34, 16, true);
+      writeString(36, 'data');
+      view.setUint32(40, channelData.length * 2, true);
+      let offset = 44;
+      for (let i = 0; i < channelData.length; i += 1) {
+        const s = Math.max(-1, Math.min(1, channelData[i]));
+        view.setInt16(offset, s < 0 ? s * 0x8000 : s * 0x7FFF, true);
+        offset += 2;
+      }
+      return new Blob([view], { type: 'audio/wav' });
+    }
+  }
+
+  window.AsmrFoleyEngine = AsmrFoleyEngine;
+})(window);

--- a/js/asmr-lab.js
+++ b/js/asmr-lab.js
@@ -1,0 +1,182 @@
+(function () {
+  'use strict';
+
+  const app = document.getElementById('asmr-lab-app');
+  if (!app) return;
+  if (!window.seAsmrLab) return;
+
+  const form = document.getElementById('asmr-lab-form');
+  const statusEl = document.getElementById('asmr-status');
+  const errorEl = document.getElementById('asmr-error');
+  const resultsEl = document.getElementById('asmr-results');
+  const previewBtn = document.getElementById('asmr-preview');
+  const stopBtn = document.getElementById('asmr-stop');
+  const exportBtn = document.getElementById('asmr-export');
+  const soundOnlyBtn = document.getElementById('asmr-sound-only');
+  const audioFeedback = document.getElementById('asmr-audio-feedback');
+  const copyPromptsBtn = document.getElementById('asmr-copy-prompts');
+
+  const engine = new window.AsmrFoleyEngine();
+  let lastPayload = null;
+  let currentRecipe = null;
+
+  function setStatus(message) {
+    if (statusEl) statusEl.textContent = message || '';
+  }
+
+  function setError(message) {
+    if (!errorEl) return;
+    if (message) {
+      errorEl.hidden = false;
+      errorEl.textContent = message;
+    } else {
+      errorEl.hidden = true;
+      errorEl.textContent = '';
+    }
+  }
+
+  function toList(parent, items) {
+    if (!parent) return;
+    parent.innerHTML = '';
+    (Array.isArray(items) ? items : []).forEach((item) => {
+      const li = document.createElement('li');
+      li.textContent = typeof item === 'string' ? item : JSON.stringify(item);
+      parent.appendChild(li);
+    });
+  }
+
+  function renderData(data) {
+    const concept = document.getElementById('asmr-concept');
+    const beats = document.getElementById('asmr-beats');
+    const prompts = document.getElementById('asmr-video-prompts');
+    const edit = document.getElementById('asmr-edit-notes');
+    const note = document.getElementById('asmr-presentation');
+    const recipe = document.getElementById('asmr-sound-json');
+
+    if (concept) {
+      concept.textContent = `${data.title} (${data.runtime_seconds}s) — ${data.hook}\n${data.concept_summary}`;
+    }
+    toList(beats, data.beat_sheet);
+    toList(prompts, data.video_prompts);
+    if (edit) edit.textContent = Array.isArray(data.edit_notes) ? data.edit_notes.join(' ') : (data.edit_notes || '');
+    if (note) note.textContent = data.presentation_note || '';
+    if (recipe) recipe.textContent = JSON.stringify(data.sound_recipe || {}, null, 2);
+
+    currentRecipe = data.sound_recipe || null;
+    if (resultsEl) resultsEl.hidden = false;
+    [previewBtn, stopBtn, exportBtn, soundOnlyBtn].forEach((b) => b && (b.disabled = !currentRecipe));
+  }
+
+  async function requestGeneration(payload) {
+    setError('');
+    setStatus('Generating in the lab...');
+    const response = await fetch(window.seAsmrLab.endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-WP-Nonce': window.seAsmrLab.nonce
+      },
+      body: JSON.stringify(payload)
+    });
+
+    let data;
+    try {
+      data = await response.json();
+    } catch (e) {
+      throw new Error('Unexpected response format from ASMR Lab service.');
+    }
+
+    if (!response.ok) {
+      throw new Error((data && data.message) ? data.message : 'Unable to generate ASMR package.');
+    }
+
+    if (!data || typeof data !== 'object' || !data.sound_recipe) {
+      throw new Error('Generated package was incomplete. Please try again.');
+    }
+
+    setStatus('Package generated. Ready to preview sound.');
+    return data;
+  }
+
+  if (form) {
+    form.addEventListener('submit', async function (event) {
+      event.preventDefault();
+      const formData = new FormData(form);
+      lastPayload = Object.fromEntries(formData.entries());
+      try {
+        const data = await requestGeneration(lastPayload);
+        renderData(data);
+      } catch (err) {
+        setError(err.message || 'Generation failed.');
+        setStatus('');
+      }
+    });
+  }
+
+  if (soundOnlyBtn) {
+    soundOnlyBtn.addEventListener('click', async function () {
+      if (!lastPayload) {
+        setError('Generate a full package first, then regenerate sound.');
+        return;
+      }
+      try {
+        const payload = Object.assign({}, lastPayload, { sound_only: true });
+        const data = await requestGeneration(payload);
+        renderData(data);
+      } catch (err) {
+        setError(err.message || 'Sound regeneration failed.');
+      }
+    });
+  }
+
+  if (previewBtn) {
+    previewBtn.addEventListener('click', async function () {
+      if (!currentRecipe) return;
+      try {
+        await engine.preview(currentRecipe);
+        if (audioFeedback) audioFeedback.textContent = 'Preview playing.';
+      } catch (err) {
+        if (audioFeedback) audioFeedback.textContent = 'Audio may be blocked until user interaction. Click preview again.';
+      }
+    });
+  }
+
+  if (stopBtn) {
+    stopBtn.addEventListener('click', function () {
+      engine.stop();
+      if (audioFeedback) audioFeedback.textContent = 'Playback stopped.';
+    });
+  }
+
+  if (exportBtn) {
+    exportBtn.addEventListener('click', async function () {
+      if (!currentRecipe) return;
+      if (audioFeedback) audioFeedback.textContent = 'Rendering WAV...';
+      try {
+        const blob = await engine.exportWav(currentRecipe);
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'asmr-lab-preview.wav';
+        a.click();
+        URL.revokeObjectURL(url);
+        if (audioFeedback) audioFeedback.textContent = 'WAV export complete.';
+      } catch (err) {
+        if (audioFeedback) audioFeedback.textContent = 'WAV export failed in this browser.';
+      }
+    });
+  }
+
+  if (copyPromptsBtn) {
+    copyPromptsBtn.addEventListener('click', async function () {
+      const promptItems = document.querySelectorAll('#asmr-video-prompts li');
+      const text = Array.from(promptItems).map((li) => li.textContent).join('\n');
+      try {
+        await navigator.clipboard.writeText(text);
+        setStatus('Video prompts copied.');
+      } catch (e) {
+        setError('Clipboard access unavailable.');
+      }
+    });
+  }
+})();

--- a/page-asmr-lab.php
+++ b/page-asmr-lab.php
@@ -1,0 +1,57 @@
+<?php
+/*
+Template Name: ASMR Lab
+*/
+
+get_header();
+?>
+<main id="primary" class="content-area asmr-lab-page">
+  <section class="asmr-lab-shell" id="asmr-lab-app">
+    <header class="asmr-lab-header">
+      <p class="asmr-kicker">Retro-futurist creative control room</p>
+      <h1 class="asmr-title">ASMR Lab</h1>
+      <p class="asmr-intro">Describe a concept and let AI generate a sensory ad concept, tactical beat sheet, tactile 8-bit foley recipe, and model-ready video prompts.</p>
+    </header>
+
+    <form id="asmr-lab-form" class="asmr-lab-form" novalidate>
+      <div class="asmr-grid">
+        <label>Concept<input type="text" name="concept" required maxlength="140" placeholder="Glitchy tea ritual launch" /></label>
+        <label>Object<input type="text" name="object" required maxlength="80" placeholder="ceramic mug" /></label>
+        <label>Setting<input type="text" name="setting" required maxlength="120" placeholder="rainy apartment at dawn" /></label>
+        <label>Mood<input type="text" name="mood" required maxlength="80" placeholder="soft tension + wonder" /></label>
+        <label>Duration (15-30 sec)<input type="number" name="duration" min="15" max="30" value="20" required /></label>
+        <label>Voice Style<input type="text" name="voice_style" maxlength="80" placeholder="minimal poetic narrator" /></label>
+        <label>Weirdness (1-10)<input type="number" name="weirdness" min="1" max="10" value="6" required /></label>
+        <label>Creative Goal<textarea name="creative_goal" rows="2" maxlength="260" placeholder="Make ordinary textures feel cinematic."></textarea></label>
+      </div>
+      <div class="asmr-actions">
+        <button type="submit" class="pixel-button">Generate ASMR Package</button>
+        <button type="button" id="asmr-sound-only" class="pixel-button secondary" disabled>Regenerate Sound Only</button>
+      </div>
+      <p id="asmr-status" class="asmr-status" role="status" aria-live="polite"></p>
+      <p id="asmr-error" class="asmr-error" role="alert" hidden></p>
+    </form>
+
+    <section class="asmr-audio-controls" aria-label="Sound preview controls">
+      <button type="button" id="asmr-preview" class="pixel-button" disabled>Preview Sound</button>
+      <button type="button" id="asmr-stop" class="pixel-button secondary" disabled>Stop</button>
+      <button type="button" id="asmr-export" class="pixel-button secondary" disabled>Export WAV</button>
+      <p id="asmr-audio-feedback" class="asmr-audio-feedback" aria-live="polite"></p>
+    </section>
+
+    <section id="asmr-results" class="asmr-results" hidden>
+      <article class="asmr-card"><h2>Concept</h2><p id="asmr-concept"></p></article>
+      <article class="asmr-card"><h2>Beat Sheet</h2><ol id="asmr-beats"></ol></article>
+      <article class="asmr-card"><h2>Video Prompts</h2><button type="button" id="asmr-copy-prompts" class="pixel-button tiny">Copy prompts</button><ul id="asmr-video-prompts"></ul></article>
+      <article class="asmr-card"><h2>Edit Notes</h2><p id="asmr-edit-notes"></p></article>
+      <article class="asmr-card"><h2>Presentation Note</h2><p id="asmr-presentation"></p></article>
+      <article class="asmr-card"><h2>Sound Recipe</h2>
+        <details>
+          <summary>View JSON recipe</summary>
+          <pre id="asmr-sound-json"></pre>
+        </details>
+      </article>
+    </section>
+  </section>
+</main>
+<?php get_footer(); ?>


### PR DESCRIPTION
### Motivation
- Provide an in-theme creative feature that turns a user prompt into a short AI-film sensory ad concept, a structured procedural 8‑bit / retro-foley sound recipe, and model-ready video prompts. 
- Ensure the preview path is fully procedural (no stock samples) and runs in the browser via Web Audio/Tone.js while keeping future hybrid sample support possible. 
- Fit into existing theme patterns for templates, OpenAI proxying, REST routes, and page-scoped asset enqueueing to avoid affecting other pages.

### Description
- Add a new page template `page-asmr-lab.php` (`Template Name: ASMR Lab`) that renders the form, loading/error states, result cards, collapsible JSON panel, video prompt copy, and preview/stop/export audio controls. 
- Add frontend orchestration `js/asmr-lab.js` to POST form payloads to the REST API, render returned JSON into the UI, support “Regenerate Sound Only”, and wire Preview/Stop/Export buttons with defensive DOM and accessibility handling. 
- Add a procedural sound engine `js/asmr-foley-engine.js` that implements the required engines (`plastic_tap`, `paper_crinkle`, `soft_tear`, `adhesive_peel`, `rain_hiss`, `breath_pulse`, `ceramic_tick`, `ui_bloop`, `low_hum`, `fiber_brush`) using oscillators, filtered noise, envelopes, bitcrush/downsample/saturation effects, and an `OfflineAudioContext` WAV export path. 
- Update `functions.php` to enqueue page-scoped CSS/JS and `Tone.js` only for the ASMR template, register `POST /wp-json/se/v1/asmr-generate`, and implement `se_handle_asmr_generate()` which sanitizes input, calls `se_openai_chat()` with a strict system prompt (single JSON object with the exact top-level keys), extracts and validates the model JSON, normalizes the `sound_recipe` schema, filters allowed engines, and returns friendly `WP_Error` responses on malformed output.

### Testing
- Ran PHP syntax checks: `php -l page-asmr-lab.php` succeeded. 
- Ran PHP syntax checks: `php -l functions.php` succeeded. 
- Performed a lightweight JS sanity check with Node: `node -e "new Function(require('fs').readFileSync('js/asmr-lab.js','utf8')); new Function(require('fs').readFileSync('js/asmr-foley-engine.js','utf8')); console.log('js ok')"` which succeeded. 
- Attempted automated browser screenshot with Playwright against `http://127.0.0.1:8080` but it failed with `ERR_EMPTY_RESPONSE` because no local server responded in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae51b925e4832e9d0376f006fe64de)