### PR TITLE
Add ASMR Lab teaser section to homepage

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -150,6 +150,13 @@ get_header();
         </div>
     </section>
 
+    <section class="asmr-lab-teaser crt-block" aria-labelledby="asmr-lab-teaser-title">
+        <p class="asmr-lab-teaser__eyebrow pixel-font">Experimental Machine Online</p>
+        <h2 id="asmr-lab-teaser-title" class="pixel-font">ASMR Lab</h2>
+        <p class="asmr-lab-teaser__description">Step into the noise chamber: AI-generated sensory ad concepts, 8-bit foley recipes, and model-ready video prompts wired for curious makers.</p>
+        <a href="<?php echo esc_url(home_url('/asmr-lab/')); ?>" class="pixel-button asmr-lab-teaser__cta">Enter ASMR Lab</a>
+    </section>
+
     <section class="track-analyzer-feature">
         <h2 class="pixel-font">Track Analyzer</h2>
         <p class="pixel-font">Upload an MP3 and get instant feedback on your mix.</p>

--- a/style.css
+++ b/style.css
@@ -582,6 +582,10 @@ body::before {
   .ai-film-feature {
     grid-template-columns: 1fr;
   }
+
+  .asmr-lab-teaser {
+    text-align: center;
+  }
 }
 
 /* ====================== */
@@ -2042,6 +2046,40 @@ body {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
+  margin-top: 14px;
+}
+
+
+
+.asmr-lab-teaser {
+  margin: 40px auto;
+  max-width: 860px;
+  padding: 24px 28px;
+  border-radius: 12px;
+  text-align: left;
+}
+
+.asmr-lab-teaser__eyebrow {
+  margin: 0 0 0.75rem;
+  font-size: 0.68rem;
+  letter-spacing: 1px;
+  color: var(--secondary-color);
+  text-transform: uppercase;
+}
+
+.asmr-lab-teaser h2 {
+  margin: 0 0 0.8rem;
+  color: #b6ffd7;
+}
+
+.asmr-lab-teaser__description {
+  margin: 0;
+  max-width: 62ch;
+  line-height: 1.7;
+  color: #e8ffee;
+}
+
+.asmr-lab-teaser__cta {
   margin-top: 14px;
 }
 


### PR DESCRIPTION
### Motivation
- Promote the new ASMR Lab feature on the homepage without embedding the full tool, presenting it as an experimental featured project. 
- Keep the visual language consistent with the existing retro arcade / creative tech aesthetic and place the teaser near other creative/AI project content. 

### Description
- Added a new teaser block to `page-home.php` immediately after the AI Film feature that includes an eyebrow line, `h2` title "ASMR Lab", short descriptive copy, and a primary CTA linking to `/asmr-lab/`. 
- The teaser uses `crt-block` and `pixel-button` classes to reuse existing theme styling, and includes `aria-labelledby` for accessible heading semantics. 
- Added scoped CSS to `style.css` for `.asmr-lab-teaser`, `.asmr-lab-teaser__eyebrow`, `.asmr-lab-teaser__description`, and `.asmr-lab-teaser__cta`, plus a small mobile tweak to center the block at narrow widths. 
- Changes are minimal and scoped so existing homepage layout and styling patterns are not disrupted. 

### Testing
- Ran `php -l page-home.php` and `php -l functions.php`, both of which reported no syntax errors. 
- Attempted an automated Playwright screenshot of the local preview, but the local PHP preview server was not reachable in this environment so the visual snapshot step failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae573def88832eacd1f6ccc148611e)