### PR TITLE
Add Vancouver Mode UI and Vancouver-specific foley & visual anchors for ASMR Lab

### DIFF
--- a/assets/css/asmr-lab.css
+++ b/assets/css/asmr-lab.css
@@ -3,7 +3,7 @@
 .asmr-title{font-family:'Press Start 2P',monospace;font-size:1.4rem;color:#b5cbff}
 .asmr-lab-form label{display:flex;flex-direction:column;gap:.35rem;font-size:.85rem}
 .asmr-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:.8rem}
-.asmr-grid input,.asmr-grid textarea,.asmr-mode-label select{background:#0a0d1c;color:#e6ecff;border:1px solid #33437f;border-radius:6px;padding:.6rem}
+.asmr-grid input,.asmr-grid textarea,.asmr-grid select,.asmr-mode-label select{background:#0a0d1c;color:#e6ecff;border:1px solid #33437f;border-radius:6px;padding:.6rem}
 .asmr-actions,.asmr-audio-controls{display:flex;gap:.6rem;flex-wrap:wrap;margin-top:1rem;align-items:center}
 .pixel-button.secondary{opacity:.86}
 .asmr-status{min-height:1.2rem;color:#7df9c1}
@@ -22,3 +22,11 @@
 .asmr-mode-label{font-size:.8rem;display:flex;gap:.35rem;align-items:center}
 .asmr-video-support{font-size:.75rem;color:#9bd9ff;opacity:.9}
 .asmr-audio-feedback{font-size:.82rem;color:#9ed4ff;margin:0}
+.asmr-foley-grid{margin-top:1rem;border:1px solid #33437f;border-radius:8px;padding:.8rem;background:#0c1226;display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:.55rem .8rem}
+.asmr-foley-grid legend{padding:0 .35rem;color:#9ec0ff;font-size:.85rem}
+.asmr-foley-grid label{display:flex;align-items:center;gap:.45rem;font-size:.82rem;background:#0a0f21;border:1px solid #293867;border-radius:6px;padding:.4rem .5rem}
+.asmr-foley-grid input{accent-color:#7aa2ff}
+.asmr-advanced-fields{margin-top:1rem;border:1px solid #2f3f73;border-radius:8px;background:#111832;padding:.65rem}
+.asmr-advanced-fields summary{cursor:pointer;color:#9ec0ff;font-size:.84rem;list-style:none}
+.asmr-advanced-fields summary::-webkit-details-marker{display:none}
+.asmr-advanced-fields[open] summary{margin-bottom:.65rem}

--- a/functions.php
+++ b/functions.php
@@ -890,6 +890,16 @@ function se_get_asmr_allowed_engines() {
         'metal_resonance',
         'snow_muffle',
         'city_electrical_hum',
+        'footsteps_wet',
+        'footsteps_snow',
+        'rain_close',
+        'rain_roof',
+        'puddle_splash',
+        'crowd_murmur',
+        'laughter_burst',
+        'skytrain_pass',
+        'bus_idle',
+        'car_horn_short',
     );
 }
 
@@ -902,6 +912,11 @@ function se_get_asmr_visual_types() {
         'chromatic_veil', 'terminal_runes', 'snow_drift', 'amber_halo', 'wet_reflection_shimmer',
         'brick_shadow_drift', 'steam_plume_column', 'clock_face_reveal', 'harbor_mist',
         'neon_wet_reflections', 'winter_particulate_depth',
+        'gastown_clock_silhouette', 'cobblestone_perspective', 'brick_wall_parallax', 'streetlamp_halo_row',
+        'granville_neon_marquee', 'neon_sign_flicker', 'traffic_light_glow',
+        'skytrain_track', 'skytrain_pass_visual',
+        'northshore_mountain_ridge', 'mountain_mist_layers',
+        'rain_streaks', 'puddle_reflections',
     );
 }
 
@@ -927,6 +942,15 @@ function se_get_asmr_semantic_cues( $payload ) {
         'cobblestone' => array( 'cobblestone' ),
         'brick' => array( 'brick' ),
         'neon reflection' => array( 'neon', 'wet_reflection' ),
+        'granville' => array( 'granville', 'neon', 'nightlife', 'marquee', 'traffic', 'urban_night' ),
+        'north shore' => array( 'north_shore', 'mountains', 'mist', 'wind', 'ridge', 'harbor' ),
+        'northshore' => array( 'north_shore', 'mountains', 'mist', 'wind', 'ridge', 'harbor' ),
+        'skytrain' => array( 'transit', 'skytrain' ),
+        'bus' => array( 'transit', 'bus' ),
+        'car horn' => array( 'transit', 'car_horn' ),
+        'footsteps' => array( 'footsteps' ),
+        'chatter' => array( 'chatter' ),
+        'laughter' => array( 'laughter' ),
         'winter hush' => array( 'winter_hush', 'snow' ),
         '8-bit' => array( 'pixel_art', 'arcade' ),
         '8bit' => array( 'pixel_art', 'arcade' ),
@@ -1153,6 +1177,129 @@ function se_enrich_asmr_event_density( $decoded ) {
     return $decoded;
 }
 
+
+function se_get_asmr_vancouver_derived_payload( $payload ) {
+    $location = sanitize_key( $payload['location'] ?? '' );
+    $weather = sanitize_key( $payload['weather'] ?? '' );
+    $foley = array_values( array_filter( array_map( 'sanitize_key', (array) ( $payload['foley'] ?? array() ) ) ) );
+
+    $location_meta = array(
+        'gastown' => array(
+            'label' => 'Gastown Steam Clock',
+            'object' => 'steam clock',
+            'setting' => 'midnight Gastown lane with wet cobblestones, brick facades, cast iron rails, and amber lamps',
+            'visual' => 'gastown_clock_silhouette',
+        ),
+        'granville' => array(
+            'label' => 'Granville Street',
+            'object' => 'neon marquee and rain-slick street',
+            'setting' => 'midnight Granville strip with neon marquees, reflective asphalt, bus shelters, and crosswalk paint',
+            'visual' => 'granville_neon_marquee',
+        ),
+        'north_shore' => array(
+            'label' => 'North Shore Mountains',
+            'object' => 'mountain ridge and harbor air',
+            'setting' => 'midnight harbor edge facing North Shore ridges with cedar silhouettes, cold air, and layered mist',
+            'visual' => 'northshore_mountain_ridge',
+        ),
+    );
+    $weather_moods = array(
+        'snow' => 'hushed and holy',
+        'rain' => 'neon melancholy',
+        'fog' => 'dreamlike and liminal',
+        'clear_cold' => 'crisp and electric',
+    );
+
+    if ( ! isset( $location_meta[ $location ] ) || ! isset( $weather_moods[ $weather ] ) ) {
+        return $payload;
+    }
+
+    $foley_text = empty( $foley ) ? 'soft civic ambience' : implode( ', ', $foley );
+    $meta = $location_meta[ $location ];
+
+    $payload['concept'] = sprintf( 'A cinematic Vancouver midnight vignette in %s, where urban signals feel sacred.', $meta['label'] );
+    $payload['object'] = $meta['object'];
+    $payload['setting'] = $meta['setting'];
+    $payload['mood'] = $weather_moods[ $weather ];
+    $payload['creative_goal'] = sprintf( 'Compose a sacred urban signal arc with %s cues anchored in %s.', $foley_text, $meta['label'] );
+    return $payload;
+}
+
+function se_inject_asmr_vancouver_anchors( $decoded, $payload ) {
+    $location = sanitize_key( $payload['location'] ?? '' );
+    $weather = sanitize_key( $payload['weather'] ?? '' );
+    $foley = array_values( array_filter( array_map( 'sanitize_key', (array) ( $payload['foley'] ?? array() ) ) ) );
+    if ( empty( $location ) && empty( $weather ) && empty( $foley ) ) {
+        return $decoded;
+    }
+
+    $runtime = max( 10, min( 30, floatval( $decoded['runtime_seconds'] ?? 20 ) ) );
+    $audio = is_array( $decoded['audio_events'] ?? null ) ? $decoded['audio_events'] : array();
+    $visual = is_array( $decoded['visual_events'] ?? null ) ? $decoded['visual_events'] : array();
+    $sync = is_array( $decoded['sync_points'] ?? null ) ? $decoded['sync_points'] : array();
+
+    $audio[] = array( 'time' => 0.08, 'duration' => 2.2, 'engine' => 'city_electrical_hum', 'intensity' => 0.28, 'params' => array(), 'sync_role' => 'vancouver_bed' );
+
+    if ( 'gastown' === $location ) {
+        $audio[] = array( 'time' => 0.52, 'duration' => 1.2, 'engine' => 'steam_clock_burst', 'intensity' => 0.72, 'params' => array(), 'sync_role' => 'gastown_anchor' );
+        $visual[] = array( 'time' => 0.22, 'duration' => 2.2, 'visual_type' => 'gastown_clock_silhouette', 'intensity' => 0.78, 'params' => array(), 'sync_role' => 'gastown_identity' );
+        $visual[] = array( 'time' => 0.16, 'duration' => 2.4, 'visual_type' => 'streetlamp_halo_row', 'intensity' => 0.6, 'params' => array(), 'sync_role' => 'streetlamp_glow' );
+        $visual[] = array( 'time' => 0.28, 'duration' => 2.8, 'visual_type' => 'cobblestone_perspective', 'intensity' => 0.62, 'params' => array(), 'sync_role' => 'street_surface' );
+    } elseif ( 'granville' === $location ) {
+        $visual[] = array( 'time' => 0.22, 'duration' => 2.4, 'visual_type' => 'granville_neon_marquee', 'intensity' => 0.76, 'params' => array(), 'sync_role' => 'granville_identity' );
+        $visual[] = array( 'time' => 0.36, 'duration' => 2.1, 'visual_type' => 'neon_sign_flicker', 'intensity' => 0.68, 'params' => array(), 'sync_role' => 'neon_flicker' );
+        $visual[] = array( 'time' => 0.42, 'duration' => 2.2, 'visual_type' => 'traffic_light_glow', 'intensity' => 0.58, 'params' => array(), 'sync_role' => 'traffic_glow' );
+    } elseif ( 'north_shore' === $location ) {
+        $visual[] = array( 'time' => 0.24, 'duration' => 2.8, 'visual_type' => 'northshore_mountain_ridge', 'intensity' => 0.78, 'params' => array(), 'sync_role' => 'mountain_identity' );
+        $visual[] = array( 'time' => 0.18, 'duration' => 3.0, 'visual_type' => 'mountain_mist_layers', 'intensity' => 0.62, 'params' => array(), 'sync_role' => 'mist_layers' );
+    }
+
+    if ( in_array( 'footsteps', $foley, true ) ) {
+        $engine = ( 'snow' === $weather ) ? 'footsteps_snow' : 'footsteps_wet';
+        $step_count = 3;
+        for ( $i = 0; $i < $step_count; $i++ ) {
+            $audio[] = array( 'time' => 0.7 + ( $i * ( $runtime * 0.14 ) ), 'duration' => 0.18, 'engine' => $engine, 'intensity' => 0.55, 'params' => array(), 'sync_role' => 'footstep_anchor' );
+        }
+    }
+
+    if ( 'rain' === $weather || in_array( 'rain', $foley, true ) ) {
+        $audio[] = array( 'time' => 0.04, 'duration' => min( 6, $runtime * 0.45 ), 'engine' => 'rain_close', 'intensity' => 0.54, 'params' => array(), 'sync_role' => 'rain_bed' );
+        $visual[] = array( 'time' => 0.08, 'duration' => min( 6, $runtime * 0.44 ), 'visual_type' => 'rain_streaks', 'intensity' => 0.68, 'params' => array(), 'sync_role' => 'rain_streaks' );
+        $visual[] = array( 'time' => 0.12, 'duration' => min( 6, $runtime * 0.4 ), 'visual_type' => 'puddle_reflections', 'intensity' => 0.62, 'params' => array(), 'sync_role' => 'puddle_reflections' );
+    }
+
+    if ( in_array( 'skytrain', $foley, true ) ) {
+        $mid = $runtime * 0.52;
+        $audio[] = array( 'time' => $mid, 'duration' => 2.2, 'engine' => 'skytrain_pass', 'intensity' => 0.7, 'params' => array(), 'sync_role' => 'skytrain_anchor' );
+        $visual[] = array( 'time' => $mid - 0.2, 'duration' => 2.4, 'visual_type' => 'skytrain_pass_visual', 'intensity' => 0.7, 'params' => array(), 'sync_role' => 'skytrain_visual' );
+        $visual[] = array( 'time' => $mid - 0.25, 'duration' => 2.5, 'visual_type' => 'skytrain_track', 'intensity' => 0.58, 'params' => array(), 'sync_role' => 'skytrain_track' );
+    }
+
+    if ( in_array( 'steam_clock', $foley, true ) ) {
+        $audio[] = array( 'time' => 0.5, 'duration' => 1.1, 'engine' => 'steam_clock_burst', 'intensity' => 0.7, 'params' => array(), 'sync_role' => 'steam_clock_toggle' );
+        $visual[] = array( 'time' => 0.28, 'duration' => 2.0, 'visual_type' => 'gastown_clock_silhouette', 'intensity' => 0.68, 'params' => array(), 'sync_role' => 'steam_clock_visual' );
+    }
+
+    if ( in_array( 'chatter', $foley, true ) ) {
+        $audio[] = array( 'time' => 1.1, 'duration' => 2.2, 'engine' => 'crowd_murmur', 'intensity' => 0.42, 'params' => array(), 'sync_role' => 'crowd_anchor' );
+    }
+    if ( in_array( 'laughter', $foley, true ) ) {
+        $audio[] = array( 'time' => $runtime * 0.4, 'duration' => 0.38, 'engine' => 'laughter_burst', 'intensity' => 0.58, 'params' => array(), 'sync_role' => 'laughter_anchor' );
+    }
+    if ( in_array( 'bus', $foley, true ) ) {
+        $audio[] = array( 'time' => $runtime * 0.32, 'duration' => 1.8, 'engine' => 'bus_idle', 'intensity' => 0.48, 'params' => array(), 'sync_role' => 'bus_anchor' );
+    }
+    if ( in_array( 'car_horn', $foley, true ) ) {
+        $audio[] = array( 'time' => $runtime * 0.62, 'duration' => 0.22, 'engine' => 'car_horn_short', 'intensity' => 0.6, 'params' => array(), 'sync_role' => 'horn_anchor' );
+    }
+
+    $decoded['style_tags'] = array_values( array_unique( array_merge( (array) ( $decoded['style_tags'] ?? array() ), array( $location, $weather, 'vancouver_mode' ), $foley ) ) );
+    $decoded['audio_events'] = $audio;
+    $decoded['visual_events'] = $visual;
+    $decoded['sync_points'] = $sync;
+    return $decoded;
+}
+
 function se_extract_json_object( $raw ) {
     $raw = trim( (string) $raw );
     if ( preg_match( '/```(?:json)?\s*(.+?)```/is', $raw, $matches ) ) {
@@ -1290,6 +1437,10 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
         $params = $req->get_params();
     }
 
+    $allowed_locations = array( 'gastown', 'granville', 'north_shore' );
+    $allowed_weather = array( 'snow', 'rain', 'fog', 'clear_cold' );
+    $allowed_foley = array( 'footsteps', 'rain', 'chatter', 'laughter', 'skytrain', 'bus', 'car_horn', 'steam_clock' );
+
     $payload = array(
         'concept' => sanitize_text_field( $params['concept'] ?? '' ),
         'object' => sanitize_text_field( $params['object'] ?? '' ),
@@ -1299,11 +1450,21 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
         'voice_style' => sanitize_text_field( $params['voice_style'] ?? '' ),
         'weirdness' => max( 1, min( 10, absint( $params['weirdness'] ?? 6 ) ) ),
         'creative_goal' => sanitize_textarea_field( $params['creative_goal'] ?? '' ),
+        'location' => sanitize_key( $params['location'] ?? '' ),
+        'weather' => sanitize_key( $params['weather'] ?? '' ),
+        'foley' => array_values( array_intersect( $allowed_foley, array_map( 'sanitize_key', (array) ( $params['foley'] ?? array() ) ) ) ),
         'sound_only' => ! empty( $params['sound_only'] ),
     );
 
-    if ( empty( $payload['concept'] ) || empty( $payload['object'] ) || empty( $payload['setting'] ) || empty( $payload['mood'] ) ) {
-        return new WP_Error( 'asmr_missing_fields', __( 'Please provide concept, object, setting, and mood.', 'suzys-music-theme' ), array( 'status' => 400 ) );
+    $has_freeform = ! empty( $payload['concept'] ) && ! empty( $payload['object'] ) && ! empty( $payload['setting'] ) && ! empty( $payload['mood'] );
+    $has_vancouver = in_array( $payload['location'], $allowed_locations, true ) && in_array( $payload['weather'], $allowed_weather, true );
+
+    if ( ! $has_freeform && ! $has_vancouver ) {
+        return new WP_Error( 'asmr_missing_fields', __( 'Provide freeform concept/object/setting/mood or use Vancouver Mode location + weather.', 'suzys-music-theme' ), array( 'status' => 400 ) );
+    }
+
+    if ( $has_vancouver && ! $has_freeform ) {
+        $payload = se_get_asmr_vancouver_derived_payload( $payload );
     }
 
     $allowed_engines = implode( ', ', se_get_asmr_allowed_engines() );
@@ -1379,6 +1540,7 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
     }
 
     $validated = se_enrich_asmr_event_density( se_apply_asmr_semantic_cues( $validated, $payload ) );
+    $validated = se_inject_asmr_vancouver_anchors( $validated, $payload );
 
     return rest_ensure_response( $validated );
 }

--- a/js/asmr-foley-engine.js
+++ b/js/asmr-foley-engine.js
@@ -8,7 +8,9 @@
     'shimmer_swirl', 'crystal_chime', 'ghost_pad', 'spectral_suck', 'voltage_flutter',
     'halo_tone', 'particle_spark', 'ritual_bass_swell', 'reverse_bloom',
     'steam_clock_burst', 'distant_bell_toll', 'cold_air_hush', 'wet_street_shimmer',
-    'harbor_fog_bed', 'metal_resonance', 'snow_muffle', 'city_electrical_hum'
+    'harbor_fog_bed', 'metal_resonance', 'snow_muffle', 'city_electrical_hum',
+    'footsteps_wet', 'footsteps_snow', 'rain_close', 'rain_roof', 'puddle_splash',
+    'crowd_murmur', 'laughter_burst', 'skytrain_pass', 'bus_idle', 'car_horn_short'
   ];
 
   function clamp(value, min, max) {
@@ -365,6 +367,56 @@
           this.scheduleTone(ctx, destination, atTime, duration, { from: p.from || 112, to: p.to || 118, peak: 0.022 + intensity * 0.04, type: 'sawtooth', pan: 0.03 });
           this.scheduleTone(ctx, destination, atTime + 0.01, duration * 0.9, { from: 224, to: 236, peak: 0.008 + intensity * 0.02, type: 'triangle', pan: -0.1 });
           break;
+
+        case 'footsteps_wet':
+        case 'footsteps_snow': {
+          const wet = event.engine === 'footsteps_wet';
+          this.scheduleNoise(ctx, destination, atTime, Math.max(0.08, duration * 0.8), { freq: wet ? 420 : 320, q: 1.25, peak: 0.02 + intensity * 0.05, filterType: 'bandpass', pan: (Math.random() * 0.26) - 0.13 });
+          this.scheduleTone(ctx, destination, atTime + 0.01, Math.max(0.07, duration * 0.5), { from: 92, to: 74, peak: 0.012 + intensity * 0.03, type: 'sine', pan: wet ? 0.05 : -0.05 });
+          if (wet) {
+            this.scheduleNoise(ctx, destination, atTime + 0.02, Math.max(0.06, duration * 0.45), { freq: 1900, q: 1.9, peak: 0.008 + intensity * 0.018, filterType: 'highpass', pan: 0.08 });
+          }
+          break;
+        }
+        case 'rain_close':
+        case 'rain_roof': {
+          const roof = event.engine === 'rain_roof';
+          this.scheduleNoise(ctx, destination, atTime, duration, { freq: roof ? 2600 : 3200, q: 0.9, peak: 0.018 + intensity * 0.04, filterType: 'highpass', pan: 0.02 });
+          const drops = Math.max(6, Math.min(36, Math.round(duration * (roof ? 4 : 7) * (0.7 + intensity))));
+          for (let i = 0; i < drops; i += 1) {
+            const dt = (i / drops) * duration;
+            this.scheduleNoise(ctx, destination, atTime + dt, 0.045, { freq: 4600 + (i % 6) * 220, q: 2.6, peak: 0.004 + intensity * 0.012, filterType: 'bandpass', pan: Math.sin(i * 2.1) * 0.35 });
+          }
+          break;
+        }
+        case 'puddle_splash':
+          this.scheduleNoise(ctx, destination, atTime, Math.max(0.1, duration * 0.8), { freq: 1500, q: 1.1, peak: 0.02 + intensity * 0.04, filterType: 'bandpass', pan: -0.12 });
+          this.scheduleTone(ctx, destination, atTime + 0.02, Math.max(0.09, duration * 0.5), { from: 220, to: 110, peak: 0.008 + intensity * 0.018, type: 'triangle', pan: 0.1 });
+          break;
+        case 'crowd_murmur':
+          this.scheduleNoise(ctx, destination, atTime, duration, { freq: 520, q: 0.65, peak: 0.02 + intensity * 0.032, filterType: 'bandpass', pan: -0.1 });
+          this.scheduleNoise(ctx, destination, atTime + 0.03, duration * 0.95, { freq: 880, q: 0.8, peak: 0.014 + intensity * 0.024, filterType: 'bandpass', pan: 0.12 });
+          this.scheduleTone(ctx, destination, atTime, duration * 0.85, { from: 190, to: 240, peak: 0.004 + intensity * 0.012, type: 'sine', pan: 0.04 });
+          break;
+        case 'laughter_burst':
+          this.scheduleTone(ctx, destination, atTime, Math.max(0.12, duration * 0.7), { from: 280, to: 420, peak: 0.012 + intensity * 0.022, type: 'triangle', pan: 0.2 });
+          this.scheduleNoise(ctx, destination, atTime + 0.015, Math.max(0.11, duration * 0.75), { freq: 1300, q: 1.4, peak: 0.012 + intensity * 0.02, filterType: 'bandpass', pan: -0.16 });
+          break;
+        case 'skytrain_pass':
+          this.scheduleTone(ctx, destination, atTime, duration, { from: 58, to: 46, peak: 0.045 + intensity * 0.07, type: 'sawtooth', pan: -0.25 });
+          this.scheduleTone(ctx, destination, atTime + 0.05, duration * 0.9, { from: 140, to: 220, peak: 0.014 + intensity * 0.026, type: 'triangle', pan: 0.2 });
+          this.scheduleNoise(ctx, destination, atTime, duration, { freq: 2600, q: 0.75, peak: 0.012 + intensity * 0.02, filterType: 'highpass', pan: 0.1 });
+          break;
+        case 'bus_idle':
+          this.scheduleTone(ctx, destination, atTime, duration, { from: 78, to: 74, peak: 0.028 + intensity * 0.045, type: 'sawtooth', pan: -0.06 });
+          this.scheduleTone(ctx, destination, atTime + 0.02, duration * 0.95, { from: 156, to: 148, peak: 0.01 + intensity * 0.02, type: 'triangle', pan: 0.08 });
+          if (duration > 1) this.scheduleNoise(ctx, destination, atTime + duration * 0.68, 0.22, { freq: 2100, q: 1.3, peak: 0.01 + intensity * 0.018, filterType: 'highpass', pan: 0.18 });
+          break;
+        case 'car_horn_short':
+          this.scheduleTone(ctx, destination, atTime, Math.max(0.12, duration), { from: 410, to: 380, peak: 0.026 + intensity * 0.04, type: 'triangle', pan: 0.05 });
+          this.scheduleTone(ctx, destination, atTime, Math.max(0.1, duration * 0.9), { from: 510, to: 480, peak: 0.018 + intensity * 0.03, type: 'sawtooth', pan: -0.04 });
+          break;
+
         default:
           break;
       }

--- a/js/asmr-lab.js
+++ b/js/asmr-lab.js
@@ -25,14 +25,12 @@
   let currentPackage = null;
 
   const QA_PRESET = {
-    concept: 'A snow-covered Gastown steam clock becomes a winter shrine, breathing light into the empty street',
-    object: 'steam clock',
-    setting: 'midnight Gastown alley with snow, wet cobblestones, amber gaslight glow, brick walls, and harbor mist',
-    mood: 'ghostly calm, urban reverence, cold wonder, then warm luminous release',
+    location: 'gastown',
+    weather: 'snow',
     duration: '20',
     voice_style: 'quiet city prayer',
     weirdness: '8',
-    creative_goal: 'Turn Gastown into a sacred winter signal using steam bursts, bell-like tones, snow drift, lamplight halos, and reflective street shimmer with a final reveal that feels haunted and beautiful.'
+    foley: ['footsteps', 'steam_clock']
   };
 
   const transport = {
@@ -133,6 +131,32 @@
       if (!b) return;
       if (b === exportVideoBtn) b.disabled = !currentPackage || !videoSupport.canExport;
       else b.disabled = !currentPackage;
+    });
+  }
+
+
+  function collectFormPayload() {
+    const formData = new FormData(form);
+    const advanced = {
+      concept: String(formData.get('concept') || '').trim(),
+      object: String(formData.get('object') || '').trim(),
+      setting: String(formData.get('setting') || '').trim(),
+      mood: String(formData.get('mood') || '').trim(),
+      creative_goal: String(formData.get('creative_goal') || '').trim()
+    };
+    const base = {
+      duration: String(formData.get('duration') || '20'),
+      weirdness: String(formData.get('weirdness') || '6'),
+      voice_style: String(formData.get('voice_style') || '').trim()
+    };
+
+    const hasAdvanced = !!(advanced.concept || advanced.object || advanced.setting || advanced.mood || advanced.creative_goal);
+    if (hasAdvanced) return Object.assign({}, base, advanced);
+
+    return Object.assign({}, base, {
+      location: String(formData.get('location') || 'gastown'),
+      weather: String(formData.get('weather') || 'snow'),
+      foley: formData.getAll('foley[]').map((item) => String(item || '').trim()).filter(Boolean)
     });
   }
 
@@ -327,7 +351,7 @@
   if (form) {
     form.addEventListener('submit', async (event) => {
       event.preventDefault();
-      lastPayload = Object.fromEntries(new FormData(form).entries());
+      lastPayload = collectFormPayload();
       try { renderData(await requestGeneration(lastPayload)); }
       catch (err) { setError(err.message || 'Generation failed.'); setStatus(''); }
     });
@@ -336,10 +360,20 @@
   if (qaPresetBtn && form) {
     qaPresetBtn.addEventListener('click', () => {
       Object.entries(QA_PRESET).forEach(([key, value]) => {
+        if (key === 'foley' && Array.isArray(value)) {
+          const boxes = form.querySelectorAll('input[name=\"foley[]\"]');
+          boxes.forEach((box) => { box.checked = value.includes(box.value); });
+          return;
+        }
         const field = form.elements.namedItem(key);
         if (field) field.value = value;
       });
-      setStatus('QA preset loaded. Generate package to test known-good mood arc.');
+      const advancedFields = ['concept', 'object', 'setting', 'mood', 'creative_goal'];
+      advancedFields.forEach((name) => {
+        const field = form.elements.namedItem(name);
+        if (field) field.value = '';
+      });
+      setStatus('QA preset loaded (Vancouver Mode Gastown + Snow). Generate package to test known-good anchors.');
       setError('');
     });
   }

--- a/js/asmr-visual-engine.js
+++ b/js/asmr-visual-engine.js
@@ -8,7 +8,12 @@
     'starfield_drift', 'orbiting_shards', 'pulse_orb', 'energy_column', 'refraction_ripple',
     'chromatic_veil', 'terminal_runes', 'snow_drift', 'amber_halo', 'wet_reflection_shimmer',
     'brick_shadow_drift', 'steam_plume_column', 'clock_face_reveal', 'harbor_mist',
-    'neon_wet_reflections', 'winter_particulate_depth'
+    'neon_wet_reflections', 'winter_particulate_depth',
+    'gastown_clock_silhouette', 'cobblestone_perspective', 'brick_wall_parallax', 'streetlamp_halo_row',
+    'granville_neon_marquee', 'neon_sign_flicker', 'traffic_light_glow',
+    'skytrain_track', 'skytrain_pass_visual',
+    'northshore_mountain_ridge', 'mountain_mist_layers',
+    'rain_streaks', 'puddle_reflections'
   ];
 
   function clamp(value, min, max) {
@@ -148,7 +153,7 @@
     resolveRenderProfile(pkg) {
       const tags = (Array.isArray(pkg.style_tags) ? pkg.style_tags : []).map((t) => String(t || '').toLowerCase());
       const pixelMode = hasAnyTag(tags, ['pixel_art', '8bit', 'arcade', 'dither', 'chiptune']);
-      const vancouverCue = hasAnyTag(tags, ['gastown', 'vancouver', 'snow', 'rain', 'fog', 'amber', 'neon', 'brick', 'cobblestone']);
+      const vancouverCue = hasAnyTag(tags, ['gastown', 'granville', 'north_shore', 'vancouver', 'snow', 'rain', 'fog', 'amber', 'neon', 'brick', 'cobblestone', 'mountains']);
       const theme = {
         bgTop: '#02050c',
         bgMid: '#070d1e',
@@ -173,7 +178,7 @@
         theme.bgBottom = '#160f18';
         theme.amber = [255, 188, 110];
       }
-      if (hasAnyTag(tags, ['neon', 'arcade', 'chiptune'])) {
+      if (hasAnyTag(tags, ['neon', 'arcade', 'chiptune', 'granville'])) {
         theme.neonA = [255, 92, 205];
         theme.neonB = [108, 250, 225];
       }
@@ -181,6 +186,7 @@
       return {
         pixelMode,
         vancouverCue,
+        tags,
         lowResScale: pixelMode ? 6 : 1,
         paletteSteps: pixelMode ? 12 : 0,
         orderedDither: pixelMode && hasAnyTag(tags, ['dither', 'pixel_art', '8bit']),
@@ -365,6 +371,16 @@
 
       const coreX = w * (0.5 + Math.sin(t * 0.13) * 0.02);
       const coreY = h * (0.5 + Math.cos(t * 0.11) * 0.02);
+
+      const tags = (this.timeline && this.timeline.renderProfile && this.timeline.renderProfile.tags) || [];
+      if (tags.includes('gastown') && t <= 0.6) {
+        this.drawEvent(ctx, { visual_type: 'gastown_clock_silhouette', params: {}, intensity: 0.26 }, 0.25, 0.26, w, h, normalized);
+      } else if (tags.includes('granville') && t <= 0.6) {
+        this.drawEvent(ctx, { visual_type: 'granville_neon_marquee', params: {}, intensity: 0.24 }, 0.25, 0.24, w, h, normalized);
+      } else if (tags.includes('north_shore') && t <= 0.6) {
+        this.drawEvent(ctx, { visual_type: 'northshore_mountain_ridge', params: {}, intensity: 0.28 }, 0.25, 0.28, w, h, normalized);
+      }
+
       const core = ctx.createRadialGradient(coreX, coreY, 2, coreX, coreY, h * 0.28);
       const coreColor = theme.core || [176, 228, 255];
       core.addColorStop(0, `rgba(${coreColor[0]},${coreColor[1]},${coreColor[2]},${0.24 + pulse * 0.18})`);
@@ -693,6 +709,124 @@
           }
           break;
         }
+
+        case 'gastown_clock_silhouette': {
+          const cx = w * 0.52;
+          const baseY = h * 0.72;
+          ctx.fillStyle = `rgba(34,24,22,${0.25 + intensity * 0.45})`;
+          ctx.fillRect(cx - 60, baseY, 120, h * 0.2);
+          ctx.fillRect(cx - 24, h * 0.36, 48, h * 0.36);
+          ctx.beginPath();
+          ctx.arc(cx, h * 0.33, 52, 0, Math.PI * 2);
+          ctx.fill();
+          ctx.fillRect(cx - 86, h * 0.5, 12, h * 0.22);
+          ctx.fillRect(cx + 74, h * 0.5, 12, h * 0.22);
+          const halo = ctx.createRadialGradient(cx, h * 0.33, 10, cx, h * 0.33, 140);
+          halo.addColorStop(0, `rgba(255,190,120,${0.22 + intensity * 0.2})`);
+          halo.addColorStop(1, 'rgba(0,0,0,0)');
+          ctx.fillStyle = halo;
+          ctx.fillRect(cx - 150, h * 0.16, 300, 300);
+          break;
+        }
+        case 'cobblestone_perspective': {
+          ctx.strokeStyle = `rgba(148,170,188,${0.12 + intensity * 0.2})`;
+          for (let row = 0; row < 10; row += 1) {
+            const y = h * 0.62 + row * (h * 0.038);
+            const count = 6 + row;
+            for (let i = 0; i < count; i += 1) {
+              const ww = w / count;
+              const x = i * ww + ((row % 2) * ww * 0.5);
+              ctx.strokeRect(x, y, ww - 4, h * 0.03);
+            }
+          }
+          break;
+        }
+        case 'brick_wall_parallax': {
+          ctx.fillStyle = `rgba(88,52,44,${0.14 + intensity * 0.2})`;
+          for (let y = 0; y < h * 0.6; y += 18) {
+            for (let x = 0; x < w * 0.22; x += 36) ctx.fillRect(x + Math.sin(normalized * 4 + y * 0.02) * 2, y, 34, 16);
+            for (let x = w * 0.78; x < w; x += 36) ctx.fillRect(x - Math.sin(normalized * 4 + y * 0.02) * 2, y, 34, 16);
+          }
+          break;
+        }
+        case 'streetlamp_halo_row': {
+          for (let i = 0; i < 4; i += 1) {
+            const lx = w * (0.14 + i * 0.22);
+            const ly = h * 0.26;
+            const glow = ctx.createRadialGradient(lx, ly, 2, lx, ly, 90);
+            glow.addColorStop(0, `rgba(255,196,128,${0.24 + intensity * 0.2})`);
+            glow.addColorStop(1, 'rgba(0,0,0,0)');
+            ctx.fillStyle = glow;
+            ctx.fillRect(lx - 90, ly - 90, 180, 180);
+          }
+          break;
+        }
+        case 'granville_neon_marquee': {
+          const neon = (this.timeline.renderProfile.theme.neonA || [255, 96, 186]);
+          ctx.fillStyle = `rgba(${neon[0]},${neon[1]},${neon[2]},${0.22 + intensity * 0.26})`;
+          ctx.fillRect(w * 0.6, h * 0.1, w * 0.08, h * 0.6);
+          ctx.fillRect(w * 0.24, h * 0.2, w * 0.05, h * 0.42);
+          break;
+        }
+        case 'neon_sign_flicker': {
+          const flick = (Math.sin(normalized * 45) > 0.2) ? 1 : 0.35;
+          ctx.fillStyle = `rgba(110,255,230,${(0.16 + intensity * 0.2) * flick})`;
+          for (let i = 0; i < 6; i += 1) ctx.fillRect(w * 0.18 + i * 60, h * 0.22 + (i % 2) * 24, 44, 8);
+          break;
+        }
+        case 'traffic_light_glow': {
+          const x = w * 0.82;
+          const ys = [h * 0.24, h * 0.3, h * 0.36];
+          const cols = ['255,60,60', '255,220,90', '90,255,130'];
+          ys.forEach((y, i) => { const g = ctx.createRadialGradient(x, y, 2, x, y, 30); g.addColorStop(0, `rgba(${cols[i]},${0.2 + intensity * 0.2})`); g.addColorStop(1, 'rgba(0,0,0,0)'); ctx.fillStyle = g; ctx.fillRect(x - 32, y - 32, 64, 64); });
+          break;
+        }
+        case 'skytrain_track': {
+          ctx.strokeStyle = `rgba(160,190,220,${0.16 + intensity * 0.2})`;
+          ctx.lineWidth = 3;
+          ctx.beginPath(); ctx.moveTo(0, h * 0.44); ctx.lineTo(w, h * 0.44); ctx.stroke();
+          ctx.beginPath(); ctx.moveTo(0, h * 0.47); ctx.lineTo(w, h * 0.47); ctx.stroke();
+          break;
+        }
+        case 'skytrain_pass_visual': {
+          const x = ((normalized * 1.4) % 1.2) * w - w * 0.2;
+          ctx.fillStyle = `rgba(190,215,236,${0.2 + intensity * 0.24})`;
+          ctx.fillRect(x, h * 0.38, w * 0.22, h * 0.08);
+          for (let i = 0; i < 7; i += 1) ctx.clearRect(x + 8 + i * 28, h * 0.4, 18, h * 0.03);
+          break;
+        }
+        case 'northshore_mountain_ridge': {
+          ctx.fillStyle = `rgba(40,62,86,${0.24 + intensity * 0.28})`;
+          ctx.beginPath();
+          ctx.moveTo(0, h * 0.62);
+          for (let i = 0; i <= 8; i += 1) ctx.lineTo((i / 8) * w, h * (0.44 + (Math.sin(i * 0.9) * 0.08)));
+          ctx.lineTo(w, h); ctx.lineTo(0, h); ctx.closePath(); ctx.fill();
+          break;
+        }
+        case 'mountain_mist_layers': {
+          ctx.fillStyle = `rgba(156,186,206,${0.08 + intensity * 0.14})`;
+          for (let i = 0; i < 12; i += 1) {
+            const y = h * 0.45 + i * 14 + Math.sin(normalized * 3 + i) * 6;
+            ctx.fillRect(-6, y, w + 12, 10);
+          }
+          break;
+        }
+        case 'rain_streaks': {
+          ctx.strokeStyle = `rgba(170,210,255,${0.14 + intensity * 0.2})`;
+          for (let i = 0; i < 120; i += 1) {
+            const x = (i * 23 + normalized * 220) % w;
+            const y = (i * 17 + normalized * 320) % h;
+            ctx.beginPath(); ctx.moveTo(x, y); ctx.lineTo(x - 4, y + 14); ctx.stroke();
+          }
+          break;
+        }
+        case 'puddle_reflections': {
+          const neon = this.timeline.renderProfile.theme.neonB || [120, 255, 220];
+          ctx.fillStyle = `rgba(${neon[0]},${neon[1]},${neon[2]},${0.08 + intensity * 0.14})`;
+          for (let i = 0; i < 14; i += 1) ctx.fillRect((i * 74 + normalized * 30) % w, h * 0.67 + (i % 4) * 16, 28, h * 0.2);
+          break;
+        }
+
         case 'winter_particulate_depth': {
           ctx.fillStyle = `rgba(200,222,255,${0.08 + intensity * 0.16})`;
           for (let i = 0; i < 90; i += 1) {

--- a/page-asmr-lab.php
+++ b/page-asmr-lab.php
@@ -25,15 +25,48 @@ get_header();
 
     <form id="asmr-lab-form" class="asmr-lab-form" novalidate>
       <div class="asmr-grid">
-        <label>Concept<input type="text" name="concept" required maxlength="140" placeholder="Retro monolith waking up" /></label>
-        <label>Object<input type="text" name="object" required maxlength="80" placeholder="glass relay core" /></label>
-        <label>Setting<input type="text" name="setting" required maxlength="120" placeholder="midnight signal chamber" /></label>
-        <label>Mood<input type="text" name="mood" required maxlength="80" placeholder="tight tension then bloom" /></label>
+        <label>Location
+          <select name="location">
+            <option value="gastown" selected>Gastown Steam Clock</option>
+            <option value="granville">Granville Street</option>
+            <option value="north_shore">North Shore Mountains</option>
+          </select>
+        </label>
+        <label>Weather
+          <select name="weather">
+            <option value="snow" selected>Snow</option>
+            <option value="rain">Rain</option>
+            <option value="fog">Fog</option>
+            <option value="clear_cold">Clear Cold</option>
+          </select>
+        </label>
         <label>Duration (10-30 sec)<input type="number" name="duration" min="10" max="30" value="20" required /></label>
         <label>Voice Style<input type="text" name="voice_style" maxlength="80" placeholder="composed machine whisper" /></label>
         <label>Weirdness (1-10)<input type="number" name="weirdness" min="1" max="10" value="6" required /></label>
-        <label>Creative Goal<textarea name="creative_goal" rows="2" maxlength="260" placeholder="Favor tactile pulses and a clear terminal reveal."></textarea></label>
       </div>
+
+      <fieldset class="asmr-foley-grid">
+        <legend>Foley Layers</legend>
+        <label><input type="checkbox" name="foley[]" value="footsteps" checked /> footsteps</label>
+        <label><input type="checkbox" name="foley[]" value="rain" /> rain</label>
+        <label><input type="checkbox" name="foley[]" value="chatter" /> chatter</label>
+        <label><input type="checkbox" name="foley[]" value="laughter" /> laughter</label>
+        <label><input type="checkbox" name="foley[]" value="skytrain" /> SkyTrain</label>
+        <label><input type="checkbox" name="foley[]" value="bus" /> bus</label>
+        <label><input type="checkbox" name="foley[]" value="car_horn" /> car horn</label>
+        <label><input type="checkbox" name="foley[]" value="steam_clock" checked /> Gastown steam clock</label>
+      </fieldset>
+
+      <details class="asmr-advanced-fields">
+        <summary>Advanced / Freeform Mode (optional override)</summary>
+        <div class="asmr-grid">
+          <label>Concept<input type="text" name="concept" maxlength="140" placeholder="Retro monolith waking up" /></label>
+          <label>Object<input type="text" name="object" maxlength="80" placeholder="glass relay core" /></label>
+          <label>Setting<input type="text" name="setting" maxlength="120" placeholder="midnight signal chamber" /></label>
+          <label>Mood<input type="text" name="mood" maxlength="80" placeholder="tight tension then bloom" /></label>
+          <label>Creative Goal<textarea name="creative_goal" rows="2" maxlength="260" placeholder="Favor tactile pulses and a clear terminal reveal."></textarea></label>
+        </div>
+      </details>
       <div class="asmr-actions">
         <button type="submit" class="pixel-button">Generate ASMR Package</button>
         <button type="button" id="asmr-qa-preset" class="pixel-button secondary">Load QA Preset</button>


### PR DESCRIPTION
### Motivation
- Make ASMR Lab output read explicitly as Vancouver (Gastown / Granville / North Shore) by introducing a simplified preset-driven UI and concrete foley/visual anchors. 
- Provide performant procedural audio and canvas visual primitives so the browser-rendered preview and 1080p export feel location-specific without external samples. 
- Preserve backward compatibility via a collapsed `Advanced / Freeform Mode` so existing free-text workflows continue to work.

### Description
- UI: added a default “Vancouver Mode” form with `location` and `weather` selects, a `foley[]` checkbox grid, and an Advanced `<details>` block containing legacy `concept/object/setting/mood/creative_goal` fields in `page-asmr-lab.php`; updated styles in `assets/css/asmr-lab.css` to present the new controls cleanly. 
- Frontend logic: implemented `collectFormPayload()` in `js/asmr-lab.js` to build either legacy freeform payloads or Vancouver-mode payloads (`location`, `weather`, `foley`, `duration`, `weirdness`, `voice_style`), updated the QA preset to a Gastown+Snow profile, and wired the form submit to send the new payload shape while preserving backward compatibility. 
- Backend generation: extended `se_handle_asmr_generate()` in `functions.php` to accept and validate `location`, `weather`, and `foley`, derive `concept/object/setting/mood/creative_goal` when Vancouver Mode is used via `se_get_asmr_vancouver_derived_payload()`, expanded allowed audio engines and visual type lists, enhanced `se_get_asmr_semantic_cues()` with Granville/North Shore/transit/foley cues, and added `se_inject_asmr_vancouver_anchors()` to deterministically inject matching audio and visual events (early silhouette + matching foley) after model validation. 
- Foley engines: added new procedural engines to `js/asmr-foley-engine.js` (e.g., `footsteps_wet`, `footsteps_snow`, `rain_close`, `puddle_splash`, `crowd_murmur`, `laughter_burst`, `skytrain_pass`, `bus_idle`, `car_horn_short`) and implemented their synthesis using existing `scheduleTone` / `scheduleNoise` primitives; registered names in `ENGINE_NAMES`. 
- Visuals: added Vancouver-specific visual types to `js/asmr-visual-engine.js` (e.g., `gastown_clock_silhouette`, `cobblestone_perspective`, `granville_neon_marquee`, `northshore_mountain_ridge`, `rain_streaks`, `puddle_reflections`) and implemented lightweight Canvas 2D draw paths for each; also added a small first-frame silhouette hint drawn when location tags are present to guarantee an early recognizable element. 

### Testing
- Ran PHP syntax checks with `php -l functions.php` and `php -l page-asmr-lab.php`, both reported no syntax errors. 
- Performed a quick JS syntax/runtime eval using `node -e "const fs=require('fs');['js/asmr-lab.js','js/asmr-foley-engine.js','js/asmr-visual-engine.js'].forEach(f=>{new Function(fs.readFileSync(f,'utf8'));}); console.log('ok');"` which completed successfully. 
- Attempted an automated browser screenshot via Playwright to validate the new UI at `http://localhost:8080/page-asmr-lab` but the local server was not reachable in this environment (`ERR_EMPTY_RESPONSE`), so the visual verification step could not be captured here. 
- All edits pass basic static validation and local runtime parsing; audio/visual behavior should be validated interactively in a browser (preview, WAV export, and 1080p export) on a running site to confirm acceptance criteria for Gastown/Granville/North Shore scenarios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b08aa21ac4832ebad8d6b450642cf8)