### PR TITLE
Improve ASMR Lab discoverability with homepage links and server-rendered explainer

### DIFF
--- a/assets/css/asmr-lab.css
+++ b/assets/css/asmr-lab.css
@@ -13,3 +13,12 @@
 .asmr-card h2{margin:.2rem 0 .5rem;font-size:1rem;color:#9ec0ff}
 .asmr-card pre{max-height:240px;overflow:auto;background:#090d1a;padding:.6rem;border-radius:6px}
 .pixel-button.tiny{font-size:.75rem;padding:.25rem .45rem}
+.asmr-intro{max-width:68ch;line-height:1.55}
+.asmr-lab-primer,.asmr-lab-how,.asmr-lab-sample{margin-top:1.1rem;padding:.95rem;background:#121833;border:1px solid #2f3f73;border-radius:8px}
+.asmr-lab-primer h2,.asmr-lab-how h2,.asmr-lab-sample h2{margin:.1rem 0 .55rem;font-size:1.02rem;color:#9ec0ff}
+.asmr-lab-primer p,.asmr-lab-how li,.asmr-lab-sample p{line-height:1.55}
+.asmr-lab-primer ul,.asmr-lab-how ol{margin:.35rem 0 .15rem 1.1rem;padding:0}
+.asmr-lab-primer li,.asmr-lab-how li{margin:.38rem 0}
+.asmr-sample-card{padding:.7rem;background:#0a0f23;border:1px dashed #3f5ab6;border-radius:6px}
+.asmr-sample-card h3{margin:.1rem 0 .55rem;color:#b5cbff}
+.asmr-lab-sample-note{color:#7aa2ff;font-size:.9rem}

--- a/footer.php
+++ b/footer.php
@@ -27,6 +27,12 @@
 <!-- Simple Footer -->
 <footer class="site-footer">
     <div class="footer-content">
+        <nav class="footer-site-links" aria-label="Explore creative projects">
+            <a href="<?php echo esc_url( home_url( '/asmr-lab/' ) ); ?>">ASMR Lab</a>
+            <a href="<?php echo esc_url( home_url( '/suzys-track-analyzer/' ) ); ?>">Track Analyzer</a>
+            <a href="<?php echo esc_url( home_url( '/riff-generator/' ) ); ?>">Riff Generator</a>
+            <a href="<?php echo esc_url( home_url( '/lousy-outages/' ) ); ?>">Lousy Outages</a>
+        </nav>
         <div class="footer-bottom">
             <p>&copy; <?php echo date('Y'); ?> Suzy Easton. All rights reserved.</p>
         </div>

--- a/header.php
+++ b/header.php
@@ -27,7 +27,7 @@
       $meta_img   = $default_img;
     } elseif ( is_page_template( 'page-asmr-lab.php' ) ) {
       $meta_title = 'ASMR Lab – AI sensory ad concepts and 8-bit foley recipes';
-      $meta_desc  = 'Build tactile ad concepts with AI: ASMR-style beats, foley recipes, and model-ready video prompts for creators and creative technologists.';
+      $meta_desc  = 'ASMR Lab generates AI sensory ad concepts, tactile beat sheets, retro-foley sound recipes, and model-ready video prompts in one creative package.';
       $meta_keywords = 'ASMR lab, AI ad concept generator, foley recipe tool, sensory marketing prompts, Suzy Easton';
       $meta_img   = $default_img;
     } elseif ( is_page_template( 'page-lousy-outages.php' ) ) {

--- a/page-asmr-lab.php
+++ b/page-asmr-lab.php
@@ -10,8 +10,43 @@ get_header();
     <header class="asmr-lab-header">
       <p class="asmr-kicker">Retro-futurist creative control room</p>
       <h1 class="asmr-title">ASMR Lab</h1>
-      <p class="asmr-intro">Describe a concept and let AI generate a sensory ad concept, tactical beat sheet, tactile 8-bit foley recipe, and model-ready video prompts.</p>
+      <p class="asmr-intro">Describe a concept and let AI generate a sensory ad concept, tactile beat sheet, tactile 8-bit foley recipe, and model-ready video prompts.</p>
     </header>
+
+
+
+    <section class="asmr-lab-primer" aria-labelledby="asmr-lab-primer-title">
+      <h2 id="asmr-lab-primer-title">What ASMR Lab generates</h2>
+      <p>ASMR Lab is a prompt-first creative tool for people building short-form ads, art videos, and sonic mood studies. You type in a concept, and the lab returns a compact package you can hand to collaborators or models without extra translation.</p>
+      <ul>
+        <li><strong>AI-generated sensory ad concepts</strong> that define hook, tone, and runtime in plain language.</li>
+        <li><strong>Tactile beat sheets</strong> to structure each moment for touch, texture, and rhythm cues.</li>
+        <li><strong>Procedural 8-bit / retro-foley sound recipes</strong> you can preview, tweak, and export.</li>
+        <li><strong>Model-ready video prompts</strong> for rapid iteration in image-to-video or text-to-video workflows.</li>
+      </ul>
+    </section>
+
+    <section class="asmr-lab-how" aria-labelledby="asmr-lab-how-title">
+      <h2 id="asmr-lab-how-title">How it works</h2>
+      <ol>
+        <li>Set your concept, object, setting, and mood.</li>
+        <li>Generate a full ASMR package from one submit action.</li>
+        <li>Preview sound, regenerate audio only, or copy prompts for your video workflow.</li>
+      </ol>
+    </section>
+
+    <section class="asmr-lab-sample" aria-labelledby="asmr-lab-sample-title">
+      <h2 id="asmr-lab-sample-title">Sample output preview</h2>
+      <p><strong>Use case:</strong> Launch teaser for a rainy-night tea brand with cozy sci-fi energy.</p>
+      <article class="asmr-sample-card">
+        <h3>Concept snapshot</h3>
+        <p><strong>Hook:</strong> "Hear the kettle before you see the city."</p>
+        <p><strong>Beat sheet:</strong> neon sign hum, ceramic tap rhythm, pour crescendo, steam hiss, whispered end-tag.</p>
+        <p><strong>Retro-foley recipe:</strong> square-wave blips under filtered pink noise, with short tape-stop drops every four bars.</p>
+        <p><strong>Video prompt line:</strong> "Macro shot of condensation crawling across a chipped mug, cyberpunk kitchen, 24fps, soft grain, VHS bloom."</p>
+      </article>
+      <p class="asmr-lab-sample-note">You can generate custom variants after submitting the form below.</p>
+    </section>
 
     <form id="asmr-lab-form" class="asmr-lab-form" novalidate>
       <div class="asmr-grid">

--- a/page-home.php
+++ b/page-home.php
@@ -61,6 +61,7 @@ get_header();
             <p class="hero-microproof">I’ve toured across Canada as a bassist, appeared on MuchMusic, and recorded in Chicago with Steve Albini. These days, I’m building apps, exploring AI models, experimenting with short AI films through BC + AI Film Club, and writing whatever songs show up next.</p>
             <div class="hero-cta-group">
                 <a href="/suzys-track-analyzer/" class="pixel-button hero-primary-cta">Start with: Track Analyzer</a>
+                <a href="/asmr-lab/" class="pixel-button hero-secondary-cta">Try: ASMR Lab</a>
                 <a href="/lousy-outages/" class="pixel-button hero-secondary-cta">Or explore: Lousy Outages</a>
                 <a href="/bio/" class="pixel-button hero-bio-button">Read full bio</a>
             </div>
@@ -110,6 +111,7 @@ get_header();
             <div class="button-group">
                 <h3 class="group-title">🎮 Games &amp; Tools</h3>
                 <div class="group-buttons">
+                    <a href="/asmr-lab/" class="pixel-button">ASMR Lab</a>
                     <a href="/suzys-track-analyzer/" class="pixel-button">Track Analyzer</a>
                     <a href="/riff-generator" class="pixel-button">Riff Generator</a>
                     <a href="/arcade" class="pixel-button">Canucks Game</a>
@@ -161,6 +163,17 @@ get_header();
         <h2 class="pixel-font">Track Analyzer</h2>
         <p class="pixel-font">Upload an MP3 and get instant feedback on your mix.</p>
         <a href="/suzys-track-analyzer/" class="pixel-button analyzer-cta">Analyze Your Track</a>
+    </section>
+
+    <section class="creative-tool-links crt-block" aria-labelledby="creative-tool-links-title">
+        <h2 id="creative-tool-links-title" class="pixel-font">Creative Tool Deck</h2>
+        <p>Prefer crawl-first browsing? Jump straight to the public tool pages:</p>
+        <ul>
+            <li><a href="<?php echo esc_url(home_url('/asmr-lab/')); ?>">ASMR Lab</a> — AI sensory ad concepts, tactile beat sheets, and retro-foley prompt kits.</li>
+            <li><a href="<?php echo esc_url(home_url('/suzys-track-analyzer/')); ?>">Track Analyzer</a> — upload a mix and get fast AI feedback.</li>
+            <li><a href="<?php echo esc_url(home_url('/riff-generator/')); ?>">Riff Generator</a> — generate guitar ideas in a retro experiment shell.</li>
+            <li><a href="<?php echo esc_url(home_url('/lousy-outages/')); ?>">Lousy Outages</a> — outage tracker with a throwback command-line vibe.</li>
+        </ul>
     </section>
 
     <section class="party-announcement crt-block">

--- a/style.css
+++ b/style.css
@@ -3438,3 +3438,62 @@ body.page-template-page-bio-php .bio-content {
     display: none;
   }
 }
+
+
+.creative-tool-links {
+  margin: 28px auto 40px;
+  max-width: 860px;
+  padding: 22px 28px;
+  border-radius: 12px;
+}
+
+.creative-tool-links h2 {
+  margin: 0 0 0.8rem;
+  color: #b6ffd7;
+}
+
+.creative-tool-links p {
+  margin: 0 0 0.8rem;
+  color: #e8ffee;
+}
+
+.creative-tool-links ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: #e8ffee;
+}
+
+.creative-tool-links li {
+  margin: 0.45rem 0;
+  line-height: 1.5;
+}
+
+.creative-tool-links a {
+  color: var(--secondary-color);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.creative-tool-links a:hover,
+.creative-tool-links a:focus {
+  text-decoration: underline;
+}
+
+.footer-site-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.footer-site-links a {
+  color: #9effd0;
+  text-decoration: none;
+  font-size: 0.86rem;
+}
+
+.footer-site-links a:hover,
+.footer-site-links a:focus {
+  text-decoration: underline;
+}


### PR DESCRIPTION
### Motivation
- Bots can fetch HTML but may not run site JavaScript, so the ASMR Lab tool needed server-rendered copy and durable internal links so crawlers understand and index it without interacting with the app.
- Keep the site tone retro/creative while avoiding hidden/overstuffed SEO content and preserving the live JS-driven experience.

### Description
- Added a visible ASMR Lab link to the homepage hero CTA row and the "Games & Tools" button cluster to increase high-visibility internal linking to `/asmr-lab/` (`page-home.php`).
- Added a new crawl-friendly homepage section `Creative Tool Deck` with durable links to ASMR Lab, Track Analyzer, Riff Generator, and Lousy Outages (`page-home.php` + `style.css`).
- Expanded `page-asmr-lab.php` with server-rendered explanatory content placed before the interactive form: a `What ASMR Lab generates` primer, a `How it works` list, and a concrete `Sample output preview` card so crawlers (and users without JS) can read a meaningful example.
- Updated ASMR Lab meta description to align with the new copy (`header.php`) so title/description match the server-rendered explanation.
- Added lightweight theme-consistent CSS for the new ASMR sections and the homepage/footer links (`assets/css/asmr-lab.css`, `style.css`).
- Added a small footer navigation block with durable links to core tool pages (`footer.php`).
- Kept all existing JS-based functionality intact (form, REST endpoint, preview/export, and `asmr-lab.js` behavior remain unchanged).

### Testing
- Ran PHP lint on modified templates: `php -l page-home.php`, `php -l page-asmr-lab.php`, `php -l footer.php`, and `php -l header.php`, and all reported "No syntax errors detected." (success).
- Attempted an automated browser screenshot to validate visible links, but the environment had no running webserver so Playwright navigation to `http://127.0.0.1:8080/` returned `ERR_EMPTY_RESPONSE` (no server available) — visual check should be performed against a running instance.
- Manual verification steps: visit `/` to confirm ASMR Lab links in hero, Games & Tools cluster, teaser and Creative Tool Deck; visit `/asmr-lab/` to confirm the primer, how-it-works, and sample output appear in raw page source before any interaction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae5d7dbebc832e972d040bbfae7dad)