### PR TITLE
Boost ASMR Lab pacing, density, and expressive AV vocabulary

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -870,7 +870,128 @@ function se_get_asmr_allowed_engines() {
         'bit_pulse',
         'low_hum',
         'digital_shimmer',
+        'glass_ping',
+        'glass_resonance',
+        'relay_click_cluster',
+        'shimmer_swirl',
+        'crystal_chime',
+        'ghost_pad',
+        'spectral_suck',
+        'voltage_flutter',
+        'halo_tone',
+        'particle_spark',
+        'ritual_bass_swell',
+        'reverse_bloom',
     );
+}
+
+function se_enrich_asmr_event_density( $decoded ) {
+    $runtime = max( 10, min( 30, floatval( $decoded['runtime_seconds'] ?? 20 ) ) );
+
+    $visual_events = is_array( $decoded['visual_events'] ?? null ) ? $decoded['visual_events'] : array();
+    $audio_events  = is_array( $decoded['audio_events'] ?? null ) ? $decoded['audio_events'] : array();
+
+    if ( empty( $visual_events ) || ( $visual_events[0]['time'] ?? 99 ) > 0.12 ) {
+        $visual_events[] = array(
+            'time' => 0,
+            'duration' => min( 6.5, $runtime * 0.42 ),
+            'visual_type' => 'volumetric_fog',
+            'intensity' => 0.45,
+            'params' => array( 'drift' => 0.35 ),
+            'sync_role' => 'opening_atmosphere',
+        );
+    }
+
+    $needs_early = true;
+    foreach ( $visual_events as $event ) {
+        if ( ( $event['time'] ?? 99 ) <= 0.8 && ( $event['intensity'] ?? 0 ) >= 0.32 ) {
+            $needs_early = false;
+            break;
+        }
+    }
+    if ( $needs_early ) {
+        $visual_events[] = array(
+            'time' => 0.46,
+            'duration' => 1.35,
+            'visual_type' => 'pulse_orb',
+            'intensity' => 0.56,
+            'params' => array(),
+            'sync_role' => 'early_reveal',
+        );
+    }
+
+    $min_visual_count = max( 8, (int) ceil( $runtime * 0.7 ) );
+    $seed_types = array( 'chromatic_veil', 'starfield_drift', 'refraction_ripple', 'halo_glyphs' );
+    while ( count( $visual_events ) < $min_visual_count ) {
+        $idx = count( $visual_events );
+        $visual_events[] = array(
+            'time' => min( $runtime - 0.15, 0.2 + ( $idx * ( $runtime / ( $min_visual_count + 1 ) ) ) ),
+            'duration' => 0.9 + ( ( $idx % 3 ) * 0.45 ),
+            'visual_type' => $seed_types[ $idx % count( $seed_types ) ],
+            'intensity' => 0.22 + ( ( $idx % 4 ) * 0.08 ),
+            'params' => array(),
+            'sync_role' => 'support_layer',
+        );
+    }
+
+    usort( $visual_events, static function( $a, $b ) {
+        return ( $a['time'] <=> $b['time'] );
+    } );
+
+    $max_gap = max( 2.6, $runtime * 0.2 );
+    $patched_visuals = array();
+    $prev_time = 0;
+    foreach ( $visual_events as $event ) {
+        $time = floatval( $event['time'] ?? 0 );
+        if ( $time - $prev_time > $max_gap ) {
+            $patched_visuals[] = array(
+                'time' => $prev_time + ( $max_gap * 0.48 ),
+                'duration' => min( 2.8, max( 1.1, $max_gap * 0.6 ) ),
+                'visual_type' => 'volumetric_fog',
+                'intensity' => 0.24,
+                'params' => array(),
+                'sync_role' => 'bridge_motion',
+            );
+        }
+        $patched_visuals[] = $event;
+        $prev_time = $time;
+    }
+    $visual_events = $patched_visuals;
+
+    if ( empty( $audio_events ) || ( $audio_events[0]['time'] ?? 99 ) > 0.24 ) {
+        $audio_events[] = array(
+            'time' => 0,
+            'duration' => min( 4.5, $runtime * 0.3 ),
+            'engine' => 'ghost_pad',
+            'intensity' => 0.24,
+            'params' => array( 'from' => 140, 'to' => 188 ),
+            'sync_role' => 'ambient_lead_in',
+        );
+    }
+
+    $min_audio_count = max( 7, (int) ceil( $runtime * 0.42 ) );
+    while ( count( $audio_events ) < $min_audio_count ) {
+        $idx = count( $audio_events );
+        $audio_events[] = array(
+            'time' => min( $runtime - 0.12, 0.3 + ( $idx * ( $runtime / ( $min_audio_count + 2 ) ) ) ),
+            'duration' => 0.3 + ( ( $idx % 4 ) * 0.18 ),
+            'engine' => ( 0 === $idx % 2 ) ? 'shimmer_swirl' : 'particle_spark',
+            'intensity' => 0.18 + ( ( $idx % 5 ) * 0.06 ),
+            'params' => array(),
+            'sync_role' => 'support_texture',
+        );
+    }
+
+    usort( $visual_events, static function( $a, $b ) {
+        return ( $a['time'] <=> $b['time'] );
+    } );
+    usort( $audio_events, static function( $a, $b ) {
+        return ( $a['time'] <=> $b['time'] );
+    } );
+
+    $decoded['visual_events'] = $visual_events;
+    $decoded['audio_events']  = $audio_events;
+    return $decoded;
 }
 
 function se_extract_json_object( $raw ) {
@@ -950,6 +1071,9 @@ function se_validate_asmr_response( $decoded ) {
     $visual_allowed = array(
         'scanline_field', 'pixel_grid_pulse', 'wireframe_horizon', 'radial_bloom', 'particle_trail',
         'glitch_flash', 'waveform_ring', 'macro_texture_drift', 'signal_bars', 'text_reveal',
+        'volumetric_fog', 'glass_refraction', 'halo_glyphs', 'cathedral_beam', 'monolith_silhouette',
+        'starfield_drift', 'orbiting_shards', 'pulse_orb', 'energy_column', 'refraction_ripple',
+        'chromatic_veil', 'terminal_runes',
     );
     $visual_events = is_array( $decoded['visual_events'] ?? null ) ? $decoded['visual_events'] : array();
     $decoded['visual_events'] = array_values( array_filter( array_map( static function( $event ) use ( $visual_allowed ) {
@@ -1004,7 +1128,7 @@ function se_validate_asmr_response( $decoded ) {
 
     $decoded['presentation_note'] = sanitize_text_field( $decoded['presentation_note'] ?? '' );
 
-    return $decoded;
+    return se_enrich_asmr_event_density( $decoded );
 }
 
 function se_handle_asmr_generate( WP_REST_Request $req ) {
@@ -1040,14 +1164,17 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
         . 'end_card must include: use_end_card, text, reveal_style. '
         . 'edit_rhythm must include: pacing_note, silence_strategy, release_strategy. '
         . 'Only use these engine names: ' . $allowed_engines . '. '
-        . 'Allowed visual_type values: scanline_field, pixel_grid_pulse, wireframe_horizon, radial_bloom, particle_trail, glitch_flash, waveform_ring, macro_texture_drift, signal_bars, text_reveal. '
-        . 'Critical staging rules: first frame must already contain meaningful visual composition (not blank canvas); include baseline atmospheric visual motion at time 0. '
+        . 'Allowed visual_type values: scanline_field, pixel_grid_pulse, wireframe_horizon, radial_bloom, particle_trail, glitch_flash, waveform_ring, macro_texture_drift, signal_bars, text_reveal, volumetric_fog, glass_refraction, halo_glyphs, cathedral_beam, monolith_silhouette, starfield_drift, orbiting_shards, pulse_orb, energy_column, refraction_ripple, chromatic_veil, terminal_runes. '
+        . 'Critical visual pacing rules: first frame must show a layered chamber state (background + atmosphere + focal hint). Include meaningful opening visual event in 0.0-0.8s and at least one clear focal event in 0.8-2.0s. '
+        . 'Do not back-load all action: craft a textured midsection with evolving layers, at least one pre-climax escalation in the middle third, and at least one bloom/reveal in the final third. '
+        . 'Visual event score should be dense but intentional, with practical browser-safe durations and avoid micro-spam faster than 0.05s. '
+        . 'Audio direction: prioritize eerie depth, layered atmospheres, tactile details, ritual/spiritual/cyber-sacred motion, softened onset, and a stronger buildup into bloom instead of blunt starts. '
         . 'Open with soft but present ambience in first 0.0-0.4s; avoid harsh transient attacks at start unless explicitly justified by the concept. '
-        . 'Ensure first audible event and first prominent visual motion are synchronized or intentionally near-synchronized within ~0.12s. '
+        . 'Ensure first audible event and first prominent visual motion are synchronized or intentionally near-synchronized within ~0.12s; provide strong audiovisual coupling in first 5 seconds. '
         . 'Event times must be practical for direct browser playback: finite, non-negative, sorted, and concentrated inside runtime_seconds. '
         . 'Shape a clear tension to bloom to reveal arc, with layered atmosphere and ceremonial build when concept or mood suggests ritual awakening. '
         . 'Use micro-events for intimacy, then earned bloom moments instead of random loudness spikes. '
-        . 'Visual score should emphasize depth, layering, glow, parallax-like drift, and terminal/sacred reveal language when appropriate. '
+        . 'Visual score should emphasize atmospheric symbolic language, depth, compositional foreground/midground/background layering, glow, parallax-like drift, and terminal/sacred reveal language when appropriate. '
         . 'sync_points must map to real event moments and reinforce audio-visual unity, especially in the first 3 seconds. '
         . 'The result should feel like an authored short sensory micro-film, not a debug demo. '
         . 'Do not include prose outside JSON.';

--- a/js/asmr-foley-engine.js
+++ b/js/asmr-foley-engine.js
@@ -4,7 +4,9 @@
   const ENGINE_NAMES = [
     'glissando_rise', 'synth_bloom', 'sub_swell', 'filtered_noise_wash', 'ceramic_tick',
     'paper_crackle', 'steam_hiss', 'tape_stop_drop', 'bit_pulse', 'breath_pulse',
-    'low_hum', 'digital_shimmer'
+    'low_hum', 'digital_shimmer', 'glass_ping', 'glass_resonance', 'relay_click_cluster',
+    'shimmer_swirl', 'crystal_chime', 'ghost_pad', 'spectral_suck', 'voltage_flutter',
+    'halo_tone', 'particle_spark', 'ritual_bass_swell', 'reverse_bloom'
   ];
 
   function clamp(value, min, max) {
@@ -53,7 +55,7 @@
       if (!pkg || !Array.isArray(pkg.audio_events)) return [];
       const runtime = clamp(Number(pkg.runtime_seconds || 20), 10, 30);
       const maxEdge = runtime + 0.5;
-      return pkg.audio_events
+      const normalized = pkg.audio_events
         .filter((event) => event && ENGINE_NAMES.includes(event.engine))
         .map((event) => {
           const time = clamp(Number(event.time || 0), 0, maxEdge);
@@ -70,6 +72,32 @@
         })
         .sort((a, b) => a.time - b.time)
         .filter((event) => event.time <= maxEdge);
+
+      if (!normalized.length || normalized[0].time > 0.22) {
+        normalized.unshift({
+          time: 0,
+          duration: Math.min(4, runtime * 0.3),
+          intensity: 0.22,
+          engine: 'ghost_pad',
+          params: { from: 122, to: 178 },
+          sync_role: 'ambient_lead_in'
+        });
+      }
+
+      const minEvents = Math.max(7, Math.ceil(runtime * 0.42));
+      while (normalized.length < minEvents) {
+        const idx = normalized.length;
+        normalized.push({
+          time: clamp(0.24 + idx * (runtime / (minEvents + 1)), 0, runtime - 0.08),
+          duration: 0.24 + (idx % 3) * 0.16,
+          intensity: 0.16 + (idx % 5) * 0.06,
+          engine: idx % 2 === 0 ? 'particle_spark' : 'shimmer_swirl',
+          params: {},
+          sync_role: 'support_texture'
+        });
+      }
+
+      return normalized.sort((a, b) => a.time - b.time);
     }
 
     buildMasterChain(ctx, destination) {
@@ -252,6 +280,58 @@
           break;
         case 'digital_shimmer':
           this.scheduleTone(ctx, destination, atTime, duration * 0.8, { from: p.from || 1000, to: p.to || 2280, peak: 0.02 + intensity * 0.05, type: 'triangle', pan: 0.3 });
+          break;
+        case 'glass_ping':
+          this.scheduleTone(ctx, destination, atTime, Math.max(0.1, duration * 0.35), { from: p.pitch || 1420, to: (p.pitch || 1420) * 0.66, peak: 0.02 + intensity * 0.045, type: 'triangle', pan: -0.24 });
+          break;
+        case 'glass_resonance':
+          this.scheduleTone(ctx, destination, atTime, duration, { from: p.from || 620, to: p.to || 470, peak: 0.028 + intensity * 0.05, type: 'sine', pan: 0.22 });
+          this.scheduleTone(ctx, destination, atTime + 0.01, duration * 0.92, { from: (p.from || 620) * 1.51, to: (p.to || 470) * 1.41, peak: 0.01 + intensity * 0.03, type: 'triangle', pan: -0.2 });
+          break;
+        case 'relay_click_cluster': {
+          const clicks = Math.max(2, Math.min(8, Math.round(2 + intensity * 6)));
+          for (let i = 0; i < clicks; i += 1) {
+            this.scheduleTone(ctx, destination, atTime + i * 0.035, 0.08, { from: 950 + i * 40, to: 320, peak: 0.012 + intensity * 0.02, type: 'square', pan: (i % 2 ? 0.22 : -0.22) });
+          }
+          break;
+        }
+        case 'shimmer_swirl':
+          this.scheduleNoise(ctx, destination, atTime, duration, { freq: p.freq || 3100, q: 0.7, peak: 0.018 + intensity * 0.04, filterType: 'bandpass', pan: 0.28 });
+          this.scheduleTone(ctx, destination, atTime + 0.02, duration * 0.85, { from: p.from || 920, to: p.to || 1520, peak: 0.01 + intensity * 0.026, type: 'triangle', pan: -0.26 });
+          break;
+        case 'crystal_chime':
+          this.scheduleTone(ctx, destination, atTime, Math.max(0.14, duration * 0.46), { from: p.from || 1180, to: p.to || 790, peak: 0.014 + intensity * 0.03, type: 'sine', pan: 0.34 });
+          this.scheduleTone(ctx, destination, atTime + 0.04, Math.max(0.16, duration * 0.52), { from: (p.from || 1180) * 1.34, to: (p.to || 790) * 1.25, peak: 0.009 + intensity * 0.024, type: 'triangle', pan: -0.3 });
+          break;
+        case 'ghost_pad':
+          this.scheduleTone(ctx, destination, atTime, duration, { from: p.from || 140, to: p.to || 210, peak: 0.03 + intensity * 0.05, type: 'sine', pan: 0 });
+          this.scheduleNoise(ctx, destination, atTime, duration, { freq: 1200, q: 0.6, peak: 0.007 + intensity * 0.02, filterType: 'lowpass', pan: -0.12 });
+          break;
+        case 'spectral_suck':
+          this.scheduleNoise(ctx, destination, atTime, duration, { freq: p.freq || 1600, q: 0.85, peak: 0.02 + intensity * 0.04, filterType: 'bandpass', pan: -0.18 });
+          this.scheduleTone(ctx, destination, atTime, duration * 0.8, { from: p.from || 380, to: p.to || 96, peak: 0.01 + intensity * 0.03, type: 'sawtooth', pan: 0.14 });
+          break;
+        case 'voltage_flutter': {
+          const bursts = Math.max(3, Math.min(10, Math.round(3 + intensity * 7)));
+          for (let i = 0; i < bursts; i += 1) {
+            this.scheduleTone(ctx, destination, atTime + i * (duration / (bursts + 1)), 0.07, { from: 280 + i * 36, to: 240 + i * 10, peak: 0.008 + intensity * 0.018, type: 'square', pan: Math.sin(i) * 0.35 });
+          }
+          break;
+        }
+        case 'halo_tone':
+          this.scheduleTone(ctx, destination, atTime, duration, { from: p.from || 320, to: p.to || 420, peak: 0.025 + intensity * 0.045, type: 'triangle', pan: -0.08 });
+          this.scheduleTone(ctx, destination, atTime, duration * 0.95, { from: (p.from || 320) * 2.01, to: (p.to || 420) * 1.98, peak: 0.008 + intensity * 0.02, type: 'sine', pan: 0.08 });
+          break;
+        case 'particle_spark':
+          this.scheduleNoise(ctx, destination, atTime, Math.max(0.08, duration * 0.45), { freq: p.freq || 4600, q: 1.8, peak: 0.008 + intensity * 0.02, filterType: 'highpass', pan: 0.12 });
+          break;
+        case 'ritual_bass_swell':
+          this.scheduleTone(ctx, destination, atTime, duration, { from: p.from || 48, to: p.to || 72, peak: 0.045 + intensity * 0.065, type: 'sine', pan: 0 });
+          this.scheduleTone(ctx, destination, atTime + 0.03, duration * 0.8, { from: p.from2 || 96, to: p.to2 || 110, peak: 0.018 + intensity * 0.035, type: 'triangle', pan: -0.06 });
+          break;
+        case 'reverse_bloom':
+          this.scheduleNoise(ctx, destination, atTime, duration * 0.75, { freq: p.freq || 2100, q: 0.8, peak: 0.02 + intensity * 0.04, filterType: 'lowpass', pan: 0.18 });
+          this.scheduleTone(ctx, destination, atTime + duration * 0.4, duration * 0.6, { from: p.from || 220, to: p.to || 860, peak: 0.016 + intensity * 0.03, type: 'triangle', pan: -0.14 });
           break;
         default:
           break;

--- a/js/asmr-lab.js
+++ b/js/asmr-lab.js
@@ -25,14 +25,14 @@
   let currentPackage = null;
 
   const QA_PRESET = {
-    concept: 'Glass relay prayer waking a dormant monolith',
+    concept: 'Signal Benediction: a glass relay core awakens a dormant monolith like a machine receiving a blessing',
     object: 'glass relay core',
-    setting: 'midnight signal chamber',
-    mood: 'spiritual tension, crystalline awe, then radiant bloom',
+    setting: 'midnight signal chamber beneath a neon cathedral grid',
+    mood: 'cyber-sacred tension, crystalline awe, then radiant bloom',
     duration: '20',
     voice_style: 'composed machine whisper',
-    weirdness: '7',
-    creative_goal: 'Build from tiny tactile pulses into a sacred electronic bloom with a terminal-style final reveal.'
+    weirdness: '8',
+    creative_goal: 'Build from near-silence and tactile relay pulses into a spiritual electronic bloom, with synchronized glass shimmer, ceremonial signal motion, and a terminal-style final reveal that feels earned.'
   };
 
   const transport = {

--- a/js/asmr-visual-engine.js
+++ b/js/asmr-visual-engine.js
@@ -3,7 +3,10 @@
 
   const VISUAL_TYPES = [
     'scanline_field', 'pixel_grid_pulse', 'wireframe_horizon', 'radial_bloom', 'particle_trail',
-    'glitch_flash', 'waveform_ring', 'macro_texture_drift', 'signal_bars', 'text_reveal'
+    'glitch_flash', 'waveform_ring', 'macro_texture_drift', 'signal_bars', 'text_reveal',
+    'volumetric_fog', 'glass_refraction', 'halo_glyphs', 'cathedral_beam', 'monolith_silhouette',
+    'starfield_drift', 'orbiting_shards', 'pulse_orb', 'energy_column', 'refraction_ripple',
+    'chromatic_veil', 'terminal_runes'
   ];
 
   function clamp(value, min, max) {
@@ -45,10 +48,69 @@
       return { canvas: c, ctx };
     }
 
+
+
+    enrichVisualEvents(events, runtime, syncPoints) {
+      const out = Array.isArray(events) ? events.slice() : [];
+      if (!out.length || Number(out[0].time || 99) > 0.12) {
+        out.unshift({ time: 0, duration: Math.min(6, runtime * 0.42), visual_type: 'volumetric_fog', intensity: 0.46, params: {}, sync_role: 'opening_atmosphere' });
+      }
+
+      const hasEarly = out.some((e) => Number(e.time || 99) <= 0.8 && Number(e.intensity || 0) >= 0.3);
+      if (!hasEarly) out.push({ time: 0.52, duration: 1.3, visual_type: 'pulse_orb', intensity: 0.58, params: {}, sync_role: 'early_focal' });
+
+      const hasMiddleEsc = out.some((e) => e.time >= runtime * 0.3 && e.time <= runtime * 0.66 && e.intensity >= 0.58);
+      if (!hasMiddleEsc) out.push({ time: runtime * 0.52, duration: 1.4, visual_type: 'energy_column', intensity: 0.64, params: {}, sync_role: 'mid_escalation' });
+
+      const hasFinalBloom = out.some((e) => e.time >= runtime * 0.66 && ['radial_bloom','glass_refraction','chromatic_veil','terminal_runes'].includes(e.visual_type));
+      if (!hasFinalBloom) out.push({ time: runtime * 0.82, duration: 1.5, visual_type: 'glass_refraction', intensity: 0.72, params: {}, sync_role: 'final_bloom' });
+
+      const minEvents = Math.max(9, Math.ceil(runtime * 0.72));
+      const support = ['chromatic_veil', 'starfield_drift', 'refraction_ripple', 'halo_glyphs', 'orbiting_shards'];
+      while (out.length < minEvents) {
+        const i = out.length;
+        out.push({
+          time: clamp(0.2 + i * (runtime / (minEvents + 1)), 0, runtime - 0.1),
+          duration: 0.9 + (i % 4) * 0.34,
+          visual_type: support[i % support.length],
+          intensity: 0.24 + (i % 5) * 0.07,
+          params: {},
+          sync_role: 'support_layer'
+        });
+      }
+
+      syncPoints.forEach((point, i) => {
+        const t = Number(point.time || 0);
+        if (t <= 0.04 || t >= runtime) return;
+        out.push({
+          time: t,
+          duration: 0.45 + (i % 2) * 0.18,
+          visual_type: (i % 2 === 0) ? 'refraction_ripple' : 'pulse_orb',
+          intensity: 0.35 + (i % 3) * 0.12,
+          params: {},
+          sync_role: 'sync_accent'
+        });
+      });
+
+      out.sort((a, b) => a.time - b.time);
+      const maxGap = Math.max(2.4, runtime * 0.2);
+      const withBridges = [];
+      let prev = 0;
+      out.forEach((e) => {
+        if (e.time - prev > maxGap) {
+          withBridges.push({ time: prev + maxGap * 0.5, duration: 1.4, visual_type: 'volumetric_fog', intensity: 0.22, params: {}, sync_role: 'bridge_motion' });
+        }
+        withBridges.push(e);
+        prev = e.time;
+      });
+
+      return withBridges.sort((a, b) => a.time - b.time);
+    }
+
     normalizeVisualTimeline(pkg) {
       const runtime = clamp(Number(pkg.runtime_seconds || 20), 10, 30);
       const events = Array.isArray(pkg.visual_events) ? pkg.visual_events : [];
-      const visualEvents = events
+      let visualEvents = events
         .filter((e) => e && VISUAL_TYPES.includes(e.visual_type))
         .map((e) => ({
           time: clamp(Number(e.time || 0), 0, runtime + 0.5),
@@ -63,6 +125,8 @@
       const syncPoints = Array.isArray(pkg.sync_points) ? pkg.sync_points
         .map((p) => ({ time: clamp(Number(p.time || 0), 0, runtime + 0.5), cue: String(p.cue || ''), importance: String(p.importance || '') }))
         .sort((a, b) => a.time - b.time) : [];
+
+      visualEvents = this.enrichVisualEvents(visualEvents, runtime, syncPoints);
 
       return {
         runtime,
@@ -184,6 +248,14 @@
         const y = (i * 31 + Math.sin(t + i) * 10) % (h * 0.9);
         ctx.fillRect(x, y, 1.6, 1.6);
       }
+
+      const coreX = w * (0.5 + Math.sin(t * 0.13) * 0.02);
+      const coreY = h * (0.5 + Math.cos(t * 0.11) * 0.02);
+      const core = ctx.createRadialGradient(coreX, coreY, 2, coreX, coreY, h * 0.28);
+      core.addColorStop(0, `rgba(176,228,255,${0.24 + pulse * 0.18})`);
+      core.addColorStop(1, 'rgba(0,0,0,0)');
+      ctx.fillStyle = core;
+      ctx.fillRect(0, 0, w, h);
     }
 
     render(t) {
@@ -295,6 +367,123 @@
           ctx.font = 'bold 30px monospace';
           ctx.fillText(txt, Math.max(18, w * 0.09), h * 0.5);
           ctx.restore();
+          break;
+        }
+        case 'volumetric_fog': {
+          ctx.fillStyle = `rgba(120,170,255,${0.04 + intensity * 0.08})`;
+          for (let i = 0; i < 22; i += 1) {
+            const x = (i * 63 + normalized * 180 + Math.sin(i + normalized * 7) * 40) % w;
+            const y = (i * 29 + normalized * 90) % h;
+            ctx.fillRect(x, y, 140, 12);
+          }
+          break;
+        }
+        case 'glass_refraction': {
+          ctx.strokeStyle = `rgba(182,236,255,${0.14 + intensity * 0.22})`;
+          ctx.lineWidth = 1.2 + intensity * 1.6;
+          for (let i = 0; i < 8; i += 1) {
+            const yy = h * (0.15 + i * 0.1) + Math.sin(normalized * 8 + i) * 10;
+            ctx.beginPath();
+            ctx.moveTo(w * 0.12, yy);
+            ctx.bezierCurveTo(w * 0.3, yy - 20, w * 0.7, yy + 20, w * 0.88, yy);
+            ctx.stroke();
+          }
+          break;
+        }
+        case 'halo_glyphs': {
+          ctx.strokeStyle = `rgba(158,255,238,${0.18 + intensity * 0.26})`;
+          for (let i = 0; i < 6; i += 1) {
+            const r = 38 + i * 22 + Math.sin(normalized * 9 + i) * 6;
+            ctx.beginPath();
+            ctx.arc(w * 0.5, h * 0.5, r, normalized + i, normalized + i + Math.PI * 0.9);
+            ctx.stroke();
+          }
+          break;
+        }
+        case 'cathedral_beam': {
+          const beamW = 40 + intensity * 110;
+          const gx = w * 0.5 + Math.sin(normalized * 2.6) * (w * 0.08);
+          const g = ctx.createLinearGradient(gx, h * 0.05, gx, h * 0.92);
+          g.addColorStop(0, `rgba(180,230,255,${0.24 + intensity * 0.24})`);
+          g.addColorStop(1, 'rgba(0,0,0,0)');
+          ctx.fillStyle = g;
+          ctx.fillRect(gx - beamW * 0.5, h * 0.05, beamW, h * 0.9);
+          break;
+        }
+        case 'monolith_silhouette': {
+          ctx.fillStyle = `rgba(6,10,18,${0.6 + intensity * 0.3})`;
+          const mw = w * 0.16;
+          const mh = h * 0.52;
+          ctx.fillRect(w * 0.5 - mw * 0.5, h * 0.5 - mh * 0.42, mw, mh);
+          break;
+        }
+        case 'starfield_drift': {
+          ctx.fillStyle = `rgba(186,232,255,${0.2 + intensity * 0.2})`;
+          for (let i = 0; i < 46; i += 1) {
+            const x = (i * 47 + normalized * 140 + Math.sin(i * 2.2) * 18) % w;
+            const y = (i * 31 + normalized * 40) % h;
+            ctx.fillRect(x, y, 1.4, 1.4);
+          }
+          break;
+        }
+        case 'orbiting_shards': {
+          for (let i = 0; i < 7; i += 1) {
+            const a = normalized * 4 + i * (Math.PI * 2 / 7);
+            const r = 90 + i * 18 + Math.sin(normalized * 8 + i) * 10;
+            const x = w * 0.5 + Math.cos(a) * r;
+            const y = h * 0.5 + Math.sin(a) * (r * 0.6);
+            ctx.fillStyle = `rgba(146,220,255,${0.14 + intensity * 0.22})`;
+            ctx.fillRect(x, y, 8, 2);
+          }
+          break;
+        }
+        case 'pulse_orb': {
+          const r = 28 + Math.sin(p * Math.PI) * (130 + intensity * 120);
+          const g = ctx.createRadialGradient(w * 0.5, h * 0.5, 1, w * 0.5, h * 0.5, r);
+          g.addColorStop(0, `rgba(214,248,255,${0.28 + intensity * 0.3})`);
+          g.addColorStop(1, 'rgba(0,0,0,0)');
+          ctx.fillStyle = g;
+          ctx.beginPath();
+          ctx.arc(w * 0.5, h * 0.5, r, 0, Math.PI * 2);
+          ctx.fill();
+          break;
+        }
+        case 'energy_column': {
+          const cx = w * (0.5 + Math.sin(normalized * 1.6) * 0.08);
+          ctx.fillStyle = `rgba(128,255,220,${0.07 + intensity * 0.16})`;
+          ctx.fillRect(cx - 22, h * 0.14, 44, h * 0.72);
+          ctx.strokeStyle = `rgba(178,255,236,${0.18 + intensity * 0.24})`;
+          ctx.strokeRect(cx - 14, h * 0.2, 28, h * 0.58);
+          break;
+        }
+        case 'refraction_ripple': {
+          ctx.strokeStyle = `rgba(162,224,255,${0.12 + intensity * 0.2})`;
+          for (let i = 0; i < 5; i += 1) {
+            ctx.beginPath();
+            const rr = 26 + i * 36 + p * 120;
+            ctx.ellipse(w * 0.5, h * 0.5, rr, rr * 0.6, 0, 0, Math.PI * 2);
+            ctx.stroke();
+          }
+          break;
+        }
+        case 'chromatic_veil': {
+          const veil = ctx.createLinearGradient(0, 0, w, h);
+          veil.addColorStop(0, `rgba(120,140,255,${0.08 + intensity * 0.08})`);
+          veil.addColorStop(0.5, `rgba(120,255,220,${0.04 + intensity * 0.08})`);
+          veil.addColorStop(1, `rgba(255,120,180,${0.04 + intensity * 0.07})`);
+          ctx.fillStyle = veil;
+          ctx.fillRect(0, 0, w, h);
+          break;
+        }
+        case 'terminal_runes': {
+          const rows = 8;
+          ctx.fillStyle = `rgba(168,255,220,${0.2 + intensity * 0.3})`;
+          ctx.font = '16px monospace';
+          for (let i = 0; i < rows; i += 1) {
+            const yy = h * 0.2 + i * 26;
+            const txt = ['∆','⟟','⌁','⟡','⋄','⟢'][i % 6] + ' SIGNAL-' + (i + 1);
+            ctx.fillText(txt, w * 0.12 + Math.sin(normalized * 6 + i) * 12, yy);
+          }
           break;
         }
         default:


### PR DESCRIPTION
### Motivation
- The generated ASMR packages were visually sparse and back-loaded, producing long static stretches that felt audio-first rather than tightly synchronized micro‑films. 
- The internal generation prompt did not provide sufficient hard constraints for early visual life, midsection density, or pre-climax escalation. 
- The client renderers assumed a well-specified visual score and lacked defensive enrichment when the model under-specified visuals or audio. 
- The procedural sound and visual vocabularies were too small to reliably produce cinematic, eerie, or ritual/cyber-sacred textures on headphones and in 1080p exports. 

### Description
- Strengthened the hidden ASMR system prompt in `functions.php` to require layered first‑frame composition, a meaningful opening visual event within `0.0–0.8s`, a focal event within `0.8–2.0s`, textured midsection, pre‑climax escalation, final‑third bloom, practical timing rules, and stronger audio direction toward eerie layered build and softened onsets, while preserving strict JSON/schema requirements (`title`, `runtime_seconds`, `hook`, `concept_summary`, `style_tags`, `audio_events`, `visual_events`, `sync_points`, `end_card`, `edit_rhythm`, `presentation_note`).
- Added defensive server‑side enrichment `se_enrich_asmr_event_density` (in `functions.php`) to automatically inject opening atmosphere, early focal visuals, minimum visual/audio event floors, and bridge/bed layers when the model output is too sparse, and to reorder/sanitize timings while preserving intent. 
- Expanded the allowed procedural audio engines and added in‑browser synthesis implementations in `js/asmr-foley-engine.js` for: `glass_ping`, `glass_resonance`, `relay_click_cluster`, `shimmer_swirl`, `crystal_chime`, `ghost_pad`, `spectral_suck`, `voltage_flutter`, `halo_tone`, `particle_spark`, `ritual_bass_swell`, and `reverse_bloom`, plus audio density guardrails that insert ambient lead‑ins and supportive textures when needed. 
- Expanded visual vocabulary and runtime enrichment in `js/asmr-visual-engine.js` with new visual types: `volumetric_fog`, `glass_refraction`, `halo_glyphs`, `cathedral_beam`, `monolith_silhouette`, `starfield_drift`, `orbiting_shards`, `pulse_orb`, `energy_column`, `refraction_ripple`, `chromatic_veil`, and `terminal_runes`, added drawing logic, a `enrichVisualEvents` hook to densify/timelock visuals, and a stronger animated baseline chamber focal core for visible first‑frame life. 
- Kept export flow intact and truthful: 1080p export still renders to a 1920x1080 canvas and the runtime checks for MP4 support vs WebM fallback remain in `js/asmr-lab.js`. 
- Updated the built‑in QA/showcase preset to the stronger demo preset `Signal Benediction` to exercise the new vocab and pacing by default. 

### Testing
- Ran `php -l functions.php` to validate PHP syntax and it succeeded. 
- Ran `node --check js/asmr-foley-engine.js`, `node --check js/asmr-visual-engine.js`, and `node --check js/asmr-lab.js` for basic JS syntax checks and they all succeeded. 
- Attempted an automated Playwright page capture of `/page-asmr-lab.php` but the local web server returned `ERR_EMPTY_RESPONSE` so no live UI screenshot/export test could be completed in this environment. 
- Notes: runtime behavior (preview, stop/replay, WAV export, 1080p export and MP4 vs WebM messaging) should be verified in a browser session; the changes are defensive so under‑specified model outputs will be enriched automatically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afbd27dbd0832eb28224fb72a59192)