### PR TITLE
Improve crawlability: use WP sitemap, add canonical tags, ASMR Lab meta, and exclude utility pages from indexing

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1060,3 +1060,67 @@ add_action('wp_head', function () {
         echo "<link rel=\"alternate\" type=\"application/rss+xml\" title=\"Lousy Outages Alerts\" href=\"{$href}\" />\n";
     }
 });
+
+// =========================================
+// 10. CRAWLABILITY / INDEXING CONTROLS
+// =========================================
+function se_get_utility_page_templates(): array {
+    return array(
+        'page-subscribe-thanks.php',
+    );
+}
+
+function se_get_utility_page_ids(): array {
+    $ids = array();
+    foreach ( se_get_utility_page_templates() as $template ) {
+        $pages = get_pages(
+            array(
+                'meta_key'    => '_wp_page_template',
+                'meta_value'  => $template,
+                'post_status' => 'publish',
+                'fields'      => 'ids',
+                'number'      => 100,
+            )
+        );
+
+        if ( is_array( $pages ) ) {
+            $ids = array_merge( $ids, $pages );
+        }
+    }
+
+    return array_values( array_unique( array_map( 'absint', $ids ) ) );
+}
+
+add_filter(
+    'wp_robots',
+    function ( array $robots ): array {
+        if ( is_page_template( se_get_utility_page_templates() ) ) {
+            $robots['noindex'] = true;
+            $robots['nofollow'] = true;
+            unset( $robots['index'] );
+            unset( $robots['follow'] );
+        }
+
+        return $robots;
+    }
+);
+
+add_filter(
+    'wp_sitemaps_posts_query_args',
+    function ( array $args, string $post_type ): array {
+        if ( 'page' !== $post_type ) {
+            return $args;
+        }
+
+        $excluded_ids = se_get_utility_page_ids();
+        if ( ! empty( $excluded_ids ) ) {
+            $args['post__not_in'] = isset( $args['post__not_in'] )
+                ? array_values( array_unique( array_merge( (array) $args['post__not_in'], $excluded_ids ) ) )
+                : $excluded_ids;
+        }
+
+        return $args;
+    },
+    10,
+    2
+);

--- a/header.php
+++ b/header.php
@@ -25,6 +25,11 @@
       $meta_desc  = 'Suzanne (Suzy) Easton shares indie music spotlights, outage stories, retro-inspired tools, and Vancouver-based creative tech experiments.';
       $meta_keywords = 'Suzy Easton, Suzanne Easton, Vancouver musician, creative technologist, Lousy Outages, indie music, retro arcade website, outage analysis';
       $meta_img   = $default_img;
+    } elseif ( is_page_template( 'page-asmr-lab.php' ) ) {
+      $meta_title = 'ASMR Lab – AI sensory ad concepts and 8-bit foley recipes';
+      $meta_desc  = 'Build tactile ad concepts with AI: ASMR-style beats, foley recipes, and model-ready video prompts for creators and creative technologists.';
+      $meta_keywords = 'ASMR lab, AI ad concept generator, foley recipe tool, sensory marketing prompts, Suzy Easton';
+      $meta_img   = $default_img;
     } elseif ( is_page_template( 'page-lousy-outages.php' ) ) {
       $meta_title = 'Lousy Outages – Retro outage dashboard for modern chaos';
       $meta_desc  = 'A retro terminal-style dashboard that tracks popular services, highlights incidents, and can send alerts when things go sideways.';
@@ -51,7 +56,11 @@
       $meta_keywords = 'Suzy Easton, musician, creative technologist, Vancouver artist';
       $meta_img   = $default_img;
     }
-    $meta_url = home_url( add_query_arg( [], $wp->request ) );
+    if ( is_singular() ) {
+      $meta_url = get_permalink();
+    } else {
+      $meta_url = home_url( add_query_arg( [], $wp->request ) );
+    }
     $structured_data = [
       '@context' => 'https://schema.org',
       '@graph'   => [
@@ -90,6 +99,7 @@
   <title><?php echo esc_html( $meta_title ); ?></title>
   <meta name="description" content="<?php echo esc_attr( $meta_desc ); ?>">
   <meta name="keywords" content="<?php echo esc_attr( $meta_keywords ); ?>">
+  <link rel="canonical" href="<?php echo esc_url( $meta_url ); ?>">
   <meta property="og:type" content="website">
   <meta property="og:title" content="<?php echo esc_attr( $meta_title ); ?>">
   <meta property="og:description" content="<?php echo esc_attr( $meta_desc ); ?>">

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://www.suzyeaston.ca/sitemap.xml
+Sitemap: https://www.suzyeaston.ca/wp-sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,21 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://www.suzyeaston.ca/</loc>
-  </url>
-  <url>
-    <loc>https://www.suzyeaston.ca/suzys-track-analyzer/</loc>
-  </url>
-  <url>
-    <loc>https://www.suzyeaston.ca/arcade/</loc>
-  </url>
-  <url>
-    <loc>https://www.suzyeaston.ca/albini-qa/</loc>
-  </url>
-  <url>
-    <loc>https://www.suzyeaston.ca/riff-generator/</loc>
-  </url>
-  <url>
-    <loc>https://www.suzyeaston.ca/music-releases/</loc>
-  </url>
-</urlset>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://www.suzyeaston.ca/wp-sitemap.xml</loc>
+  </sitemap>
+</sitemapindex>


### PR DESCRIPTION
### Motivation
- The repo contained a small, hand-maintained static sitemap and no canonical output, which risks stale coverage and duplicate/discoverability issues.
- New public templates like ASMR Lab lacked dedicated meta/title handling to surface them to crawlers.
- Transactional/utility pages (subscribe thank-you) were eligible for indexing and could appear in sitemaps despite being low-value.

### Description
- Point `robots.txt` at WordPress’ native sitemap by changing the sitemap directive to `/wp-sitemap.xml` and replace the static `sitemap.xml` with a lightweight sitemap index that forwards to the WP sitemap.
- Add page-level ASMR Lab meta (title/description/keywords) and emit a canonical `<link rel="canonical">` in `header.php`, using `get_permalink()` for singular content.
- Add crawl/indexing guardrails in `functions.php`: register utility templates (`page-subscribe-thanks.php`), set `noindex,nofollow` via the `wp_robots` filter for those templates, and exclude their post IDs from WordPress sitemap generation via `wp_sitemaps_posts_query_args`.
- Keep changes small and theme-native (no SEO plugin bloat) and rely on WP core sitemap generation for maintainability.

### Testing
- Ran PHP syntax checks with `php -l functions.php` and `php -l header.php`, both succeeded. 
- Confirmed files updated: `robots.txt`, `sitemap.xml` (now a sitemap index), `header.php` (canonical + ASMR meta), and `functions.php` (index/sitemap filters).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae5a0327e8832ea0e3e27653ff4389)