### PR TITLE
Refactor ASMR Lab into motif-first audio/visual rack

### DIFF
--- a/assets/css/asmr-lab.css
+++ b/assets/css/asmr-lab.css
@@ -32,3 +32,10 @@
 .asmr-advanced-fields summary{cursor:pointer;color:#9ec0ff;font-size:.84rem;list-style:none}
 .asmr-advanced-fields summary::-webkit-details-marker{display:none}
 .asmr-advanced-fields[open] summary{margin-bottom:.65rem}
+.asmr-layer-groups{display:block;padding:1rem}
+.asmr-inline-label{margin-bottom:.7rem}
+.asmr-inline-label input{max-width:360px}
+.asmr-motif-group{margin:.55rem 0 .85rem;padding:.55rem;border:1px solid #2f3f73;border-radius:8px;background:#0a1022}
+.asmr-motif-group h3{margin:0 0 .45rem;font-family:'Press Start 2P',monospace;font-size:.6rem;letter-spacing:.06em;color:#9ec0ff;text-transform:uppercase;border-bottom:1px solid #2a3563;padding-bottom:.35rem}
+.asmr-motif-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(210px,1fr));gap:.45rem .65rem}
+.asmr-motif-grid label{display:flex;align-items:center;gap:.45rem;font-size:.8rem;background:#090f21;border:1px solid #293867;border-radius:6px;padding:.42rem .5rem}

--- a/functions.php
+++ b/functions.php
@@ -900,6 +900,13 @@ function se_get_asmr_allowed_engines() {
         'skytrain_pass',
         'bus_idle',
         'car_horn_short',
+        'seabus_horn',
+        'gulls_distant',
+        'crosswalk_chirp',
+        'compass_tap',
+        'bike_bell',
+        'skateboard_roll',
+        'siren_distant',
     );
 }
 
@@ -918,6 +925,8 @@ function se_get_asmr_visual_types() {
         'northshore_mountain_ridge', 'mountain_mist_layers',
         'rain_streaks', 'puddle_reflections',
         'science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof',
+        'lions_gate_bridge', 'bc_place_dome', 'port_cranes',
+        'gastown_scene', 'granville_scene', 'north_shore_scene', 'clear_cold_shimmer',
     );
 }
 
@@ -1192,33 +1201,63 @@ function se_enrich_asmr_event_density( $decoded ) {
 
 
 function se_get_asmr_audio_layers_allowed() {
-    return array( 'footsteps', 'rain_ambience', 'chatter', 'laughter', 'skytrain', 'bus', 'car_horn', 'steam_clock' );
+    return array(
+        'footsteps', 'footsteps_snow_mode', 'rain_ambience', 'wind_gust', 'crowd_murmur', 'laughter_burst',
+        'skytrain_pass', 'bus_pass', 'car_horn_short', 'steam_clock',
+        'seabus_horn', 'gulls_distant', 'crosswalk_chirp', 'compass_tap', 'bike_bell', 'skateboard_roll', 'siren_distant'
+    );
 }
 
 function se_get_asmr_visual_layers_allowed() {
     return array(
-        'rain_streaks', 'snow_drift', 'harbor_mist', 'skytrain_pass_visual', 'bus_pass_visual',
-        'traffic_light_glow', 'puddle_reflections', 'cobblestone_perspective', 'brick_wall_parallax', 'streetlamp_halo_row',
-        'science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'gastown_clock_silhouette'
+        'rain_streaks', 'snow_drift', 'harbor_mist', 'clear_cold_shimmer',
+        'gastown_scene', 'granville_scene', 'north_shore_scene',
+        'gastown_clock_silhouette', 'science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof',
+        'lions_gate_bridge', 'bc_place_dome', 'port_cranes',
+        'cobblestone_perspective', 'brick_wall_parallax', 'puddle_reflections', 'streetlamp_halo_row',
+        'skytrain_track', 'skytrain_pass_visual', 'bus_pass_visual',
+        'scanline_field', 'glitch_flash', 'signal_bars', 'chromatic_veil', 'neon_sign_flicker',
+        'granville_neon_marquee', 'traffic_light_glow', 'northshore_mountain_ridge', 'mountain_mist_layers', 'volumetric_fog'
     );
 }
 
-function se_get_asmr_audio_to_visual_map() {
+function se_get_asmr_visual_to_audio_map() {
     return array(
-        'skytrain' => 'skytrain_pass_visual',
-        'bus' => 'bus_pass_visual',
-        'rain_ambience' => 'rain_streaks',
-        'footsteps' => 'cobblestone_perspective',
-        'steam_clock' => 'gastown_clock_silhouette',
+        'skytrain_pass_visual' => array( 'skytrain_pass' ),
+        'bus_pass_visual' => array( 'bus_pass' ),
+        'rain_streaks' => array( 'rain_ambience' ),
+        'gastown_clock_silhouette' => array( 'steam_clock' ),
+        'gastown_scene' => array( 'steam_clock' ),
+        'snow_drift' => array( 'footsteps_snow_mode' ),
+    );
+}
+
+function se_get_asmr_scene_visual_support_map() {
+    return array(
+        'gastown_scene' => array( 'gastown_clock_silhouette', 'streetlamp_halo_row', 'cobblestone_perspective', 'brick_wall_parallax' ),
+        'granville_scene' => array( 'granville_neon_marquee', 'traffic_light_glow', 'puddle_reflections' ),
+        'north_shore_scene' => array( 'northshore_mountain_ridge', 'mountain_mist_layers', 'harbor_mist' ),
     );
 }
 
 function se_get_asmr_legacy_audio_map() {
-    return array( 'rain' => 'rain_ambience' );
+    return array(
+        'rain' => 'rain_ambience',
+        'chatter' => 'crowd_murmur',
+        'laughter' => 'laughter_burst',
+        'skytrain' => 'skytrain_pass',
+        'bus' => 'bus_pass',
+        'car_horn' => 'car_horn_short',
+    );
 }
 
 function se_get_asmr_mapped_visual_layers_from_audio( $audio_layers ) {
-    $map = se_get_asmr_audio_to_visual_map();
+    $map = array(
+        'skytrain_pass' => 'skytrain_pass_visual',
+        'bus_pass' => 'bus_pass_visual',
+        'rain_ambience' => 'rain_streaks',
+        'steam_clock' => 'gastown_clock_silhouette',
+    );
     $visual = array();
     foreach ( (array) $audio_layers as $token ) {
         $key = sanitize_key( $token );
@@ -1230,137 +1269,173 @@ function se_get_asmr_mapped_visual_layers_from_audio( $audio_layers ) {
 }
 
 function se_get_asmr_vancouver_derived_payload( $payload ) {
-    $location = sanitize_key( $payload['location'] ?? '' );
-    $weather = sanitize_key( $payload['weather'] ?? '' );
     $audio_layers = array_values( array_filter( array_map( 'sanitize_key', (array) ( $payload['audio_layers'] ?? array() ) ) ) );
-
-    $location_meta = array(
-        'gastown' => array(
-            'label' => 'Gastown Steam Clock',
-            'object' => 'steam clock',
-            'setting' => 'midnight Gastown lane with wet cobblestones, brick facades, cast iron rails, and amber lamps',
-            'visual' => 'gastown_clock_silhouette',
-        ),
-        'granville' => array(
-            'label' => 'Granville Street',
-            'object' => 'neon marquee and rain-slick street',
-            'setting' => 'midnight Granville strip with neon marquees, reflective asphalt, bus shelters, and crosswalk paint',
-            'visual' => 'granville_neon_marquee',
-        ),
-        'north_shore' => array(
-            'label' => 'North Shore Mountains',
-            'object' => 'mountain ridge and harbor air',
-            'setting' => 'midnight harbor edge facing North Shore ridges with cedar silhouettes, cold air, and layered mist',
-            'visual' => 'northshore_mountain_ridge',
-        ),
-    );
-    $weather_moods = array(
-        'snow' => 'hushed and holy',
-        'rain' => 'neon melancholy',
-        'fog' => 'dreamlike and liminal',
-        'clear_cold' => 'crisp and electric',
-    );
-
-    if ( ! isset( $location_meta[ $location ] ) || ! isset( $weather_moods[ $weather ] ) ) {
-        return $payload;
+    $visual_layers = array_values( array_filter( array_map( 'sanitize_key', (array) ( $payload['visual_layers'] ?? array() ) ) ) );
+    if ( empty( $visual_layers ) ) {
+        $visual_layers = array( 'granville_scene', 'rain_streaks', 'skytrain_pass_visual' );
     }
 
+    $motif_line = implode( ' + ', $visual_layers );
     $foley_text = empty( $audio_layers ) ? 'soft civic ambience' : implode( ', ', $audio_layers );
-    $meta = $location_meta[ $location ];
-
-    $payload['concept'] = sprintf( 'A cinematic Vancouver midnight vignette in %s, where urban signals feel sacred.', $meta['label'] );
-    $payload['object'] = $meta['object'];
-    $payload['setting'] = $meta['setting'];
-    $payload['mood'] = $weather_moods[ $weather ];
-    $payload['creative_goal'] = sprintf( 'Compose a sacred urban signal arc with %s cues anchored in %s.', $foley_text, $meta['label'] );
+    $payload['concept'] = sprintf( 'Vancouver Motif Stack: %s', $motif_line );
+    $payload['object'] = 'city motif rack';
+    $payload['setting'] = 'retro arcade CRT Vancouver night world';
+    $payload['mood'] = 'atmospheric, tactile, and cinematic';
+    $payload['creative_goal'] = sprintf( 'Build a readable motif-forward timeline with %s while preserving coherent visual geography.', $foley_text );
     return $payload;
 }
 
 function se_inject_asmr_vancouver_anchors( $decoded, $payload ) {
-    $location = sanitize_key( $payload['location'] ?? '' );
-    $weather = sanitize_key( $payload['weather'] ?? '' );
     $link_av = ! array_key_exists( 'link_av', $payload ) || ! empty( $payload['link_av'] );
     $audio_layers = array_values( array_filter( array_map( 'sanitize_key', (array) ( $payload['audio_layers'] ?? array() ) ) ) );
     $visual_layers = array_values( array_filter( array_map( 'sanitize_key', (array) ( $payload['visual_layers'] ?? array() ) ) ) );
 
-    if ( empty( $location ) && empty( $weather ) && empty( $audio_layers ) && empty( $visual_layers ) ) {
+    if ( empty( $audio_layers ) && empty( $visual_layers ) ) {
         return $decoded;
     }
 
     if ( $link_av ) {
+        foreach ( se_get_asmr_visual_to_audio_map() as $visual_token => $mapped_audio ) {
+            if ( ! in_array( $visual_token, $visual_layers, true ) ) {
+                continue;
+            }
+            foreach ( $mapped_audio as $audio_token ) {
+                if ( 'footsteps_snow_mode' === $audio_token ) {
+                    if ( in_array( 'footsteps', $audio_layers, true ) ) {
+                        $audio_layers[] = 'footsteps_snow_mode';
+                    }
+                } else {
+                    $audio_layers[] = $audio_token;
+                }
+            }
+        }
+        $audio_layers = array_values( array_unique( $audio_layers ) );
         $visual_layers = array_values( array_unique( array_merge( $visual_layers, se_get_asmr_mapped_visual_layers_from_audio( $audio_layers ) ) ) );
     }
 
+    foreach ( se_get_asmr_scene_visual_support_map() as $scene => $support_visuals ) {
+        if ( in_array( $scene, $visual_layers, true ) ) {
+            $visual_layers = array_values( array_unique( array_merge( $visual_layers, $support_visuals ) ) );
+        }
+    }
+
     $runtime = max( 10, min( 30, floatval( $decoded['runtime_seconds'] ?? 20 ) ) );
-    $audio = is_array( $decoded['audio_events'] ?? null ) ? $decoded['audio_events'] : array();
-    $visual = is_array( $decoded['visual_events'] ?? null ) ? $decoded['visual_events'] : array();
-    $sync = is_array( $decoded['sync_points'] ?? null ) ? $decoded['sync_points'] : array();
+    $audio = array();
+    $visual = array();
 
-    $audio[] = array( 'time' => 0.08, 'duration' => 2.2, 'engine' => 'city_electrical_hum', 'intensity' => 0.28, 'params' => array(), 'sync_role' => 'vancouver_bed' );
-
-    if ( 'gastown' === $location ) {
-        $visual[] = array( 'time' => 0.22, 'duration' => 2.2, 'visual_type' => 'gastown_clock_silhouette', 'intensity' => 0.78, 'params' => array(), 'sync_role' => 'gastown_identity' );
-        $visual[] = array( 'time' => 0.16, 'duration' => 2.4, 'visual_type' => 'streetlamp_halo_row', 'intensity' => 0.6, 'params' => array(), 'sync_role' => 'streetlamp_glow' );
-        $visual[] = array( 'time' => 0.28, 'duration' => 2.8, 'visual_type' => 'cobblestone_perspective', 'intensity' => 0.62, 'params' => array(), 'sync_role' => 'street_surface' );
-    } elseif ( 'granville' === $location ) {
-        $visual[] = array( 'time' => 0.22, 'duration' => 2.4, 'visual_type' => 'granville_neon_marquee', 'intensity' => 0.76, 'params' => array(), 'sync_role' => 'granville_identity' );
-        $visual[] = array( 'time' => 0.36, 'duration' => 2.1, 'visual_type' => 'neon_sign_flicker', 'intensity' => 0.68, 'params' => array(), 'sync_role' => 'neon_flicker' );
-        $visual[] = array( 'time' => 0.42, 'duration' => 2.2, 'visual_type' => 'traffic_light_glow', 'intensity' => 0.58, 'params' => array(), 'sync_role' => 'traffic_glow' );
-    } elseif ( 'north_shore' === $location ) {
-        $visual[] = array( 'time' => 0.24, 'duration' => 2.8, 'visual_type' => 'northshore_mountain_ridge', 'intensity' => 0.78, 'params' => array(), 'sync_role' => 'mountain_identity' );
-        $visual[] = array( 'time' => 0.18, 'duration' => 3.0, 'visual_type' => 'mountain_mist_layers', 'intensity' => 0.62, 'params' => array(), 'sync_role' => 'mist_layers' );
-    }
-
-    // Weather defaults always influence atmosphere visuals.
-    if ( 'rain' === $weather ) {
-        $visual[] = array( 'time' => 0.08, 'duration' => min( 6, $runtime * 0.44 ), 'visual_type' => 'rain_streaks', 'intensity' => 0.55, 'params' => array(), 'sync_role' => 'weather_rain_default' );
-    } elseif ( 'snow' === $weather ) {
-        $visual[] = array( 'time' => 0.08, 'duration' => min( 6, $runtime * 0.48 ), 'visual_type' => 'snow_drift', 'intensity' => 0.58, 'params' => array(), 'sync_role' => 'weather_snow_default' );
-    } elseif ( 'fog' === $weather ) {
-        $visual[] = array( 'time' => 0.08, 'duration' => min( 6, $runtime * 0.5 ), 'visual_type' => 'harbor_mist', 'intensity' => 0.58, 'params' => array(), 'sync_role' => 'weather_fog_default' );
-    }
+    $scene_or_landmark = array(
+        'gastown_scene', 'granville_scene', 'north_shore_scene', 'gastown_clock_silhouette', 'science_world_dome',
+        'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'lions_gate_bridge', 'bc_place_dome', 'port_cranes'
+    );
 
     foreach ( $audio_layers as $layer ) {
-        if ( 'footsteps' === $layer ) {
-            $engine = ( 'snow' === $weather ) ? 'footsteps_snow' : 'footsteps_wet';
+        if ( 'footsteps' === $layer || 'footsteps_snow_mode' === $layer ) {
+            $engine = in_array( 'footsteps_snow_mode', $audio_layers, true ) ? 'footsteps_snow' : 'footsteps_wet';
             for ( $i = 0; $i < 3; $i++ ) {
-                $audio[] = array( 'time' => 0.7 + ( $i * ( $runtime * 0.14 ) ), 'duration' => 0.18, 'engine' => $engine, 'intensity' => 0.55, 'params' => array(), 'sync_role' => 'footstep_anchor' );
+                $audio[] = array( 'time' => 0.7 + ( $i * ( $runtime * 0.14 ) ), 'duration' => 0.18, 'engine' => $engine, 'intensity' => 0.5, 'params' => array(), 'sync_role' => 'footstep_anchor' );
             }
         } elseif ( 'rain_ambience' === $layer ) {
-            $audio[] = array( 'time' => 0.04, 'duration' => min( 6, $runtime * 0.45 ), 'engine' => 'rain_close', 'intensity' => 0.54, 'params' => array(), 'sync_role' => 'rain_bed' );
-        } elseif ( 'skytrain' === $layer ) {
+            $audio[] = array( 'time' => 0.02, 'duration' => max( 4.2, $runtime * 0.52 ), 'engine' => 'rain_close', 'intensity' => 0.5, 'params' => array(), 'sync_role' => 'rain_bed' );
+        } elseif ( 'wind_gust' === $layer ) {
+            $audio[] = array( 'time' => $runtime * 0.22, 'duration' => min( 3.8, $runtime * 0.24 ), 'engine' => 'cold_air_hush', 'intensity' => 0.44, 'params' => array(), 'sync_role' => 'wind_gust' );
+        } elseif ( 'crowd_murmur' === $layer ) {
+            $audio[] = array( 'time' => 0.9, 'duration' => 2.4, 'engine' => 'crowd_murmur', 'intensity' => 0.38, 'params' => array(), 'sync_role' => 'crowd_anchor' );
+        } elseif ( 'laughter_burst' === $layer ) {
+            $audio[] = array( 'time' => $runtime * 0.42, 'duration' => 0.34, 'engine' => 'laughter_burst', 'intensity' => 0.5, 'params' => array(), 'sync_role' => 'laughter_anchor' );
+        } elseif ( 'skytrain_pass' === $layer ) {
             $mid = $runtime * 0.52;
-            $audio[] = array( 'time' => $mid, 'duration' => 2.2, 'engine' => 'skytrain_pass', 'intensity' => 0.7, 'params' => array(), 'sync_role' => 'skytrain_anchor' );
+            $audio[] = array( 'time' => $mid, 'duration' => 2.1, 'engine' => 'skytrain_pass', 'intensity' => 0.62, 'params' => array(), 'sync_role' => 'skytrain_anchor' );
+        } elseif ( 'bus_pass' === $layer ) {
+            $audio[] = array( 'time' => $runtime * 0.3, 'duration' => 1.8, 'engine' => 'bus_idle', 'intensity' => 0.44, 'params' => array(), 'sync_role' => 'bus_anchor' );
+        } elseif ( 'car_horn_short' === $layer ) {
+            $audio[] = array( 'time' => $runtime * 0.64, 'duration' => 0.2, 'engine' => 'car_horn_short', 'intensity' => 0.48, 'params' => array(), 'sync_role' => 'horn_anchor' );
         } elseif ( 'steam_clock' === $layer ) {
-            $audio[] = array( 'time' => 0.5, 'duration' => 1.1, 'engine' => 'steam_clock_burst', 'intensity' => 0.7, 'params' => array(), 'sync_role' => 'steam_clock_toggle' );
-        } elseif ( 'chatter' === $layer ) {
-            $audio[] = array( 'time' => 1.1, 'duration' => 2.2, 'engine' => 'crowd_murmur', 'intensity' => 0.42, 'params' => array(), 'sync_role' => 'crowd_anchor' );
-        } elseif ( 'laughter' === $layer ) {
-            $audio[] = array( 'time' => $runtime * 0.4, 'duration' => 0.38, 'engine' => 'laughter_burst', 'intensity' => 0.58, 'params' => array(), 'sync_role' => 'laughter_anchor' );
-        } elseif ( 'bus' === $layer ) {
-            $audio[] = array( 'time' => $runtime * 0.32, 'duration' => 1.8, 'engine' => 'bus_idle', 'intensity' => 0.48, 'params' => array(), 'sync_role' => 'bus_anchor' );
-        } elseif ( 'car_horn' === $layer ) {
-            $audio[] = array( 'time' => $runtime * 0.62, 'duration' => 0.22, 'engine' => 'car_horn_short', 'intensity' => 0.6, 'params' => array(), 'sync_role' => 'horn_anchor' );
+            $audio[] = array( 'time' => 0.52, 'duration' => 1.1, 'engine' => 'steam_clock_burst', 'intensity' => 0.62, 'params' => array(), 'sync_role' => 'steam_clock_toggle' );
+        } elseif ( 'seabus_horn' === $layer ) {
+            $audio[] = array( 'time' => $runtime * 0.36, 'duration' => 1.6, 'engine' => 'seabus_horn', 'intensity' => 0.42, 'params' => array(), 'sync_role' => 'seabus_horn' );
+        } elseif ( 'gulls_distant' === $layer ) {
+            $audio[] = array( 'time' => 0.48, 'duration' => 2.2, 'engine' => 'gulls_distant', 'intensity' => 0.34, 'params' => array(), 'sync_role' => 'gulls_distant' );
+        } elseif ( 'crosswalk_chirp' === $layer ) {
+            $audio[] = array( 'time' => $runtime * 0.56, 'duration' => 0.85, 'engine' => 'crosswalk_chirp', 'intensity' => 0.32, 'params' => array(), 'sync_role' => 'crosswalk_chirp' );
+        } elseif ( 'compass_tap' === $layer ) {
+            $audio[] = array( 'time' => $runtime * 0.46, 'duration' => 0.2, 'engine' => 'compass_tap', 'intensity' => 0.3, 'params' => array(), 'sync_role' => 'compass_tap' );
+        } elseif ( 'bike_bell' === $layer ) {
+            $audio[] = array( 'time' => $runtime * 0.38, 'duration' => 0.38, 'engine' => 'bike_bell', 'intensity' => 0.34, 'params' => array(), 'sync_role' => 'bike_bell' );
+        } elseif ( 'skateboard_roll' === $layer ) {
+            $audio[] = array( 'time' => $runtime * 0.28, 'duration' => 1.6, 'engine' => 'skateboard_roll', 'intensity' => 0.38, 'params' => array(), 'sync_role' => 'skateboard_roll' );
+        } elseif ( 'siren_distant' === $layer ) {
+            $audio[] = array( 'time' => $runtime * 0.62, 'duration' => 1.8, 'engine' => 'siren_distant', 'intensity' => 0.28, 'params' => array(), 'sync_role' => 'siren_distant' );
         }
     }
 
     foreach ( $visual_layers as $visual_type ) {
+        if ( in_array( $visual_type, array( 'rain_streaks', 'snow_drift', 'harbor_mist', 'clear_cold_shimmer' ), true ) ) {
+            $visual[] = array( 'time' => 0.0, 'duration' => max( 4.0, $runtime * 0.56 ), 'visual_type' => $visual_type, 'intensity' => 0.52, 'params' => array(), 'sync_role' => 'atmosphere_bed' );
+            continue;
+        }
         if ( 'skytrain_pass_visual' === $visual_type ) {
             $mid = $runtime * 0.52;
-            $visual[] = array( 'time' => $mid - 0.2, 'duration' => 2.4, 'visual_type' => 'skytrain_pass_visual', 'intensity' => 0.7, 'params' => array(), 'sync_role' => 'skytrain_visual' );
-            $visual[] = array( 'time' => $mid - 0.25, 'duration' => 2.5, 'visual_type' => 'skytrain_track', 'intensity' => 0.58, 'params' => array(), 'sync_role' => 'skytrain_track' );
-        } elseif ( 'bus_pass_visual' === $visual_type ) {
-            $visual[] = array( 'time' => $runtime * 0.3, 'duration' => 2.1, 'visual_type' => 'bus_pass_visual', 'intensity' => 0.64, 'params' => array(), 'sync_role' => 'bus_visual' );
-        } else {
-            $visual[] = array( 'time' => 0.12, 'duration' => min( 5.4, $runtime * 0.4 ), 'visual_type' => $visual_type, 'intensity' => 0.62, 'params' => array(), 'sync_role' => 'visual_motif_toggle' );
+            $visual[] = array( 'time' => $mid - 0.2, 'duration' => 2.4, 'visual_type' => 'skytrain_pass_visual', 'intensity' => 0.66, 'params' => array(), 'sync_role' => 'skytrain_visual' );
+            $visual[] = array( 'time' => $mid - 0.25, 'duration' => 2.5, 'visual_type' => 'skytrain_track', 'intensity' => 0.56, 'params' => array(), 'sync_role' => 'skytrain_track' );
+            continue;
+        }
+        if ( 'bus_pass_visual' === $visual_type ) {
+            $visual[] = array( 'time' => $runtime * 0.3, 'duration' => 2.0, 'visual_type' => 'bus_pass_visual', 'intensity' => 0.6, 'params' => array(), 'sync_role' => 'bus_visual' );
+            continue;
+        }
+        if ( in_array( $visual_type, array( 'gastown_scene', 'granville_scene', 'north_shore_scene' ), true ) ) {
+            $visual[] = array( 'time' => 0.18, 'duration' => min( 3.2, $runtime * 0.22 ), 'visual_type' => $visual_type, 'intensity' => 0.7, 'params' => array(), 'sync_role' => 'scene_anchor' );
+            $visual[] = array( 'time' => $runtime * 0.44, 'duration' => min( 2.4, $runtime * 0.2 ), 'visual_type' => $visual_type, 'intensity' => 0.58, 'params' => array(), 'sync_role' => 'scene_recur' );
+            continue;
+        }
+        $visual[] = array( 'time' => 0.14, 'duration' => min( 5.2, $runtime * 0.36 ), 'visual_type' => $visual_type, 'intensity' => 0.6, 'params' => array(), 'sync_role' => 'visual_motif_toggle' );
+    }
+
+    $has_scene_or_landmark = false;
+    foreach ( $visual_layers as $token ) {
+        if ( in_array( $token, $scene_or_landmark, true ) ) {
+            $has_scene_or_landmark = true;
+            break;
         }
     }
 
-    $weird_tag = 'weirdness_' . max( 1, min( 10, absint( $payload['weirdness'] ?? 6 ) ) );
-    $decoded['style_tags'] = array_values( array_unique( array_merge( (array) ( $decoded['style_tags'] ?? array() ), array( $location, $weather, 'vancouver_mode', $weird_tag ), $audio_layers, $visual_layers ) ) );
+    if ( $has_scene_or_landmark ) {
+        $already_early = false;
+        foreach ( $visual as $event ) {
+            if ( in_array( $event['visual_type'], $scene_or_landmark, true ) && floatval( $event['time'] ) <= 0.6 ) {
+                $already_early = true;
+                break;
+            }
+        }
+        if ( ! $already_early ) {
+            $fallback = 'gastown_clock_silhouette';
+            foreach ( $visual_layers as $token ) {
+                if ( in_array( $token, $scene_or_landmark, true ) ) {
+                    $fallback = $token;
+                    break;
+                }
+            }
+            $visual[] = array( 'time' => 0.24, 'duration' => min( 2.6, $runtime * 0.2 ), 'visual_type' => $fallback, 'intensity' => 0.66, 'params' => array(), 'sync_role' => 'early_readability_anchor' );
+        }
+    }
+
+    usort(
+        $audio,
+        static function( $a, $b ) {
+            return (float) $a['time'] <=> (float) $b['time'];
+        }
+    );
+    usort(
+        $visual,
+        static function( $a, $b ) {
+            return (float) $a['time'] <=> (float) $b['time'];
+        }
+    );
+
+    $decoded['style_tags'] = array_values( array_unique( array_merge( array( 'retro_arcade_crt' ), $audio_layers, $visual_layers ) ) );
     $decoded['audio_events'] = $audio;
     $decoded['visual_events'] = $visual;
-    $decoded['sync_points'] = $sync;
+    $decoded['presentation_note'] = 'Motif-rack composition with conservative A/V pairing and first-frame readability anchors.';
     return $decoded;
 }
 
@@ -1531,7 +1606,6 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
         'mood' => sanitize_text_field( $params['mood'] ?? '' ),
         'duration' => max( 10, min( 30, absint( $params['duration'] ?? 20 ) ) ),
         'voice_style' => sanitize_text_field( $params['voice_style'] ?? '' ),
-        'weirdness' => max( 1, min( 10, absint( $params['weirdness'] ?? 6 ) ) ),
         'creative_goal' => sanitize_textarea_field( $params['creative_goal'] ?? '' ),
         'location' => sanitize_key( $params['location'] ?? '' ),
         'weather' => sanitize_key( $params['weather'] ?? '' ),
@@ -1542,15 +1616,14 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
         'sound_only' => ! empty( $params['sound_only'] ),
     );
 
-    $has_freeform = ! empty( $payload['concept'] ) && ! empty( $payload['object'] ) && ! empty( $payload['setting'] ) && ! empty( $payload['mood'] );
-    $has_vancouver = in_array( $payload['location'], $allowed_locations, true ) && in_array( $payload['weather'], $allowed_weather, true );
+    $has_freeform = ! empty( $payload['concept'] ) || ! empty( $payload['object'] ) || ! empty( $payload['setting'] ) || ! empty( $payload['mood'] ) || ! empty( $payload['creative_goal'] );
+    $has_legacy_location_weather = in_array( $payload['location'], $allowed_locations, true ) && in_array( $payload['weather'], $allowed_weather, true );
 
-    if ( ! $has_freeform && ! $has_vancouver ) {
-        return new WP_Error( 'asmr_missing_fields', __( 'Provide freeform concept/object/setting/mood or use Vancouver Mode location + weather.', 'suzys-music-theme' ), array( 'status' => 400 ) );
-    }
-
-    if ( $has_vancouver && ! $has_freeform ) {
+    if ( ! $has_freeform ) {
         $payload = se_get_asmr_vancouver_derived_payload( $payload );
+        if ( $has_legacy_location_weather ) {
+            $payload['style_tags_legacy'] = array( $payload['location'], $payload['weather'] );
+        }
     }
 
     $allowed_engines = implode( ', ', se_get_asmr_allowed_engines() );
@@ -1576,10 +1649,10 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
         . 'Use micro-events for intimacy, then earned bloom moments instead of random loudness spikes. '
         . 'Visual score should emphasize atmospheric symbolic language, depth, compositional foreground/midground/background layering, glow, parallax-like drift, and terminal/sacred reveal language when appropriate. '
         . 'sync_points must map to real event moments and reinforce audio-visual unity, especially in the first 3 seconds. '
-        . 'When a real place is named (for example Gastown or Vancouver), strongly ground the package in that location with concrete materials, weather, object identity, and environmental acoustics. '
-        . 'Prompt interpretation priority: named location > named object > weather condition > mood adjectives. '
+        . 'When motif tokens imply a place, ground the package in concrete materials, atmospheric lighting, and local acoustics. '
+        . 'Prompt interpretation priority: selected visual motifs > selected audio motifs > named object > mood adjectives. '
         . 'For Gastown/Vancouver scenes, favor steam clock cues, harbor fog bed, amber streetlamp halos, wet cobblestone reflections, brick facade texture, neon-on-wet shimmer, and winter hush pacing where relevant. '
-        . 'Avoid generic abstract output when prompts include specific geography or weather terms. '
+        . 'Avoid generic abstract output when prompts include specific motif or geography terms. '
         . 'The result should feel like an authored short sensory micro-film, not a debug demo. '
         . 'Do not include prose outside JSON.';
 

--- a/js/asmr-foley-engine.js
+++ b/js/asmr-foley-engine.js
@@ -10,7 +10,7 @@
     'steam_clock_burst', 'distant_bell_toll', 'cold_air_hush', 'wet_street_shimmer',
     'harbor_fog_bed', 'metal_resonance', 'snow_muffle', 'city_electrical_hum',
     'footsteps_wet', 'footsteps_snow', 'rain_close', 'rain_roof', 'puddle_splash',
-    'crowd_murmur', 'laughter_burst', 'skytrain_pass', 'bus_idle', 'car_horn_short'
+    'crowd_murmur', 'laughter_burst', 'skytrain_pass', 'bus_idle', 'car_horn_short', 'seabus_horn', 'gulls_distant', 'crosswalk_chirp', 'compass_tap', 'bike_bell', 'skateboard_roll', 'siren_distant'
   ];
 
   function clamp(value, min, max) {
@@ -415,6 +415,49 @@
         case 'car_horn_short':
           this.scheduleTone(ctx, destination, atTime, Math.max(0.12, duration), { from: 410, to: 380, peak: 0.026 + intensity * 0.04, type: 'triangle', pan: 0.05 });
           this.scheduleTone(ctx, destination, atTime, Math.max(0.1, duration * 0.9), { from: 510, to: 480, peak: 0.018 + intensity * 0.03, type: 'sawtooth', pan: -0.04 });
+          break;
+
+
+        case 'seabus_horn':
+          this.scheduleTone(ctx, destination, atTime, duration, { from: 86, to: 72, peak: 0.02 + intensity * 0.04, type: 'sine', pan: -0.08 });
+          this.scheduleTone(ctx, destination, atTime + 0.03, duration * 0.92, { from: 118, to: 96, peak: 0.012 + intensity * 0.025, type: 'triangle', pan: 0.06 });
+          this.scheduleNoise(ctx, destination, atTime, duration * 0.7, { freq: 420, q: 0.8, peak: 0.006 + intensity * 0.012, filterType: 'bandpass' });
+          break;
+        case 'gulls_distant': {
+          const chirps = Math.max(2, Math.min(6, Math.round(duration * 1.4)));
+          for (let i = 0; i < chirps; i += 1) {
+            const dt = (i / Math.max(1, chirps - 1)) * Math.max(0.1, duration * 0.9);
+            this.scheduleTone(ctx, destination, atTime + dt, 0.12, { from: 980 + (i % 3) * 120, to: 760, peak: 0.006 + intensity * 0.012, type: 'triangle', pan: (i % 2 ? 0.22 : -0.18) });
+          }
+          this.scheduleNoise(ctx, destination, atTime, duration, { freq: 1900, q: 0.7, peak: 0.004 + intensity * 0.01, filterType: 'bandpass' });
+          break;
+        }
+        case 'crosswalk_chirp': {
+          const pulses = Math.max(3, Math.min(10, Math.round(duration / 0.12)));
+          for (let i = 0; i < pulses; i += 1) {
+            this.scheduleTone(ctx, destination, atTime + i * 0.12, 0.08, { from: 1320, to: 1180, peak: 0.006 + intensity * 0.014, type: 'square', pan: 0.04 });
+          }
+          break;
+        }
+        case 'compass_tap':
+          this.scheduleNoise(ctx, destination, atTime, Math.max(0.06, duration * 0.7), { freq: 2200, q: 2.2, peak: 0.008 + intensity * 0.014, filterType: 'bandpass' });
+          this.scheduleTone(ctx, destination, atTime + 0.01, Math.max(0.07, duration * 0.6), { from: 1620, to: 1240, peak: 0.006 + intensity * 0.012, type: 'triangle', pan: 0.12 });
+          break;
+        case 'bike_bell':
+          this.scheduleTone(ctx, destination, atTime, Math.max(0.12, duration * 0.62), { from: 980, to: 760, peak: 0.008 + intensity * 0.015, type: 'sine', pan: -0.06 });
+          this.scheduleTone(ctx, destination, atTime + 0.05, Math.max(0.14, duration * 0.65), { from: 1320, to: 990, peak: 0.006 + intensity * 0.013, type: 'triangle', pan: 0.07 });
+          break;
+        case 'skateboard_roll':
+          this.scheduleNoise(ctx, destination, atTime, duration, { freq: 260, q: 0.7, peak: 0.012 + intensity * 0.02, filterType: 'bandpass', pan: -0.08 });
+          this.scheduleTone(ctx, destination, atTime, duration, { from: 92, to: 80, peak: 0.008 + intensity * 0.014, type: 'sine', pan: 0.08 });
+          for (let i = 0; i < 6; i += 1) {
+            this.scheduleNoise(ctx, destination, atTime + i * (duration / 6), 0.035, { freq: 1800, q: 1.8, peak: 0.003 + intensity * 0.008, filterType: 'highpass', pan: ((i % 2) ? -0.12 : 0.12) });
+          }
+          break;
+        case 'siren_distant':
+          this.scheduleTone(ctx, destination, atTime, duration, { from: 420, to: 620, peak: 0.006 + intensity * 0.012, type: 'triangle', pan: -0.18 });
+          this.scheduleTone(ctx, destination, atTime + 0.15, duration * 0.9, { from: 560, to: 380, peak: 0.005 + intensity * 0.011, type: 'sine', pan: 0.18 });
+          this.scheduleNoise(ctx, destination, atTime, duration, { freq: 1200, q: 0.9, peak: 0.002 + intensity * 0.006, filterType: 'bandpass' });
           break;
 
         default:

--- a/js/asmr-lab.js
+++ b/js/asmr-lab.js
@@ -25,12 +25,19 @@
   let currentPackage = null;
 
 
-  const LINKED_LAYER_MAP = {
-    skytrain: 'skytrain_pass_visual',
-    bus: 'bus_pass_visual',
-    rain_ambience: 'rain_streaks',
-    footsteps: 'cobblestone_perspective',
-    steam_clock: 'gastown_clock_silhouette'
+  const LINKED_VISUAL_TO_AUDIO = {
+    skytrain_pass_visual: ['skytrain_pass'],
+    bus_pass_visual: ['bus_pass'],
+    rain_streaks: ['rain_ambience'],
+    gastown_clock_silhouette: ['steam_clock'],
+    gastown_scene: ['steam_clock'],
+    snow_drift: ['footsteps_snow_mode']
+  };
+
+  const SCENE_TO_SUPPORT_VISUALS = {
+    gastown_scene: ['gastown_clock_silhouette', 'streetlamp_halo_row', 'cobblestone_perspective', 'brick_wall_parallax'],
+    granville_scene: ['granville_neon_marquee', 'traffic_light_glow', 'puddle_reflections'],
+    north_shore_scene: ['northshore_mountain_ridge', 'mountain_mist_layers']
   };
 
   function applyLayerLinking(audioLayers, visualLayers, isLinked) {
@@ -40,9 +47,20 @@
       return { audio_layers: Array.from(audioSet), visual_layers: Array.from(visualSet) };
     }
 
-    Object.entries(LINKED_LAYER_MAP).forEach(([audioToken, visualToken]) => {
-      if (audioSet.has(audioToken)) visualSet.add(visualToken);
-      if (visualSet.has(visualToken)) audioSet.add(audioToken);
+    Object.entries(LINKED_VISUAL_TO_AUDIO).forEach(([visualToken, audioTokens]) => {
+      if (!visualSet.has(visualToken)) return;
+      audioTokens.forEach((audioToken) => {
+        if (audioToken === 'footsteps_snow_mode') {
+          if (audioSet.has('footsteps')) audioSet.add('footsteps_snow_mode');
+        } else {
+          audioSet.add(audioToken);
+        }
+      });
+    });
+
+    Object.entries(SCENE_TO_SUPPORT_VISUALS).forEach(([sceneToken, supportVisuals]) => {
+      if (!visualSet.has(sceneToken)) return;
+      supportVisuals.forEach((visualToken) => visualSet.add(visualToken));
     });
 
     return { audio_layers: Array.from(audioSet), visual_layers: Array.from(visualSet) };
@@ -50,14 +68,11 @@
 
 
   const QA_PRESET = {
-    location: 'gastown',
-    weather: 'snow',
     duration: '20',
     voice_style: 'quiet city prayer',
-    weirdness: '8',
-    link_av: true,
+    link_av: false,
     audio_layers: ['footsteps'],
-    visual_layers: ['rain_streaks', 'science_world_dome']
+    visual_layers: ['granville_scene', 'rain_streaks', 'neon_sign_flicker', 'skytrain_pass_visual']
   };
 
   const transport = {
@@ -173,7 +188,6 @@
     };
     const base = {
       duration: String(formData.get('duration') || '20'),
-      weirdness: String(formData.get('weirdness') || '6'),
       voice_style: String(formData.get('voice_style') || '').trim()
     };
 
@@ -186,8 +200,6 @@
     const linked = applyLayerLinking(audioLayers, visualLayers, linkAV);
 
     return Object.assign({}, base, {
-      location: String(formData.get('location') || 'gastown'),
-      weather: String(formData.get('weather') || 'snow'),
       link_av: linkAV,
       audio_layers: linked.audio_layers,
       visual_layers: linked.visual_layers
@@ -412,7 +424,7 @@
         const field = form.elements.namedItem(name);
         if (field) field.value = '';
       });
-      setStatus('QA preset loaded (separate rain visuals + footsteps audio). Generate package to test A/V separation.');
+      setStatus('QA preset loaded (motif rack flow, link OFF). Generate package to test visual-only rain.');
       setError('');
     });
   }

--- a/js/asmr-visual-engine.js
+++ b/js/asmr-visual-engine.js
@@ -14,7 +14,7 @@
     'skytrain_track', 'skytrain_pass_visual', 'bus_pass_visual',
     'northshore_mountain_ridge', 'mountain_mist_layers',
     'rain_streaks', 'puddle_reflections',
-    'science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof'
+    'science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'lions_gate_bridge', 'bc_place_dome', 'port_cranes', 'gastown_scene', 'granville_scene', 'north_shore_scene', 'clear_cold_shimmer'
   ];
 
   function clamp(value, min, max) {
@@ -296,8 +296,8 @@
     }
 
     drawSceneLayers(ctx, width, height, t, normalized, overlays) {
-      const landmarkTypes = ['science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'gastown_clock_silhouette', 'skytrain_pass_visual', 'bus_pass_visual'];
-      const atmosphereTypes = ['rain_streaks', 'snow_drift', 'harbor_mist', 'mountain_mist_layers', 'puddle_reflections', 'volumetric_fog'];
+      const landmarkTypes = ['science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'lions_gate_bridge', 'bc_place_dome', 'port_cranes', 'gastown_clock_silhouette'];
+      const atmosphereTypes = ['rain_streaks', 'snow_drift', 'harbor_mist', 'mountain_mist_layers', 'puddle_reflections', 'volumetric_fog', 'clear_cold_shimmer'];
       const weirdness = this.parseWeirdnessLevel();
       const weirdNorm = (weirdness - 1) / 9;
       let distortion = 0.04 + (0.18 - 0.04) * weirdNorm;
@@ -896,6 +896,80 @@
           ctx.stroke();
           break;
         }
+
+        case 'clear_cold_shimmer': {
+          ctx.fillStyle = `rgba(196,226,255,${0.06 + intensity * 0.12})`;
+          for (let i = 0; i < 70; i += 1) {
+            const x = (i * 47 + normalized * 90) % w;
+            const y = (i * 23 + normalized * 60) % (h * 0.8);
+            const s = 1 + ((i % 3) * 0.8);
+            ctx.fillRect(x, y, s, s);
+          }
+          break;
+        }
+        case 'gastown_scene': {
+          this.drawEvent(ctx, { visual_type: 'brick_wall_parallax', params: {}, intensity: intensity * 0.8 }, p, intensity, w, h, normalized);
+          this.drawEvent(ctx, { visual_type: 'cobblestone_perspective', params: {}, intensity: intensity * 0.8 }, p, intensity, w, h, normalized);
+          this.drawEvent(ctx, { visual_type: 'streetlamp_halo_row', params: {}, intensity: intensity * 0.85 }, p, intensity, w, h, normalized);
+          this.drawEvent(ctx, { visual_type: 'gastown_clock_silhouette', params: {}, intensity: intensity * 0.9 }, p, intensity, w, h, normalized);
+          break;
+        }
+        case 'granville_scene': {
+          this.drawEvent(ctx, { visual_type: 'granville_neon_marquee', params: {}, intensity: intensity * 0.9 }, p, intensity, w, h, normalized);
+          this.drawEvent(ctx, { visual_type: 'neon_sign_flicker', params: {}, intensity: intensity * 0.85 }, p, intensity, w, h, normalized);
+          this.drawEvent(ctx, { visual_type: 'traffic_light_glow', params: {}, intensity: intensity * 0.7 }, p, intensity, w, h, normalized);
+          this.drawEvent(ctx, { visual_type: 'puddle_reflections', params: {}, intensity: intensity * 0.72 }, p, intensity, w, h, normalized);
+          break;
+        }
+        case 'north_shore_scene': {
+          this.drawEvent(ctx, { visual_type: 'northshore_mountain_ridge', params: {}, intensity: intensity * 0.9 }, p, intensity, w, h, normalized);
+          this.drawEvent(ctx, { visual_type: 'mountain_mist_layers', params: {}, intensity: intensity * 0.9 }, p, intensity, w, h, normalized);
+          this.drawEvent(ctx, { visual_type: 'harbor_mist', params: {}, intensity: intensity * 0.75 }, p, intensity, w, h, normalized);
+          break;
+        }
+
+
+        case 'lions_gate_bridge': {
+          const y = h * 0.56;
+          ctx.strokeStyle = `rgba(176,208,224,${0.26 + intensity * 0.3})`;
+          ctx.lineWidth = 3;
+          ctx.beginPath(); ctx.moveTo(w * 0.18, y); ctx.lineTo(w * 0.82, y); ctx.stroke();
+          ctx.fillStyle = `rgba(120,154,180,${0.24 + intensity * 0.26})`;
+          ctx.fillRect(w * 0.2, h * 0.36, w * 0.03, h * 0.2);
+          ctx.fillRect(w * 0.77, h * 0.36, w * 0.03, h * 0.2);
+          for (let i = 0; i < 7; i += 1) {
+            const x = w * (0.23 + i * 0.08);
+            ctx.beginPath(); ctx.moveTo(x, h * 0.38); ctx.lineTo(x, y); ctx.stroke();
+          }
+          break;
+        }
+        case 'bc_place_dome': {
+          const cx = w * 0.52;
+          const cy = h * 0.72;
+          const rx = w * 0.24;
+          const ry = h * 0.14;
+          ctx.strokeStyle = `rgba(182,216,234,${0.28 + intensity * 0.3})`;
+          ctx.lineWidth = 2;
+          ctx.beginPath();
+          ctx.ellipse(cx, cy, rx, ry, 0, Math.PI, 0, true);
+          ctx.stroke();
+          for (let i = -4; i <= 4; i += 1) {
+            const x = cx + i * (rx / 4.5);
+            ctx.beginPath(); ctx.moveTo(x, cy); ctx.lineTo(cx, cy - ry * 1.3); ctx.stroke();
+          }
+          break;
+        }
+        case 'port_cranes': {
+          ctx.strokeStyle = `rgba(164,188,208,${0.22 + intensity * 0.26})`;
+          ctx.lineWidth = 3;
+          for (let i = 0; i < 4; i += 1) {
+            const x = w * (0.16 + i * 0.16);
+            const base = h * 0.68;
+            ctx.beginPath(); ctx.moveTo(x, base); ctx.lineTo(x, h * 0.5); ctx.lineTo(x + w * 0.1, h * 0.46); ctx.stroke();
+          }
+          break;
+        }
+
         case 'northshore_mountain_ridge': {
           ctx.fillStyle = `rgba(40,62,86,${0.24 + intensity * 0.28})`;
           ctx.beginPath();

--- a/page-asmr-lab.php
+++ b/page-asmr-lab.php
@@ -25,55 +25,94 @@ get_header();
 
     <form id="asmr-lab-form" class="asmr-lab-form" novalidate>
       <div class="asmr-grid">
-        <label>Location
-          <select name="location">
-            <option value="gastown" selected>Gastown Steam Clock</option>
-            <option value="granville">Granville Street</option>
-            <option value="north_shore">North Shore Mountains</option>
-          </select>
-        </label>
-        <label>Weather
-          <select name="weather">
-            <option value="snow" selected>Snow</option>
-            <option value="rain">Rain</option>
-            <option value="fog">Fog</option>
-            <option value="clear_cold">Clear Cold</option>
-          </select>
-        </label>
         <label>Duration (10-30 sec)<input type="number" name="duration" min="10" max="30" value="20" required /></label>
-        <label>Voice Style<input type="text" name="voice_style" maxlength="80" placeholder="composed machine whisper" /></label>
-        <label>Weirdness (1-10)<input type="number" name="weirdness" min="1" max="10" value="6" required /></label>
       </div>
 
-      <fieldset class="asmr-layer-grid">
+      <fieldset class="asmr-layer-grid asmr-layer-groups">
         <legend>Sound Layers</legend>
-        <label><input type="checkbox" name="audio_layers[]" value="footsteps" checked /> footsteps</label>
-        <label><input type="checkbox" name="audio_layers[]" value="rain_ambience" /> rain ambience</label>
-        <label><input type="checkbox" name="audio_layers[]" value="chatter" /> chatter</label>
-        <label><input type="checkbox" name="audio_layers[]" value="laughter" /> laughter</label>
-        <label><input type="checkbox" name="audio_layers[]" value="skytrain" /> SkyTrain</label>
-        <label><input type="checkbox" name="audio_layers[]" value="bus" /> bus</label>
-        <label><input type="checkbox" name="audio_layers[]" value="car_horn" /> car horn</label>
-        <label><input type="checkbox" name="audio_layers[]" value="steam_clock" checked /> Gastown steam clock</label>
+        <label class="asmr-inline-label">Voice Style<input type="text" name="voice_style" maxlength="80" placeholder="composed machine whisper" /></label>
+        <div class="asmr-motif-group">
+          <h3>Core City Layers</h3>
+          <div class="asmr-motif-grid">
+            <label><input type="checkbox" name="audio_layers[]" value="footsteps" checked /> footsteps</label>
+            <label><input type="checkbox" name="audio_layers[]" value="rain_ambience" /> rain ambience bed</label>
+            <label><input type="checkbox" name="audio_layers[]" value="wind_gust" /> wind gust</label>
+            <label><input type="checkbox" name="audio_layers[]" value="crowd_murmur" /> crowd murmur</label>
+            <label><input type="checkbox" name="audio_layers[]" value="laughter_burst" /> laughter burst</label>
+            <label><input type="checkbox" name="audio_layers[]" value="skytrain_pass" /> SkyTrain pass</label>
+            <label><input type="checkbox" name="audio_layers[]" value="bus_pass" /> bus pass</label>
+            <label><input type="checkbox" name="audio_layers[]" value="car_horn_short" /> car horn short</label>
+            <label><input type="checkbox" name="audio_layers[]" value="steam_clock" checked /> steam clock</label>
+          </div>
+        </div>
+        <div class="asmr-motif-group">
+          <h3>Vancouver Details</h3>
+          <div class="asmr-motif-grid">
+            <label><input type="checkbox" name="audio_layers[]" value="seabus_horn" /> SeaBus horn</label>
+            <label><input type="checkbox" name="audio_layers[]" value="gulls_distant" /> distant gulls</label>
+            <label><input type="checkbox" name="audio_layers[]" value="crosswalk_chirp" /> crosswalk chirp</label>
+            <label><input type="checkbox" name="audio_layers[]" value="compass_tap" /> compass tap</label>
+            <label><input type="checkbox" name="audio_layers[]" value="bike_bell" /> bike bell</label>
+            <label><input type="checkbox" name="audio_layers[]" value="skateboard_roll" /> skateboard roll</label>
+            <label><input type="checkbox" name="audio_layers[]" value="siren_distant" /> distant siren</label>
+          </div>
+        </div>
       </fieldset>
 
-      <fieldset class="asmr-layer-grid">
+      <fieldset class="asmr-layer-grid asmr-layer-groups">
         <legend>Visual Motifs</legend>
-        <label><input type="checkbox" name="visual_layers[]" value="rain_streaks" /> rain streaks</label>
-        <label><input type="checkbox" name="visual_layers[]" value="snow_drift" /> snow drift</label>
-        <label><input type="checkbox" name="visual_layers[]" value="harbor_mist" /> fog / mist</label>
-        <label><input type="checkbox" name="visual_layers[]" value="skytrain_pass_visual" /> skytrain pass</label>
-        <label><input type="checkbox" name="visual_layers[]" value="bus_pass_visual" /> bus pass</label>
-        <label><input type="checkbox" name="visual_layers[]" value="traffic_light_glow" /> traffic glow</label>
-        <label><input type="checkbox" name="visual_layers[]" value="puddle_reflections" /> puddle reflections</label>
-        <label><input type="checkbox" name="visual_layers[]" value="cobblestone_perspective" /> cobblestone perspective</label>
-        <label><input type="checkbox" name="visual_layers[]" value="brick_wall_parallax" /> brick wall parallax</label>
-        <label><input type="checkbox" name="visual_layers[]" value="streetlamp_halo_row" /> streetlamp halos</label>
-        <label><input type="checkbox" name="visual_layers[]" value="science_world_dome" /> Science World dome silhouette</label>
-        <label><input type="checkbox" name="visual_layers[]" value="chinatown_gate" /> Chinatown gate silhouette</label>
-        <label><input type="checkbox" name="visual_layers[]" value="english_bay_inukshuk" /> English Bay inukshuk silhouette</label>
-        <label><input type="checkbox" name="visual_layers[]" value="maritime_museum_sailroof" /> Maritime Museum sail roof silhouette</label>
-        <label><input type="checkbox" name="visual_layers[]" value="gastown_clock_silhouette" /> Gastown clock silhouette</label>
+        <div class="asmr-motif-group">
+          <h3>Atmosphere</h3>
+          <div class="asmr-motif-grid">
+            <label><input type="checkbox" name="visual_layers[]" value="rain_streaks" /> rain streaks</label>
+            <label><input type="checkbox" name="visual_layers[]" value="snow_drift" /> snow drift</label>
+            <label><input type="checkbox" name="visual_layers[]" value="harbor_mist" /> harbor mist</label>
+            <label><input type="checkbox" name="visual_layers[]" value="clear_cold_shimmer" /> clear cold shimmer</label>
+          </div>
+        </div>
+        <div class="asmr-motif-group">
+          <h3>Scenes</h3>
+          <div class="asmr-motif-grid">
+            <label><input type="checkbox" name="visual_layers[]" value="gastown_scene" /> Gastown scene</label>
+            <label><input type="checkbox" name="visual_layers[]" value="granville_scene" checked /> Granville scene</label>
+            <label><input type="checkbox" name="visual_layers[]" value="north_shore_scene" /> North Shore scene</label>
+          </div>
+        </div>
+        <div class="asmr-motif-group">
+          <h3>Landmarks</h3>
+          <div class="asmr-motif-grid">
+            <label><input type="checkbox" name="visual_layers[]" value="gastown_clock_silhouette" /> Gastown clock</label>
+            <label><input type="checkbox" name="visual_layers[]" value="science_world_dome" /> Science World dome</label>
+            <label><input type="checkbox" name="visual_layers[]" value="chinatown_gate" /> Chinatown gate</label>
+            <label><input type="checkbox" name="visual_layers[]" value="english_bay_inukshuk" /> English Bay inukshuk</label>
+            <label><input type="checkbox" name="visual_layers[]" value="maritime_museum_sailroof" /> Maritime Museum sail roof</label>
+            <label><input type="checkbox" name="visual_layers[]" value="lions_gate_bridge" /> Lions Gate Bridge</label>
+            <label><input type="checkbox" name="visual_layers[]" value="bc_place_dome" /> BC Place dome</label>
+            <label><input type="checkbox" name="visual_layers[]" value="port_cranes" /> Port cranes</label>
+          </div>
+        </div>
+        <div class="asmr-motif-group">
+          <h3>Street Texture</h3>
+          <div class="asmr-motif-grid">
+            <label><input type="checkbox" name="visual_layers[]" value="cobblestone_perspective" /> cobblestones</label>
+            <label><input type="checkbox" name="visual_layers[]" value="brick_wall_parallax" /> brick wall parallax</label>
+            <label><input type="checkbox" name="visual_layers[]" value="puddle_reflections" /> puddle reflections</label>
+            <label><input type="checkbox" name="visual_layers[]" value="streetlamp_halo_row" /> streetlamp halos</label>
+          </div>
+        </div>
+        <div class="asmr-motif-group">
+          <h3>Transit + CRT</h3>
+          <div class="asmr-motif-grid">
+            <label><input type="checkbox" name="visual_layers[]" value="skytrain_track" /> SkyTrain track</label>
+            <label><input type="checkbox" name="visual_layers[]" value="skytrain_pass_visual" checked /> SkyTrain pass visual</label>
+            <label><input type="checkbox" name="visual_layers[]" value="bus_pass_visual" /> bus pass visual</label>
+            <label><input type="checkbox" name="visual_layers[]" value="scanline_field" /> scanline field</label>
+            <label><input type="checkbox" name="visual_layers[]" value="glitch_flash" /> glitch flash</label>
+            <label><input type="checkbox" name="visual_layers[]" value="signal_bars" /> signal bars</label>
+            <label><input type="checkbox" name="visual_layers[]" value="chromatic_veil" /> chromatic veil</label>
+            <label><input type="checkbox" name="visual_layers[]" value="neon_sign_flicker" checked /> neon sign flicker</label>
+          </div>
+        </div>
       </fieldset>
 
       <label class="asmr-link-toggle"><input type="checkbox" name="link_av" checked /> Link sound + visual for selected motifs</label>


### PR DESCRIPTION
### Motivation
- Remove the confusing Location + Weather controls and make the builder motif-first: users pick Sound Layers and Visual Motifs while `Duration` remains the only global control. 
- Move location/weather semantics into selectable visual motifs and optional sound pairings to make world-building explicit and non-redundant. 
- Preserve Advanced / Freeform override and the conservative A/V linking behavior as a toggle for backwards compatibility and power users.

### Description
- UI: removed `location`/`weather` selects and rebuilt the top controls and layer panels in `page-asmr-lab.php` to expose a Duration field, grouped Sound Layers, grouped Visual Motifs, a `link_av` toggle, and moved `voice_style` under Sound Layers. (see `page-asmr-lab.php`)
- Client: updated payload assembly and linking logic in `js/asmr-lab.js` to send `duration`, `audio_layers`, `visual_layers`, `link_av`, and optional `voice_style`; replaced the old linked map with conservative visual→audio pairing and scene support expansion, and refreshed the QA preset to a motif-first example.
- Backend: expanded allowlists and motif handling in `functions.php` (new `se_get_asmr_audio_layers_allowed`, `se_get_asmr_visual_layers_allowed`, `se_get_asmr_visual_to_audio_map`, `se_get_asmr_scene_visual_support_map`); accepted legacy `location`/`weather` for compatibility but derive `concept`/`setting`/`creative_goal` from selected motifs when Advanced mode is not used; deterministic injection now produces audio only from `audio_layers` (plus conservative `link_av` pairings) and visuals only from `visual_layers` and ensures early scene/landmark readability and atmosphere beds.
- Foley engine: added procedural Vancouver-style engines and safe render code to `js/asmr-foley-engine.js` (`seabus_horn`, `gulls_distant`, `crosswalk_chirp`, `compass_tap`, `bike_bell`, `skateboard_roll`, `siren_distant`) and preserved limiter/master chain behavior.
- Visual engine: added new motif renderers and landmark silhouettes in `js/asmr-visual-engine.js` (`gastown_scene`, `granville_scene`, `north_shore_scene`, `clear_cold_shimmer`, `lions_gate_bridge`, `bc_place_dome`, `port_cranes`) and kept CRT layering, scanlines, and readability clamps.
- Styling: added grouped motif rack styles in `assets/css/asmr-lab.css` to keep the retro CRT / pixel aesthetic.

### Testing
- Ran PHP syntax checks: `php -l functions.php` and `php -l page-asmr-lab.php`, both returned no syntax errors.
- Ran JavaScript static checks: `node --check js/asmr-lab.js`, `node --check js/asmr-foley-engine.js`, and `node --check js/asmr-visual-engine.js`, all succeeded.
- Started a local PHP dev server for manual validation; attempted automated screenshot via Playwright failed because Chromium crashed in this environment (SIGSEGV) so no screenshot was produced.
- Overall lint/sanity checks passed for the modified PHP and JS files; browser render verification should be performed in a full browser environment to confirm visual/interactive behaviors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b099200f30832e8b1b9bb8a9f9942c)