### PR TITLE
Split ASMR Lab into separate Sound Layers and Visual Motifs with optional link toggle

### DIFF
--- a/assets/css/asmr-lab.css
+++ b/assets/css/asmr-lab.css
@@ -22,10 +22,12 @@
 .asmr-mode-label{font-size:.8rem;display:flex;gap:.35rem;align-items:center}
 .asmr-video-support{font-size:.75rem;color:#9bd9ff;opacity:.9}
 .asmr-audio-feedback{font-size:.82rem;color:#9ed4ff;margin:0}
-.asmr-foley-grid{margin-top:1rem;border:1px solid #33437f;border-radius:8px;padding:.8rem;background:#0c1226;display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:.55rem .8rem}
-.asmr-foley-grid legend{padding:0 .35rem;color:#9ec0ff;font-size:.85rem}
-.asmr-foley-grid label{display:flex;align-items:center;gap:.45rem;font-size:.82rem;background:#0a0f21;border:1px solid #293867;border-radius:6px;padding:.4rem .5rem}
-.asmr-foley-grid input{accent-color:#7aa2ff}
+.asmr-layer-grid{margin-top:1rem;border:1px solid #33437f;border-radius:8px;padding:.8rem;background:#0c1226;display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:.55rem .8rem}
+.asmr-layer-grid legend{padding:0 .35rem;color:#9ec0ff;font-size:.9rem;letter-spacing:.02em}
+.asmr-layer-grid label{display:flex;align-items:center;gap:.45rem;font-size:.82rem;background:#0a0f21;border:1px solid #293867;border-radius:6px;padding:.4rem .5rem}
+.asmr-layer-grid input{accent-color:#7aa2ff}
+.asmr-link-toggle{margin-top:.8rem;display:flex!important;flex-direction:row!important;align-items:center;gap:.5rem;padding:.55rem .65rem;border:1px solid #2f3f73;border-radius:8px;background:#111832;color:#bcd3ff;font-size:.82rem}
+.asmr-link-toggle input{accent-color:#7aa2ff}
 .asmr-advanced-fields{margin-top:1rem;border:1px solid #2f3f73;border-radius:8px;background:#111832;padding:.65rem}
 .asmr-advanced-fields summary{cursor:pointer;color:#9ec0ff;font-size:.84rem;list-style:none}
 .asmr-advanced-fields summary::-webkit-details-marker{display:none}

--- a/functions.php
+++ b/functions.php
@@ -914,9 +914,10 @@ function se_get_asmr_visual_types() {
         'neon_wet_reflections', 'winter_particulate_depth',
         'gastown_clock_silhouette', 'cobblestone_perspective', 'brick_wall_parallax', 'streetlamp_halo_row',
         'granville_neon_marquee', 'neon_sign_flicker', 'traffic_light_glow',
-        'skytrain_track', 'skytrain_pass_visual',
+        'skytrain_track', 'skytrain_pass_visual', 'bus_pass_visual',
         'northshore_mountain_ridge', 'mountain_mist_layers',
         'rain_streaks', 'puddle_reflections',
+        'science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof',
     );
 }
 
@@ -927,6 +928,8 @@ function se_get_asmr_semantic_cues( $payload ) {
         (string) ( $payload['setting'] ?? '' ),
         (string) ( $payload['mood'] ?? '' ),
         (string) ( $payload['creative_goal'] ?? '' ),
+        implode( ' ', (array) ( $payload['audio_layers'] ?? array() ) ),
+        implode( ' ', (array) ( $payload['visual_layers'] ?? array() ) ),
     ) ) );
 
     $cue_map = array(
@@ -966,6 +969,13 @@ function se_get_asmr_semantic_cues( $payload ) {
         'cinematic' => array( 'cinematic' ),
         'city' => array( 'urban_night' ),
         'urban' => array( 'urban_night' ),
+        'science world' => array( 'science_world', 'dome', 'landmark' ),
+        'science_world' => array( 'science_world', 'dome', 'landmark' ),
+        'chinatown gate' => array( 'chinatown_gate', 'landmark' ),
+        'inukshuk' => array( 'inukshuk', 'landmark' ),
+        'english bay' => array( 'english_bay', 'coastal', 'landmark' ),
+        'maritime museum' => array( 'maritime_museum', 'harbor', 'landmark' ),
+        'sail roof' => array( 'maritime_museum', 'sailroof', 'landmark' ),
     );
 
     $cues = array();
@@ -1048,6 +1058,8 @@ function se_apply_asmr_semantic_cues( $decoded, $payload ) {
         (string) ( $payload['setting'] ?? '' ),
         (string) ( $payload['mood'] ?? '' ),
         (string) ( $payload['creative_goal'] ?? '' ),
+        implode( ' ', (array) ( $payload['audio_layers'] ?? array() ) ),
+        implode( ' ', (array) ( $payload['visual_layers'] ?? array() ) ),
     ) ) );
     if ( false !== strpos( $source, 'event card' ) || false !== strpos( $source, 'screening' ) || false !== strpos( $source, 'film club' ) || false !== strpos( $source, 'deadline' ) ) {
         $end_card = is_array( $decoded['end_card'] ?? null ) ? $decoded['end_card'] : array();
@@ -1178,10 +1190,49 @@ function se_enrich_asmr_event_density( $decoded ) {
 }
 
 
+
+function se_get_asmr_audio_layers_allowed() {
+    return array( 'footsteps', 'rain_ambience', 'chatter', 'laughter', 'skytrain', 'bus', 'car_horn', 'steam_clock' );
+}
+
+function se_get_asmr_visual_layers_allowed() {
+    return array(
+        'rain_streaks', 'snow_drift', 'harbor_mist', 'skytrain_pass_visual', 'bus_pass_visual',
+        'traffic_light_glow', 'puddle_reflections', 'cobblestone_perspective', 'brick_wall_parallax', 'streetlamp_halo_row',
+        'science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'gastown_clock_silhouette'
+    );
+}
+
+function se_get_asmr_audio_to_visual_map() {
+    return array(
+        'skytrain' => 'skytrain_pass_visual',
+        'bus' => 'bus_pass_visual',
+        'rain_ambience' => 'rain_streaks',
+        'footsteps' => 'cobblestone_perspective',
+        'steam_clock' => 'gastown_clock_silhouette',
+    );
+}
+
+function se_get_asmr_legacy_audio_map() {
+    return array( 'rain' => 'rain_ambience' );
+}
+
+function se_get_asmr_mapped_visual_layers_from_audio( $audio_layers ) {
+    $map = se_get_asmr_audio_to_visual_map();
+    $visual = array();
+    foreach ( (array) $audio_layers as $token ) {
+        $key = sanitize_key( $token );
+        if ( isset( $map[ $key ] ) ) {
+            $visual[] = $map[ $key ];
+        }
+    }
+    return array_values( array_unique( $visual ) );
+}
+
 function se_get_asmr_vancouver_derived_payload( $payload ) {
     $location = sanitize_key( $payload['location'] ?? '' );
     $weather = sanitize_key( $payload['weather'] ?? '' );
-    $foley = array_values( array_filter( array_map( 'sanitize_key', (array) ( $payload['foley'] ?? array() ) ) ) );
+    $audio_layers = array_values( array_filter( array_map( 'sanitize_key', (array) ( $payload['audio_layers'] ?? array() ) ) ) );
 
     $location_meta = array(
         'gastown' => array(
@@ -1214,7 +1265,7 @@ function se_get_asmr_vancouver_derived_payload( $payload ) {
         return $payload;
     }
 
-    $foley_text = empty( $foley ) ? 'soft civic ambience' : implode( ', ', $foley );
+    $foley_text = empty( $audio_layers ) ? 'soft civic ambience' : implode( ', ', $audio_layers );
     $meta = $location_meta[ $location ];
 
     $payload['concept'] = sprintf( 'A cinematic Vancouver midnight vignette in %s, where urban signals feel sacred.', $meta['label'] );
@@ -1228,9 +1279,16 @@ function se_get_asmr_vancouver_derived_payload( $payload ) {
 function se_inject_asmr_vancouver_anchors( $decoded, $payload ) {
     $location = sanitize_key( $payload['location'] ?? '' );
     $weather = sanitize_key( $payload['weather'] ?? '' );
-    $foley = array_values( array_filter( array_map( 'sanitize_key', (array) ( $payload['foley'] ?? array() ) ) ) );
-    if ( empty( $location ) && empty( $weather ) && empty( $foley ) ) {
+    $link_av = ! array_key_exists( 'link_av', $payload ) || ! empty( $payload['link_av'] );
+    $audio_layers = array_values( array_filter( array_map( 'sanitize_key', (array) ( $payload['audio_layers'] ?? array() ) ) ) );
+    $visual_layers = array_values( array_filter( array_map( 'sanitize_key', (array) ( $payload['visual_layers'] ?? array() ) ) ) );
+
+    if ( empty( $location ) && empty( $weather ) && empty( $audio_layers ) && empty( $visual_layers ) ) {
         return $decoded;
+    }
+
+    if ( $link_av ) {
+        $visual_layers = array_values( array_unique( array_merge( $visual_layers, se_get_asmr_mapped_visual_layers_from_audio( $audio_layers ) ) ) );
     }
 
     $runtime = max( 10, min( 30, floatval( $decoded['runtime_seconds'] ?? 20 ) ) );
@@ -1241,7 +1299,6 @@ function se_inject_asmr_vancouver_anchors( $decoded, $payload ) {
     $audio[] = array( 'time' => 0.08, 'duration' => 2.2, 'engine' => 'city_electrical_hum', 'intensity' => 0.28, 'params' => array(), 'sync_role' => 'vancouver_bed' );
 
     if ( 'gastown' === $location ) {
-        $audio[] = array( 'time' => 0.52, 'duration' => 1.2, 'engine' => 'steam_clock_burst', 'intensity' => 0.72, 'params' => array(), 'sync_role' => 'gastown_anchor' );
         $visual[] = array( 'time' => 0.22, 'duration' => 2.2, 'visual_type' => 'gastown_clock_silhouette', 'intensity' => 0.78, 'params' => array(), 'sync_role' => 'gastown_identity' );
         $visual[] = array( 'time' => 0.16, 'duration' => 2.4, 'visual_type' => 'streetlamp_halo_row', 'intensity' => 0.6, 'params' => array(), 'sync_role' => 'streetlamp_glow' );
         $visual[] = array( 'time' => 0.28, 'duration' => 2.8, 'visual_type' => 'cobblestone_perspective', 'intensity' => 0.62, 'params' => array(), 'sync_role' => 'street_surface' );
@@ -1254,46 +1311,53 @@ function se_inject_asmr_vancouver_anchors( $decoded, $payload ) {
         $visual[] = array( 'time' => 0.18, 'duration' => 3.0, 'visual_type' => 'mountain_mist_layers', 'intensity' => 0.62, 'params' => array(), 'sync_role' => 'mist_layers' );
     }
 
-    if ( in_array( 'footsteps', $foley, true ) ) {
-        $engine = ( 'snow' === $weather ) ? 'footsteps_snow' : 'footsteps_wet';
-        $step_count = 3;
-        for ( $i = 0; $i < $step_count; $i++ ) {
-            $audio[] = array( 'time' => 0.7 + ( $i * ( $runtime * 0.14 ) ), 'duration' => 0.18, 'engine' => $engine, 'intensity' => 0.55, 'params' => array(), 'sync_role' => 'footstep_anchor' );
+    // Weather defaults always influence atmosphere visuals.
+    if ( 'rain' === $weather ) {
+        $visual[] = array( 'time' => 0.08, 'duration' => min( 6, $runtime * 0.44 ), 'visual_type' => 'rain_streaks', 'intensity' => 0.55, 'params' => array(), 'sync_role' => 'weather_rain_default' );
+    } elseif ( 'snow' === $weather ) {
+        $visual[] = array( 'time' => 0.08, 'duration' => min( 6, $runtime * 0.48 ), 'visual_type' => 'snow_drift', 'intensity' => 0.58, 'params' => array(), 'sync_role' => 'weather_snow_default' );
+    } elseif ( 'fog' === $weather ) {
+        $visual[] = array( 'time' => 0.08, 'duration' => min( 6, $runtime * 0.5 ), 'visual_type' => 'harbor_mist', 'intensity' => 0.58, 'params' => array(), 'sync_role' => 'weather_fog_default' );
+    }
+
+    foreach ( $audio_layers as $layer ) {
+        if ( 'footsteps' === $layer ) {
+            $engine = ( 'snow' === $weather ) ? 'footsteps_snow' : 'footsteps_wet';
+            for ( $i = 0; $i < 3; $i++ ) {
+                $audio[] = array( 'time' => 0.7 + ( $i * ( $runtime * 0.14 ) ), 'duration' => 0.18, 'engine' => $engine, 'intensity' => 0.55, 'params' => array(), 'sync_role' => 'footstep_anchor' );
+            }
+        } elseif ( 'rain_ambience' === $layer ) {
+            $audio[] = array( 'time' => 0.04, 'duration' => min( 6, $runtime * 0.45 ), 'engine' => 'rain_close', 'intensity' => 0.54, 'params' => array(), 'sync_role' => 'rain_bed' );
+        } elseif ( 'skytrain' === $layer ) {
+            $mid = $runtime * 0.52;
+            $audio[] = array( 'time' => $mid, 'duration' => 2.2, 'engine' => 'skytrain_pass', 'intensity' => 0.7, 'params' => array(), 'sync_role' => 'skytrain_anchor' );
+        } elseif ( 'steam_clock' === $layer ) {
+            $audio[] = array( 'time' => 0.5, 'duration' => 1.1, 'engine' => 'steam_clock_burst', 'intensity' => 0.7, 'params' => array(), 'sync_role' => 'steam_clock_toggle' );
+        } elseif ( 'chatter' === $layer ) {
+            $audio[] = array( 'time' => 1.1, 'duration' => 2.2, 'engine' => 'crowd_murmur', 'intensity' => 0.42, 'params' => array(), 'sync_role' => 'crowd_anchor' );
+        } elseif ( 'laughter' === $layer ) {
+            $audio[] = array( 'time' => $runtime * 0.4, 'duration' => 0.38, 'engine' => 'laughter_burst', 'intensity' => 0.58, 'params' => array(), 'sync_role' => 'laughter_anchor' );
+        } elseif ( 'bus' === $layer ) {
+            $audio[] = array( 'time' => $runtime * 0.32, 'duration' => 1.8, 'engine' => 'bus_idle', 'intensity' => 0.48, 'params' => array(), 'sync_role' => 'bus_anchor' );
+        } elseif ( 'car_horn' === $layer ) {
+            $audio[] = array( 'time' => $runtime * 0.62, 'duration' => 0.22, 'engine' => 'car_horn_short', 'intensity' => 0.6, 'params' => array(), 'sync_role' => 'horn_anchor' );
         }
     }
 
-    if ( 'rain' === $weather || in_array( 'rain', $foley, true ) ) {
-        $audio[] = array( 'time' => 0.04, 'duration' => min( 6, $runtime * 0.45 ), 'engine' => 'rain_close', 'intensity' => 0.54, 'params' => array(), 'sync_role' => 'rain_bed' );
-        $visual[] = array( 'time' => 0.08, 'duration' => min( 6, $runtime * 0.44 ), 'visual_type' => 'rain_streaks', 'intensity' => 0.68, 'params' => array(), 'sync_role' => 'rain_streaks' );
-        $visual[] = array( 'time' => 0.12, 'duration' => min( 6, $runtime * 0.4 ), 'visual_type' => 'puddle_reflections', 'intensity' => 0.62, 'params' => array(), 'sync_role' => 'puddle_reflections' );
+    foreach ( $visual_layers as $visual_type ) {
+        if ( 'skytrain_pass_visual' === $visual_type ) {
+            $mid = $runtime * 0.52;
+            $visual[] = array( 'time' => $mid - 0.2, 'duration' => 2.4, 'visual_type' => 'skytrain_pass_visual', 'intensity' => 0.7, 'params' => array(), 'sync_role' => 'skytrain_visual' );
+            $visual[] = array( 'time' => $mid - 0.25, 'duration' => 2.5, 'visual_type' => 'skytrain_track', 'intensity' => 0.58, 'params' => array(), 'sync_role' => 'skytrain_track' );
+        } elseif ( 'bus_pass_visual' === $visual_type ) {
+            $visual[] = array( 'time' => $runtime * 0.3, 'duration' => 2.1, 'visual_type' => 'bus_pass_visual', 'intensity' => 0.64, 'params' => array(), 'sync_role' => 'bus_visual' );
+        } else {
+            $visual[] = array( 'time' => 0.12, 'duration' => min( 5.4, $runtime * 0.4 ), 'visual_type' => $visual_type, 'intensity' => 0.62, 'params' => array(), 'sync_role' => 'visual_motif_toggle' );
+        }
     }
 
-    if ( in_array( 'skytrain', $foley, true ) ) {
-        $mid = $runtime * 0.52;
-        $audio[] = array( 'time' => $mid, 'duration' => 2.2, 'engine' => 'skytrain_pass', 'intensity' => 0.7, 'params' => array(), 'sync_role' => 'skytrain_anchor' );
-        $visual[] = array( 'time' => $mid - 0.2, 'duration' => 2.4, 'visual_type' => 'skytrain_pass_visual', 'intensity' => 0.7, 'params' => array(), 'sync_role' => 'skytrain_visual' );
-        $visual[] = array( 'time' => $mid - 0.25, 'duration' => 2.5, 'visual_type' => 'skytrain_track', 'intensity' => 0.58, 'params' => array(), 'sync_role' => 'skytrain_track' );
-    }
-
-    if ( in_array( 'steam_clock', $foley, true ) ) {
-        $audio[] = array( 'time' => 0.5, 'duration' => 1.1, 'engine' => 'steam_clock_burst', 'intensity' => 0.7, 'params' => array(), 'sync_role' => 'steam_clock_toggle' );
-        $visual[] = array( 'time' => 0.28, 'duration' => 2.0, 'visual_type' => 'gastown_clock_silhouette', 'intensity' => 0.68, 'params' => array(), 'sync_role' => 'steam_clock_visual' );
-    }
-
-    if ( in_array( 'chatter', $foley, true ) ) {
-        $audio[] = array( 'time' => 1.1, 'duration' => 2.2, 'engine' => 'crowd_murmur', 'intensity' => 0.42, 'params' => array(), 'sync_role' => 'crowd_anchor' );
-    }
-    if ( in_array( 'laughter', $foley, true ) ) {
-        $audio[] = array( 'time' => $runtime * 0.4, 'duration' => 0.38, 'engine' => 'laughter_burst', 'intensity' => 0.58, 'params' => array(), 'sync_role' => 'laughter_anchor' );
-    }
-    if ( in_array( 'bus', $foley, true ) ) {
-        $audio[] = array( 'time' => $runtime * 0.32, 'duration' => 1.8, 'engine' => 'bus_idle', 'intensity' => 0.48, 'params' => array(), 'sync_role' => 'bus_anchor' );
-    }
-    if ( in_array( 'car_horn', $foley, true ) ) {
-        $audio[] = array( 'time' => $runtime * 0.62, 'duration' => 0.22, 'engine' => 'car_horn_short', 'intensity' => 0.6, 'params' => array(), 'sync_role' => 'horn_anchor' );
-    }
-
-    $decoded['style_tags'] = array_values( array_unique( array_merge( (array) ( $decoded['style_tags'] ?? array() ), array( $location, $weather, 'vancouver_mode' ), $foley ) ) );
+    $weird_tag = 'weirdness_' . max( 1, min( 10, absint( $payload['weirdness'] ?? 6 ) ) );
+    $decoded['style_tags'] = array_values( array_unique( array_merge( (array) ( $decoded['style_tags'] ?? array() ), array( $location, $weather, 'vancouver_mode', $weird_tag ), $audio_layers, $visual_layers ) ) );
     $decoded['audio_events'] = $audio;
     $decoded['visual_events'] = $visual;
     $decoded['sync_points'] = $sync;
@@ -1439,7 +1503,26 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
 
     $allowed_locations = array( 'gastown', 'granville', 'north_shore' );
     $allowed_weather = array( 'snow', 'rain', 'fog', 'clear_cold' );
-    $allowed_foley = array( 'footsteps', 'rain', 'chatter', 'laughter', 'skytrain', 'bus', 'car_horn', 'steam_clock' );
+    $allowed_audio = se_get_asmr_audio_layers_allowed();
+    $allowed_visual = se_get_asmr_visual_layers_allowed();
+    $legacy_audio_map = se_get_asmr_legacy_audio_map();
+
+    $raw_legacy_foley = array_map( 'sanitize_key', (array) ( $params['foley'] ?? array() ) );
+    $legacy_audio_layers = array();
+    foreach ( $raw_legacy_foley as $token ) {
+        $legacy_audio_layers[] = $legacy_audio_map[ $token ] ?? $token;
+    }
+
+    $link_av = ! array_key_exists( 'link_av', $params ) || filter_var( $params['link_av'], FILTER_VALIDATE_BOOLEAN );
+    $audio_layers = array_values( array_intersect( $allowed_audio, array_map( 'sanitize_key', (array) ( $params['audio_layers'] ?? array() ) ) ) );
+    if ( empty( $audio_layers ) && ! empty( $legacy_audio_layers ) ) {
+        $audio_layers = array_values( array_intersect( $allowed_audio, $legacy_audio_layers ) );
+    }
+
+    $visual_layers = array_values( array_intersect( $allowed_visual, array_map( 'sanitize_key', (array) ( $params['visual_layers'] ?? array() ) ) ) );
+    if ( empty( $visual_layers ) && ! empty( $raw_legacy_foley ) && $link_av ) {
+        $visual_layers = array_values( array_intersect( $allowed_visual, se_get_asmr_mapped_visual_layers_from_audio( $legacy_audio_layers ) ) );
+    }
 
     $payload = array(
         'concept' => sanitize_text_field( $params['concept'] ?? '' ),
@@ -1452,7 +1535,10 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
         'creative_goal' => sanitize_textarea_field( $params['creative_goal'] ?? '' ),
         'location' => sanitize_key( $params['location'] ?? '' ),
         'weather' => sanitize_key( $params['weather'] ?? '' ),
-        'foley' => array_values( array_intersect( $allowed_foley, array_map( 'sanitize_key', (array) ( $params['foley'] ?? array() ) ) ) ),
+        'link_av' => $link_av,
+        'audio_layers' => $audio_layers,
+        'visual_layers' => $visual_layers,
+        'foley' => $raw_legacy_foley,
         'sound_only' => ! empty( $params['sound_only'] ),
     );
 

--- a/js/asmr-lab.js
+++ b/js/asmr-lab.js
@@ -24,13 +24,40 @@
   let lastPayload = null;
   let currentPackage = null;
 
+
+  const LINKED_LAYER_MAP = {
+    skytrain: 'skytrain_pass_visual',
+    bus: 'bus_pass_visual',
+    rain_ambience: 'rain_streaks',
+    footsteps: 'cobblestone_perspective',
+    steam_clock: 'gastown_clock_silhouette'
+  };
+
+  function applyLayerLinking(audioLayers, visualLayers, isLinked) {
+    const audioSet = new Set(Array.isArray(audioLayers) ? audioLayers : []);
+    const visualSet = new Set(Array.isArray(visualLayers) ? visualLayers : []);
+    if (!isLinked) {
+      return { audio_layers: Array.from(audioSet), visual_layers: Array.from(visualSet) };
+    }
+
+    Object.entries(LINKED_LAYER_MAP).forEach(([audioToken, visualToken]) => {
+      if (audioSet.has(audioToken)) visualSet.add(visualToken);
+      if (visualSet.has(visualToken)) audioSet.add(audioToken);
+    });
+
+    return { audio_layers: Array.from(audioSet), visual_layers: Array.from(visualSet) };
+  }
+
+
   const QA_PRESET = {
     location: 'gastown',
     weather: 'snow',
     duration: '20',
     voice_style: 'quiet city prayer',
     weirdness: '8',
-    foley: ['footsteps', 'steam_clock']
+    link_av: true,
+    audio_layers: ['footsteps'],
+    visual_layers: ['rain_streaks', 'science_world_dome']
   };
 
   const transport = {
@@ -153,10 +180,17 @@
     const hasAdvanced = !!(advanced.concept || advanced.object || advanced.setting || advanced.mood || advanced.creative_goal);
     if (hasAdvanced) return Object.assign({}, base, advanced);
 
+    const linkAV = !!formData.get('link_av');
+    const audioLayers = formData.getAll('audio_layers[]').map((item) => String(item || '').trim()).filter(Boolean);
+    const visualLayers = formData.getAll('visual_layers[]').map((item) => String(item || '').trim()).filter(Boolean);
+    const linked = applyLayerLinking(audioLayers, visualLayers, linkAV);
+
     return Object.assign({}, base, {
       location: String(formData.get('location') || 'gastown'),
       weather: String(formData.get('weather') || 'snow'),
-      foley: formData.getAll('foley[]').map((item) => String(item || '').trim()).filter(Boolean)
+      link_av: linkAV,
+      audio_layers: linked.audio_layers,
+      visual_layers: linked.visual_layers
     });
   }
 
@@ -360,9 +394,14 @@
   if (qaPresetBtn && form) {
     qaPresetBtn.addEventListener('click', () => {
       Object.entries(QA_PRESET).forEach(([key, value]) => {
-        if (key === 'foley' && Array.isArray(value)) {
-          const boxes = form.querySelectorAll('input[name=\"foley[]\"]');
+        if ((key === 'audio_layers' || key === 'visual_layers') && Array.isArray(value)) {
+          const boxes = form.querySelectorAll(`input[name="${key}[]"]`);
           boxes.forEach((box) => { box.checked = value.includes(box.value); });
+          return;
+        }
+        if (key === 'link_av') {
+          const box = form.querySelector('input[name="link_av"]');
+          if (box) box.checked = !!value;
           return;
         }
         const field = form.elements.namedItem(key);
@@ -373,7 +412,7 @@
         const field = form.elements.namedItem(name);
         if (field) field.value = '';
       });
-      setStatus('QA preset loaded (Vancouver Mode Gastown + Snow). Generate package to test known-good anchors.');
+      setStatus('QA preset loaded (separate rain visuals + footsteps audio). Generate package to test A/V separation.');
       setError('');
     });
   }

--- a/js/asmr-visual-engine.js
+++ b/js/asmr-visual-engine.js
@@ -11,9 +11,10 @@
     'neon_wet_reflections', 'winter_particulate_depth',
     'gastown_clock_silhouette', 'cobblestone_perspective', 'brick_wall_parallax', 'streetlamp_halo_row',
     'granville_neon_marquee', 'neon_sign_flicker', 'traffic_light_glow',
-    'skytrain_track', 'skytrain_pass_visual',
+    'skytrain_track', 'skytrain_pass_visual', 'bus_pass_visual',
     'northshore_mountain_ridge', 'mountain_mist_layers',
-    'rain_streaks', 'puddle_reflections'
+    'rain_streaks', 'puddle_reflections',
+    'science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof'
   ];
 
   function clamp(value, min, max) {
@@ -286,15 +287,51 @@
       ctx.putImageData(image, 0, 0);
     }
 
+    parseWeirdnessLevel() {
+      const tags = (this.timeline && this.timeline.renderProfile && this.timeline.renderProfile.tags) || [];
+      const found = tags.find((tag) => /^weirdness_\d+$/.test(tag));
+      if (!found) return 6;
+      const level = Number(found.split('_')[1] || 6);
+      return clamp(level, 1, 10);
+    }
+
     drawSceneLayers(ctx, width, height, t, normalized, overlays) {
-      this.drawBaseChamber(ctx, width, height, t, normalized);
+      const landmarkTypes = ['science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'gastown_clock_silhouette', 'skytrain_pass_visual', 'bus_pass_visual'];
+      const atmosphereTypes = ['rain_streaks', 'snow_drift', 'harbor_mist', 'mountain_mist_layers', 'puddle_reflections', 'volumetric_fog'];
+      const weirdness = this.parseWeirdnessLevel();
+      const weirdNorm = (weirdness - 1) / 9;
+      let distortion = 0.04 + (0.18 - 0.04) * weirdNorm;
+      const activeEvents = [];
 
       this.timeline.visualEvents.forEach((event) => {
         const progress = this.eventProgress(event, t);
         if (progress <= -0.03 || progress >= 1.2) return;
-        const intensity = Math.max(0.05, Math.min(1, Number(event.intensity || 0.5)));
-        this.drawEvent(ctx, event, progress, intensity, width, height, normalized);
+        activeEvents.push({ event, progress });
       });
+
+      const hasLandmark = activeEvents.some((item) => landmarkTypes.includes(item.event.visual_type));
+      if (hasLandmark) distortion *= 0.6;
+
+      this.drawBaseChamber(ctx, width, height, t, normalized);
+
+      activeEvents.filter((item) => atmosphereTypes.includes(item.event.visual_type)).forEach((item) => {
+        const intensity = Math.max(0.05, Math.min(1, Number(item.event.intensity || 0.5)));
+        this.drawEvent(ctx, item.event, item.progress, intensity, width, height, normalized);
+      });
+
+      activeEvents.filter((item) => !atmosphereTypes.includes(item.event.visual_type)).forEach((item) => {
+        const intensity = Math.max(0.05, Math.min(1, Number(item.event.intensity || 0.5)));
+        this.drawEvent(ctx, item.event, item.progress, intensity, width, height, normalized);
+      });
+
+      if (distortion > 0) {
+        ctx.save();
+        ctx.globalAlpha = Math.min(0.1, distortion * 0.45);
+        const jitter = Math.sin(t * 13) * distortion * 18;
+        ctx.fillStyle = 'rgba(140,170,255,0.22)';
+        ctx.fillRect(jitter, 0, width, height);
+        ctx.restore();
+      }
 
       this.drawSyncMarkers(ctx, t, width, height);
       if (overlays) {
@@ -793,6 +830,70 @@
           ctx.fillStyle = `rgba(190,215,236,${0.2 + intensity * 0.24})`;
           ctx.fillRect(x, h * 0.38, w * 0.22, h * 0.08);
           for (let i = 0; i < 7; i += 1) ctx.clearRect(x + 8 + i * 28, h * 0.4, 18, h * 0.03);
+          break;
+        }
+        case 'bus_pass_visual': {
+          const x = ((normalized * 1.1) % 1.25) * w - w * 0.25;
+          ctx.fillStyle = `rgba(228,186,110,${0.22 + intensity * 0.25})`;
+          ctx.fillRect(x, h * 0.44, w * 0.26, h * 0.09);
+          ctx.fillStyle = 'rgba(20,26,36,0.55)';
+          for (let i = 0; i < 6; i += 1) ctx.fillRect(x + 10 + i * 30, h * 0.46, 18, h * 0.028);
+          break;
+        }
+        case 'science_world_dome': {
+          const cx = w * 0.5;
+          const cy = h * 0.72;
+          const r = Math.min(w, h) * 0.24;
+          ctx.strokeStyle = `rgba(180,210,230,${0.32 + intensity * 0.34})`;
+          ctx.lineWidth = 2;
+          ctx.beginPath();
+          ctx.arc(cx, cy, r, Math.PI, 0);
+          ctx.stroke();
+          for (let i = 1; i < 5; i += 1) {
+            ctx.beginPath();
+            ctx.arc(cx, cy, r * (i / 5), Math.PI, 0);
+            ctx.stroke();
+          }
+          for (let i = -4; i <= 4; i += 1) {
+            const x1 = cx + i * (r / 4);
+            ctx.beginPath();
+            ctx.moveTo(x1, cy);
+            ctx.lineTo(cx, cy - r);
+            ctx.stroke();
+          }
+          break;
+        }
+        case 'chinatown_gate': {
+          const baseY = h * 0.68;
+          ctx.fillStyle = `rgba(170,82,88,${0.28 + intensity * 0.24})`;
+          ctx.fillRect(w * 0.3, baseY - h * 0.16, w * 0.04, h * 0.16);
+          ctx.fillRect(w * 0.66, baseY - h * 0.16, w * 0.04, h * 0.16);
+          ctx.fillRect(w * 0.41, baseY - h * 0.18, w * 0.18, h * 0.18);
+          ctx.fillRect(w * 0.25, baseY - h * 0.22, w * 0.16, h * 0.06);
+          ctx.fillRect(w * 0.59, baseY - h * 0.22, w * 0.16, h * 0.06);
+          ctx.fillStyle = `rgba(240,182,132,${0.2 + intensity * 0.24})`;
+          for (let i = 0; i < 5; i += 1) ctx.beginPath(), ctx.arc(w * (0.34 + i * 0.08), baseY - h * 0.24, 2, 0, Math.PI * 2), ctx.fill();
+          break;
+        }
+        case 'english_bay_inukshuk': {
+          ctx.fillStyle = `rgba(176,188,202,${0.22 + intensity * 0.28})`;
+          ctx.fillRect(w * 0.46, h * 0.5, w * 0.08, h * 0.18);
+          ctx.fillRect(w * 0.4, h * 0.54, w * 0.2, h * 0.05);
+          ctx.fillRect(w * 0.48, h * 0.44, w * 0.04, h * 0.05);
+          ctx.fillRect(w * 0.44, h * 0.68, w * 0.12, h * 0.05);
+          break;
+        }
+        case 'maritime_museum_sailroof': {
+          ctx.strokeStyle = `rgba(186,214,226,${0.28 + intensity * 0.3})`;
+          ctx.lineWidth = 3;
+          ctx.beginPath();
+          ctx.moveTo(w * 0.24, h * 0.68);
+          ctx.quadraticCurveTo(w * 0.54, h * 0.28, w * 0.8, h * 0.66);
+          ctx.stroke();
+          ctx.beginPath();
+          ctx.moveTo(w * 0.54, h * 0.68);
+          ctx.lineTo(w * 0.54, h * 0.36);
+          ctx.stroke();
           break;
         }
         case 'northshore_mountain_ridge': {

--- a/page-asmr-lab.php
+++ b/page-asmr-lab.php
@@ -45,17 +45,38 @@ get_header();
         <label>Weirdness (1-10)<input type="number" name="weirdness" min="1" max="10" value="6" required /></label>
       </div>
 
-      <fieldset class="asmr-foley-grid">
-        <legend>Foley Layers</legend>
-        <label><input type="checkbox" name="foley[]" value="footsteps" checked /> footsteps</label>
-        <label><input type="checkbox" name="foley[]" value="rain" /> rain</label>
-        <label><input type="checkbox" name="foley[]" value="chatter" /> chatter</label>
-        <label><input type="checkbox" name="foley[]" value="laughter" /> laughter</label>
-        <label><input type="checkbox" name="foley[]" value="skytrain" /> SkyTrain</label>
-        <label><input type="checkbox" name="foley[]" value="bus" /> bus</label>
-        <label><input type="checkbox" name="foley[]" value="car_horn" /> car horn</label>
-        <label><input type="checkbox" name="foley[]" value="steam_clock" checked /> Gastown steam clock</label>
+      <fieldset class="asmr-layer-grid">
+        <legend>Sound Layers</legend>
+        <label><input type="checkbox" name="audio_layers[]" value="footsteps" checked /> footsteps</label>
+        <label><input type="checkbox" name="audio_layers[]" value="rain_ambience" /> rain ambience</label>
+        <label><input type="checkbox" name="audio_layers[]" value="chatter" /> chatter</label>
+        <label><input type="checkbox" name="audio_layers[]" value="laughter" /> laughter</label>
+        <label><input type="checkbox" name="audio_layers[]" value="skytrain" /> SkyTrain</label>
+        <label><input type="checkbox" name="audio_layers[]" value="bus" /> bus</label>
+        <label><input type="checkbox" name="audio_layers[]" value="car_horn" /> car horn</label>
+        <label><input type="checkbox" name="audio_layers[]" value="steam_clock" checked /> Gastown steam clock</label>
       </fieldset>
+
+      <fieldset class="asmr-layer-grid">
+        <legend>Visual Motifs</legend>
+        <label><input type="checkbox" name="visual_layers[]" value="rain_streaks" /> rain streaks</label>
+        <label><input type="checkbox" name="visual_layers[]" value="snow_drift" /> snow drift</label>
+        <label><input type="checkbox" name="visual_layers[]" value="harbor_mist" /> fog / mist</label>
+        <label><input type="checkbox" name="visual_layers[]" value="skytrain_pass_visual" /> skytrain pass</label>
+        <label><input type="checkbox" name="visual_layers[]" value="bus_pass_visual" /> bus pass</label>
+        <label><input type="checkbox" name="visual_layers[]" value="traffic_light_glow" /> traffic glow</label>
+        <label><input type="checkbox" name="visual_layers[]" value="puddle_reflections" /> puddle reflections</label>
+        <label><input type="checkbox" name="visual_layers[]" value="cobblestone_perspective" /> cobblestone perspective</label>
+        <label><input type="checkbox" name="visual_layers[]" value="brick_wall_parallax" /> brick wall parallax</label>
+        <label><input type="checkbox" name="visual_layers[]" value="streetlamp_halo_row" /> streetlamp halos</label>
+        <label><input type="checkbox" name="visual_layers[]" value="science_world_dome" /> Science World dome silhouette</label>
+        <label><input type="checkbox" name="visual_layers[]" value="chinatown_gate" /> Chinatown gate silhouette</label>
+        <label><input type="checkbox" name="visual_layers[]" value="english_bay_inukshuk" /> English Bay inukshuk silhouette</label>
+        <label><input type="checkbox" name="visual_layers[]" value="maritime_museum_sailroof" /> Maritime Museum sail roof silhouette</label>
+        <label><input type="checkbox" name="visual_layers[]" value="gastown_clock_silhouette" /> Gastown clock silhouette</label>
+      </fieldset>
+
+      <label class="asmr-link-toggle"><input type="checkbox" name="link_av" checked /> Link sound + visual for selected motifs</label>
 
       <details class="asmr-advanced-fields">
         <summary>Advanced / Freeform Mode (optional override)</summary>


### PR DESCRIPTION
### Motivation
- Separate the existing single Foley control so audio and visuals can be chosen independently and avoid unwanted entanglement between sound and visual selections. 
- Provide a conservative, opt-in linking behavior so obvious A/V pairs can be synced automatically while keeping full independence when desired. 
- Preserve Advanced/Freeform Mode and legacy `foley` callers for backward compatibility.

### Description
- UI: replaced the single Foley block with two checkbox sections `audio_layers[]` and `visual_layers[]` and added a default-checked `link_av` toggle, with styling updates to keep the retro CRT look ({`page-asmr-lab.php`, `assets/css/asmr-lab.css`}).
- Frontend: `js/asmr-lab.js` now builds Vancouver payloads with `audio_layers`, `visual_layers`, and `link_av`, applies a conservative client-side pairing map (`skytrain`, `bus`, `rain_ambience`, `footsteps`, `steam_clock`) when linking is enabled, and updated the QA preset to demonstrate separation.
- Backend: `functions.php` now accepts and validates `audio_layers`, `visual_layers`, and `link_av`, preserves `foley` as legacy input (mapping `rain` -> `rain_ambience` and mapping legacy audio to visuals when `link_av` is true), and injects audio events only for `audio_layers` and visual events only for `visual_layers` during Vancouver-mode deterministic anchoring; helper functions and allowed-layer lists were added.
- Visual engine: `js/asmr-visual-engine.js` received new lightweight canvas silhouette renderers (`science_world_dome`, `chinatown_gate`, `english_bay_inukshuk`, `maritime_museum_sailroof`, `bus_pass_visual`), an explicit layer ordering (background → atmosphere → motifs → overlays), and a weirdness-scaled distortion control that clamps when landmarks are active for readability.

### Testing
- `php -l functions.php` ran successfully with no syntax errors.
- `node --check js/asmr-lab.js js/asmr-visual-engine.js js/asmr-foley-engine.js` ran successfully with no syntax errors reported.
- Headless smoke screenshot of the lab page was generated via an automated Playwright run and produced `artifacts/asmr-lab.png` as a visual sanity check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b091abad9c832e983eb8d698840aa4)