### PR TITLE
Simplify ASMR Lab motif rack and add waterfront/ocean modules

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -901,6 +901,7 @@ function se_get_asmr_allowed_engines() {
         'bus_idle',
         'car_horn_short',
         'seabus_horn',
+        'ocean_waves',
         'gulls_distant',
         'crosswalk_chirp',
         'compass_tap',
@@ -926,7 +927,7 @@ function se_get_asmr_visual_types() {
         'rain_streaks', 'puddle_reflections',
         'science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof',
         'lions_gate_bridge', 'bc_place_dome', 'port_cranes',
-        'gastown_scene', 'granville_scene', 'north_shore_scene', 'clear_cold_shimmer',
+        'gastown_scene', 'granville_scene', 'north_shore_scene', 'waterfront_scene', 'clear_cold_shimmer', 'ocean_surface_shimmer', 'seabus_silhouette',
     );
 }
 
@@ -1204,39 +1205,41 @@ function se_get_asmr_audio_layers_allowed() {
     return array(
         'footsteps', 'footsteps_snow_mode', 'rain_ambience', 'wind_gust', 'crowd_murmur', 'laughter_burst',
         'skytrain_pass', 'bus_pass', 'car_horn_short', 'steam_clock',
-        'seabus_horn', 'gulls_distant', 'crosswalk_chirp', 'compass_tap', 'bike_bell', 'skateboard_roll', 'siren_distant'
+        'seabus_horn', 'ocean_waves', 'gulls_distant', 'crosswalk_chirp', 'compass_tap', 'bike_bell', 'skateboard_roll', 'siren_distant'
     );
 }
 
 function se_get_asmr_visual_layers_allowed() {
     return array(
         'rain_streaks', 'snow_drift', 'harbor_mist', 'clear_cold_shimmer',
-        'gastown_scene', 'granville_scene', 'north_shore_scene',
+        'gastown_scene', 'granville_scene', 'north_shore_scene', 'waterfront_scene',
         'gastown_clock_silhouette', 'science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof',
         'lions_gate_bridge', 'bc_place_dome', 'port_cranes',
         'cobblestone_perspective', 'brick_wall_parallax', 'puddle_reflections', 'streetlamp_halo_row',
         'skytrain_track', 'skytrain_pass_visual', 'bus_pass_visual',
-        'scanline_field', 'glitch_flash', 'signal_bars', 'chromatic_veil', 'neon_sign_flicker',
+        'scanline_field', 'glitch_flash', 'signal_bars', 'chromatic_veil', 'neon_sign_flicker', 'ocean_surface_shimmer', 'seabus_silhouette',
         'granville_neon_marquee', 'traffic_light_glow', 'northshore_mountain_ridge', 'mountain_mist_layers', 'volumetric_fog'
     );
 }
 
 function se_get_asmr_visual_to_audio_map() {
     return array(
+        'ocean_surface_shimmer' => array( 'ocean_waves' ),
+        'waterfront_scene' => array( 'ocean_waves' ),
+        'seabus_silhouette' => array( 'seabus_horn' ),
         'skytrain_pass_visual' => array( 'skytrain_pass' ),
         'bus_pass_visual' => array( 'bus_pass' ),
         'rain_streaks' => array( 'rain_ambience' ),
-        'gastown_clock_silhouette' => array( 'steam_clock' ),
         'gastown_scene' => array( 'steam_clock' ),
-        'snow_drift' => array( 'footsteps_snow_mode' ),
     );
 }
 
 function se_get_asmr_scene_visual_support_map() {
     return array(
-        'gastown_scene' => array( 'gastown_clock_silhouette', 'streetlamp_halo_row', 'cobblestone_perspective', 'brick_wall_parallax' ),
-        'granville_scene' => array( 'granville_neon_marquee', 'traffic_light_glow', 'puddle_reflections' ),
-        'north_shore_scene' => array( 'northshore_mountain_ridge', 'mountain_mist_layers', 'harbor_mist' ),
+        'gastown_scene' => array( 'gastown_clock_silhouette', 'streetlamp_halo_row' ),
+        'granville_scene' => array( 'granville_neon_marquee', 'puddle_reflections' ),
+        'north_shore_scene' => array( 'northshore_mountain_ridge', 'mountain_mist_layers' ),
+        'waterfront_scene' => array( 'ocean_surface_shimmer', 'seabus_silhouette' ),
     );
 }
 
@@ -1257,6 +1260,8 @@ function se_get_asmr_mapped_visual_layers_from_audio( $audio_layers ) {
         'bus_pass' => 'bus_pass_visual',
         'rain_ambience' => 'rain_streaks',
         'steam_clock' => 'gastown_clock_silhouette',
+        'ocean_waves' => 'ocean_surface_shimmer',
+        'seabus_horn' => 'seabus_silhouette',
     );
     $visual = array();
     foreach ( (array) $audio_layers as $token ) {
@@ -1272,7 +1277,7 @@ function se_get_asmr_vancouver_derived_payload( $payload ) {
     $audio_layers = array_values( array_filter( array_map( 'sanitize_key', (array) ( $payload['audio_layers'] ?? array() ) ) ) );
     $visual_layers = array_values( array_filter( array_map( 'sanitize_key', (array) ( $payload['visual_layers'] ?? array() ) ) ) );
     if ( empty( $visual_layers ) ) {
-        $visual_layers = array( 'granville_scene', 'rain_streaks', 'skytrain_pass_visual' );
+        $visual_layers = array( 'waterfront_scene', 'harbor_mist', 'ocean_surface_shimmer' );
     }
 
     $motif_line = implode( ' + ', $visual_layers );
@@ -1283,6 +1288,32 @@ function se_get_asmr_vancouver_derived_payload( $payload ) {
     $payload['mood'] = 'atmospheric, tactile, and cinematic';
     $payload['creative_goal'] = sprintf( 'Build a readable motif-forward timeline with %s while preserving coherent visual geography.', $foley_text );
     return $payload;
+}
+
+
+function se_get_asmr_motif_brief( $payload ) {
+    $visual_layers = array_values( array_filter( array_map( 'sanitize_key', (array) ( $payload['visual_layers'] ?? array() ) ) ) );
+    $audio_layers = array_values( array_filter( array_map( 'sanitize_key', (array) ( $payload['audio_layers'] ?? array() ) ) ) );
+
+    $scene = array_values( array_intersect( $visual_layers, array( 'gastown_scene', 'granville_scene', 'north_shore_scene', 'waterfront_scene' ) ) );
+    $atmosphere = array_values( array_intersect( $visual_layers, array( 'rain_streaks', 'snow_drift', 'harbor_mist', 'clear_cold_shimmer' ) ) );
+    $signature = array_values( array_intersect( $visual_layers, array( 'science_world_dome', 'chinatown_gate', 'lions_gate_bridge', 'gastown_clock_silhouette', 'seabus_silhouette' ) ) );
+
+    $parts = array();
+    if ( ! empty( $scene ) ) {
+        $parts[] = 'Selected scene: ' . implode( ', ', $scene ) . '.';
+    }
+    if ( ! empty( $atmosphere ) ) {
+        $parts[] = 'Atmosphere: ' . implode( ', ', $atmosphere ) . '.';
+    }
+    if ( ! empty( $signature ) ) {
+        $parts[] = 'Signature: ' . implode( ', ', $signature ) . '.';
+    }
+    if ( ! empty( $audio_layers ) ) {
+        $parts[] = 'Audio: ' . implode( ' + ', $audio_layers ) . '.';
+    }
+
+    return implode( ' ', $parts );
 }
 
 function se_inject_asmr_vancouver_anchors( $decoded, $payload ) {
@@ -1325,7 +1356,7 @@ function se_inject_asmr_vancouver_anchors( $decoded, $payload ) {
 
     $scene_or_landmark = array(
         'gastown_scene', 'granville_scene', 'north_shore_scene', 'gastown_clock_silhouette', 'science_world_dome',
-        'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'lions_gate_bridge', 'bc_place_dome', 'port_cranes'
+        'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'lions_gate_bridge', 'bc_place_dome', 'port_cranes', 'waterfront_scene', 'seabus_silhouette'
     );
 
     foreach ( $audio_layers as $layer ) {
@@ -1352,7 +1383,7 @@ function se_inject_asmr_vancouver_anchors( $decoded, $payload ) {
         } elseif ( 'steam_clock' === $layer ) {
             $audio[] = array( 'time' => 0.52, 'duration' => 1.1, 'engine' => 'steam_clock_burst', 'intensity' => 0.62, 'params' => array(), 'sync_role' => 'steam_clock_toggle' );
         } elseif ( 'seabus_horn' === $layer ) {
-            $audio[] = array( 'time' => $runtime * 0.36, 'duration' => 1.6, 'engine' => 'seabus_horn', 'intensity' => 0.42, 'params' => array(), 'sync_role' => 'seabus_horn' );
+            $audio[] = array( 'time' => $runtime * 0.32, 'duration' => 1.8, 'engine' => 'seabus_horn', 'intensity' => 0.36, 'params' => array(), 'sync_role' => 'seabus_horn' );
         } elseif ( 'gulls_distant' === $layer ) {
             $audio[] = array( 'time' => 0.48, 'duration' => 2.2, 'engine' => 'gulls_distant', 'intensity' => 0.34, 'params' => array(), 'sync_role' => 'gulls_distant' );
         } elseif ( 'crosswalk_chirp' === $layer ) {
@@ -1383,7 +1414,7 @@ function se_inject_asmr_vancouver_anchors( $decoded, $payload ) {
             $visual[] = array( 'time' => $runtime * 0.3, 'duration' => 2.0, 'visual_type' => 'bus_pass_visual', 'intensity' => 0.6, 'params' => array(), 'sync_role' => 'bus_visual' );
             continue;
         }
-        if ( in_array( $visual_type, array( 'gastown_scene', 'granville_scene', 'north_shore_scene' ), true ) ) {
+        if ( in_array( $visual_type, array( 'gastown_scene', 'granville_scene', 'north_shore_scene', 'waterfront_scene' ), true ) ) {
             $visual[] = array( 'time' => 0.18, 'duration' => min( 3.2, $runtime * 0.22 ), 'visual_type' => $visual_type, 'intensity' => 0.7, 'params' => array(), 'sync_role' => 'scene_anchor' );
             $visual[] = array( 'time' => $runtime * 0.44, 'duration' => min( 2.4, $runtime * 0.2 ), 'visual_type' => $visual_type, 'intensity' => 0.58, 'params' => array(), 'sync_role' => 'scene_recur' );
             continue;
@@ -1397,6 +1428,19 @@ function se_inject_asmr_vancouver_anchors( $decoded, $payload ) {
             $has_scene_or_landmark = true;
             break;
         }
+    }
+
+
+    if ( in_array( 'ocean_waves', $audio_layers, true ) ) {
+        $audio[] = array( 'time' => 0.02, 'duration' => max( 6.2, $runtime * 0.64 ), 'engine' => 'ocean_waves', 'intensity' => 0.5, 'params' => array(), 'sync_role' => 'ocean_wave_anchor' );
+    }
+
+    if ( in_array( 'ocean_surface_shimmer', $visual_layers, true ) ) {
+        $visual[] = array( 'time' => 0.0, 'duration' => max( 5.6, $runtime * 0.68 ), 'visual_type' => 'ocean_surface_shimmer', 'intensity' => 0.62, 'params' => array(), 'sync_role' => 'waterfront_shimmer_anchor' );
+    }
+
+    if ( in_array( 'seabus_silhouette', $visual_layers, true ) ) {
+        $visual[] = array( 'time' => 0.5, 'duration' => min( 4.4, $runtime * 0.3 ), 'visual_type' => 'seabus_silhouette', 'intensity' => 0.62, 'params' => array(), 'sync_role' => 'seabus_silhouette_anchor' );
     }
 
     if ( $has_scene_or_landmark ) {
@@ -1605,7 +1649,6 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
         'setting' => sanitize_text_field( $params['setting'] ?? '' ),
         'mood' => sanitize_text_field( $params['mood'] ?? '' ),
         'duration' => max( 10, min( 30, absint( $params['duration'] ?? 20 ) ) ),
-        'voice_style' => sanitize_text_field( $params['voice_style'] ?? '' ),
         'creative_goal' => sanitize_textarea_field( $params['creative_goal'] ?? '' ),
         'location' => sanitize_key( $params['location'] ?? '' ),
         'weather' => sanitize_key( $params['weather'] ?? '' ),
@@ -1625,6 +1668,8 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
             $payload['style_tags_legacy'] = array( $payload['location'], $payload['weather'] );
         }
     }
+
+    $payload['motif_brief'] = se_get_asmr_motif_brief( $payload );
 
     $allowed_engines = implode( ', ', se_get_asmr_allowed_engines() );
     $system_prompt = 'You are ASMR Lab, a retro-futurist sensory film composer for a browser performance engine. '

--- a/js/asmr-foley-engine.js
+++ b/js/asmr-foley-engine.js
@@ -10,7 +10,7 @@
     'steam_clock_burst', 'distant_bell_toll', 'cold_air_hush', 'wet_street_shimmer',
     'harbor_fog_bed', 'metal_resonance', 'snow_muffle', 'city_electrical_hum',
     'footsteps_wet', 'footsteps_snow', 'rain_close', 'rain_roof', 'puddle_splash',
-    'crowd_murmur', 'laughter_burst', 'skytrain_pass', 'bus_idle', 'car_horn_short', 'seabus_horn', 'gulls_distant', 'crosswalk_chirp', 'compass_tap', 'bike_bell', 'skateboard_roll', 'siren_distant'
+    'crowd_murmur', 'laughter_burst', 'skytrain_pass', 'bus_idle', 'car_horn_short', 'seabus_horn', 'ocean_waves', 'gulls_distant', 'crosswalk_chirp', 'compass_tap', 'bike_bell', 'skateboard_roll', 'siren_distant'
   ];
 
   function clamp(value, min, max) {
@@ -106,7 +106,7 @@
 
     buildMasterChain(ctx, destination) {
       const input = ctx.createGain();
-      input.gain.value = 0.68;
+      input.gain.value = 0.58;
 
       const preHP = ctx.createBiquadFilter();
       preHP.type = 'highpass';
@@ -124,7 +124,7 @@
       comp.release.value = 0.25;
 
       const limiter = ctx.createDynamicsCompressor();
-      limiter.threshold.value = -8;
+      limiter.threshold.value = -9;
       limiter.knee.value = 2;
       limiter.ratio.value = 14;
       limiter.attack.value = 0.002;
@@ -135,9 +135,9 @@
 
       const convolver = this.makeTinyReverb(ctx);
       const wet = ctx.createGain();
-      wet.gain.value = 0.2;
+      wet.gain.value = 0.17;
       const dry = ctx.createGain();
-      dry.gain.value = 0.8;
+      dry.gain.value = 0.83;
 
       input.connect(preHP);
       preHP.connect(toneLP);
@@ -418,11 +418,25 @@
           break;
 
 
-        case 'seabus_horn':
-          this.scheduleTone(ctx, destination, atTime, duration, { from: 86, to: 72, peak: 0.02 + intensity * 0.04, type: 'sine', pan: -0.08 });
-          this.scheduleTone(ctx, destination, atTime + 0.03, duration * 0.92, { from: 118, to: 96, peak: 0.012 + intensity * 0.025, type: 'triangle', pan: 0.06 });
-          this.scheduleNoise(ctx, destination, atTime, duration * 0.7, { freq: 420, q: 0.8, peak: 0.006 + intensity * 0.012, filterType: 'bandpass' });
+        case 'seabus_horn': {
+          const wobble = Math.max(0.1, duration * 0.5);
+          this.scheduleTone(ctx, destination, atTime, duration, { from: 82, to: 74, peak: 0.014 + intensity * 0.022, type: 'triangle', pan: -0.08 });
+          this.scheduleTone(ctx, destination, atTime + 0.04, duration * 0.95, { from: 108, to: 98, peak: 0.01 + intensity * 0.016, type: 'sine', pan: 0.06 });
+          this.scheduleTone(ctx, destination, atTime + 0.08, wobble, { from: 95, to: 89, peak: 0.004 + intensity * 0.008, type: 'sine', pan: 0 });
+          this.scheduleNoise(ctx, destination, atTime + 0.04, duration * 0.58, { freq: 360, q: 0.9, peak: 0.002 + intensity * 0.006, filterType: 'bandpass' });
           break;
+        }
+        case 'ocean_waves': {
+          const swells = Math.max(3, Math.round(duration / 2.4));
+          this.scheduleNoise(ctx, destination, atTime, duration, { freq: 240, q: 0.55, peak: 0.01 + intensity * 0.02, filterType: 'bandpass', pan: -0.18 });
+          this.scheduleNoise(ctx, destination, atTime + 0.02, duration, { freq: 520, q: 0.7, peak: 0.006 + intensity * 0.014, filterType: 'lowpass', pan: 0.18 });
+          for (let i = 0; i < swells; i += 1) {
+            const dt = (i / Math.max(1, swells - 1)) * Math.max(0.3, duration - 0.6);
+            this.scheduleTone(ctx, destination, atTime + dt, 1.4, { from: 62, to: 52, peak: 0.004 + intensity * 0.01, type: 'sine', pan: (i % 2 ? 0.1 : -0.1) });
+            this.scheduleNoise(ctx, destination, atTime + dt + 0.25, 0.34, { freq: 1900, q: 1.1, peak: 0.002 + intensity * 0.006, filterType: 'highpass', pan: (i % 2 ? -0.14 : 0.14) });
+          }
+          break;
+        }
         case 'gulls_distant': {
           const chirps = Math.max(2, Math.min(6, Math.round(duration * 1.4)));
           for (let i = 0; i < chirps; i += 1) {

--- a/js/asmr-lab.js
+++ b/js/asmr-lab.js
@@ -26,18 +26,37 @@
 
 
   const LINKED_VISUAL_TO_AUDIO = {
-    skytrain_pass_visual: ['skytrain_pass'],
-    bus_pass_visual: ['bus_pass'],
+    ocean_surface_shimmer: ['ocean_waves'],
+    waterfront_scene: ['ocean_waves'],
+    seabus_silhouette: ['seabus_horn'],
     rain_streaks: ['rain_ambience'],
-    gastown_clock_silhouette: ['steam_clock'],
-    gastown_scene: ['steam_clock'],
-    snow_drift: ['footsteps_snow_mode']
+    skytrain_pass_visual: ['skytrain_pass'],
+    gastown_scene: ['steam_clock']
+  };
+
+  const OPTIONAL_LINK_AUDIO = {
+    waterfront_scene: ['ocean_waves'],
+    gastown_scene: ['steam_clock']
   };
 
   const SCENE_TO_SUPPORT_VISUALS = {
-    gastown_scene: ['gastown_clock_silhouette', 'streetlamp_halo_row', 'cobblestone_perspective', 'brick_wall_parallax'],
-    granville_scene: ['granville_neon_marquee', 'traffic_light_glow', 'puddle_reflections'],
-    north_shore_scene: ['northshore_mountain_ridge', 'mountain_mist_layers']
+    gastown_scene: ['gastown_clock_silhouette'],
+    granville_scene: ['puddle_reflections'],
+    north_shore_scene: ['mountain_mist_layers'],
+    waterfront_scene: ['ocean_surface_shimmer', 'seabus_silhouette']
+  };
+
+  const VISUAL_CAPS = {
+    scene: 1,
+    atmosphere: 1,
+    landmark: 1,
+    modifier: 3
+  };
+
+  const AUDIO_CAPS = {
+    bed: 1,
+    movement: 2,
+    accent: 2
   };
 
   function applyLayerLinking(audioLayers, visualLayers, isLinked) {
@@ -47,20 +66,16 @@
       return { audio_layers: Array.from(audioSet), visual_layers: Array.from(visualSet) };
     }
 
-    Object.entries(LINKED_VISUAL_TO_AUDIO).forEach(([visualToken, audioTokens]) => {
-      if (!visualSet.has(visualToken)) return;
-      audioTokens.forEach((audioToken) => {
-        if (audioToken === 'footsteps_snow_mode') {
-          if (audioSet.has('footsteps')) audioSet.add('footsteps_snow_mode');
-        } else {
-          audioSet.add(audioToken);
-        }
-      });
-    });
-
     Object.entries(SCENE_TO_SUPPORT_VISUALS).forEach(([sceneToken, supportVisuals]) => {
       if (!visualSet.has(sceneToken)) return;
-      supportVisuals.forEach((visualToken) => visualSet.add(visualToken));
+      supportVisuals.slice(0, 2).forEach((visualToken) => visualSet.add(visualToken));
+    });
+
+    Object.entries(LINKED_VISUAL_TO_AUDIO).forEach(([visualToken, audioTokens]) => {
+      if (!visualSet.has(visualToken)) return;
+      const isOptional = Object.prototype.hasOwnProperty.call(OPTIONAL_LINK_AUDIO, visualToken);
+      if (isOptional && !isLinked) return;
+      audioTokens.forEach((audioToken) => audioSet.add(audioToken));
     });
 
     return { audio_layers: Array.from(audioSet), visual_layers: Array.from(visualSet) };
@@ -69,10 +84,9 @@
 
   const QA_PRESET = {
     duration: '20',
-    voice_style: 'quiet city prayer',
-    link_av: false,
-    audio_layers: ['footsteps'],
-    visual_layers: ['granville_scene', 'rain_streaks', 'neon_sign_flicker', 'skytrain_pass_visual']
+    link_av: true,
+    audio_layers: ['ocean_waves', 'seabus_horn'],
+    visual_layers: ['waterfront_scene', 'harbor_mist', 'lions_gate_bridge', 'ocean_surface_shimmer']
   };
 
   const transport = {
@@ -145,6 +159,32 @@
     }
   }
 
+
+  function enforceLayerCaps(input) {
+    if (!input || !input.checked) return;
+    const name = input.name;
+    const group = String(input.dataset.layerGroup || '').trim();
+    if (!group) return;
+
+    const caps = name === 'visual_layers[]' ? VISUAL_CAPS : (name === 'audio_layers[]' ? AUDIO_CAPS : null);
+    if (!caps || !Object.prototype.hasOwnProperty.call(caps, group)) return;
+
+    const groupBoxes = Array.from(form.querySelectorAll(`input[name="${name}"][data-layer-group="${group}"]`));
+    const checked = groupBoxes.filter((box) => box.checked);
+    if (checked.length <= caps[group]) return;
+
+    input.checked = false;
+    setStatus(`Too many ${group} modules selected (max ${caps[group]}).`);
+  }
+
+  function attachLayerCapHandlers() {
+    if (!form) return;
+    const boxes = form.querySelectorAll('input[name="audio_layers[]"], input[name="visual_layers[]"]');
+    boxes.forEach((box) => {
+      box.addEventListener('change', () => enforceLayerCaps(box));
+    });
+  }
+
   function renderData(data) {
     const concept = document.getElementById('asmr-concept');
     const beats = document.getElementById('asmr-beats');
@@ -179,20 +219,9 @@
 
   function collectFormPayload() {
     const formData = new FormData(form);
-    const advanced = {
-      concept: String(formData.get('concept') || '').trim(),
-      object: String(formData.get('object') || '').trim(),
-      setting: String(formData.get('setting') || '').trim(),
-      mood: String(formData.get('mood') || '').trim(),
-      creative_goal: String(formData.get('creative_goal') || '').trim()
-    };
     const base = {
-      duration: String(formData.get('duration') || '20'),
-      voice_style: String(formData.get('voice_style') || '').trim()
+      duration: String(formData.get('duration') || '20')
     };
-
-    const hasAdvanced = !!(advanced.concept || advanced.object || advanced.setting || advanced.mood || advanced.creative_goal);
-    if (hasAdvanced) return Object.assign({}, base, advanced);
 
     const linkAV = !!formData.get('link_av');
     const audioLayers = formData.getAll('audio_layers[]').map((item) => String(item || '').trim()).filter(Boolean);
@@ -419,12 +448,7 @@
         const field = form.elements.namedItem(key);
         if (field) field.value = value;
       });
-      const advancedFields = ['concept', 'object', 'setting', 'mood', 'creative_goal'];
-      advancedFields.forEach((name) => {
-        const field = form.elements.namedItem(name);
-        if (field) field.value = '';
-      });
-      setStatus('QA preset loaded (motif rack flow, link OFF). Generate package to test visual-only rain.');
+      setStatus('QA preset loaded (waterfront rack). Generate package to test ocean-linked motifs.');
       setError('');
     });
   }
@@ -487,6 +511,8 @@
       }
     });
   }
+
+  attachLayerCapHandlers();
 
   window.addEventListener('resize', function () { if (visuals) visuals.resize(); });
 })();

--- a/js/asmr-visual-engine.js
+++ b/js/asmr-visual-engine.js
@@ -14,7 +14,7 @@
     'skytrain_track', 'skytrain_pass_visual', 'bus_pass_visual',
     'northshore_mountain_ridge', 'mountain_mist_layers',
     'rain_streaks', 'puddle_reflections',
-    'science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'lions_gate_bridge', 'bc_place_dome', 'port_cranes', 'gastown_scene', 'granville_scene', 'north_shore_scene', 'clear_cold_shimmer'
+    'science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'lions_gate_bridge', 'bc_place_dome', 'port_cranes', 'gastown_scene', 'granville_scene', 'north_shore_scene', 'waterfront_scene', 'clear_cold_shimmer', 'ocean_surface_shimmer', 'seabus_silhouette'
   ];
 
   function clamp(value, min, max) {
@@ -296,7 +296,7 @@
     }
 
     drawSceneLayers(ctx, width, height, t, normalized, overlays) {
-      const landmarkTypes = ['science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'lions_gate_bridge', 'bc_place_dome', 'port_cranes', 'gastown_clock_silhouette'];
+      const landmarkTypes = ['science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'lions_gate_bridge', 'bc_place_dome', 'port_cranes', 'gastown_clock_silhouette', 'seabus_silhouette', 'waterfront_scene'];
       const atmosphereTypes = ['rain_streaks', 'snow_drift', 'harbor_mist', 'mountain_mist_layers', 'puddle_reflections', 'volumetric_fog', 'clear_cold_shimmer'];
       const weirdness = this.parseWeirdnessLevel();
       const weirdNorm = (weirdness - 1) / 9;
@@ -928,6 +928,52 @@
           break;
         }
 
+
+
+        case 'waterfront_scene': {
+          const horizon = h * 0.58;
+          ctx.strokeStyle = `rgba(146,190,220,${0.2 + intensity * 0.2})`;
+          ctx.lineWidth = 2;
+          ctx.beginPath();
+          ctx.moveTo(0, horizon);
+          ctx.lineTo(w, horizon);
+          ctx.stroke();
+          this.drawEvent(ctx, { visual_type: 'port_cranes', params: {}, intensity: intensity * 0.58 }, p, intensity, w, h, normalized);
+          this.drawEvent(ctx, { visual_type: 'ocean_surface_shimmer', params: {}, intensity: intensity * 0.78 }, p, intensity, w, h, normalized);
+          const glow = ctx.createLinearGradient(0, horizon - 40, 0, horizon + 80);
+          glow.addColorStop(0, `rgba(255,140,210,${0.06 + intensity * 0.08})`);
+          glow.addColorStop(1, 'rgba(0,0,0,0)');
+          ctx.fillStyle = glow;
+          ctx.fillRect(0, horizon - 40, w, 120);
+          break;
+        }
+        case 'ocean_surface_shimmer': {
+          ctx.fillStyle = `rgba(106,170,220,${0.05 + intensity * 0.08})`;
+          for (let i = 0; i < 20; i += 1) {
+            const yy = h * 0.58 + i * 7 + Math.sin(normalized * 9 + i) * 2;
+            const ww = w * (0.44 + (i % 6) * 0.08);
+            const xx = (Math.sin(normalized * 3 + i * 0.6) * 0.24 + 0.5) * (w - ww);
+            ctx.fillRect(xx, yy, ww, 2);
+          }
+          break;
+        }
+        case 'seabus_silhouette': {
+          const progress = (normalized % 1);
+          const x = -w * 0.2 + progress * (w * 1.4);
+          const y = h * 0.57;
+          ctx.fillStyle = `rgba(26,36,48,${0.32 + intensity * 0.28})`;
+          ctx.fillRect(x, y, w * 0.16, h * 0.03);
+          ctx.fillRect(x + w * 0.03, y - h * 0.02, w * 0.06, h * 0.02);
+          ctx.strokeStyle = `rgba(146,190,220,${0.14 + intensity * 0.16})`;
+          ctx.lineWidth = 1;
+          ctx.beginPath();
+          ctx.moveTo(x - 10, y + h * 0.035);
+          ctx.lineTo(x - 34, y + h * 0.045);
+          ctx.moveTo(x - 2, y + h * 0.035);
+          ctx.lineTo(x - 24, y + h * 0.052);
+          ctx.stroke();
+          break;
+        }
 
         case 'lions_gate_bridge': {
           const y = h * 0.56;

--- a/page-asmr-lab.php
+++ b/page-asmr-lab.php
@@ -30,103 +30,85 @@ get_header();
 
       <fieldset class="asmr-layer-grid asmr-layer-groups">
         <legend>Sound Layers</legend>
-        <label class="asmr-inline-label">Voice Style<input type="text" name="voice_style" maxlength="80" placeholder="composed machine whisper" /></label>
         <div class="asmr-motif-group">
-          <h3>Core City Layers</h3>
+          <h3>Core Modules</h3>
           <div class="asmr-motif-grid">
-            <label><input type="checkbox" name="audio_layers[]" value="footsteps" checked /> footsteps</label>
-            <label><input type="checkbox" name="audio_layers[]" value="rain_ambience" /> rain ambience bed</label>
-            <label><input type="checkbox" name="audio_layers[]" value="wind_gust" /> wind gust</label>
-            <label><input type="checkbox" name="audio_layers[]" value="crowd_murmur" /> crowd murmur</label>
-            <label><input type="checkbox" name="audio_layers[]" value="laughter_burst" /> laughter burst</label>
-            <label><input type="checkbox" name="audio_layers[]" value="skytrain_pass" /> SkyTrain pass</label>
-            <label><input type="checkbox" name="audio_layers[]" value="bus_pass" /> bus pass</label>
-            <label><input type="checkbox" name="audio_layers[]" value="car_horn_short" /> car horn short</label>
-            <label><input type="checkbox" name="audio_layers[]" value="steam_clock" checked /> steam clock</label>
+            <label><input type="checkbox" name="audio_layers[]" value="rain_ambience" data-layer-group="bed" /> rain ambience bed</label>
+            <label><input type="checkbox" name="audio_layers[]" value="ocean_waves" data-layer-group="bed" checked /> ocean waves bed</label>
+            <label><input type="checkbox" name="audio_layers[]" value="wind_gust" data-layer-group="bed" /> wind gust</label>
+            <label><input type="checkbox" name="audio_layers[]" value="footsteps" data-layer-group="movement" /> footsteps</label>
+            <label><input type="checkbox" name="audio_layers[]" value="skytrain_pass" data-layer-group="movement" /> SkyTrain pass</label>
+            <label><input type="checkbox" name="audio_layers[]" value="seabus_horn" data-layer-group="movement" checked /> SeaBus horn</label>
+            <label><input type="checkbox" name="audio_layers[]" value="crowd_murmur" data-layer-group="accent" /> crowd murmur</label>
+            <label><input type="checkbox" name="audio_layers[]" value="steam_clock" data-layer-group="accent" /> steam clock</label>
+            <label><input type="checkbox" name="audio_layers[]" value="bike_bell" data-layer-group="accent" /> bike bell</label>
+            <label><input type="checkbox" name="audio_layers[]" value="crosswalk_chirp" data-layer-group="accent" /> crosswalk chirp</label>
           </div>
         </div>
-        <div class="asmr-motif-group">
-          <h3>Vancouver Details</h3>
-          <div class="asmr-motif-grid">
-            <label><input type="checkbox" name="audio_layers[]" value="seabus_horn" /> SeaBus horn</label>
-            <label><input type="checkbox" name="audio_layers[]" value="gulls_distant" /> distant gulls</label>
-            <label><input type="checkbox" name="audio_layers[]" value="crosswalk_chirp" /> crosswalk chirp</label>
-            <label><input type="checkbox" name="audio_layers[]" value="compass_tap" /> compass tap</label>
-            <label><input type="checkbox" name="audio_layers[]" value="bike_bell" /> bike bell</label>
-            <label><input type="checkbox" name="audio_layers[]" value="skateboard_roll" /> skateboard roll</label>
-            <label><input type="checkbox" name="audio_layers[]" value="siren_distant" /> distant siren</label>
+        <details class="asmr-motif-more">
+          <summary>More modules</summary>
+          <div class="asmr-motif-group">
+            <div class="asmr-motif-grid">
+              <label><input type="checkbox" name="audio_layers[]" value="gulls_distant" data-layer-group="accent" /> distant gulls</label>
+              <label><input type="checkbox" name="audio_layers[]" value="compass_tap" data-layer-group="accent" /> compass tap</label>
+              <label><input type="checkbox" name="audio_layers[]" value="skateboard_roll" data-layer-group="movement" /> skateboard roll</label>
+              <label><input type="checkbox" name="audio_layers[]" value="siren_distant" data-layer-group="accent" /> distant siren</label>
+              <label><input type="checkbox" name="audio_layers[]" value="laughter_burst" data-layer-group="accent" /> laughter burst</label>
+              <label><input type="checkbox" name="audio_layers[]" value="bus_pass" data-layer-group="movement" /> bus pass</label>
+              <label><input type="checkbox" name="audio_layers[]" value="car_horn_short" data-layer-group="accent" /> car horn short</label>
+            </div>
           </div>
-        </div>
+        </details>
       </fieldset>
 
       <fieldset class="asmr-layer-grid asmr-layer-groups">
         <legend>Visual Motifs</legend>
         <div class="asmr-motif-group">
-          <h3>Atmosphere</h3>
+          <h3>Core Modules</h3>
           <div class="asmr-motif-grid">
-            <label><input type="checkbox" name="visual_layers[]" value="rain_streaks" /> rain streaks</label>
-            <label><input type="checkbox" name="visual_layers[]" value="snow_drift" /> snow drift</label>
-            <label><input type="checkbox" name="visual_layers[]" value="harbor_mist" /> harbor mist</label>
-            <label><input type="checkbox" name="visual_layers[]" value="clear_cold_shimmer" /> clear cold shimmer</label>
+            <label><input type="checkbox" name="visual_layers[]" value="rain_streaks" data-layer-group="atmosphere" /> rain streaks</label>
+            <label><input type="checkbox" name="visual_layers[]" value="snow_drift" data-layer-group="atmosphere" /> snow drift</label>
+            <label><input type="checkbox" name="visual_layers[]" value="harbor_mist" data-layer-group="atmosphere" checked /> harbor mist</label>
+            <label><input type="checkbox" name="visual_layers[]" value="gastown_scene" data-layer-group="scene" /> Gastown scene</label>
+            <label><input type="checkbox" name="visual_layers[]" value="granville_scene" data-layer-group="scene" /> Granville scene</label>
+            <label><input type="checkbox" name="visual_layers[]" value="north_shore_scene" data-layer-group="scene" /> North Shore scene</label>
+            <label><input type="checkbox" name="visual_layers[]" value="waterfront_scene" data-layer-group="scene" checked /> Waterfront scene</label>
+            <label><input type="checkbox" name="visual_layers[]" value="science_world_dome" data-layer-group="landmark" /> Science World dome</label>
+            <label><input type="checkbox" name="visual_layers[]" value="chinatown_gate" data-layer-group="landmark" /> Chinatown gate</label>
+            <label><input type="checkbox" name="visual_layers[]" value="lions_gate_bridge" data-layer-group="landmark" checked /> Lions Gate Bridge</label>
+            <label><input type="checkbox" name="visual_layers[]" value="puddle_reflections" data-layer-group="modifier" /> puddle reflections</label>
+            <label><input type="checkbox" name="visual_layers[]" value="neon_sign_flicker" data-layer-group="modifier" /> neon sign flicker</label>
+            <label><input type="checkbox" name="visual_layers[]" value="scanline_field" data-layer-group="modifier" /> scanline field</label>
+            <label><input type="checkbox" name="visual_layers[]" value="skytrain_pass_visual" data-layer-group="modifier" /> SkyTrain pass visual</label>
+            <label><input type="checkbox" name="visual_layers[]" value="ocean_surface_shimmer" data-layer-group="modifier" checked /> ocean surface shimmer</label>
+            <label><input type="checkbox" name="visual_layers[]" value="seabus_silhouette" data-layer-group="modifier" checked /> SeaBus silhouette</label>
           </div>
         </div>
-        <div class="asmr-motif-group">
-          <h3>Scenes</h3>
-          <div class="asmr-motif-grid">
-            <label><input type="checkbox" name="visual_layers[]" value="gastown_scene" /> Gastown scene</label>
-            <label><input type="checkbox" name="visual_layers[]" value="granville_scene" checked /> Granville scene</label>
-            <label><input type="checkbox" name="visual_layers[]" value="north_shore_scene" /> North Shore scene</label>
+        <details class="asmr-motif-more">
+          <summary>More modules</summary>
+          <div class="asmr-motif-group">
+            <div class="asmr-motif-grid">
+              <label><input type="checkbox" name="visual_layers[]" value="clear_cold_shimmer" data-layer-group="atmosphere" /> clear cold shimmer</label>
+              <label><input type="checkbox" name="visual_layers[]" value="gastown_clock_silhouette" data-layer-group="landmark" /> Gastown clock</label>
+              <label><input type="checkbox" name="visual_layers[]" value="english_bay_inukshuk" data-layer-group="landmark" /> English Bay inukshuk</label>
+              <label><input type="checkbox" name="visual_layers[]" value="maritime_museum_sailroof" data-layer-group="landmark" /> Maritime Museum sail roof</label>
+              <label><input type="checkbox" name="visual_layers[]" value="bc_place_dome" data-layer-group="landmark" /> BC Place dome</label>
+              <label><input type="checkbox" name="visual_layers[]" value="port_cranes" data-layer-group="landmark" /> Port cranes</label>
+              <label><input type="checkbox" name="visual_layers[]" value="glitch_flash" data-layer-group="modifier" /> glitch flash</label>
+              <label><input type="checkbox" name="visual_layers[]" value="signal_bars" data-layer-group="modifier" /> signal bars</label>
+              <label><input type="checkbox" name="visual_layers[]" value="chromatic_veil" data-layer-group="modifier" /> chromatic veil</label>
+              <label><input type="checkbox" name="visual_layers[]" value="brick_wall_parallax" data-layer-group="modifier" /> brick wall parallax</label>
+              <label><input type="checkbox" name="visual_layers[]" value="streetlamp_halo_row" data-layer-group="modifier" /> streetlamp halos</label>
+              <label><input type="checkbox" name="visual_layers[]" value="bus_pass_visual" data-layer-group="modifier" /> bus pass visual</label>
+              <label><input type="checkbox" name="visual_layers[]" value="cobblestone_perspective" data-layer-group="modifier" /> cobblestones</label>
+              <label><input type="checkbox" name="visual_layers[]" value="skytrain_track" data-layer-group="modifier" /> SkyTrain track</label>
+            </div>
           </div>
-        </div>
-        <div class="asmr-motif-group">
-          <h3>Landmarks</h3>
-          <div class="asmr-motif-grid">
-            <label><input type="checkbox" name="visual_layers[]" value="gastown_clock_silhouette" /> Gastown clock</label>
-            <label><input type="checkbox" name="visual_layers[]" value="science_world_dome" /> Science World dome</label>
-            <label><input type="checkbox" name="visual_layers[]" value="chinatown_gate" /> Chinatown gate</label>
-            <label><input type="checkbox" name="visual_layers[]" value="english_bay_inukshuk" /> English Bay inukshuk</label>
-            <label><input type="checkbox" name="visual_layers[]" value="maritime_museum_sailroof" /> Maritime Museum sail roof</label>
-            <label><input type="checkbox" name="visual_layers[]" value="lions_gate_bridge" /> Lions Gate Bridge</label>
-            <label><input type="checkbox" name="visual_layers[]" value="bc_place_dome" /> BC Place dome</label>
-            <label><input type="checkbox" name="visual_layers[]" value="port_cranes" /> Port cranes</label>
-          </div>
-        </div>
-        <div class="asmr-motif-group">
-          <h3>Street Texture</h3>
-          <div class="asmr-motif-grid">
-            <label><input type="checkbox" name="visual_layers[]" value="cobblestone_perspective" /> cobblestones</label>
-            <label><input type="checkbox" name="visual_layers[]" value="brick_wall_parallax" /> brick wall parallax</label>
-            <label><input type="checkbox" name="visual_layers[]" value="puddle_reflections" /> puddle reflections</label>
-            <label><input type="checkbox" name="visual_layers[]" value="streetlamp_halo_row" /> streetlamp halos</label>
-          </div>
-        </div>
-        <div class="asmr-motif-group">
-          <h3>Transit + CRT</h3>
-          <div class="asmr-motif-grid">
-            <label><input type="checkbox" name="visual_layers[]" value="skytrain_track" /> SkyTrain track</label>
-            <label><input type="checkbox" name="visual_layers[]" value="skytrain_pass_visual" checked /> SkyTrain pass visual</label>
-            <label><input type="checkbox" name="visual_layers[]" value="bus_pass_visual" /> bus pass visual</label>
-            <label><input type="checkbox" name="visual_layers[]" value="scanline_field" /> scanline field</label>
-            <label><input type="checkbox" name="visual_layers[]" value="glitch_flash" /> glitch flash</label>
-            <label><input type="checkbox" name="visual_layers[]" value="signal_bars" /> signal bars</label>
-            <label><input type="checkbox" name="visual_layers[]" value="chromatic_veil" /> chromatic veil</label>
-            <label><input type="checkbox" name="visual_layers[]" value="neon_sign_flicker" checked /> neon sign flicker</label>
-          </div>
-        </div>
+        </details>
       </fieldset>
 
       <label class="asmr-link-toggle"><input type="checkbox" name="link_av" checked /> Link sound + visual for selected motifs</label>
-
-      <details class="asmr-advanced-fields">
-        <summary>Advanced / Freeform Mode (optional override)</summary>
-        <div class="asmr-grid">
-          <label>Concept<input type="text" name="concept" maxlength="140" placeholder="Retro monolith waking up" /></label>
-          <label>Object<input type="text" name="object" maxlength="80" placeholder="glass relay core" /></label>
-          <label>Setting<input type="text" name="setting" maxlength="120" placeholder="midnight signal chamber" /></label>
-          <label>Mood<input type="text" name="mood" maxlength="80" placeholder="tight tension then bloom" /></label>
-          <label>Creative Goal<textarea name="creative_goal" rows="2" maxlength="260" placeholder="Favor tactile pulses and a clear terminal reveal."></textarea></label>
-        </div>
-      </details>
+      <p class="asmr-link-tip">Tip: Fewer modules = clearer scenes. Try 1 scene + 1 atmosphere + 1 signature.</p>
       <div class="asmr-actions">
         <button type="submit" class="pixel-button">Generate ASMR Package</button>
         <button type="button" id="asmr-qa-preset" class="pixel-button secondary">Load QA Preset</button>


### PR DESCRIPTION
### Motivation
- Reduce UI complexity and checkbox overload by removing voice/advanced freeform paths and exposing a small, curated motif rack (sound + visual + duration + link). 
- Make the theme feel like a tight retro rack with Vancouver waterfront/ocean specificity while keeping everything procedural and browser-safe. 
- Add conservative A/V linking and selection guardrails so timelines remain clear and readable. 
- Improve backend guidance to the OpenAI model (motif-aware brief) without reintroducing freeform input fields.

### Description
- UI: removed the `Voice Style` field and the entire Advanced / Freeform `<details>` block and reworked the motif lists into **Core Modules** and collapsible **More modules** with `data-layer-group` attributes for cap enforcement (file: `page-asmr-lab.php`).
- Client logic: simplified `collectFormPayload()` to only send `{ duration, link_av, audio_layers, visual_layers }`, removed advanced/freeform handling and `voice_style` from QA preset, added category caps and handlers to enforce max selections client-side, and tightened A/V linking to conservative pairs with an optional map for gentler injections (file: `js/asmr-lab.js`).
- Backend: expanded allowlists and maps to add `ocean_waves`, `waterfront_scene`, `ocean_surface_shimmer`, and `seabus_silhouette`, removed reading `voice_style` from payload handling, added `se_get_asmr_motif_brief()` and inject `motif_brief` into the OpenAI payload, and updated deterministic Vancouver anchor injection to guarantee early waterfront/ocean anchors and readable first-frame events (file: `functions.php`).
- Engines: implemented procedural `ocean_waves` synthesis and softened `seabus_horn` plus tightened master mix/limiter settings; added CRT-safe waterfront visuals and shimmer/silhouette primitives in the visual engine (files: `js/asmr-foley-engine.js`, `js/asmr-visual-engine.js`).

### Testing
- Ran `node --check js/asmr-lab.js`, `node --check js/asmr-foley-engine.js`, and `node --check js/asmr-visual-engine.js`, and all JS syntax checks passed. 
- Ran `php -l functions.php` and `php -l page-asmr-lab.php`, and both PHP syntax checks passed. 
- Attempted a local PHP dev server + Playwright screenshot to validate UI rendering, but standalone `php -S` cannot bootstrap WordPress template helpers (error: `get_header()` undefined), so the screenshot attempt reflected environment limitation rather than runtime issues.
- Changes committed locally (single commit) and include updates to `page-asmr-lab.php`, `js/asmr-lab.js`, `js/asmr-foley-engine.js`, `js/asmr-visual-engine.js`, and `functions.php`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b09e51b080832eb71f6a7869962005)