### PR TITLE
Deepen ASMR Lab semantic grounding for Gastown/Vancouver prompts

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -882,7 +882,144 @@ function se_get_asmr_allowed_engines() {
         'particle_spark',
         'ritual_bass_swell',
         'reverse_bloom',
+        'steam_clock_burst',
+        'distant_bell_toll',
+        'cold_air_hush',
+        'wet_street_shimmer',
+        'harbor_fog_bed',
+        'metal_resonance',
+        'snow_muffle',
+        'city_electrical_hum',
     );
+}
+
+function se_get_asmr_visual_types() {
+    return array(
+        'scanline_field', 'pixel_grid_pulse', 'wireframe_horizon', 'radial_bloom', 'particle_trail',
+        'glitch_flash', 'waveform_ring', 'macro_texture_drift', 'signal_bars', 'text_reveal',
+        'volumetric_fog', 'glass_refraction', 'halo_glyphs', 'cathedral_beam', 'monolith_silhouette',
+        'starfield_drift', 'orbiting_shards', 'pulse_orb', 'energy_column', 'refraction_ripple',
+        'chromatic_veil', 'terminal_runes', 'snow_drift', 'amber_halo', 'wet_reflection_shimmer',
+        'brick_shadow_drift', 'steam_plume_column', 'clock_face_reveal', 'harbor_mist',
+        'neon_wet_reflections', 'winter_particulate_depth',
+    );
+}
+
+function se_get_asmr_semantic_cues( $payload ) {
+    $source = strtolower( implode( ' ', array(
+        (string) ( $payload['concept'] ?? '' ),
+        (string) ( $payload['object'] ?? '' ),
+        (string) ( $payload['setting'] ?? '' ),
+        (string) ( $payload['mood'] ?? '' ),
+        (string) ( $payload['creative_goal'] ?? '' ),
+    ) ) );
+
+    $cue_map = array(
+        'gastown' => array( 'steam_clock', 'cobblestone', 'brick', 'amber', 'urban_night' ),
+        'vancouver' => array( 'harbor', 'fog', 'coastal', 'urban_night' ),
+        'steam clock' => array( 'steam_clock', 'metal', 'bell' ),
+        'snow' => array( 'snow', 'winter_hush', 'cold_air' ),
+        'rain' => array( 'rain', 'wet_reflection' ),
+        'harbor fog' => array( 'harbor', 'fog' ),
+        'amber' => array( 'amber', 'streetlamp' ),
+        'streetlamp' => array( 'streetlamp', 'amber' ),
+        'wet cobblestone' => array( 'wet_reflection', 'cobblestone' ),
+        'cobblestone' => array( 'cobblestone' ),
+        'brick' => array( 'brick' ),
+        'neon reflection' => array( 'neon', 'wet_reflection' ),
+        'winter hush' => array( 'winter_hush', 'snow' ),
+        'spiritual' => array( 'spiritual' ),
+        'reverent' => array( 'spiritual' ),
+        'haunted' => array( 'haunted' ),
+        'cinematic' => array( 'cinematic' ),
+        'city' => array( 'urban_night' ),
+        'urban' => array( 'urban_night' ),
+    );
+
+    $cues = array();
+    foreach ( $cue_map as $needle => $tags ) {
+        if ( false !== strpos( $source, $needle ) ) {
+            $cues = array_merge( $cues, $tags );
+        }
+    }
+
+    if ( false !== strpos( $source, 'vancouver' ) && false !== strpos( $source, 'snow' ) ) {
+        $cues[] = 'vancouver_winter';
+    }
+    if ( false !== strpos( $source, 'gastown' ) && false !== strpos( $source, 'clock' ) ) {
+        $cues[] = 'gastown_clock_focus';
+    }
+
+    return array_values( array_unique( $cues ) );
+}
+
+function se_apply_asmr_semantic_cues( $decoded, $payload ) {
+    $runtime = max( 10, min( 30, floatval( $decoded['runtime_seconds'] ?? 20 ) ) );
+    $cues = se_get_asmr_semantic_cues( $payload );
+    if ( empty( $cues ) ) {
+        return $decoded;
+    }
+
+    $decoded['style_tags'] = array_values( array_unique( array_merge( (array) ( $decoded['style_tags'] ?? array() ), $cues ) ) );
+
+    $audio = is_array( $decoded['audio_events'] ?? null ) ? $decoded['audio_events'] : array();
+    $visual = is_array( $decoded['visual_events'] ?? null ) ? $decoded['visual_events'] : array();
+    $sync = is_array( $decoded['sync_points'] ?? null ) ? $decoded['sync_points'] : array();
+
+    if ( in_array( 'gastown_clock_focus', $cues, true ) || in_array( 'steam_clock', $cues, true ) ) {
+        $audio[] = array( 'time' => 0.55, 'duration' => 1.4, 'engine' => 'steam_clock_burst', 'intensity' => 0.7, 'params' => array(), 'sync_role' => 'steam_clock_identity' );
+        $audio[] = array( 'time' => $runtime * 0.68, 'duration' => 1.1, 'engine' => 'distant_bell_toll', 'intensity' => 0.58, 'params' => array(), 'sync_role' => 'clock_chime_reveal' );
+        $visual[] = array( 'time' => 0.5, 'duration' => 2.1, 'visual_type' => 'clock_face_reveal', 'intensity' => 0.72, 'params' => array(), 'sync_role' => 'clock_face_entry' );
+        $visual[] = array( 'time' => 0.3, 'duration' => 2.2, 'visual_type' => 'steam_plume_column', 'intensity' => 0.64, 'params' => array(), 'sync_role' => 'steam_column' );
+    }
+
+    if ( in_array( 'snow', $cues, true ) || in_array( 'winter_hush', $cues, true ) ) {
+        $audio[] = array( 'time' => 0, 'duration' => min( 8.5, $runtime * 0.5 ), 'engine' => 'snow_muffle', 'intensity' => 0.45, 'params' => array(), 'sync_role' => 'winter_bed' );
+        $audio[] = array( 'time' => 0.2, 'duration' => min( 7.5, $runtime * 0.45 ), 'engine' => 'cold_air_hush', 'intensity' => 0.42, 'params' => array(), 'sync_role' => 'cold_air_layer' );
+        $visual[] = array( 'time' => 0, 'duration' => min( 8, $runtime * 0.52 ), 'visual_type' => 'snow_drift', 'intensity' => 0.68, 'params' => array(), 'sync_role' => 'winter_particles' );
+        $visual[] = array( 'time' => $runtime * 0.12, 'duration' => min( 7, $runtime * 0.4 ), 'visual_type' => 'winter_particulate_depth', 'intensity' => 0.62, 'params' => array(), 'sync_role' => 'depth_atmosphere' );
+    }
+
+    if ( in_array( 'harbor', $cues, true ) || in_array( 'fog', $cues, true ) ) {
+        $audio[] = array( 'time' => 0, 'duration' => min( 9, $runtime * 0.6 ), 'engine' => 'harbor_fog_bed', 'intensity' => 0.46, 'params' => array(), 'sync_role' => 'harbor_ambience' );
+        $visual[] = array( 'time' => 0, 'duration' => min( 9, $runtime * 0.64 ), 'visual_type' => 'harbor_mist', 'intensity' => 0.6, 'params' => array(), 'sync_role' => 'harbor_layer' );
+    }
+
+    if ( in_array( 'wet_reflection', $cues, true ) || in_array( 'rain', $cues, true ) ) {
+        $audio[] = array( 'time' => $runtime * 0.15, 'duration' => min( 6.2, $runtime * 0.35 ), 'engine' => 'wet_street_shimmer', 'intensity' => 0.52, 'params' => array(), 'sync_role' => 'wet_street_texture' );
+        $visual[] = array( 'time' => $runtime * 0.12, 'duration' => min( 6.2, $runtime * 0.38 ), 'visual_type' => 'wet_reflection_shimmer', 'intensity' => 0.64, 'params' => array(), 'sync_role' => 'street_reflection' );
+        $visual[] = array( 'time' => $runtime * 0.2, 'duration' => min( 5.5, $runtime * 0.32 ), 'visual_type' => 'neon_wet_reflections', 'intensity' => 0.55, 'params' => array(), 'sync_role' => 'neon_reflection' );
+    }
+
+    if ( in_array( 'brick', $cues, true ) || in_array( 'cobblestone', $cues, true ) ) {
+        $visual[] = array( 'time' => 0.4, 'duration' => min( 6.5, $runtime * 0.45 ), 'visual_type' => 'brick_shadow_drift', 'intensity' => 0.58, 'params' => array(), 'sync_role' => 'material_grounding' );
+        $audio[] = array( 'time' => 0.9, 'duration' => 1.2, 'engine' => 'metal_resonance', 'intensity' => 0.42, 'params' => array(), 'sync_role' => 'urban_material_ping' );
+    }
+
+    if ( in_array( 'amber', $cues, true ) || in_array( 'streetlamp', $cues, true ) ) {
+        $visual[] = array( 'time' => 0.25, 'duration' => min( 8, $runtime * 0.52 ), 'visual_type' => 'amber_halo', 'intensity' => 0.65, 'params' => array(), 'sync_role' => 'streetlamp_glow' );
+    }
+
+    if ( in_array( 'urban_night', $cues, true ) ) {
+        $audio[] = array( 'time' => 0.05, 'duration' => min( 8, $runtime * 0.6 ), 'engine' => 'city_electrical_hum', 'intensity' => 0.35, 'params' => array(), 'sync_role' => 'city_grid_bed' );
+    }
+
+    if ( in_array( 'haunted', $cues, true ) || in_array( 'spiritual', $cues, true ) ) {
+        $audio[] = array( 'time' => $runtime * 0.74, 'duration' => 1.3, 'engine' => 'distant_bell_toll', 'intensity' => 0.5, 'params' => array(), 'sync_role' => 'reverent_release' );
+        $visual[] = array( 'time' => $runtime * 0.78, 'duration' => 1.6, 'visual_type' => 'clock_face_reveal', 'intensity' => 0.44, 'params' => array(), 'sync_role' => 'haunted_reveal' );
+    }
+
+    $sync[] = array( 'time' => 0.55, 'cue' => 'semantic place identity enters', 'importance' => 'high' );
+    $sync[] = array( 'time' => $runtime * 0.68, 'cue' => 'location-specific reveal toll', 'importance' => 'high' );
+
+    usort( $audio, static function( $a, $b ) { return ( floatval( $a['time'] ?? 0 ) <=> floatval( $b['time'] ?? 0 ) ); } );
+    usort( $visual, static function( $a, $b ) { return ( floatval( $a['time'] ?? 0 ) <=> floatval( $b['time'] ?? 0 ) ); } );
+    usort( $sync, static function( $a, $b ) { return ( floatval( $a['time'] ?? 0 ) <=> floatval( $b['time'] ?? 0 ) ); } );
+
+    $decoded['audio_events'] = $audio;
+    $decoded['visual_events'] = $visual;
+    $decoded['sync_points'] = $sync;
+    return $decoded;
 }
 
 function se_enrich_asmr_event_density( $decoded ) {
@@ -1068,13 +1205,7 @@ function se_validate_asmr_response( $decoded ) {
     } );
     $decoded['audio_events'] = $sanitized_events;
 
-    $visual_allowed = array(
-        'scanline_field', 'pixel_grid_pulse', 'wireframe_horizon', 'radial_bloom', 'particle_trail',
-        'glitch_flash', 'waveform_ring', 'macro_texture_drift', 'signal_bars', 'text_reveal',
-        'volumetric_fog', 'glass_refraction', 'halo_glyphs', 'cathedral_beam', 'monolith_silhouette',
-        'starfield_drift', 'orbiting_shards', 'pulse_orb', 'energy_column', 'refraction_ripple',
-        'chromatic_veil', 'terminal_runes',
-    );
+    $visual_allowed = se_get_asmr_visual_types();
     $visual_events = is_array( $decoded['visual_events'] ?? null ) ? $decoded['visual_events'] : array();
     $decoded['visual_events'] = array_values( array_filter( array_map( static function( $event ) use ( $visual_allowed ) {
         if ( ! is_array( $event ) ) {
@@ -1128,7 +1259,7 @@ function se_validate_asmr_response( $decoded ) {
 
     $decoded['presentation_note'] = sanitize_text_field( $decoded['presentation_note'] ?? '' );
 
-    return se_enrich_asmr_event_density( $decoded );
+    return $decoded;
 }
 
 function se_handle_asmr_generate( WP_REST_Request $req ) {
@@ -1164,7 +1295,7 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
         . 'end_card must include: use_end_card, text, reveal_style. '
         . 'edit_rhythm must include: pacing_note, silence_strategy, release_strategy. '
         . 'Only use these engine names: ' . $allowed_engines . '. '
-        . 'Allowed visual_type values: scanline_field, pixel_grid_pulse, wireframe_horizon, radial_bloom, particle_trail, glitch_flash, waveform_ring, macro_texture_drift, signal_bars, text_reveal, volumetric_fog, glass_refraction, halo_glyphs, cathedral_beam, monolith_silhouette, starfield_drift, orbiting_shards, pulse_orb, energy_column, refraction_ripple, chromatic_veil, terminal_runes. '
+        . 'Allowed visual_type values: ' . implode( ', ', se_get_asmr_visual_types() ) . '. '
         . 'Critical visual pacing rules: first frame must show a layered chamber state (background + atmosphere + focal hint). Include meaningful opening visual event in 0.0-0.8s and at least one clear focal event in 0.8-2.0s. '
         . 'Do not back-load all action: craft a textured midsection with evolving layers, at least one pre-climax escalation in the middle third, and at least one bloom/reveal in the final third. '
         . 'Visual event score should be dense but intentional, with practical browser-safe durations and avoid micro-spam faster than 0.05s. '
@@ -1176,6 +1307,10 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
         . 'Use micro-events for intimacy, then earned bloom moments instead of random loudness spikes. '
         . 'Visual score should emphasize atmospheric symbolic language, depth, compositional foreground/midground/background layering, glow, parallax-like drift, and terminal/sacred reveal language when appropriate. '
         . 'sync_points must map to real event moments and reinforce audio-visual unity, especially in the first 3 seconds. '
+        . 'When a real place is named (for example Gastown or Vancouver), strongly ground the package in that location with concrete materials, weather, object identity, and environmental acoustics. '
+        . 'Prompt interpretation priority: named location > named object > weather condition > mood adjectives. '
+        . 'For Gastown/Vancouver scenes, favor steam clock cues, harbor fog bed, amber streetlamp halos, wet cobblestone reflections, brick facade texture, neon-on-wet shimmer, and winter hush pacing where relevant. '
+        . 'Avoid generic abstract output when prompts include specific geography or weather terms. '
         . 'The result should feel like an authored short sensory micro-film, not a debug demo. '
         . 'Do not include prose outside JSON.';
 
@@ -1220,6 +1355,8 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
     if ( is_wp_error( $validated ) ) {
         return $validated;
     }
+
+    $validated = se_enrich_asmr_event_density( se_apply_asmr_semantic_cues( $validated, $payload ) );
 
     return rest_ensure_response( $validated );
 }

--- a/js/asmr-foley-engine.js
+++ b/js/asmr-foley-engine.js
@@ -6,7 +6,9 @@
     'paper_crackle', 'steam_hiss', 'tape_stop_drop', 'bit_pulse', 'breath_pulse',
     'low_hum', 'digital_shimmer', 'glass_ping', 'glass_resonance', 'relay_click_cluster',
     'shimmer_swirl', 'crystal_chime', 'ghost_pad', 'spectral_suck', 'voltage_flutter',
-    'halo_tone', 'particle_spark', 'ritual_bass_swell', 'reverse_bloom'
+    'halo_tone', 'particle_spark', 'ritual_bass_swell', 'reverse_bloom',
+    'steam_clock_burst', 'distant_bell_toll', 'cold_air_hush', 'wet_street_shimmer',
+    'harbor_fog_bed', 'metal_resonance', 'snow_muffle', 'city_electrical_hum'
   ];
 
   function clamp(value, min, max) {
@@ -332,6 +334,36 @@
         case 'reverse_bloom':
           this.scheduleNoise(ctx, destination, atTime, duration * 0.75, { freq: p.freq || 2100, q: 0.8, peak: 0.02 + intensity * 0.04, filterType: 'lowpass', pan: 0.18 });
           this.scheduleTone(ctx, destination, atTime + duration * 0.4, duration * 0.6, { from: p.from || 220, to: p.to || 860, peak: 0.016 + intensity * 0.03, type: 'triangle', pan: -0.14 });
+          break;
+        case 'steam_clock_burst':
+          this.scheduleNoise(ctx, destination, atTime, duration * 0.92, { freq: p.freq || 2800, q: 0.44, peak: 0.03 + intensity * 0.07, filterType: 'bandpass', pan: 0.16 });
+          this.scheduleTone(ctx, destination, atTime + 0.06, Math.max(0.1, duration * 0.34), { from: p.from || 620, to: p.to || 420, peak: 0.014 + intensity * 0.03, type: 'triangle', pan: -0.12 });
+          break;
+        case 'distant_bell_toll':
+          this.scheduleTone(ctx, destination, atTime, duration, { from: p.from || 540, to: p.to || 420, peak: 0.026 + intensity * 0.05, type: 'sine', pan: 0.05 });
+          this.scheduleTone(ctx, destination, atTime + 0.03, duration * 0.86, { from: (p.from || 540) * 1.5, to: (p.to || 420) * 1.4, peak: 0.012 + intensity * 0.026, type: 'triangle', pan: -0.18 });
+          break;
+        case 'cold_air_hush':
+          this.scheduleNoise(ctx, destination, atTime, duration, { freq: p.freq || 1200, q: 0.72, peak: 0.02 + intensity * 0.045, filterType: 'highpass', pan: -0.08 });
+          break;
+        case 'wet_street_shimmer':
+          this.scheduleNoise(ctx, destination, atTime, duration, { freq: p.freq || 2400, q: 1.2, peak: 0.014 + intensity * 0.03, filterType: 'bandpass', pan: 0.24 });
+          this.scheduleTone(ctx, destination, atTime + 0.04, duration * 0.7, { from: p.from || 700, to: p.to || 1060, peak: 0.008 + intensity * 0.018, type: 'triangle', pan: -0.2 });
+          break;
+        case 'harbor_fog_bed':
+          this.scheduleTone(ctx, destination, atTime, duration, { from: p.from || 74, to: p.to || 66, peak: 0.03 + intensity * 0.055, type: 'sine' });
+          this.scheduleNoise(ctx, destination, atTime, duration, { freq: p.freq || 620, q: 0.45, peak: 0.016 + intensity * 0.034, filterType: 'lowpass', pan: 0 });
+          break;
+        case 'metal_resonance':
+          this.scheduleTone(ctx, destination, atTime, Math.max(0.12, duration * 0.5), { from: p.from || 980, to: p.to || 340, peak: 0.02 + intensity * 0.04, type: 'triangle', pan: 0.22 });
+          this.scheduleTone(ctx, destination, atTime + 0.02, duration * 0.7, { from: (p.from || 980) * 1.28, to: (p.to || 340) * 1.5, peak: 0.007 + intensity * 0.02, type: 'sine', pan: -0.24 });
+          break;
+        case 'snow_muffle':
+          this.scheduleNoise(ctx, destination, atTime, duration, { freq: p.freq || 840, q: 0.38, peak: 0.015 + intensity * 0.028, filterType: 'lowpass', pan: -0.04 });
+          break;
+        case 'city_electrical_hum':
+          this.scheduleTone(ctx, destination, atTime, duration, { from: p.from || 112, to: p.to || 118, peak: 0.022 + intensity * 0.04, type: 'sawtooth', pan: 0.03 });
+          this.scheduleTone(ctx, destination, atTime + 0.01, duration * 0.9, { from: 224, to: 236, peak: 0.008 + intensity * 0.02, type: 'triangle', pan: -0.1 });
           break;
         default:
           break;

--- a/js/asmr-lab.js
+++ b/js/asmr-lab.js
@@ -25,14 +25,14 @@
   let currentPackage = null;
 
   const QA_PRESET = {
-    concept: 'Signal Benediction: a glass relay core awakens a dormant monolith like a machine receiving a blessing',
-    object: 'glass relay core',
-    setting: 'midnight signal chamber beneath a neon cathedral grid',
-    mood: 'cyber-sacred tension, crystalline awe, then radiant bloom',
+    concept: 'A snow-covered Gastown steam clock becomes a winter shrine, breathing light into the empty street',
+    object: 'steam clock',
+    setting: 'midnight Gastown alley with snow, wet cobblestones, amber gaslight glow, brick walls, and harbor mist',
+    mood: 'ghostly calm, urban reverence, cold wonder, then warm luminous release',
     duration: '20',
-    voice_style: 'composed machine whisper',
+    voice_style: 'quiet city prayer',
     weirdness: '8',
-    creative_goal: 'Build from near-silence and tactile relay pulses into a spiritual electronic bloom, with synchronized glass shimmer, ceremonial signal motion, and a terminal-style final reveal that feels earned.'
+    creative_goal: 'Turn Gastown into a sacred winter signal using steam bursts, bell-like tones, snow drift, lamplight halos, and reflective street shimmer with a final reveal that feels haunted and beautiful.'
   };
 
   const transport = {

--- a/js/asmr-visual-engine.js
+++ b/js/asmr-visual-engine.js
@@ -6,7 +6,9 @@
     'glitch_flash', 'waveform_ring', 'macro_texture_drift', 'signal_bars', 'text_reveal',
     'volumetric_fog', 'glass_refraction', 'halo_glyphs', 'cathedral_beam', 'monolith_silhouette',
     'starfield_drift', 'orbiting_shards', 'pulse_orb', 'energy_column', 'refraction_ripple',
-    'chromatic_veil', 'terminal_runes'
+    'chromatic_veil', 'terminal_runes', 'snow_drift', 'amber_halo', 'wet_reflection_shimmer',
+    'brick_shadow_drift', 'steam_plume_column', 'clock_face_reveal', 'harbor_mist',
+    'neon_wet_reflections', 'winter_particulate_depth'
   ];
 
   function clamp(value, min, max) {
@@ -483,6 +485,106 @@
             const yy = h * 0.2 + i * 26;
             const txt = ['∆','⟟','⌁','⟡','⋄','⟢'][i % 6] + ' SIGNAL-' + (i + 1);
             ctx.fillText(txt, w * 0.12 + Math.sin(normalized * 6 + i) * 12, yy);
+          }
+          break;
+        }
+        case 'snow_drift': {
+          ctx.fillStyle = `rgba(218,236,255,${0.12 + intensity * 0.2})`;
+          for (let i = 0; i < 70; i += 1) {
+            const x = (i * 41 + normalized * 50 + Math.sin(i + normalized * 5) * 10) % w;
+            const y = (i * 26 + normalized * 120 + i * 0.5) % h;
+            ctx.fillRect(x, y, 1.8, 1.8);
+          }
+          break;
+        }
+        case 'amber_halo': {
+          for (let i = 0; i < 3; i += 1) {
+            const lx = w * (0.2 + i * 0.3);
+            const ly = h * (0.26 + (i % 2) * 0.08);
+            const r = 44 + intensity * 80;
+            const halo = ctx.createRadialGradient(lx, ly, 1, lx, ly, r);
+            halo.addColorStop(0, `rgba(255,196,118,${0.22 + intensity * 0.22})`);
+            halo.addColorStop(1, 'rgba(0,0,0,0)');
+            ctx.fillStyle = halo;
+            ctx.fillRect(lx - r, ly - r, r * 2, r * 2);
+          }
+          break;
+        }
+        case 'wet_reflection_shimmer': {
+          ctx.fillStyle = `rgba(120,170,255,${0.06 + intensity * 0.12})`;
+          for (let i = 0; i < 18; i += 1) {
+            const yy = h * 0.62 + i * 9 + Math.sin(normalized * 10 + i) * 2;
+            ctx.fillRect(0, yy, w, 2);
+          }
+          break;
+        }
+        case 'brick_shadow_drift': {
+          ctx.fillStyle = `rgba(78,52,44,${0.1 + intensity * 0.12})`;
+          const brickW = 40;
+          const brickH = 16;
+          for (let y = 0; y < h * 0.6; y += brickH) {
+            for (let x = ((y / brickH) % 2) * (brickW / 2); x < w; x += brickW) {
+              ctx.fillRect(x + Math.sin(normalized * 3 + y * 0.01) * 2, y, brickW - 2, brickH - 2);
+            }
+          }
+          break;
+        }
+        case 'steam_plume_column': {
+          const cx = w * 0.5;
+          ctx.fillStyle = `rgba(206,224,240,${0.08 + intensity * 0.16})`;
+          for (let i = 0; i < 18; i += 1) {
+            const ww = 22 + i * 10;
+            const yy = h * 0.75 - i * 18 - (normalized * 22 % 18);
+            ctx.fillRect(cx - ww * 0.5 + Math.sin(i + normalized * 4) * 8, yy, ww, 12);
+          }
+          break;
+        }
+        case 'clock_face_reveal': {
+          const r = 70 + intensity * 90;
+          ctx.strokeStyle = `rgba(255,236,190,${0.18 + intensity * 0.26})`;
+          ctx.lineWidth = 2;
+          ctx.beginPath();
+          ctx.arc(w * 0.5, h * 0.45, r, 0, Math.PI * 2);
+          ctx.stroke();
+          for (let i = 0; i < 12; i += 1) {
+            const a = (i / 12) * Math.PI * 2 + normalized * 0.2;
+            const x1 = w * 0.5 + Math.cos(a) * (r - 10);
+            const y1 = h * 0.45 + Math.sin(a) * (r - 10);
+            const x2 = w * 0.5 + Math.cos(a) * r;
+            const y2 = h * 0.45 + Math.sin(a) * r;
+            ctx.beginPath();
+            ctx.moveTo(x1, y1);
+            ctx.lineTo(x2, y2);
+            ctx.stroke();
+          }
+          break;
+        }
+        case 'harbor_mist': {
+          ctx.fillStyle = `rgba(142,176,188,${0.06 + intensity * 0.12})`;
+          for (let i = 0; i < 16; i += 1) {
+            const y = h * 0.52 + i * 12 + Math.sin(normalized * 4 + i) * 4;
+            ctx.fillRect(-8, y, w + 16, 10);
+          }
+          break;
+        }
+        case 'neon_wet_reflections': {
+          const colors = ['rgba(90,190,255,', 'rgba(255,96,186,', 'rgba(120,255,220,'];
+          for (let i = 0; i < 12; i += 1) {
+            const x = (i * 83 + normalized * 60) % w;
+            const alpha = 0.08 + intensity * 0.12;
+            ctx.fillStyle = `${colors[i % colors.length]}${alpha})`;
+            ctx.fillRect(x, h * 0.64 + Math.sin(i + normalized * 8) * 9, 22, h * 0.24);
+          }
+          break;
+        }
+        case 'winter_particulate_depth': {
+          ctx.fillStyle = `rgba(200,222,255,${0.08 + intensity * 0.16})`;
+          for (let i = 0; i < 90; i += 1) {
+            const depth = 0.4 + (i % 5) * 0.15;
+            const x = (i * 29 + normalized * 80 * depth) % w;
+            const y = (i * 17 + normalized * 110 * (1.2 - depth)) % h;
+            const size = 1 + depth;
+            ctx.fillRect(x, y, size, size);
           }
           break;
         }


### PR DESCRIPTION
### Motivation

- Make prompt wording materially affect generated audiovisual output by adding a semantic interpretation layer and location-aware cue mapping so real places (Gastown/Vancouver) and weather/object terms produce distinct results. 
- Provide a richer, place-specific sound and visual vocabulary so prompts like `Gastown Vancouver in the Snow` feel geographically and atmospherically grounded rather than generically abstract.

### Description

- Added a semantic cue layer: new functions `se_get_asmr_semantic_cues()` and `se_apply_asmr_semantic_cues()` interpret the user `concept`, `object`, `setting`, `mood`, and `creative_goal` and inject place/weather/object-specific audio/visual/sync events before density enrichment. (changes in `functions.php`).
- Extended sound vocabulary and allowed engines by adding `steam_clock_burst`, `distant_bell_toll`, `cold_air_hush`, `wet_street_shimmer`, `harbor_fog_bed`, `metal_resonance`, `snow_muffle`, and `city_electrical_hum`, and implemented their synthesis behavior in `js/asmr-foley-engine.js`.
- Extended visual vocabulary and renderer support by adding types such as `snow_drift`, `amber_halo`, `wet_reflection_shimmer`, `brick_shadow_drift`, `steam_plume_column`, `clock_face_reveal`, `harbor_mist`, `neon_wet_reflections`, and `winter_particulate_depth` with draw implementations in `js/asmr-visual-engine.js` and by exposing the expanded allowed visual types via `se_get_asmr_visual_types()`.
- Strengthened the internal generation/system prompt to prioritize named location > object > weather > mood and to explicitly instruct the model to ground packages when a real place is present; the allowed visual types list in the prompt is generated from the new `se_get_asmr_visual_types()` helper (changes in `functions.php`).
- Replaced the QA preset in `js/asmr-lab.js` with a new city-nocturne Gastown winter showcase preset (steam clock object, midnight Gastown alley, amber gaslight, snow/wet cobbles, harbor mist, specific mood/voice/creative goal).
- Preserved UI and export behavior: preview/stop/WAV export/1080p export flows and MP4 vs WebM fallback remain intact in `js/asmr-lab.js` and engines.

### Testing

- Ran PHP lint: `php -l functions.php` — success.
- JavaScript static checks: `node --check js/asmr-foley-engine.js`, `node --check js/asmr-visual-engine.js`, and `node --check js/asmr-lab.js` — all succeeded with no syntax errors.
- Ran repository tests: `npm test --silent` — test suite executed but failed (5 failing subtests); failures are unrelated pre-existing DOM shims in the `lousy-outages` tests (`anchor.parentNode.insertBefore is not a function`) and do not affect the ASMR Lab changes.
- Attempted a Playwright page screenshot; it failed because no local web server was available at `http://localhost:8080` in this environment, so visual smoke capture could not be performed.

Files changed: `functions.php`, `js/asmr-foley-engine.js`, `js/asmr-visual-engine.js`, `js/asmr-lab.js`.

If you want, I can (1) run focused generation smoke tests against the REST endpoint (if an API key and server are available), or (2) add a small local unit harness to exercise `se_get_asmr_semantic_cues()` mapping and the engines' allowed lists.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b07a9759a4832eb644822e601dda5c)