### PR TITLE
Add 8‑bit pixel render pipeline, event‑card end screen, and frame‑forced video export

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -928,6 +928,14 @@ function se_get_asmr_semantic_cues( $payload ) {
         'brick' => array( 'brick' ),
         'neon reflection' => array( 'neon', 'wet_reflection' ),
         'winter hush' => array( 'winter_hush', 'snow' ),
+        '8-bit' => array( 'pixel_art', 'arcade' ),
+        '8bit' => array( 'pixel_art', 'arcade' ),
+        'pixel art' => array( 'pixel_art', 'dither' ),
+        'pixel' => array( 'pixel_art' ),
+        'dither' => array( 'dither' ),
+        'arcade' => array( 'arcade' ),
+        'chiptune' => array( 'arcade' ),
+        'sprite' => array( 'pixel_art' ),
         'spiritual' => array( 'spiritual' ),
         'reverent' => array( 'spiritual' ),
         'haunted' => array( 'haunted' ),
@@ -1004,9 +1012,23 @@ function se_apply_asmr_semantic_cues( $decoded, $payload ) {
         $audio[] = array( 'time' => 0.05, 'duration' => min( 8, $runtime * 0.6 ), 'engine' => 'city_electrical_hum', 'intensity' => 0.35, 'params' => array(), 'sync_role' => 'city_grid_bed' );
     }
 
-    if ( in_array( 'haunted', $cues, true ) || in_array( 'spiritual', $cues, true ) ) {
-        $audio[] = array( 'time' => $runtime * 0.74, 'duration' => 1.3, 'engine' => 'distant_bell_toll', 'intensity' => 0.5, 'params' => array(), 'sync_role' => 'reverent_release' );
-        $visual[] = array( 'time' => $runtime * 0.78, 'duration' => 1.6, 'visual_type' => 'clock_face_reveal', 'intensity' => 0.44, 'params' => array(), 'sync_role' => 'haunted_reveal' );
+    if ( in_array( 'pixel_art', $cues, true ) || in_array( 'dither', $cues, true ) || in_array( 'arcade', $cues, true ) ) {
+        $visual[] = array( 'time' => 0.08, 'duration' => min( 3.8, $runtime * 0.24 ), 'visual_type' => 'pixel_grid_pulse', 'intensity' => 0.72, 'params' => array(), 'sync_role' => 'pixel_language_early' );
+        $visual[] = array( 'time' => 0.16, 'duration' => min( 4.2, $runtime * 0.28 ), 'visual_type' => 'scanline_field', 'intensity' => 0.62, 'params' => array(), 'sync_role' => 'pixel_scan_early' );
+        $visual[] = array( 'time' => 0.3, 'duration' => min( 3.4, $runtime * 0.22 ), 'visual_type' => 'signal_bars', 'intensity' => 0.56, 'params' => array(), 'sync_role' => 'arcade_signal_early' );
+    }
+
+    $source = strtolower( implode( ' ', array(
+        (string) ( $payload['concept'] ?? '' ),
+        (string) ( $payload['object'] ?? '' ),
+        (string) ( $payload['setting'] ?? '' ),
+        (string) ( $payload['mood'] ?? '' ),
+        (string) ( $payload['creative_goal'] ?? '' ),
+    ) ) );
+    if ( false !== strpos( $source, 'event card' ) || false !== strpos( $source, 'screening' ) || false !== strpos( $source, 'film club' ) || false !== strpos( $source, 'deadline' ) ) {
+        $end_card = is_array( $decoded['end_card'] ?? null ) ? $decoded['end_card'] : array();
+        $end_card['reveal_style'] = 'event_card';
+        $decoded['end_card'] = $end_card;
     }
 
     $sync[] = array( 'time' => 0.55, 'cue' => 'semantic place identity enters', 'importance' => 'high' );
@@ -1246,7 +1268,7 @@ function se_validate_asmr_response( $decoded ) {
     $end_card = is_array( $decoded['end_card'] ?? null ) ? $decoded['end_card'] : array();
     $decoded['end_card'] = array(
         'use_end_card' => ! empty( $end_card['use_end_card'] ),
-        'text' => sanitize_text_field( $end_card['text'] ?? '' ),
+        'text' => sanitize_textarea_field( $end_card['text'] ?? '' ),
         'reveal_style' => sanitize_text_field( $end_card['reveal_style'] ?? '' ),
     );
 

--- a/js/asmr-lab.js
+++ b/js/asmr-lab.js
@@ -179,16 +179,32 @@
     if (audioFeedback) audioFeedback.textContent = fullMode ? 'Synchronized preview playing.' : 'Sound-only preview playing.';
   }
 
-  async function exportVideo() {
-    if (!currentPackage) return;
-    if (!videoSupport.canExport) throw new Error('Video export is not supported in this browser/runtime.');
+  async function inspectRecordedBlob(blob) {
+    const meta = { size: blob ? blob.size : 0, duration: 0 };
+    if (!blob || !blob.size) return meta;
+    await new Promise((resolve) => {
+      const probe = document.createElement('video');
+      probe.preload = 'metadata';
+      probe.muted = true;
+      const url = URL.createObjectURL(blob);
+      probe.onloadedmetadata = () => {
+        meta.duration = Number.isFinite(probe.duration) ? probe.duration : 0;
+        URL.revokeObjectURL(url);
+        resolve();
+      };
+      probe.onerror = () => {
+        URL.revokeObjectURL(url);
+        resolve();
+      };
+      probe.src = url;
+    });
+    return meta;
+  }
 
-    transport.stopAll();
-    engine.stop();
-    if (visuals) visuals.stop();
-
-    const runtime = Math.max(10, Math.min(30, Number(currentPackage.runtime_seconds || 20)));
+  async function recordVideoWithMime(pkg, mimeType, extension) {
+    const runtime = Math.max(10, Math.min(30, Number(pkg.runtime_seconds || 20)));
     const fps = 30;
+    const frameMs = Math.round(1000 / fps);
 
     const target = document.createElement('canvas');
     target.width = 1920;
@@ -196,13 +212,14 @@
     const targetCtx = target.getContext('2d');
 
     const exportVisuals = new window.AsmrVisualEngine(target);
-    exportVisuals.loadTimeline(currentPackage);
+    exportVisuals.loadTimeline(pkg);
     exportVisuals.renderToContext(targetCtx, 1920, 1080, 0);
 
-    const stream = target.captureStream(fps);
+    const stream = target.captureStream(0);
+    const videoTrack = stream.getVideoTracks()[0];
     const audioCtx = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: 48000 });
     if (audioCtx.state === 'suspended') await audioCtx.resume();
-    const rendered = await engine.renderToOfflineBuffer(currentPackage, 48000);
+    const rendered = await engine.renderToOfflineBuffer(pkg, 48000);
     const source = audioCtx.createBufferSource();
     source.buffer = rendered;
     const gain = audioCtx.createGain();
@@ -213,26 +230,28 @@
     mediaDest.stream.getAudioTracks().forEach((track) => stream.addTrack(track));
 
     const chunks = [];
-    const rec = new MediaRecorder(stream, { mimeType: videoSupport.preferredMime, videoBitsPerSecond: 12_000_000 });
+    const rec = new MediaRecorder(stream, { mimeType, videoBitsPerSecond: 12_000_000 });
     rec.ondataavailable = (event) => { if (event.data && event.data.size > 0) chunks.push(event.data); };
 
     await new Promise((resolve, reject) => {
-      const startAt = audioCtx.currentTime + 0.08;
-      let raf = null;
+      const startAt = audioCtx.currentTime + 0.12;
       let ended = false;
+      let timer = null;
+      let frameIndex = 0;
 
       const cleanup = () => {
-        if (raf) cancelAnimationFrame(raf);
+        if (timer) window.clearInterval(timer);
         source.onended = null;
         try { source.stop(); } catch (e) {}
         stream.getTracks().forEach((t) => t.stop());
         audioCtx.close().catch(() => {});
       };
 
-      const frameLoop = () => {
-        const t = Math.max(0, audioCtx.currentTime - startAt);
-        exportVisuals.renderToContext(targetCtx, 1920, 1080, Math.min(t, runtime));
-        if (t < runtime + 0.12 && !ended) raf = requestAnimationFrame(frameLoop);
+      const drawFrame = () => {
+        const t = Math.min(runtime, frameIndex / fps);
+        exportVisuals.renderToContext(targetCtx, 1920, 1080, t);
+        if (videoTrack && typeof videoTrack.requestFrame === 'function') videoTrack.requestFrame();
+        frameIndex += 1;
       };
 
       rec.onstop = () => {
@@ -246,28 +265,64 @@
 
       source.onended = () => {
         ended = true;
-        window.setTimeout(() => { try { rec.stop(); } catch (e) {} }, 120);
+        window.setTimeout(() => { try { rec.stop(); } catch (e) {} }, 180);
       };
 
       rec.start(250);
       source.start(startAt, 0, runtime);
-      frameLoop();
+
+      timer = window.setInterval(() => {
+        if (ended) return;
+        drawFrame();
+      }, frameMs);
+
+      drawFrame();
     });
 
-    const blob = new Blob(chunks, { type: videoSupport.preferredMime });
-    const url = URL.createObjectURL(blob);
+    const blob = new Blob(chunks, { type: mimeType });
+    const inspection = await inspectRecordedBlob(blob);
+    return { blob, extension, mimeType, inspection, runtime };
+  }
+
+  async function exportVideo() {
+    if (!currentPackage) return;
+    if (!videoSupport.canExport) throw new Error('Video export is not supported in this browser/runtime.');
+
+    transport.stopAll();
+    engine.stop();
+    if (visuals) visuals.stop();
+
+    const attempts = [];
+    if (videoSupport.preferredMime) attempts.push({ mimeType: videoSupport.preferredMime, extension: videoSupport.extension });
+    if (videoSupport.webmMime && videoSupport.webmMime !== videoSupport.preferredMime) {
+      attempts.push({ mimeType: videoSupport.webmMime, extension: 'webm' });
+    }
+
+    let result = null;
+    for (let i = 0; i < attempts.length; i += 1) {
+      const attempt = attempts[i];
+      result = await recordVideoWithMime(currentPackage, attempt.mimeType, attempt.extension);
+      const tinyBlob = result.inspection.size < 300000;
+      const shortDuration = result.inspection.duration > 0 && result.inspection.duration < result.runtime * 0.8;
+      const shouldRetryWebm = attempt.extension === 'mp4' && attempts[i + 1] && (tinyBlob || shortDuration);
+      if (!shouldRetryWebm) break;
+      if (audioFeedback) audioFeedback.textContent = 'MP4 export looked incomplete; retrying WebM fallback...';
+    }
+
+    const url = URL.createObjectURL(result.blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = `asmr-lab-film-1920x1080.${videoSupport.extension}`;
+    a.download = `asmr-lab-film-1920x1080.${result.extension}`;
     a.click();
     URL.revokeObjectURL(url);
 
     if (audioFeedback) {
-      audioFeedback.textContent = videoSupport.extension === 'mp4'
+      audioFeedback.textContent = result.extension === 'mp4'
         ? '1080p MP4 export complete.'
-        : '1080p WebM export complete (MP4 not supported in this browser).';
+        : '1080p WebM export complete (fallback mode).';
     }
   }
+
 
   if (form) {
     form.addEventListener('submit', async (event) => {

--- a/js/asmr-visual-engine.js
+++ b/js/asmr-visual-engine.js
@@ -15,6 +15,10 @@
     return Math.min(max, Math.max(min, value));
   }
 
+  function hasAnyTag(tags, needles) {
+    return needles.some((needle) => tags.includes(needle));
+  }
+
   class AsmrVisualEngine {
     constructor(canvas) {
       this.canvas = canvas;
@@ -25,6 +29,7 @@
       this.startPerf = 0;
       this.clockOffset = 0;
       this.currentTime = 0;
+      this.lowResTarget = null;
     }
 
     setCanvas(canvas) {
@@ -135,7 +140,53 @@
         visualEvents,
         syncPoints,
         endCard: pkg.end_card || {},
-        title: String(pkg.title || 'ASMR LAB')
+        title: String(pkg.title || 'ASMR LAB'),
+        renderProfile: this.resolveRenderProfile(pkg)
+      };
+    }
+
+    resolveRenderProfile(pkg) {
+      const tags = (Array.isArray(pkg.style_tags) ? pkg.style_tags : []).map((t) => String(t || '').toLowerCase());
+      const pixelMode = hasAnyTag(tags, ['pixel_art', '8bit', 'arcade', 'dither', 'chiptune']);
+      const vancouverCue = hasAnyTag(tags, ['gastown', 'vancouver', 'snow', 'rain', 'fog', 'amber', 'neon', 'brick', 'cobblestone']);
+      const theme = {
+        bgTop: '#02050c',
+        bgMid: '#070d1e',
+        bgBottom: '#050911',
+        fog: [74, 112, 255],
+        particles: [120, 220, 255],
+        core: [176, 228, 255],
+        amber: [255, 196, 118],
+        neonA: [255, 96, 186],
+        neonB: [120, 255, 220]
+      };
+
+      if (hasAnyTag(tags, ['fog', 'snow', 'rain', 'vancouver'])) {
+        theme.bgTop = '#071020';
+        theme.bgMid = '#10243a';
+        theme.bgBottom = '#0a1a29';
+        theme.fog = [122, 170, 215];
+        theme.particles = [186, 220, 255];
+      }
+      if (hasAnyTag(tags, ['gastown', 'amber', 'brick', 'cobblestone'])) {
+        theme.bgMid = '#211a21';
+        theme.bgBottom = '#160f18';
+        theme.amber = [255, 188, 110];
+      }
+      if (hasAnyTag(tags, ['neon', 'arcade', 'chiptune'])) {
+        theme.neonA = [255, 92, 205];
+        theme.neonB = [108, 250, 225];
+      }
+
+      return {
+        pixelMode,
+        vancouverCue,
+        lowResScale: pixelMode ? 6 : 1,
+        paletteSteps: pixelMode ? 12 : 0,
+        orderedDither: pixelMode && hasAnyTag(tags, ['dither', 'pixel_art', '8bit']),
+        scanlines: true,
+        glow: true,
+        theme
       };
     }
 
@@ -193,11 +244,43 @@
       return (t - start) / duration;
     }
 
-    renderToContext(ctx, width, height, t) {
-      if (!ctx || !this.timeline) return;
-      const runtime = this.timeline.runtime;
-      const normalized = clamp(t / Math.max(1, runtime), 0, 1.2);
+    getLowResTarget(width, height, profile) {
+      const scale = Math.max(2, Number(profile.lowResScale || 6));
+      const lowW = Math.max(160, Math.floor(width / scale));
+      const lowH = Math.max(90, Math.floor(height / scale));
+      if (this.lowResTarget && this.lowResTarget.canvas.width === lowW && this.lowResTarget.canvas.height === lowH) {
+        return this.lowResTarget;
+      }
+      this.lowResTarget = this.createRenderTarget(lowW, lowH);
+      return this.lowResTarget;
+    }
 
+    applyPixelPost(ctx, width, height, profile) {
+      const steps = Math.max(2, Number(profile.paletteSteps || 0));
+      if (steps <= 1) return;
+      const image = ctx.getImageData(0, 0, width, height);
+      const data = image.data;
+      const bayer = [
+        [0, 8, 2, 10],
+        [12, 4, 14, 6],
+        [3, 11, 1, 9],
+        [15, 7, 13, 5]
+      ];
+      const ditherOn = !!profile.orderedDither;
+      for (let y = 0; y < height; y += 1) {
+        for (let x = 0; x < width; x += 1) {
+          const i = (y * width + x) * 4;
+          const threshold = ditherOn ? ((bayer[y % 4][x % 4] / 16) - 0.5) * (255 / steps) : 0;
+          for (let c = 0; c < 3; c += 1) {
+            const v = clamp(data[i + c] + threshold, 0, 255);
+            data[i + c] = Math.round((v / 255) * (steps - 1)) * (255 / (steps - 1));
+          }
+        }
+      }
+      ctx.putImageData(image, 0, 0);
+    }
+
+    drawSceneLayers(ctx, width, height, t, normalized, overlays) {
       this.drawBaseChamber(ctx, width, height, t, normalized);
 
       this.timeline.visualEvents.forEach((event) => {
@@ -208,8 +291,34 @@
       });
 
       this.drawSyncMarkers(ctx, t, width, height);
-      this.drawScanlines(ctx, width, height, normalized);
-      this.drawGlow(ctx, width, height, normalized);
+      if (overlays) {
+        this.drawScanlines(ctx, width, height, normalized);
+        this.drawGlow(ctx, width, height, normalized);
+      }
+    }
+
+    renderToContext(ctx, width, height, t) {
+      if (!ctx || !this.timeline) return;
+      const runtime = this.timeline.runtime;
+      const normalized = clamp(t / Math.max(1, runtime), 0, 1.2);
+      const profile = this.timeline.renderProfile || this.resolveRenderProfile({});
+
+      if (profile.pixelMode) {
+        const lowRes = this.getLowResTarget(width, height, profile);
+        this.drawSceneLayers(lowRes.ctx, lowRes.canvas.width, lowRes.canvas.height, t, normalized, false);
+        this.applyPixelPost(lowRes.ctx, lowRes.canvas.width, lowRes.canvas.height, profile);
+
+        ctx.save();
+        ctx.imageSmoothingEnabled = false;
+        ctx.clearRect(0, 0, width, height);
+        ctx.drawImage(lowRes.canvas, 0, 0, width, height);
+        ctx.restore();
+
+        if (profile.scanlines) this.drawScanlines(ctx, width, height, normalized);
+        if (profile.glow) this.drawGlow(ctx, width, height, normalized);
+      } else {
+        this.drawSceneLayers(ctx, width, height, t, normalized, true);
+      }
 
       if (this.timeline.endCard && this.timeline.endCard.use_end_card && t > runtime - 1.6) {
         const p = Math.max(0, Math.min(1, (t - (runtime - 1.6)) / 1.4));
@@ -218,18 +327,20 @@
     }
 
     drawBaseChamber(ctx, w, h, t, normalized) {
+      const theme = (this.timeline && this.timeline.renderProfile && this.timeline.renderProfile.theme) || {};
       const horizon = h * 0.6;
       const pulse = 0.5 + 0.5 * Math.sin(t * 1.9);
 
       const bg = ctx.createLinearGradient(0, 0, 0, h);
-      bg.addColorStop(0, '#02050c');
-      bg.addColorStop(0.58, '#070d1e');
-      bg.addColorStop(1, '#050911');
+      bg.addColorStop(0, theme.bgTop || '#02050c');
+      bg.addColorStop(0.58, theme.bgMid || '#070d1e');
+      bg.addColorStop(1, theme.bgBottom || '#050911');
       ctx.fillStyle = bg;
       ctx.fillRect(0, 0, w, h);
 
       const radial = ctx.createRadialGradient(w * 0.52, h * 0.52, 20, w * 0.52, h * 0.54, Math.max(w, h) * 0.72);
-      radial.addColorStop(0, `rgba(74,112,255,${0.1 + pulse * 0.05})`);
+      const fog = theme.fog || [74, 112, 255];
+      radial.addColorStop(0, `rgba(${fog[0]},${fog[1]},${fog[2]},${0.1 + pulse * 0.05})`);
       radial.addColorStop(1, 'rgba(0,0,0,0)');
       ctx.fillStyle = radial;
       ctx.fillRect(0, 0, w, h);
@@ -244,7 +355,8 @@
         ctx.stroke();
       }
 
-      ctx.fillStyle = `rgba(120,220,255,${0.06 + normalized * 0.1})`;
+      const particles = theme.particles || [120, 220, 255];
+      ctx.fillStyle = `rgba(${particles[0]},${particles[1]},${particles[2]},${0.06 + normalized * 0.1})`;
       for (let i = 0; i < 46; i += 1) {
         const x = (i * 53 + t * (8 + (i % 5))) % w;
         const y = (i * 31 + Math.sin(t + i) * 10) % (h * 0.9);
@@ -254,7 +366,8 @@
       const coreX = w * (0.5 + Math.sin(t * 0.13) * 0.02);
       const coreY = h * (0.5 + Math.cos(t * 0.11) * 0.02);
       const core = ctx.createRadialGradient(coreX, coreY, 2, coreX, coreY, h * 0.28);
-      core.addColorStop(0, `rgba(176,228,255,${0.24 + pulse * 0.18})`);
+      const coreColor = theme.core || [176, 228, 255];
+      core.addColorStop(0, `rgba(${coreColor[0]},${coreColor[1]},${coreColor[2]},${0.24 + pulse * 0.18})`);
       core.addColorStop(1, 'rgba(0,0,0,0)');
       ctx.fillStyle = core;
       ctx.fillRect(0, 0, w, h);
@@ -568,7 +681,10 @@
           break;
         }
         case 'neon_wet_reflections': {
-          const colors = ['rgba(90,190,255,', 'rgba(255,96,186,', 'rgba(120,255,220,'];
+          const theme = (this.timeline && this.timeline.renderProfile && this.timeline.renderProfile.theme) || {};
+          const neonA = theme.neonA || [255, 96, 186];
+          const neonB = theme.neonB || [120, 255, 220];
+          const colors = [`rgba(90,190,255,`, `rgba(${neonA[0]},${neonA[1]},${neonA[2]},`, `rgba(${neonB[0]},${neonB[1]},${neonB[2]},`];
           for (let i = 0; i < 12; i += 1) {
             const x = (i * 83 + normalized * 60) % w;
             const alpha = 0.08 + intensity * 0.12;
@@ -619,12 +735,81 @@
     drawEndCard(ctx, endCard, progress, w, h) {
       ctx.fillStyle = `rgba(1,5,15,${0.5 * progress})`;
       ctx.fillRect(0, 0, w, h);
+      const style = String(endCard.reveal_style || '').toLowerCase();
+      const lines = String(endCard.text || 'END SIGNAL').split(/\n/);
+      const lineHeight = Math.max(20, h * 0.045);
+      const originX = w * 0.08;
+      const originY = h * 0.36;
+      const charsToShow = Math.floor(lines.join('\n').length * progress);
+      let shown = 0;
+
       ctx.globalAlpha = progress;
       ctx.fillStyle = '#dcf7ff';
       ctx.shadowColor = 'rgba(120,236,255,0.85)';
-      ctx.shadowBlur = 14;
-      ctx.font = 'bold 34px monospace';
-      ctx.fillText(String(endCard.text || 'END SIGNAL'), w * 0.1, h * 0.52);
+      ctx.shadowBlur = 10;
+      ctx.textBaseline = 'top';
+
+      if (style === 'event_card') {
+        const cardW = w * 0.76;
+        const cardH = h * 0.56;
+        const cardX = w * 0.12;
+        const cardY = h * 0.2;
+        ctx.fillStyle = 'rgba(6,15,28,0.86)';
+        ctx.fillRect(cardX, cardY, cardW, cardH);
+        ctx.strokeStyle = 'rgba(125,220,255,0.75)';
+        ctx.lineWidth = 2;
+        ctx.strokeRect(cardX, cardY, cardW, cardH);
+
+        const filtered = lines.filter((l) => l.trim().length || l === '');
+        const header = filtered[0] || 'AI FILM CLUB';
+        const meta = filtered[1] || '';
+        const title = filtered[3] || filtered[2] || 'END SIGNAL';
+        const body = filtered.slice(4);
+        let y = cardY + 24;
+        ctx.fillStyle = '#89e6ff';
+        ctx.font = 'bold 26px monospace';
+        ctx.fillText(header, cardX + 24, y);
+        y += lineHeight * 1.1;
+        ctx.fillStyle = '#b8d7ef';
+        ctx.font = '16px monospace';
+        if (meta) ctx.fillText(meta, cardX + 24, y);
+        y += lineHeight * 1.05;
+        ctx.fillStyle = '#f7fcff';
+        ctx.font = 'bold 30px monospace';
+        ctx.fillText(title, cardX + 24, y);
+        y += lineHeight * 1.3;
+        ctx.fillStyle = '#d4ebff';
+        ctx.font = '18px monospace';
+        body.forEach((line) => {
+          if (!line.trim()) {
+            y += lineHeight * 0.45;
+            return;
+          }
+          ctx.fillText(line, cardX + 24, y);
+          y += lineHeight * 0.95;
+        });
+      } else {
+        ctx.font = 'bold 32px monospace';
+        lines.forEach((line, i) => {
+          let out = line;
+          if (style === 'typewriter') {
+            const remain = Math.max(0, charsToShow - shown);
+            out = line.slice(0, remain);
+            shown += line.length + 1;
+          }
+          if (style === 'glitch_wipe') {
+            const wipe = clamp((progress - (i * 0.08)) * 1.8, 0, 1);
+            ctx.save();
+            ctx.beginPath();
+            ctx.rect(originX, originY + i * lineHeight, w * 0.86 * wipe, lineHeight + 4);
+            ctx.clip();
+            ctx.fillText(out, originX, originY + i * lineHeight);
+            ctx.restore();
+          } else {
+            ctx.fillText(out, originX, originY + i * lineHeight);
+          }
+        });
+      }
       ctx.globalAlpha = 1;
       ctx.shadowBlur = 0;
     }


### PR DESCRIPTION
### Motivation
- Provide an "8‑bit pixel cinematic" rendering mode that can be auto-enabled from semantic/style tags so ASMR Lab outputs look visibly different for pixel/arcade prompts.
- Allow structured, readable multi‑line end cards with multiple reveal styles to support event listings and film‑club style screens.
- Make canvas video export reliable by forcing frame delivery so long exports do not collapse to a few video frames while audio is correct.

### Description
- Add a style‑tag driven render profile in `js/asmr-visual-engine.js` via `resolveRenderProfile(pkg)` and wire it into timeline normalization to enable `pixelMode`, palette biasing, scanlines/glow toggles, and theme overrides. 
- Implement a low‑resolution offscreen pipeline that renders to a small canvas, applies posterization and optional Bayer ordered dithering (`applyPixelPost`), and upscales to the display/export canvas with nearest‑neighbor (image smoothing disabled); scanline and glow overlays are applied after upscale. 
- Upgrade `drawEndCard` in `js/asmr-visual-engine.js` to support multiline text and three reveal styles: `typewriter`, `glitch_wipe`, and `event_card` (boxed header/meta/title/body layout with readable spacing and pixel/monospace styling). 
- Improve video export in `js/asmr-lab.js` by using `canvas.captureStream(0)`, forcing frames with `requestFrame()` on the capture track in a deterministic 30fps timer (`recordVideoWithMime`), and adding an MP4 safety check that retries with WebM when the recorded blob is tiny or too short. 
- Expand semantic cue detection in `functions.php` (`se_get_asmr_semantic_cues` / `se_apply_asmr_semantic_cues`) to recognize `8-bit`, `8bit`, `pixel art`, `pixel`, `dither`, `arcade`, `chiptune`, and `sprite`, inject early pixel‑style visual events (`pixel_grid_pulse`, `scanline_field`, `signal_bars`) when present, and auto‑set `end_card.reveal_style = 'event_card'` for event/screening/film club contexts. 
- Preserve multiline end card server‑side by switching to `sanitize_textarea_field` for `end_card.text` in `functions.php`.

### Testing
- Ran `node --check js/asmr-visual-engine.js` and the file passed JavaScript syntax checks. (success)
- Ran `node --check js/asmr-lab.js` and the file passed JavaScript syntax checks. (success)
- Ran `php -l functions.php` and the PHP file passed syntax checking. (success)
- Attempted a Playwright screenshot (`page.goto('http://localhost:8080')`) to exercise runtime rendering, but the environment had no local server responding (`ERR_EMPTY_RESPONSE`), so a headless integration test could not be performed here. (environment limitation)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b084748a04832eafe5c1650c3c95f8)