### PR TITLE
Upgrade ASMR Lab: stronger generation prompt, synced transport, improved audio/visual engines, 1080p export

### DIFF
--- a/assets/css/asmr-lab.css
+++ b/assets/css/asmr-lab.css
@@ -20,3 +20,5 @@
 .asmr-visual-preview{margin-top:1rem;background:#060b19;border:1px solid #2f3f73;border-radius:8px;padding:.5rem;box-shadow:inset 0 0 24px rgba(85,160,255,.14)}
 #asmr-visual-canvas{display:block;width:100%;height:auto;min-height:240px;background:#050812;border:1px solid #26396a;border-radius:6px}
 .asmr-mode-label{font-size:.8rem;display:flex;gap:.35rem;align-items:center}
+.asmr-video-support{font-size:.75rem;color:#9bd9ff;opacity:.9}
+.asmr-audio-feedback{font-size:.82rem;color:#9ed4ff;margin:0}

--- a/functions.php
+++ b/functions.php
@@ -942,6 +942,9 @@ function se_validate_asmr_response( $decoded ) {
         return new WP_Error( 'asmr_sound_events_missing', __( 'Sound recipe had no usable events. Try regenerate.', 'suzys-music-theme' ), array( 'status' => 500 ) );
     }
 
+    usort( $sanitized_events, static function( $a, $b ) {
+        return ( $a['time'] <=> $b['time'] );
+    } );
     $decoded['audio_events'] = $sanitized_events;
 
     $visual_allowed = array(
@@ -966,6 +969,9 @@ function se_validate_asmr_response( $decoded ) {
             'sync_role' => sanitize_text_field( $event['sync_role'] ?? '' ),
         );
     }, $visual_events ) ) );
+    usort( $decoded['visual_events'], static function( $a, $b ) {
+        return ( $a['time'] <=> $b['time'] );
+    } );
 
     $sync_points = is_array( $decoded['sync_points'] ?? null ) ? $decoded['sync_points'] : array();
     $decoded['sync_points'] = array_values( array_filter( array_map( static function( $point ) {
@@ -978,6 +984,9 @@ function se_validate_asmr_response( $decoded ) {
             'importance' => sanitize_text_field( $point['importance'] ?? '' ),
         );
     }, $sync_points ) ) );
+    usort( $decoded['sync_points'], static function( $a, $b ) {
+        return ( $a['time'] <=> $b['time'] );
+    } );
 
     $end_card = is_array( $decoded['end_card'] ?? null ) ? $decoded['end_card'] : array();
     $decoded['end_card'] = array(
@@ -1021,8 +1030,8 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
     }
 
     $allowed_engines = implode( ', ', se_get_asmr_allowed_engines() );
-    $system_prompt = 'You are ASMR Lab, a collaboration between human taste and machine excess. '
-        . 'Generate an original 10-30 second sensory micro-film performable score for a browser-based retro-futurist control room. '
+    $system_prompt = 'You are ASMR Lab, a retro-futurist sensory film composer for a browser performance engine. '
+        . 'Generate an original 10-30 second procedural audiovisual score that feels composed, eerie, spiritual, tactile, and cinematic when prompted. '
         . 'Return ONE strict JSON object and no markdown. '
         . 'Use exactly and only these top-level keys: title, runtime_seconds, hook, concept_summary, style_tags, audio_events, visual_events, sync_points, end_card, edit_rhythm, presentation_note. '
         . 'audio_events objects must include: time, duration, engine, intensity, params, sync_role. '
@@ -1032,7 +1041,15 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
         . 'edit_rhythm must include: pacing_note, silence_strategy, release_strategy. '
         . 'Only use these engine names: ' . $allowed_engines . '. '
         . 'Allowed visual_type values: scanline_field, pixel_grid_pulse, wireframe_horizon, radial_bloom, particle_trail, glitch_flash, waveform_ring, macro_texture_drift, signal_bars, text_reveal. '
-        . 'Sound and visual events must be intentionally synchronized and should include a tension arc, reveal, and ending gesture. '
+        . 'Critical staging rules: first frame must already contain meaningful visual composition (not blank canvas); include baseline atmospheric visual motion at time 0. '
+        . 'Open with soft but present ambience in first 0.0-0.4s; avoid harsh transient attacks at start unless explicitly justified by the concept. '
+        . 'Ensure first audible event and first prominent visual motion are synchronized or intentionally near-synchronized within ~0.12s. '
+        . 'Event times must be practical for direct browser playback: finite, non-negative, sorted, and concentrated inside runtime_seconds. '
+        . 'Shape a clear tension to bloom to reveal arc, with layered atmosphere and ceremonial build when concept or mood suggests ritual awakening. '
+        . 'Use micro-events for intimacy, then earned bloom moments instead of random loudness spikes. '
+        . 'Visual score should emphasize depth, layering, glow, parallax-like drift, and terminal/sacred reveal language when appropriate. '
+        . 'sync_points must map to real event moments and reinforce audio-visual unity, especially in the first 3 seconds. '
+        . 'The result should feel like an authored short sensory micro-film, not a debug demo. '
         . 'Do not include prose outside JSON.';
 
     if ( $payload['sound_only'] ) {

--- a/js/asmr-foley-engine.js
+++ b/js/asmr-foley-engine.js
@@ -16,8 +16,11 @@
       this.ctx = null;
       this.masterNode = null;
       this.nodes = [];
-      this.activeOscillators = [];
+      this.activeSources = [];
+      this.activeTimers = [];
       this.isPlaying = false;
+      this.lastPreview = null;
+      this.defaultPrerollSeconds = 0.28;
     }
 
     async ensureContext() {
@@ -31,8 +34,10 @@
     }
 
     clearActiveNodes() {
-      this.activeOscillators.forEach((osc) => { try { osc.stop(); } catch (e) {} });
-      this.activeOscillators = [];
+      this.activeTimers.forEach((timer) => window.clearTimeout(timer));
+      this.activeTimers = [];
+      this.activeSources.forEach((source) => { try { source.stop(); } catch (e) {} });
+      this.activeSources = [];
       this.nodes.forEach((node) => { try { node.disconnect(); } catch (e) {} });
       this.nodes = [];
     }
@@ -40,155 +45,236 @@
     stop() {
       this.clearActiveNodes();
       this.isPlaying = false;
+      this.masterNode = null;
+      this.lastPreview = null;
+    }
+
+    normalizeAudioEvents(pkg) {
+      if (!pkg || !Array.isArray(pkg.audio_events)) return [];
+      const runtime = clamp(Number(pkg.runtime_seconds || 20), 10, 30);
+      const maxEdge = runtime + 0.5;
+      return pkg.audio_events
+        .filter((event) => event && ENGINE_NAMES.includes(event.engine))
+        .map((event) => {
+          const time = clamp(Number(event.time || 0), 0, maxEdge);
+          const duration = clamp(Number(event.duration || 0.2), 0.04, 4.5);
+          const intensity = clamp(Number(event.intensity || 0.5), 0, 1);
+          return {
+            time,
+            duration,
+            intensity,
+            engine: event.engine,
+            params: (event.params && typeof event.params === 'object') ? event.params : {},
+            sync_role: String(event.sync_role || '')
+          };
+        })
+        .sort((a, b) => a.time - b.time)
+        .filter((event) => event.time <= maxEdge);
     }
 
     buildMasterChain(ctx, destination) {
       const input = ctx.createGain();
-      input.gain.value = 0.84;
+      input.gain.value = 0.68;
+
+      const preHP = ctx.createBiquadFilter();
+      preHP.type = 'highpass';
+      preHP.frequency.value = 28;
+
+      const toneLP = ctx.createBiquadFilter();
+      toneLP.type = 'lowpass';
+      toneLP.frequency.value = 10400;
+
       const comp = ctx.createDynamicsCompressor();
-      comp.threshold.value = -22;
-      comp.ratio.value = 4;
-      const lowpass = ctx.createBiquadFilter();
-      lowpass.type = 'lowpass';
-      lowpass.frequency.value = 12000;
+      comp.threshold.value = -26;
+      comp.knee.value = 16;
+      comp.ratio.value = 3.4;
+      comp.attack.value = 0.01;
+      comp.release.value = 0.25;
+
+      const limiter = ctx.createDynamicsCompressor();
+      limiter.threshold.value = -8;
+      limiter.knee.value = 2;
+      limiter.ratio.value = 14;
+      limiter.attack.value = 0.002;
+      limiter.release.value = 0.1;
+
+      const stereo = ctx.createStereoPanner ? ctx.createStereoPanner() : null;
+      if (stereo) stereo.pan.value = 0;
+
       const convolver = this.makeTinyReverb(ctx);
       const wet = ctx.createGain();
-      wet.gain.value = 0.16;
+      wet.gain.value = 0.2;
       const dry = ctx.createGain();
-      dry.gain.value = 0.84;
-      const bit = this.makeBitCrusherNode(ctx, { bits: 8, normfreq: 0.8 });
+      dry.gain.value = 0.8;
 
-      input.connect(comp);
-      comp.connect(lowpass);
-      lowpass.connect(dry);
-      lowpass.connect(convolver);
+      input.connect(preHP);
+      preHP.connect(toneLP);
+      toneLP.connect(comp);
+      comp.connect(dry);
+      comp.connect(convolver);
       convolver.connect(wet);
-      dry.connect(bit);
-      wet.connect(bit);
-      bit.connect(destination);
-      this.nodes.push(input, comp, lowpass, convolver, wet, dry, bit);
-      return input;
-    }
+      dry.connect(limiter);
+      wet.connect(limiter);
+      if (stereo) {
+        limiter.connect(stereo);
+        stereo.connect(destination);
+      } else {
+        limiter.connect(destination);
+      }
 
-    makeBitCrusherNode(ctx, options) {
-      const bits = options.bits || 8;
-      const normfreq = options.normfreq || 1;
-      const node = ctx.createScriptProcessor(4096, 1, 1);
-      let phaser = 0;
-      let last = 0;
-      const step = Math.pow(0.5, bits);
-      node.onaudioprocess = function (e) {
-        const input = e.inputBuffer.getChannelData(0);
-        const output = e.outputBuffer.getChannelData(0);
-        for (let i = 0; i < input.length; i += 1) {
-          phaser += normfreq;
-          if (phaser >= 1.0) {
-            phaser -= 1.0;
-            last = step * Math.floor(input[i] / step + 0.5);
-          }
-          output[i] = last;
-        }
-      };
-      return node;
+      this.nodes.push(input, preHP, toneLP, comp, limiter, convolver, wet, dry);
+      if (stereo) this.nodes.push(stereo);
+      return input;
     }
 
     makeTinyReverb(ctx) {
       const c = ctx.createConvolver();
-      const length = Math.floor(ctx.sampleRate * 0.6);
+      const length = Math.floor(ctx.sampleRate * 1.1);
       const i = ctx.createBuffer(2, length, ctx.sampleRate);
       for (let ch = 0; ch < 2; ch += 1) {
         const d = i.getChannelData(ch);
-        for (let n = 0; n < length; n += 1) d[n] = (Math.random() * 2 - 1) * Math.pow(1 - n / length, 2.2);
+        for (let n = 0; n < length; n += 1) {
+          const env = Math.pow(1 - n / length, 2.4);
+          d[n] = (Math.random() * 2 - 1) * env * (0.65 + (ch * 0.06));
+        }
       }
       c.buffer = i;
       return c;
     }
 
+    shapeEnvelope(gainParam, start, duration, peak) {
+      const attack = Math.min(0.18, Math.max(0.025, duration * 0.24));
+      const hold = Math.max(0.01, duration * 0.2);
+      const releaseStart = start + attack + hold;
+      gainParam.setValueAtTime(0.0001, start);
+      gainParam.exponentialRampToValueAtTime(Math.max(0.0025, peak), start + attack);
+      gainParam.exponentialRampToValueAtTime(Math.max(0.0015, peak * 0.75), releaseStart);
+      gainParam.exponentialRampToValueAtTime(0.0001, start + duration);
+    }
+
     scheduleTone(ctx, target, start, duration, opts) {
       const osc = ctx.createOscillator();
       osc.type = opts.type || 'sine';
+      const pan = ctx.createStereoPanner ? ctx.createStereoPanner() : null;
+      const panAmount = clamp(Number(opts.pan || 0), -1, 1);
+      if (pan) pan.pan.setValueAtTime(panAmount, start);
+
       osc.frequency.setValueAtTime(Math.max(20, opts.from || 220), start);
       if (opts.to) osc.frequency.exponentialRampToValueAtTime(Math.max(20, opts.to), start + duration);
       const gain = ctx.createGain();
-      gain.gain.setValueAtTime(0.0001, start);
-      gain.gain.exponentialRampToValueAtTime(Math.max(0.001, opts.peak || 0.2), start + Math.min(0.03, duration * 0.2));
-      gain.gain.exponentialRampToValueAtTime(0.0001, start + duration);
+      this.shapeEnvelope(gain.gain, start, duration, opts.peak || 0.1);
+
       osc.connect(gain);
-      gain.connect(target);
+      if (pan) {
+        gain.connect(pan);
+        pan.connect(target);
+      } else {
+        gain.connect(target);
+      }
+
       osc.start(start);
-      osc.stop(start + duration + 0.03);
-      this.activeOscillators.push(osc);
+      osc.stop(start + duration + 0.05);
+      this.activeSources.push(osc);
       this.nodes.push(osc, gain);
+      if (pan) this.nodes.push(pan);
     }
 
     scheduleNoise(ctx, target, start, duration, opts) {
       const buffer = ctx.createBuffer(1, Math.max(1, Math.floor(ctx.sampleRate * duration)), ctx.sampleRate);
       const data = buffer.getChannelData(0);
-      for (let i = 0; i < data.length; i += 1) data[i] = Math.random() * 2 - 1;
+      for (let i = 0; i < data.length; i += 1) data[i] = (Math.random() * 2 - 1) * (1 - (i / data.length) * 0.2);
       const source = ctx.createBufferSource();
       source.buffer = buffer;
       const filter = ctx.createBiquadFilter();
       filter.type = opts.filterType || 'bandpass';
       filter.frequency.value = opts.freq || 1400;
       filter.Q.value = opts.q || 1;
+      const pan = ctx.createStereoPanner ? ctx.createStereoPanner() : null;
+      if (pan) pan.pan.value = clamp(Number(opts.pan || 0), -1, 1);
       const gain = ctx.createGain();
-      gain.gain.setValueAtTime(0.0001, start);
-      gain.gain.exponentialRampToValueAtTime(Math.max(0.001, opts.peak || 0.12), start + Math.min(0.05, duration * 0.35));
-      gain.gain.exponentialRampToValueAtTime(0.0001, start + duration);
+      this.shapeEnvelope(gain.gain, start, duration, opts.peak || 0.08);
+
       source.connect(filter);
       filter.connect(gain);
-      gain.connect(target);
+      if (pan) {
+        gain.connect(pan);
+        pan.connect(target);
+      } else {
+        gain.connect(target);
+      }
+
       source.start(start);
-      source.stop(start + duration + 0.02);
+      source.stop(start + duration + 0.03);
+      this.activeSources.push(source);
       this.nodes.push(source, filter, gain);
+      if (pan) this.nodes.push(pan);
     }
 
     renderEvent(ctx, destination, event, atTime) {
-      const duration = clamp(Number(event.duration || 0.2), 0.03, 8);
+      const duration = clamp(Number(event.duration || 0.2), 0.04, 8);
       const intensity = clamp(Number(event.intensity || 0.5), 0, 1);
       const p = event.params || {};
 
       switch (event.engine) {
         case 'glissando_rise':
-          this.scheduleTone(ctx, destination, atTime, duration, { from: p.from || 160, to: p.to || 1280, peak: 0.12 + intensity * 0.2, type: 'sawtooth' });
+          this.scheduleTone(ctx, destination, atTime, duration, { from: p.from || 140, to: p.to || 1180, peak: 0.06 + intensity * 0.12, type: 'sawtooth', pan: -0.15 });
           break;
         case 'synth_bloom':
-          this.scheduleTone(ctx, destination, atTime, duration * 0.9, { from: p.from || 280, to: p.to || 520, peak: 0.08 + intensity * 0.15, type: 'triangle' });
-          this.scheduleTone(ctx, destination, atTime + 0.02, duration, { from: (p.from || 280) * 1.5, to: (p.to || 520) * 1.5, peak: 0.05 + intensity * 0.1, type: 'sine' });
+          this.scheduleTone(ctx, destination, atTime, duration * 0.94, { from: p.from || 240, to: p.to || 530, peak: 0.05 + intensity * 0.11, type: 'triangle', pan: 0.14 });
+          this.scheduleTone(ctx, destination, atTime + 0.02, duration, { from: (p.from || 240) * 1.52, to: (p.to || 530) * 1.52, peak: 0.03 + intensity * 0.08, type: 'sine', pan: -0.14 });
           break;
         case 'sub_swell':
-          this.scheduleTone(ctx, destination, atTime, duration, { from: p.freq || 48, to: (p.freq || 48) * 1.08, peak: 0.13 + intensity * 0.2, type: 'sine' });
+          this.scheduleTone(ctx, destination, atTime, duration, { from: p.freq || 44, to: (p.freq || 44) * 1.05, peak: 0.08 + intensity * 0.1, type: 'sine' });
           break;
         case 'filtered_noise_wash':
-          this.scheduleNoise(ctx, destination, atTime, duration, { freq: p.freq || 2800, q: 0.7, peak: 0.08 + intensity * 0.12, filterType: 'lowpass' });
+          this.scheduleNoise(ctx, destination, atTime, duration, { freq: p.freq || 2300, q: 0.65, peak: 0.045 + intensity * 0.08, filterType: 'lowpass', pan: 0.24 });
           break;
         case 'ceramic_tick':
-          this.scheduleTone(ctx, destination, atTime, duration * 0.25, { from: p.pitch || 980, to: 360, peak: 0.06 + intensity * 0.12, type: 'triangle' });
+          this.scheduleTone(ctx, destination, atTime, Math.max(0.08, duration * 0.4), { from: p.pitch || 840, to: 300, peak: 0.025 + intensity * 0.05, type: 'triangle', pan: -0.36 });
           break;
         case 'paper_crackle':
-          this.scheduleNoise(ctx, destination, atTime, duration, { freq: p.freq || 2100, q: 1.4, peak: 0.05 + intensity * 0.1, filterType: 'highpass' });
+          this.scheduleNoise(ctx, destination, atTime, duration, { freq: p.freq || 1700, q: 1.2, peak: 0.025 + intensity * 0.05, filterType: 'highpass', pan: -0.2 });
           break;
         case 'steam_hiss':
-          this.scheduleNoise(ctx, destination, atTime, duration, { freq: p.freq || 5200, q: 0.5, peak: 0.04 + intensity * 0.1, filterType: 'lowpass' });
+          this.scheduleNoise(ctx, destination, atTime, duration, { freq: p.freq || 3900, q: 0.55, peak: 0.025 + intensity * 0.05, filterType: 'lowpass', pan: 0.2 });
           break;
         case 'tape_stop_drop':
-          this.scheduleTone(ctx, destination, atTime, duration, { from: p.from || 280, to: p.to || 35, peak: 0.1 + intensity * 0.13, type: 'square' });
+          this.scheduleTone(ctx, destination, atTime, duration, { from: p.from || 220, to: p.to || 32, peak: 0.05 + intensity * 0.09, type: 'square' });
           break;
         case 'bit_pulse':
-          this.scheduleTone(ctx, destination, atTime, duration * 0.2, { from: p.freq || 420, to: p.freq || 420, peak: 0.08 + intensity * 0.1, type: 'square' });
+          this.scheduleTone(ctx, destination, atTime, Math.max(0.08, duration * 0.5), { from: p.freq || 360, to: p.freq || 360, peak: 0.035 + intensity * 0.06, type: 'square', pan: 0.1 });
           break;
         case 'breath_pulse':
-          this.scheduleNoise(ctx, destination, atTime, duration, { freq: p.freq || 780, q: 0.9, peak: 0.05 + intensity * 0.1, filterType: 'bandpass' });
+          this.scheduleNoise(ctx, destination, atTime, duration, { freq: p.freq || 760, q: 0.8, peak: 0.03 + intensity * 0.05, filterType: 'bandpass' });
           break;
         case 'low_hum':
-          this.scheduleTone(ctx, destination, atTime, duration, { from: p.freq || 72, to: p.freq || 72, peak: 0.06 + intensity * 0.16, type: 'sine' });
+          this.scheduleTone(ctx, destination, atTime, duration, { from: p.freq || 66, to: p.freq || 66, peak: 0.035 + intensity * 0.08, type: 'sine' });
           break;
         case 'digital_shimmer':
-          this.scheduleTone(ctx, destination, atTime, duration * 0.7, { from: p.from || 1200, to: p.to || 2400, peak: 0.04 + intensity * 0.08, type: 'triangle' });
+          this.scheduleTone(ctx, destination, atTime, duration * 0.8, { from: p.from || 1000, to: p.to || 2280, peak: 0.02 + intensity * 0.05, type: 'triangle', pan: 0.3 });
           break;
         default:
           break;
       }
+    }
+
+    scheduleBed(ctx, destination, startAt, runtime) {
+      const lowHum = {
+        time: 0,
+        duration: Math.max(1.6, runtime * 0.95),
+        intensity: 0.18,
+        engine: 'low_hum',
+        params: { freq: 58 }
+      };
+      const airy = {
+        time: 0.06,
+        duration: Math.max(1.8, runtime * 0.85),
+        intensity: 0.2,
+        engine: 'filtered_noise_wash',
+        params: { freq: 1800 }
+      };
+      this.renderEvent(ctx, destination, lowHum, startAt + lowHum.time);
+      this.renderEvent(ctx, destination, airy, startAt + airy.time);
     }
 
     validateRecipe(pkg) {
@@ -201,51 +287,75 @@
       await this.ensureContext();
       if (!this.validateRecipe(pkg)) throw new Error('Audio package is invalid or uses unsupported engines.');
       this.stop();
-      const now = this.ctx.currentTime + 0.05;
+
+      const events = this.normalizeAudioEvents(pkg);
+      const runtime = clamp(Number(pkg.runtime_seconds || 20), 10, 30);
+      const preroll = this.defaultPrerollSeconds;
+      const now = this.ctx.currentTime;
+      const audioStartAt = now + preroll;
+
       this.masterNode = this.buildMasterChain(this.ctx, this.ctx.destination);
-      pkg.audio_events.forEach((event) => {
-        const timeOffset = Math.max(0, Number(event.time || 0));
-        this.renderEvent(this.ctx, this.masterNode, event, now + timeOffset);
-      });
-      const total = pkg.audio_events.reduce((max, event) => Math.max(max, Number(event.time || 0) + Number(event.duration || 0.2)), 0);
+      this.scheduleBed(this.ctx, this.masterNode, audioStartAt, runtime);
+      events.forEach((event) => this.renderEvent(this.ctx, this.masterNode, event, audioStartAt + event.time));
+
+      const total = Math.max(runtime, events.reduce((max, event) => Math.max(max, event.time + event.duration), runtime));
       this.isPlaying = true;
-      setTimeout(() => { this.isPlaying = false; this.clearActiveNodes(); }, (total + 1.1) * 1000);
-      return { startAt: now, total };
+      const timer = window.setTimeout(() => {
+        this.isPlaying = false;
+        this.clearActiveNodes();
+      }, (total + preroll + 1.2) * 1000);
+      this.activeTimers.push(timer);
+
+      this.lastPreview = { startAt: audioStartAt, preroll, total, runtime };
+      return this.lastPreview;
+    }
+
+    renderToOfflineBuffer(pkg, sampleRate = 48000) {
+      if (!this.validateRecipe(pkg)) throw new Error('Cannot export: invalid audio events.');
+      const events = this.normalizeAudioEvents(pkg);
+      const runtime = clamp(Number(pkg.runtime_seconds || 20), 10, 30);
+      const lengthSec = Math.max(runtime + 1, events.reduce((max, e) => Math.max(max, e.time + e.duration), runtime) + 1);
+      const offline = new OfflineAudioContext(2, Math.ceil(lengthSec * sampleRate), sampleRate);
+      const master = this.buildMasterChain(offline, offline.destination);
+      this.scheduleBed(offline, master, 0, runtime);
+      events.forEach((event) => this.renderEvent(offline, master, event, event.time));
+      return offline.startRendering();
     }
 
     async exportWav(pkg) {
-      if (!this.validateRecipe(pkg)) throw new Error('Cannot export: invalid audio events.');
-      const sr = 44100;
-      const lengthSec = Math.max(2, pkg.audio_events.reduce((max, e) => Math.max(max, Number(e.time || 0) + Number(e.duration || 0.2)), 0) + 1);
-      const offline = new OfflineAudioContext(1, Math.ceil(lengthSec * sr), sr);
-      const master = this.buildMasterChain(offline, offline.destination);
-      pkg.audio_events.forEach((event) => this.renderEvent(offline, master, event, Math.max(0, Number(event.time || 0))));
-      const rendered = await offline.startRendering();
+      const rendered = await this.renderToOfflineBuffer(pkg, 44100);
       return this.audioBufferToWav(rendered);
     }
 
     audioBufferToWav(buffer) {
-      const channelData = buffer.getChannelData(0);
-      const bytes = 44 + channelData.length * 2;
+      const channels = Math.min(2, buffer.numberOfChannels);
+      const length = buffer.length;
+      const bytes = 44 + length * channels * 2;
       const view = new DataView(new ArrayBuffer(bytes));
       const writeString = (o, s) => { for (let i = 0; i < s.length; i += 1) view.setUint8(o + i, s.charCodeAt(i)); };
       writeString(0, 'RIFF');
-      view.setUint32(4, 36 + channelData.length * 2, true);
+      view.setUint32(4, 36 + length * channels * 2, true);
       writeString(8, 'WAVEfmt ');
       view.setUint32(16, 16, true);
       view.setUint16(20, 1, true);
-      view.setUint16(22, 1, true);
+      view.setUint16(22, channels, true);
       view.setUint32(24, buffer.sampleRate, true);
-      view.setUint32(28, buffer.sampleRate * 2, true);
-      view.setUint16(32, 2, true);
+      view.setUint32(28, buffer.sampleRate * channels * 2, true);
+      view.setUint16(32, channels * 2, true);
       view.setUint16(34, 16, true);
       writeString(36, 'data');
-      view.setUint32(40, channelData.length * 2, true);
+      view.setUint32(40, length * channels * 2, true);
+
+      const channelData = [];
+      for (let ch = 0; ch < channels; ch += 1) channelData.push(buffer.getChannelData(ch));
+
       let o = 44;
-      for (let i = 0; i < channelData.length; i += 1) {
-        const s = Math.max(-1, Math.min(1, channelData[i]));
-        view.setInt16(o, s < 0 ? s * 0x8000 : s * 0x7FFF, true);
-        o += 2;
+      for (let i = 0; i < length; i += 1) {
+        for (let ch = 0; ch < channels; ch += 1) {
+          const s = Math.max(-1, Math.min(1, channelData[ch][i] || 0));
+          view.setInt16(o, s < 0 ? s * 0x8000 : s * 0x7FFF, true);
+          o += 2;
+        }
       }
       return new Blob([view], { type: 'audio/wav' });
     }

--- a/js/asmr-lab.js
+++ b/js/asmr-lab.js
@@ -11,15 +11,46 @@
   const previewBtn = document.getElementById('asmr-preview');
   const stopBtn = document.getElementById('asmr-stop');
   const exportBtn = document.getElementById('asmr-export');
+  const exportVideoBtn = document.getElementById('asmr-export-video');
   const soundOnlyBtn = document.getElementById('asmr-sound-only');
+  const qaPresetBtn = document.getElementById('asmr-qa-preset');
   const audioFeedback = document.getElementById('asmr-audio-feedback');
   const modeToggle = document.getElementById('asmr-playback-mode');
+  const videoSupportEl = document.getElementById('asmr-video-support');
   const canvas = document.getElementById('asmr-visual-canvas');
 
   const engine = new window.AsmrFoleyEngine();
   const visuals = window.AsmrVisualEngine ? new window.AsmrVisualEngine(canvas) : null;
   let lastPayload = null;
   let currentPackage = null;
+
+  const QA_PRESET = {
+    concept: 'Glass relay prayer waking a dormant monolith',
+    object: 'glass relay core',
+    setting: 'midnight signal chamber',
+    mood: 'spiritual tension, crystalline awe, then radiant bloom',
+    duration: '20',
+    voice_style: 'composed machine whisper',
+    weirdness: '7',
+    creative_goal: 'Build from tiny tactile pulses into a sacred electronic bloom with a terminal-style final reveal.'
+  };
+
+  const transport = {
+    playing: false,
+    stopFns: [],
+    previewMeta: null,
+    registerStop(fn) {
+      this.stopFns.push(fn);
+    },
+    stopAll() {
+      while (this.stopFns.length) {
+        const fn = this.stopFns.pop();
+        try { fn(); } catch (e) {}
+      }
+      this.playing = false;
+      this.previewMeta = null;
+    }
+  };
 
   function setStatus(m) { if (statusEl) statusEl.textContent = m || ''; }
   function setError(m) {
@@ -36,6 +67,42 @@
       li.textContent = typeof item === 'string' ? item : JSON.stringify(item);
       parent.appendChild(li);
     });
+  }
+
+  function getVideoSupport() {
+    const support = {
+      canCaptureCanvas: !!(window.HTMLCanvasElement && HTMLCanvasElement.prototype.captureStream),
+      hasMediaRecorder: !!window.MediaRecorder,
+      mp4Mime: '',
+      webmMime: ''
+    };
+
+    if (support.hasMediaRecorder) {
+      const mp4Types = ['video/mp4;codecs=avc1.42E01E,mp4a.40.2', 'video/mp4'];
+      for (let i = 0; i < mp4Types.length; i += 1) {
+        if (MediaRecorder.isTypeSupported(mp4Types[i])) { support.mp4Mime = mp4Types[i]; break; }
+      }
+      const webmTypes = ['video/webm;codecs=vp9,opus', 'video/webm;codecs=vp8,opus', 'video/webm'];
+      for (let i = 0; i < webmTypes.length; i += 1) {
+        if (MediaRecorder.isTypeSupported(webmTypes[i])) { support.webmMime = webmTypes[i]; break; }
+      }
+    }
+
+    support.canExport = support.canCaptureCanvas && support.hasMediaRecorder && !!(support.mp4Mime || support.webmMime);
+    support.preferredMime = support.mp4Mime || support.webmMime || '';
+    support.extension = support.mp4Mime ? 'mp4' : 'webm';
+    return support;
+  }
+
+  const videoSupport = getVideoSupport();
+  if (videoSupportEl) {
+    if (videoSupport.mp4Mime) {
+      videoSupportEl.textContent = 'Video export: MP4 supported on this browser.';
+    } else if (videoSupport.webmMime) {
+      videoSupportEl.textContent = 'Video export: MP4 unavailable here; exporting WebM fallback.';
+    } else {
+      videoSupportEl.textContent = 'Video export unavailable in this browser/runtime.';
+    }
   }
 
   function renderData(data) {
@@ -62,7 +129,11 @@
       visuals.seek(0);
     }
     if (resultsEl) resultsEl.hidden = false;
-    [previewBtn, stopBtn, exportBtn, soundOnlyBtn].forEach((b) => b && (b.disabled = !currentPackage));
+    [previewBtn, stopBtn, exportBtn, soundOnlyBtn, exportVideoBtn].forEach((b) => {
+      if (!b) return;
+      if (b === exportVideoBtn) b.disabled = !currentPackage || !videoSupport.canExport;
+      else b.disabled = !currentPackage;
+    });
   }
 
   async function requestGeneration(payload) {
@@ -83,12 +154,138 @@
     return data;
   }
 
+  async function startPreview() {
+    if (!currentPackage) return;
+    transport.stopAll();
+    engine.stop();
+    if (visuals) visuals.stop();
+
+    const fullMode = !modeToggle || modeToggle.value === 'audiovisual';
+    if (visuals && fullMode) {
+      visuals.loadTimeline(currentPackage);
+      visuals.seek(0); // meaningful first frame before audio transport start
+    }
+
+    const playback = await engine.preview(currentPackage);
+    transport.previewMeta = playback;
+    transport.playing = true;
+
+    if (visuals && fullMode) {
+      visuals.play(-playback.preroll);
+      transport.registerStop(() => visuals.stop());
+    }
+    transport.registerStop(() => engine.stop());
+
+    if (audioFeedback) audioFeedback.textContent = fullMode ? 'Synchronized preview playing.' : 'Sound-only preview playing.';
+  }
+
+  async function exportVideo() {
+    if (!currentPackage) return;
+    if (!videoSupport.canExport) throw new Error('Video export is not supported in this browser/runtime.');
+
+    transport.stopAll();
+    engine.stop();
+    if (visuals) visuals.stop();
+
+    const runtime = Math.max(10, Math.min(30, Number(currentPackage.runtime_seconds || 20)));
+    const fps = 30;
+
+    const target = document.createElement('canvas');
+    target.width = 1920;
+    target.height = 1080;
+    const targetCtx = target.getContext('2d');
+
+    const exportVisuals = new window.AsmrVisualEngine(target);
+    exportVisuals.loadTimeline(currentPackage);
+    exportVisuals.renderToContext(targetCtx, 1920, 1080, 0);
+
+    const stream = target.captureStream(fps);
+    const audioCtx = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: 48000 });
+    if (audioCtx.state === 'suspended') await audioCtx.resume();
+    const rendered = await engine.renderToOfflineBuffer(currentPackage, 48000);
+    const source = audioCtx.createBufferSource();
+    source.buffer = rendered;
+    const gain = audioCtx.createGain();
+    gain.gain.value = 0.95;
+    const mediaDest = audioCtx.createMediaStreamDestination();
+    source.connect(gain);
+    gain.connect(mediaDest);
+    mediaDest.stream.getAudioTracks().forEach((track) => stream.addTrack(track));
+
+    const chunks = [];
+    const rec = new MediaRecorder(stream, { mimeType: videoSupport.preferredMime, videoBitsPerSecond: 12_000_000 });
+    rec.ondataavailable = (event) => { if (event.data && event.data.size > 0) chunks.push(event.data); };
+
+    await new Promise((resolve, reject) => {
+      const startAt = audioCtx.currentTime + 0.08;
+      let raf = null;
+      let ended = false;
+
+      const cleanup = () => {
+        if (raf) cancelAnimationFrame(raf);
+        source.onended = null;
+        try { source.stop(); } catch (e) {}
+        stream.getTracks().forEach((t) => t.stop());
+        audioCtx.close().catch(() => {});
+      };
+
+      const frameLoop = () => {
+        const t = Math.max(0, audioCtx.currentTime - startAt);
+        exportVisuals.renderToContext(targetCtx, 1920, 1080, Math.min(t, runtime));
+        if (t < runtime + 0.12 && !ended) raf = requestAnimationFrame(frameLoop);
+      };
+
+      rec.onstop = () => {
+        cleanup();
+        resolve();
+      };
+      rec.onerror = () => {
+        cleanup();
+        reject(new Error('Video recorder failed.'));
+      };
+
+      source.onended = () => {
+        ended = true;
+        window.setTimeout(() => { try { rec.stop(); } catch (e) {} }, 120);
+      };
+
+      rec.start(250);
+      source.start(startAt, 0, runtime);
+      frameLoop();
+    });
+
+    const blob = new Blob(chunks, { type: videoSupport.preferredMime });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `asmr-lab-film-1920x1080.${videoSupport.extension}`;
+    a.click();
+    URL.revokeObjectURL(url);
+
+    if (audioFeedback) {
+      audioFeedback.textContent = videoSupport.extension === 'mp4'
+        ? '1080p MP4 export complete.'
+        : '1080p WebM export complete (MP4 not supported in this browser).';
+    }
+  }
+
   if (form) {
     form.addEventListener('submit', async (event) => {
       event.preventDefault();
       lastPayload = Object.fromEntries(new FormData(form).entries());
       try { renderData(await requestGeneration(lastPayload)); }
       catch (err) { setError(err.message || 'Generation failed.'); setStatus(''); }
+    });
+  }
+
+  if (qaPresetBtn && form) {
+    qaPresetBtn.addEventListener('click', () => {
+      Object.entries(QA_PRESET).forEach(([key, value]) => {
+        const field = form.elements.namedItem(key);
+        if (field) field.value = value;
+      });
+      setStatus('QA preset loaded. Generate package to test known-good mood arc.');
+      setError('');
     });
   }
 
@@ -104,10 +301,7 @@
     previewBtn.addEventListener('click', async () => {
       if (!currentPackage) return;
       try {
-        const playback = await engine.preview(currentPackage);
-        const fullMode = !modeToggle || modeToggle.value === 'audiovisual';
-        if (visuals && fullMode) visuals.play(playback.startAt - engine.ctx.currentTime);
-        if (audioFeedback) audioFeedback.textContent = fullMode ? 'Synchronized preview playing.' : 'Sound-only preview playing.';
+        await startPreview();
       } catch (err) {
         if (audioFeedback) audioFeedback.textContent = 'Audio may be blocked until user interaction. Click preview again.';
       }
@@ -116,8 +310,9 @@
 
   if (stopBtn) {
     stopBtn.addEventListener('click', () => {
-      engine.stop();
+      transport.stopAll();
       if (visuals) visuals.stop();
+      engine.stop();
       if (audioFeedback) audioFeedback.textContent = 'Playback stopped.';
     });
   }
@@ -137,6 +332,18 @@
         if (audioFeedback) audioFeedback.textContent = 'WAV export complete.';
       } catch (err) {
         if (audioFeedback) audioFeedback.textContent = 'WAV export failed in this browser.';
+      }
+    });
+  }
+
+  if (exportVideoBtn) {
+    exportVideoBtn.addEventListener('click', async () => {
+      if (!currentPackage) return;
+      if (audioFeedback) audioFeedback.textContent = 'Rendering 1920x1080 video...';
+      try {
+        await exportVideo();
+      } catch (err) {
+        if (audioFeedback) audioFeedback.textContent = err.message || 'Video export failed in this browser.';
       }
     });
   }

--- a/js/asmr-visual-engine.js
+++ b/js/asmr-visual-engine.js
@@ -6,6 +6,10 @@
     'glitch_flash', 'waveform_ring', 'macro_texture_drift', 'signal_bars', 'text_reveal'
   ];
 
+  function clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
+  }
+
   class AsmrVisualEngine {
     constructor(canvas) {
       this.canvas = canvas;
@@ -16,7 +20,6 @@
       this.startPerf = 0;
       this.clockOffset = 0;
       this.currentTime = 0;
-      this.particles = [];
     }
 
     setCanvas(canvas) {
@@ -34,13 +37,44 @@
       if (this.ctx) this.ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
     }
 
-    loadTimeline(pkg) {
-      this.timeline = {
-        runtime: Math.max(1, Number(pkg.runtime_seconds || 12)),
-        visualEvents: Array.isArray(pkg.visual_events) ? pkg.visual_events.filter((e) => VISUAL_TYPES.includes(e.visual_type)) : [],
-        syncPoints: Array.isArray(pkg.sync_points) ? pkg.sync_points : [],
-        endCard: pkg.end_card || {}
+    createRenderTarget(width, height) {
+      const c = document.createElement('canvas');
+      c.width = width;
+      c.height = height;
+      const ctx = c.getContext('2d');
+      return { canvas: c, ctx };
+    }
+
+    normalizeVisualTimeline(pkg) {
+      const runtime = clamp(Number(pkg.runtime_seconds || 20), 10, 30);
+      const events = Array.isArray(pkg.visual_events) ? pkg.visual_events : [];
+      const visualEvents = events
+        .filter((e) => e && VISUAL_TYPES.includes(e.visual_type))
+        .map((e) => ({
+          time: clamp(Number(e.time || 0), 0, runtime + 0.5),
+          duration: clamp(Number(e.duration || 0.5), 0.04, 8),
+          visual_type: e.visual_type,
+          intensity: clamp(Number(e.intensity || 0.5), 0, 1),
+          params: (e.params && typeof e.params === 'object') ? e.params : {},
+          sync_role: String(e.sync_role || '')
+        }))
+        .sort((a, b) => a.time - b.time);
+
+      const syncPoints = Array.isArray(pkg.sync_points) ? pkg.sync_points
+        .map((p) => ({ time: clamp(Number(p.time || 0), 0, runtime + 0.5), cue: String(p.cue || ''), importance: String(p.importance || '') }))
+        .sort((a, b) => a.time - b.time) : [];
+
+      return {
+        runtime,
+        visualEvents,
+        syncPoints,
+        endCard: pkg.end_card || {},
+        title: String(pkg.title || 'ASMR LAB')
       };
+    }
+
+    loadTimeline(pkg) {
+      this.timeline = this.normalizeVisualTimeline(pkg || {});
     }
 
     play(clockOffset) {
@@ -72,7 +106,7 @@
       if (!this.ctx || !this.canvas) return;
       const w = this.canvas.clientWidth || 640;
       const h = this.canvas.clientHeight || 360;
-      this.ctx.fillStyle = '#050812';
+      this.ctx.fillStyle = '#03060f';
       this.ctx.fillRect(0, 0, w, h);
     }
 
@@ -80,7 +114,7 @@
       if (!this.running) return;
       this.currentTime = (performance.now() - this.startPerf) / 1000;
       this.render(this.currentTime);
-      if (this.currentTime >= this.timeline.runtime + 1.2) {
+      if (this.currentTime >= this.timeline.runtime + 1.25) {
         this.stop();
         return;
       }
@@ -90,65 +124,105 @@
     eventProgress(event, t) {
       const start = Number(event.time || 0);
       const duration = Math.max(0.01, Number(event.duration || 0.5));
-      const p = (t - start) / duration;
-      return Math.max(0, Math.min(1, p));
+      return (t - start) / duration;
+    }
+
+    renderToContext(ctx, width, height, t) {
+      if (!ctx || !this.timeline) return;
+      const runtime = this.timeline.runtime;
+      const normalized = clamp(t / Math.max(1, runtime), 0, 1.2);
+
+      this.drawBaseChamber(ctx, width, height, t, normalized);
+
+      this.timeline.visualEvents.forEach((event) => {
+        const progress = this.eventProgress(event, t);
+        if (progress <= -0.03 || progress >= 1.2) return;
+        const intensity = Math.max(0.05, Math.min(1, Number(event.intensity || 0.5)));
+        this.drawEvent(ctx, event, progress, intensity, width, height, normalized);
+      });
+
+      this.drawSyncMarkers(ctx, t, width, height);
+      this.drawScanlines(ctx, width, height, normalized);
+      this.drawGlow(ctx, width, height, normalized);
+
+      if (this.timeline.endCard && this.timeline.endCard.use_end_card && t > runtime - 1.6) {
+        const p = Math.max(0, Math.min(1, (t - (runtime - 1.6)) / 1.4));
+        this.drawEndCard(ctx, this.timeline.endCard, p, width, height);
+      }
+    }
+
+    drawBaseChamber(ctx, w, h, t, normalized) {
+      const horizon = h * 0.6;
+      const pulse = 0.5 + 0.5 * Math.sin(t * 1.9);
+
+      const bg = ctx.createLinearGradient(0, 0, 0, h);
+      bg.addColorStop(0, '#02050c');
+      bg.addColorStop(0.58, '#070d1e');
+      bg.addColorStop(1, '#050911');
+      ctx.fillStyle = bg;
+      ctx.fillRect(0, 0, w, h);
+
+      const radial = ctx.createRadialGradient(w * 0.52, h * 0.52, 20, w * 0.52, h * 0.54, Math.max(w, h) * 0.72);
+      radial.addColorStop(0, `rgba(74,112,255,${0.1 + pulse * 0.05})`);
+      radial.addColorStop(1, 'rgba(0,0,0,0)');
+      ctx.fillStyle = radial;
+      ctx.fillRect(0, 0, w, h);
+
+      ctx.strokeStyle = 'rgba(110,150,255,0.12)';
+      for (let i = 0; i < 14; i += 1) {
+        const p = i / 13;
+        const y = horizon + Math.pow(p, 1.8) * (h - horizon);
+        ctx.beginPath();
+        ctx.moveTo(0, y + Math.sin(t * 0.8 + i) * 0.35);
+        ctx.lineTo(w, y);
+        ctx.stroke();
+      }
+
+      ctx.fillStyle = `rgba(120,220,255,${0.06 + normalized * 0.1})`;
+      for (let i = 0; i < 46; i += 1) {
+        const x = (i * 53 + t * (8 + (i % 5))) % w;
+        const y = (i * 31 + Math.sin(t + i) * 10) % (h * 0.9);
+        ctx.fillRect(x, y, 1.6, 1.6);
+      }
     }
 
     render(t) {
       if (!this.ctx || !this.canvas || !this.timeline) return;
       const w = this.canvas.clientWidth || 640;
       const h = this.canvas.clientHeight || 360;
-      const ctx = this.ctx;
-
-      ctx.fillStyle = 'rgba(4,7,16,0.26)';
-      ctx.fillRect(0, 0, w, h);
-
-      this.timeline.visualEvents.forEach((event) => {
-        const progress = this.eventProgress(event, t);
-        if (progress <= 0 || progress >= 1.03) return;
-        const intensity = Math.max(0.05, Math.min(1, Number(event.intensity || 0.5)));
-        this.drawEvent(event, progress, intensity, w, h);
-      });
-
-      this.drawSyncMarkers(t, w, h);
-      this.drawScanlines(w, h);
-      this.drawGlow(w, h);
-
-      if (this.timeline.endCard && this.timeline.endCard.use_end_card && t > this.timeline.runtime - 1.5) {
-        const p = Math.max(0, Math.min(1, (t - (this.timeline.runtime - 1.5)) / 1.3));
-        this.drawEndCard(this.timeline.endCard, p, w, h);
-      }
+      this.renderToContext(this.ctx, w, h, t);
     }
 
-    drawEvent(event, progress, intensity, w, h) {
-      const ctx = this.ctx;
+    drawEvent(ctx, event, progress, intensity, w, h, normalized) {
       const params = event.params || {};
+      const p = clamp(progress, 0, 1);
       switch (event.visual_type) {
         case 'pixel_grid_pulse': {
-          const spacing = Number(params.spacing || 24);
-          ctx.strokeStyle = `rgba(105,170,255,${0.08 + intensity * 0.25 * (1 - progress)})`;
+          const spacing = Number(params.spacing || 22);
+          ctx.strokeStyle = `rgba(105,170,255,${0.06 + intensity * 0.24 * (1 - p)})`;
           for (let x = 0; x < w; x += spacing) {
-            for (let y = 0; y < h; y += spacing) ctx.strokeRect(x, y, 2, 2);
+            for (let y = 0; y < h; y += spacing) ctx.strokeRect(x, y, 1.5 + intensity, 1.5 + intensity);
           }
           break;
         }
         case 'wireframe_horizon': {
-          ctx.strokeStyle = `rgba(180,220,255,${0.25 * intensity})`;
+          ctx.strokeStyle = `rgba(180,220,255,${0.18 + intensity * 0.18})`;
           const horizon = h * 0.58;
-          for (let i = 0; i < 18; i += 1) {
-            const p = i / 18;
-            const y = horizon + Math.pow(p, 1.6) * (h - horizon);
+          for (let i = 0; i < 16; i += 1) {
+            const lp = i / 16;
+            const y = horizon + Math.pow(lp, 1.5) * (h - horizon);
             ctx.beginPath();
-            ctx.moveTo(0, y);
-            ctx.lineTo(w, y);
+            ctx.moveTo(w * 0.5, horizon);
+            ctx.lineTo((i / 15) * w, y);
             ctx.stroke();
           }
           break;
         }
         case 'radial_bloom': {
-          const r = (80 + progress * (Math.max(w, h) * 0.45));
+          const r = (60 + p * (Math.max(w, h) * 0.55));
           const grad = ctx.createRadialGradient(w / 2, h / 2, 0, w / 2, h / 2, r);
-          grad.addColorStop(0, `rgba(170,240,255,${0.2 * intensity})`);
+          grad.addColorStop(0, `rgba(190,244,255,${0.2 * intensity})`);
+          grad.addColorStop(0.6, `rgba(128,176,255,${0.12 * intensity * (1 - p * 0.5)})`);
           grad.addColorStop(1, 'rgba(0,0,0,0)');
           ctx.fillStyle = grad;
           ctx.beginPath();
@@ -157,30 +231,29 @@
           break;
         }
         case 'particle_trail': {
-          for (let i = 0; i < 2; i += 1) {
-            this.particles.push({ x: Math.random() * w, y: h * (0.2 + Math.random() * 0.6), vx: -1 + Math.random() * 2, life: 0.5 + Math.random() * 0.7 });
+          const count = Math.max(4, Math.floor(8 * intensity));
+          ctx.fillStyle = `rgba(158,212,255,${0.18 + 0.22 * intensity})`;
+          for (let i = 0; i < count; i += 1) {
+            const px = (w * (0.2 + (i / count) * 0.6) + Math.sin((normalized * 11) + i) * 24);
+            const py = (h * (0.25 + (i / count) * 0.52) + Math.cos((normalized * 9) + i) * 18);
+            ctx.fillRect(px, py, 2, 2);
           }
-          this.particles = this.particles.filter((p) => p.life > 0);
-          ctx.fillStyle = `rgba(158,212,255,${0.4 * intensity})`;
-          this.particles.forEach((p) => {
-            p.x += p.vx;
-            p.life -= 0.016;
-            ctx.fillRect(p.x, p.y, 2, 2);
-          });
           break;
         }
         case 'glitch_flash': {
-          ctx.fillStyle = `rgba(220,245,255,${0.16 * (1 - progress) * intensity})`;
-          ctx.fillRect(Math.random() * w * 0.2, Math.random() * h, w * (0.4 + Math.random() * 0.5), 3 + Math.random() * 12);
+          ctx.fillStyle = `rgba(220,245,255,${0.09 * (1 - p) * intensity})`;
+          for (let i = 0; i < 3; i += 1) {
+            ctx.fillRect((Math.sin(i + normalized * 13) * 0.45 + 0.5) * w * 0.6, (i * 0.22 + (normalized % 0.3)) * h, w * 0.45, 2 + (i * 3));
+          }
           break;
         }
         case 'waveform_ring': {
-          const radius = 40 + progress * 180;
-          ctx.strokeStyle = `rgba(122,234,255,${0.36 * intensity * (1 - progress)})`;
+          const radius = 30 + p * 220;
+          ctx.strokeStyle = `rgba(122,234,255,${0.2 + 0.25 * intensity * (1 - p)})`;
           ctx.lineWidth = 1 + intensity * 2;
           ctx.beginPath();
           for (let a = 0; a <= Math.PI * 2 + 0.1; a += 0.08) {
-            const wobble = Math.sin(a * 8 + progress * 18) * (6 + intensity * 10);
+            const wobble = Math.sin(a * 7 + p * 14) * (5 + intensity * 11);
             const rr = radius + wobble;
             const x = w / 2 + Math.cos(a) * rr;
             const y = h / 2 + Math.sin(a) * rr;
@@ -190,28 +263,37 @@
           break;
         }
         case 'macro_texture_drift': {
-          ctx.fillStyle = `rgba(90,120,180,${0.08 * intensity})`;
-          for (let i = 0; i < 40; i += 1) ctx.fillRect((i * 37 + progress * 80) % w, (i * 53) % h, 18, 1);
-          break;
-        }
-        case 'signal_bars': {
-          const bars = 8;
-          for (let i = 0; i < bars; i += 1) {
-            const bh = (0.1 + Math.abs(Math.sin(progress * 10 + i)) * 0.8) * h * 0.22;
-            ctx.fillStyle = `rgba(120,255,205,${0.2 + intensity * 0.3})`;
-            ctx.fillRect(24 + i * 22, h - 18 - bh, 14, bh);
+          ctx.fillStyle = `rgba(90,120,180,${0.05 + 0.08 * intensity})`;
+          for (let i = 0; i < 52; i += 1) {
+            const x = (i * 37 + normalized * 210 + Math.sin(i + normalized * 9) * 8) % w;
+            const y = (i * 21 + normalized * 90) % h;
+            ctx.fillRect(x, y, 22, 1);
           }
           break;
         }
-        case 'scanline_field':
+        case 'signal_bars': {
+          const bars = 9;
+          for (let i = 0; i < bars; i += 1) {
+            const bh = (0.08 + Math.abs(Math.sin((p + normalized) * 8 + i)) * 0.85) * h * 0.22;
+            ctx.fillStyle = `rgba(120,255,205,${0.16 + intensity * 0.26})`;
+            ctx.fillRect(24 + i * 20, h - 16 - bh, 12, bh);
+          }
           break;
+        }
+        case 'scanline_field': {
+          ctx.fillStyle = `rgba(105,160,255,${0.03 + intensity * 0.06})`;
+          for (let y = 0; y < h; y += 4) ctx.fillRect(0, y + Math.sin(y * 0.02 + normalized * 18) * 0.35, w, 1);
+          break;
+        }
         case 'text_reveal': {
           const txt = String(params.text || 'SYSTEM READY');
           ctx.save();
-          ctx.globalAlpha = Math.max(0, Math.min(1, progress * 1.5)) * intensity;
+          ctx.globalAlpha = Math.max(0, Math.min(1, p * 1.6)) * intensity;
           ctx.fillStyle = '#d8f4ff';
-          ctx.font = 'bold 28px monospace';
-          ctx.fillText(txt, Math.max(18, w * 0.1), h * 0.52);
+          ctx.shadowColor = 'rgba(160,240,255,0.9)';
+          ctx.shadowBlur = 12;
+          ctx.font = 'bold 30px monospace';
+          ctx.fillText(txt, Math.max(18, w * 0.09), h * 0.5);
           ctx.restore();
           break;
         }
@@ -220,40 +302,40 @@
       }
     }
 
-    drawSyncMarkers(t, w, h) {
-      const ctx = this.ctx;
-      this.timeline.syncPoints.forEach((p) => {
-        const dt = Math.abs(t - Number(p.time || 0));
-        if (dt > 0.16) return;
-        ctx.fillStyle = `rgba(255,220,160,${(0.16 - dt) * 3})`;
-        ctx.fillRect(0, h - 6, w, 2);
+    drawSyncMarkers(ctx, t, w, h) {
+      this.timeline.syncPoints.forEach((point) => {
+        const dt = Math.abs(t - Number(point.time || 0));
+        if (dt > 0.14) return;
+        const alpha = (0.14 - dt) * 4.2;
+        ctx.fillStyle = `rgba(255,220,160,${alpha})`;
+        ctx.fillRect(0, h - 8, w, 2);
       });
     }
 
-    drawScanlines(w, h) {
-      const ctx = this.ctx;
-      ctx.fillStyle = 'rgba(120,160,255,0.045)';
-      for (let y = 0; y < h; y += 3) ctx.fillRect(0, y, w, 1);
+    drawScanlines(ctx, w, h, normalized) {
+      ctx.fillStyle = 'rgba(132,172,255,0.042)';
+      for (let y = 0; y < h; y += 3) ctx.fillRect(0, y + Math.sin(normalized * 30 + y * 0.02) * 0.2, w, 1);
     }
 
-    drawGlow(w, h) {
-      const ctx = this.ctx;
-      const g = ctx.createRadialGradient(w / 2, h / 2, 30, w / 2, h / 2, Math.max(w, h) * 0.85);
-      g.addColorStop(0, 'rgba(80,120,255,0.08)');
-      g.addColorStop(1, 'rgba(0,0,0,0.35)');
+    drawGlow(ctx, w, h, normalized) {
+      const g = ctx.createRadialGradient(w / 2, h / 2, 24, w / 2, h / 2, Math.max(w, h) * 0.88);
+      g.addColorStop(0, `rgba(80,120,255,${0.07 + normalized * 0.07})`);
+      g.addColorStop(1, 'rgba(0,0,0,0.44)');
       ctx.fillStyle = g;
       ctx.fillRect(0, 0, w, h);
     }
 
-    drawEndCard(endCard, progress, w, h) {
-      const ctx = this.ctx;
+    drawEndCard(ctx, endCard, progress, w, h) {
       ctx.fillStyle = `rgba(1,5,15,${0.5 * progress})`;
       ctx.fillRect(0, 0, w, h);
       ctx.globalAlpha = progress;
       ctx.fillStyle = '#dcf7ff';
-      ctx.font = 'bold 30px monospace';
-      ctx.fillText(String(endCard.text || 'END SIGNAL'), w * 0.12, h * 0.52);
+      ctx.shadowColor = 'rgba(120,236,255,0.85)';
+      ctx.shadowBlur = 14;
+      ctx.font = 'bold 34px monospace';
+      ctx.fillText(String(endCard.text || 'END SIGNAL'), w * 0.1, h * 0.52);
       ctx.globalAlpha = 1;
+      ctx.shadowBlur = 0;
     }
   }
 

--- a/page-asmr-lab.php
+++ b/page-asmr-lab.php
@@ -19,7 +19,7 @@ get_header();
         <li><strong>Strict timeline JSON</strong> with synchronized audio + visual events.</li>
         <li><strong>Procedural sound synthesis</strong> using browser-generated textures.</li>
         <li><strong>Reactive CRT-inspired visuals</strong> driven by the same shared clock.</li>
-        <li><strong>Preview, stop, and WAV export</strong> without leaving the control room.</li>
+        <li><strong>Preview, stop, WAV export, and 1080p video export</strong> without leaving the control room.</li>
       </ul>
     </section>
 
@@ -36,6 +36,7 @@ get_header();
       </div>
       <div class="asmr-actions">
         <button type="submit" class="pixel-button">Generate ASMR Package</button>
+        <button type="button" id="asmr-qa-preset" class="pixel-button secondary">Load QA Preset</button>
         <button type="button" id="asmr-sound-only" class="pixel-button secondary" disabled>Regenerate Sound Only</button>
       </div>
       <p id="asmr-status" class="asmr-status" role="status" aria-live="polite"></p>
@@ -52,6 +53,8 @@ get_header();
       <button type="button" id="asmr-preview" class="pixel-button" disabled>Preview</button>
       <button type="button" id="asmr-stop" class="pixel-button secondary" disabled>Stop</button>
       <button type="button" id="asmr-export" class="pixel-button secondary" disabled>Export WAV</button>
+      <button type="button" id="asmr-export-video" class="pixel-button secondary" disabled>Export Video 1080p</button>
+      <span id="asmr-video-support" class="asmr-video-support" aria-live="polite"></span>
       <p id="asmr-audio-feedback" class="asmr-audio-feedback" aria-live="polite"></p>
     </section>
 


### PR DESCRIPTION
### Motivation
- Improve opening-state composition and avoid harsh unsmoothed transients by coordinating the generation prompt, playback transport, and procedural engines. 
- Make generated packages more performable and production-ready (smoother first second, clearer tension→bloom→reveal arc, deterministic timelines). 
- Add a reliable 1920x1080 export path with honest MP4 support detection and a QA preset for quick validation.

### Description
- Strengthened the internal ASMR generation `system_prompt` to require a meaningful first-frame, soft opening ambience, early audio/visual synchronization (~0.12s), sorted/practical event timings, layered atmosphere, and a clear tension→bloom→reveal arc while preserving the strict JSON schema (modified in `functions.php`).
- Added defensive server-side timeline normalization and deterministic ordering for `audio_events`, `visual_events`, and `sync_points` during validation to ensure browser-friendly playback timing (`functions.php`).
- Implemented an explicit transport/preview flow so visuals render a meaningful first frame, then audio starts with a short preroll and both engines run from a shared timing plan; Stop now fully halts audio, visuals, timers, and resets transport state (`js/asmr-lab.js`, `js/asmr-foley-engine.js`, `js/asmr-visual-engine.js`).
- Reworked the procedural audio engine for smoother envelopes, safer gain staging, a persistent ambient bed, stereo panning, limiter + compressor + reverb master chain, normalized event timing, and OfflineAudioContext export support (changes in `js/asmr-foley-engine.js`).
- Rebuilt the visual baseline rendering so t=0 is non-empty and atmospheric, with layered chamber composition, improved glow/scanlines/scanline motion, stronger depth/parallax cues, and audio-reactive sync markers (`js/asmr-visual-engine.js`).
- Added synchronized 1920x1080 video export using deterministic offline audio rendering + canvas capture + `MediaRecorder`, with runtime capability detection that only uses MP4 when `MediaRecorder.isTypeSupported` confirms it and otherwise falls back to WebM and shows clear UI messaging (`js/asmr-lab.js`, page template `page-asmr-lab.php`).
- Added a built-in QA preset button for the requested “Glass relay prayer waking a dormant monolith” scenario and small UI/stylesheet updates for video support and export feedback (`page-asmr-lab.php`, `assets/css/asmr-lab.css`, `js/asmr-lab.js`).

### Testing
- Ran PHP syntax checks: `php -l functions.php` and `php -l page-asmr-lab.php`, both succeeded. 
- Validated JS syntax with Node: `node --check js/asmr-lab.js`, `node --check js/asmr-foley-engine.js`, and `node --check js/asmr-visual-engine.js`, all succeeded. 
- Attempted a headless browser screenshot via Playwright to validate the page, but the local web server at `http://127.0.0.1:8080` returned `ERR_EMPTY_RESPONSE` in this environment, so runtime visual QA could not be captured here. 
- Manual QA steps added in the acceptance notes (Preview sync, Stop/replay, QA preset, Export WAV, Export Video 1080p, MP4 vs WebM fallback) and explicit instructions are included in the commit message for local validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afb70edbb8832e8af99e6f7c0023a7)