### PR TITLE
ASMR Lab: remove selection caps, add Vancouver & Planetarium motifs, and story-beats output

### DIFF
--- a/assets/css/asmr-lab.css
+++ b/assets/css/asmr-lab.css
@@ -39,3 +39,6 @@
 .asmr-motif-group h3{margin:0 0 .45rem;font-family:'Press Start 2P',monospace;font-size:.6rem;letter-spacing:.06em;color:#9ec0ff;text-transform:uppercase;border-bottom:1px solid #2a3563;padding-bottom:.35rem}
 .asmr-motif-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(210px,1fr));gap:.45rem .65rem}
 .asmr-motif-grid label{display:flex;align-items:center;gap:.45rem;font-size:.8rem;background:#090f21;border:1px solid #293867;border-radius:6px;padding:.42rem .5rem}
+
+.asmr-card ol{margin:.2rem 0 .2rem 1.15rem;padding:0}
+.asmr-card ol li{margin:.25rem 0;line-height:1.45}

--- a/functions.php
+++ b/functions.php
@@ -908,6 +908,12 @@ function se_get_asmr_allowed_engines() {
         'bike_bell',
         'skateboard_roll',
         'siren_distant',
+        'gastown_clock_whistle',
+        'church_bells',
+        'harbour_noon_horn',
+        'nine_oclock_gun',
+        'planetarium_hum',
+        'planetarium_chime',
     );
 }
 
@@ -927,6 +933,7 @@ function se_get_asmr_visual_types() {
         'rain_streaks', 'puddle_reflections',
         'science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof',
         'lions_gate_bridge', 'bc_place_dome', 'port_cranes',
+        'planetarium_dome', 'starfield_projection', 'constellation_lines', 'canada_place_sails',
         'gastown_scene', 'granville_scene', 'north_shore_scene', 'waterfront_scene', 'clear_cold_shimmer', 'ocean_surface_shimmer', 'seabus_silhouette',
     );
 }
@@ -1205,7 +1212,8 @@ function se_get_asmr_audio_layers_allowed() {
     return array(
         'footsteps', 'footsteps_snow_mode', 'rain_ambience', 'wind_gust', 'crowd_murmur', 'laughter_burst',
         'skytrain_pass', 'bus_pass', 'car_horn_short', 'steam_clock',
-        'seabus_horn', 'ocean_waves', 'gulls_distant', 'crosswalk_chirp', 'compass_tap', 'bike_bell', 'skateboard_roll', 'siren_distant'
+        'seabus_horn', 'ocean_waves', 'gulls_distant', 'crosswalk_chirp', 'compass_tap', 'bike_bell', 'skateboard_roll', 'siren_distant',
+        'gastown_clock_whistle', 'church_bells', 'harbour_noon_horn', 'nine_oclock_gun', 'planetarium_hum', 'planetarium_chime'
     );
 }
 
@@ -1214,7 +1222,7 @@ function se_get_asmr_visual_layers_allowed() {
         'rain_streaks', 'snow_drift', 'harbor_mist', 'clear_cold_shimmer',
         'gastown_scene', 'granville_scene', 'north_shore_scene', 'waterfront_scene',
         'gastown_clock_silhouette', 'science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof',
-        'lions_gate_bridge', 'bc_place_dome', 'port_cranes',
+        'lions_gate_bridge', 'bc_place_dome', 'port_cranes', 'planetarium_dome', 'starfield_projection', 'constellation_lines', 'canada_place_sails',
         'cobblestone_perspective', 'brick_wall_parallax', 'puddle_reflections', 'streetlamp_halo_row',
         'skytrain_track', 'skytrain_pass_visual', 'bus_pass_visual',
         'scanline_field', 'glitch_flash', 'signal_bars', 'chromatic_veil', 'neon_sign_flicker', 'ocean_surface_shimmer', 'seabus_silhouette',
@@ -1230,7 +1238,9 @@ function se_get_asmr_visual_to_audio_map() {
         'skytrain_pass_visual' => array( 'skytrain_pass' ),
         'bus_pass_visual' => array( 'bus_pass' ),
         'rain_streaks' => array( 'rain_ambience' ),
-        'gastown_scene' => array( 'steam_clock' ),
+        'gastown_scene' => array( 'gastown_clock_whistle' ),
+        'planetarium_dome' => array( 'planetarium_hum' ),
+        'starfield_projection' => array( 'planetarium_chime' ),
     );
 }
 
@@ -1239,7 +1249,7 @@ function se_get_asmr_scene_visual_support_map() {
         'gastown_scene' => array( 'gastown_clock_silhouette', 'streetlamp_halo_row' ),
         'granville_scene' => array( 'granville_neon_marquee', 'puddle_reflections' ),
         'north_shore_scene' => array( 'northshore_mountain_ridge', 'mountain_mist_layers' ),
-        'waterfront_scene' => array( 'ocean_surface_shimmer', 'seabus_silhouette' ),
+        'waterfront_scene' => array( 'ocean_surface_shimmer', 'seabus_silhouette', 'canada_place_sails' ),
     );
 }
 
@@ -1260,6 +1270,11 @@ function se_get_asmr_mapped_visual_layers_from_audio( $audio_layers ) {
         'bus_pass' => 'bus_pass_visual',
         'rain_ambience' => 'rain_streaks',
         'steam_clock' => 'gastown_clock_silhouette',
+        'gastown_clock_whistle' => 'gastown_clock_silhouette',
+        'church_bells' => 'constellation_lines',
+        'harbour_noon_horn' => 'waterfront_scene',
+        'planetarium_hum' => 'planetarium_dome',
+        'planetarium_chime' => 'starfield_projection',
         'ocean_waves' => 'ocean_surface_shimmer',
         'seabus_horn' => 'seabus_silhouette',
     );
@@ -1297,7 +1312,7 @@ function se_get_asmr_motif_brief( $payload ) {
 
     $scene = array_values( array_intersect( $visual_layers, array( 'gastown_scene', 'granville_scene', 'north_shore_scene', 'waterfront_scene' ) ) );
     $atmosphere = array_values( array_intersect( $visual_layers, array( 'rain_streaks', 'snow_drift', 'harbor_mist', 'clear_cold_shimmer' ) ) );
-    $signature = array_values( array_intersect( $visual_layers, array( 'science_world_dome', 'chinatown_gate', 'lions_gate_bridge', 'gastown_clock_silhouette', 'seabus_silhouette' ) ) );
+    $signature = array_values( array_intersect( $visual_layers, array( 'science_world_dome', 'chinatown_gate', 'lions_gate_bridge', 'gastown_clock_silhouette', 'seabus_silhouette', 'planetarium_dome', 'starfield_projection', 'canada_place_sails' ) ) );
 
     $parts = array();
     if ( ! empty( $scene ) ) {
@@ -1356,7 +1371,8 @@ function se_inject_asmr_vancouver_anchors( $decoded, $payload ) {
 
     $scene_or_landmark = array(
         'gastown_scene', 'granville_scene', 'north_shore_scene', 'gastown_clock_silhouette', 'science_world_dome',
-        'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'lions_gate_bridge', 'bc_place_dome', 'port_cranes', 'waterfront_scene', 'seabus_silhouette'
+        'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'lions_gate_bridge', 'bc_place_dome', 'port_cranes', 'waterfront_scene', 'seabus_silhouette',
+        'planetarium_dome', 'starfield_projection', 'canada_place_sails'
     );
 
     foreach ( $audio_layers as $layer ) {
@@ -1382,6 +1398,18 @@ function se_inject_asmr_vancouver_anchors( $decoded, $payload ) {
             $audio[] = array( 'time' => $runtime * 0.64, 'duration' => 0.2, 'engine' => 'car_horn_short', 'intensity' => 0.48, 'params' => array(), 'sync_role' => 'horn_anchor' );
         } elseif ( 'steam_clock' === $layer ) {
             $audio[] = array( 'time' => 0.52, 'duration' => 1.1, 'engine' => 'steam_clock_burst', 'intensity' => 0.62, 'params' => array(), 'sync_role' => 'steam_clock_toggle' );
+        } elseif ( 'gastown_clock_whistle' === $layer ) {
+            $audio[] = array( 'time' => 0.54, 'duration' => 1.25, 'engine' => 'gastown_clock_whistle', 'intensity' => 0.64, 'params' => array(), 'sync_role' => 'gastown_clock_whistle' );
+        } elseif ( 'church_bells' === $layer ) {
+            $audio[] = array( 'time' => $runtime * 0.48, 'duration' => 1.9, 'engine' => 'church_bells', 'intensity' => 0.48, 'params' => array(), 'sync_role' => 'church_bells' );
+        } elseif ( 'harbour_noon_horn' === $layer ) {
+            $audio[] = array( 'time' => $runtime * 0.34, 'duration' => 2.3, 'engine' => 'harbour_noon_horn', 'intensity' => 0.44, 'params' => array(), 'sync_role' => 'harbour_noon_horn' );
+        } elseif ( 'nine_oclock_gun' === $layer ) {
+            $audio[] = array( 'time' => $runtime * 0.74, 'duration' => 1.2, 'engine' => 'nine_oclock_gun', 'intensity' => 0.46, 'params' => array(), 'sync_role' => 'nine_oclock_gun' );
+        } elseif ( 'planetarium_hum' === $layer ) {
+            $audio[] = array( 'time' => 0.05, 'duration' => max( 5.4, $runtime * 0.58 ), 'engine' => 'planetarium_hum', 'intensity' => 0.32, 'params' => array(), 'sync_role' => 'planetarium_hum' );
+        } elseif ( 'planetarium_chime' === $layer ) {
+            $audio[] = array( 'time' => $runtime * 0.41, 'duration' => 0.42, 'engine' => 'planetarium_chime', 'intensity' => 0.32, 'params' => array(), 'sync_role' => 'planetarium_chime' );
         } elseif ( 'seabus_horn' === $layer ) {
             $audio[] = array( 'time' => $runtime * 0.32, 'duration' => 1.8, 'engine' => 'seabus_horn', 'intensity' => 0.36, 'params' => array(), 'sync_role' => 'seabus_horn' );
         } elseif ( 'gulls_distant' === $layer ) {
@@ -1417,6 +1445,13 @@ function se_inject_asmr_vancouver_anchors( $decoded, $payload ) {
         if ( in_array( $visual_type, array( 'gastown_scene', 'granville_scene', 'north_shore_scene', 'waterfront_scene' ), true ) ) {
             $visual[] = array( 'time' => 0.18, 'duration' => min( 3.2, $runtime * 0.22 ), 'visual_type' => $visual_type, 'intensity' => 0.7, 'params' => array(), 'sync_role' => 'scene_anchor' );
             $visual[] = array( 'time' => $runtime * 0.44, 'duration' => min( 2.4, $runtime * 0.2 ), 'visual_type' => $visual_type, 'intensity' => 0.58, 'params' => array(), 'sync_role' => 'scene_recur' );
+            continue;
+        }
+        if ( in_array( $visual_type, array( 'planetarium_dome', 'starfield_projection', 'constellation_lines', 'canada_place_sails' ), true ) ) {
+            $visual[] = array( 'time' => 0.16, 'duration' => min( 4.8, $runtime * 0.4 ), 'visual_type' => $visual_type, 'intensity' => 0.66, 'params' => array(), 'sync_role' => 'planetarium_landmark_anchor' );
+            if ( 'planetarium_dome' === $visual_type ) {
+                $visual[] = array( 'time' => 0.42, 'duration' => min( 3.4, $runtime * 0.28 ), 'visual_type' => 'starfield_projection', 'intensity' => 0.54, 'params' => array(), 'sync_role' => 'planetarium_projection_follow' );
+            }
             continue;
         }
         $visual[] = array( 'time' => 0.14, 'duration' => min( 5.2, $runtime * 0.36 ), 'visual_type' => $visual_type, 'intensity' => 0.6, 'params' => array(), 'sync_role' => 'visual_motif_toggle' );
@@ -1506,6 +1541,8 @@ function se_validate_asmr_response( $decoded ) {
         'runtime_seconds',
         'hook',
         'concept_summary',
+        'logline',
+        'story_beats',
         'style_tags',
         'audio_events',
         'visual_events',
@@ -1526,6 +1563,21 @@ function se_validate_asmr_response( $decoded ) {
     $decoded['runtime_seconds'] = max( 10, min( 30, absint( $decoded['runtime_seconds'] ) ) );
 
     $decoded['style_tags'] = array_values( array_filter( array_map( 'sanitize_text_field', (array) ( $decoded['style_tags'] ?? array() ) ) ) );
+
+    $decoded['logline'] = sanitize_text_field( $decoded['logline'] ?? '' );
+
+    $story_beats = is_array( $decoded['story_beats'] ?? null ) ? $decoded['story_beats'] : array();
+    $decoded['story_beats'] = array_values( array_map( static function( $beat ) {
+        if ( ! is_array( $beat ) ) {
+            return array( 't0' => 0.0, 't1' => 0.0, 'beat' => '', 'intent' => '' );
+        }
+        return array(
+            't0' => max( 0, floatval( $beat['t0'] ?? 0 ) ),
+            't1' => max( 0, floatval( $beat['t1'] ?? 0 ) ),
+            'beat' => sanitize_text_field( $beat['beat'] ?? '' ),
+            'intent' => sanitize_text_field( $beat['intent'] ?? '' ),
+        );
+    }, $story_beats ) );
 
     $events = is_array( $decoded['audio_events'] ?? null ) ? $decoded['audio_events'] : array();
     $allowed_engines = se_get_asmr_allowed_engines();
@@ -1657,6 +1709,7 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
         'visual_layers' => $visual_layers,
         'foley' => $raw_legacy_foley,
         'sound_only' => ! empty( $params['sound_only'] ),
+        'story_mode' => true,
     );
 
     $has_freeform = ! empty( $payload['concept'] ) || ! empty( $payload['object'] ) || ! empty( $payload['setting'] ) || ! empty( $payload['mood'] ) || ! empty( $payload['creative_goal'] );
@@ -1675,10 +1728,10 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
     $system_prompt = 'You are ASMR Lab, a retro-futurist sensory film composer for a browser performance engine. '
         . 'Generate an original 10-30 second procedural audiovisual score that feels composed, eerie, spiritual, tactile, and cinematic when prompted. '
         . 'Return ONE strict JSON object and no markdown. '
-        . 'Use exactly and only these top-level keys: title, runtime_seconds, hook, concept_summary, style_tags, audio_events, visual_events, sync_points, end_card, edit_rhythm, presentation_note. '
+        . 'Use exactly and only these top-level keys: title, runtime_seconds, hook, concept_summary, logline, story_beats, style_tags, audio_events, visual_events, sync_points, end_card, edit_rhythm, presentation_note. '
         . 'audio_events objects must include: time, duration, engine, intensity, params, sync_role. '
         . 'visual_events objects must include: time, duration, visual_type, intensity, params, sync_role. '
-        . 'sync_points objects must include: time, cue, importance. '
+        . 'sync_points objects must include: time, cue, importance. story_beats must be an array of exactly 4 objects with: t0, t1, beat, intent (Opening, Arrival, Ritual Lift, Resolve). '
         . 'end_card must include: use_end_card, text, reveal_style. '
         . 'edit_rhythm must include: pacing_note, silence_strategy, release_strategy. '
         . 'Only use these engine names: ' . $allowed_engines . '. '
@@ -1697,9 +1750,10 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
         . 'When motif tokens imply a place, ground the package in concrete materials, atmospheric lighting, and local acoustics. '
         . 'Prompt interpretation priority: selected visual motifs > selected audio motifs > named object > mood adjectives. '
         . 'For Gastown/Vancouver scenes, favor steam clock cues, harbor fog bed, amber streetlamp halos, wet cobblestone reflections, brick facade texture, neon-on-wet shimmer, and winter hush pacing where relevant. '
+ . 'Vancouver sound palette guide: gastown_clock_whistle=steam whistle toot, iconic Gastown clock, breathy warm; church_bells=distant cathedral bells, warm decay; harbour_noon_horn=harbour ship horn at noon, low and foggy; ocean_waves=waterfront waves, soft swell; skytrain_pass=SkyTrain whoosh and rail hum; seabus_horn=short ferry foghorn; planetarium_hum=quiet dome room tone; planetarium_chime=tiny sparkle chime; nine_oclock_gun=low ceremonial boom. '
         . 'Avoid generic abstract output when prompts include specific motif or geography terms. '
         . 'The result should feel like an authored short sensory micro-film, not a debug demo. '
-        . 'Do not include prose outside JSON.';
+        . 'Every beat transition must be marked by a signature cue pair (audio + visual) from selected motifs when story_mode is true. Do not include prose outside JSON.';
 
     if ( $payload['sound_only'] ) {
         $system_prompt .= ' If sound_only is true, keep other fields concise but still present and focus creative detail in audio_events.';

--- a/js/asmr-foley-engine.js
+++ b/js/asmr-foley-engine.js
@@ -10,7 +10,8 @@
     'steam_clock_burst', 'distant_bell_toll', 'cold_air_hush', 'wet_street_shimmer',
     'harbor_fog_bed', 'metal_resonance', 'snow_muffle', 'city_electrical_hum',
     'footsteps_wet', 'footsteps_snow', 'rain_close', 'rain_roof', 'puddle_splash',
-    'crowd_murmur', 'laughter_burst', 'skytrain_pass', 'bus_idle', 'car_horn_short', 'seabus_horn', 'ocean_waves', 'gulls_distant', 'crosswalk_chirp', 'compass_tap', 'bike_bell', 'skateboard_roll', 'siren_distant'
+    'crowd_murmur', 'laughter_burst', 'skytrain_pass', 'bus_idle', 'car_horn_short', 'seabus_horn', 'ocean_waves', 'gulls_distant', 'crosswalk_chirp', 'compass_tap', 'bike_bell', 'skateboard_roll', 'siren_distant',
+    'gastown_clock_whistle', 'church_bells', 'harbour_noon_horn', 'nine_oclock_gun', 'planetarium_hum', 'planetarium_chime'
   ];
 
   function clamp(value, min, max) {
@@ -473,6 +474,42 @@
           this.scheduleTone(ctx, destination, atTime + 0.15, duration * 0.9, { from: 560, to: 380, peak: 0.005 + intensity * 0.011, type: 'sine', pan: 0.18 });
           this.scheduleNoise(ctx, destination, atTime, duration, { freq: 1200, q: 0.9, peak: 0.002 + intensity * 0.006, filterType: 'bandpass' });
           break;
+
+        case 'gastown_clock_whistle': {
+          this.scheduleNoise(ctx, destination, atTime, duration, { freq: 1600, q: 0.85, peak: 0.012 + intensity * 0.02, filterType: 'bandpass', pan: 0.05 });
+          this.scheduleTone(ctx, destination, atTime + 0.03, duration * 0.88, { from: 540, to: 500, peak: 0.012 + intensity * 0.022, type: 'triangle', pan: -0.08 });
+          this.scheduleTone(ctx, destination, atTime + 0.05, duration * 0.84, { from: 560, to: 520, peak: 0.007 + intensity * 0.014, type: 'sine', pan: 0.08 });
+          break;
+        }
+        case 'church_bells': {
+          this.scheduleTone(ctx, destination, atTime, duration, { from: 392, to: 252, peak: 0.012 + intensity * 0.018, type: 'sine', pan: -0.04 });
+          this.scheduleTone(ctx, destination, atTime + 0.01, duration * 0.94, { from: 645, to: 418, peak: 0.008 + intensity * 0.014, type: 'triangle', pan: 0.06 });
+          this.scheduleTone(ctx, destination, atTime + 0.02, duration * 0.88, { from: 898, to: 584, peak: 0.006 + intensity * 0.01, type: 'sine', pan: -0.07 });
+          this.scheduleTone(ctx, destination, atTime + 0.03, duration * 0.82, { from: 1132, to: 728, peak: 0.004 + intensity * 0.008, type: 'triangle', pan: 0.09 });
+          break;
+        }
+        case 'harbour_noon_horn': {
+          this.scheduleTone(ctx, destination, atTime, duration, { from: 74, to: 68, peak: 0.014 + intensity * 0.022, type: 'sine', pan: 0 });
+          this.scheduleTone(ctx, destination, atTime + 0.02, duration * 0.92, { from: 148, to: 136, peak: 0.008 + intensity * 0.014, type: 'triangle', pan: -0.06 });
+          this.scheduleNoise(ctx, destination, atTime + 0.06, duration * 0.72, { freq: 340, q: 0.7, peak: 0.003 + intensity * 0.007, filterType: 'bandpass', pan: 0.04 });
+          break;
+        }
+        case 'nine_oclock_gun': {
+          this.scheduleNoise(ctx, destination, atTime, Math.max(0.2, duration * 0.4), { freq: 220, q: 0.65, peak: 0.018 + intensity * 0.03, filterType: 'lowpass', pan: -0.03 });
+          this.scheduleTone(ctx, destination, atTime, Math.max(0.28, duration * 0.55), { from: 54, to: 40, peak: 0.02 + intensity * 0.032, type: 'sine', pan: 0.02 });
+          this.scheduleNoise(ctx, destination, atTime + 0.06, Math.max(0.25, duration * 0.45), { freq: 880, q: 0.8, peak: 0.005 + intensity * 0.01, filterType: 'bandpass', pan: 0.06 });
+          break;
+        }
+        case 'planetarium_hum': {
+          this.scheduleTone(ctx, destination, atTime, duration, { from: 92, to: 96, peak: 0.005 + intensity * 0.01, type: 'sine', pan: -0.02 });
+          this.scheduleNoise(ctx, destination, atTime, duration, { freq: 780, q: 0.55, peak: 0.003 + intensity * 0.007, filterType: 'lowpass', pan: 0.03 });
+          break;
+        }
+        case 'planetarium_chime': {
+          this.scheduleTone(ctx, destination, atTime, Math.max(0.1, duration * 0.65), { from: 880, to: 660, peak: 0.006 + intensity * 0.01, type: 'square', pan: 0.1 });
+          this.scheduleTone(ctx, destination, atTime + 0.03, Math.max(0.1, duration * 0.56), { from: 1108, to: 830, peak: 0.005 + intensity * 0.008, type: 'triangle', pan: -0.08 });
+          break;
+        }
 
         default:
           break;

--- a/js/asmr-lab.js
+++ b/js/asmr-lab.js
@@ -31,12 +31,12 @@
     seabus_silhouette: ['seabus_horn'],
     rain_streaks: ['rain_ambience'],
     skytrain_pass_visual: ['skytrain_pass'],
-    gastown_scene: ['steam_clock']
+    gastown_scene: ['gastown_clock_whistle']
   };
 
   const OPTIONAL_LINK_AUDIO = {
     waterfront_scene: ['ocean_waves'],
-    gastown_scene: ['steam_clock']
+    gastown_scene: ['gastown_clock_whistle']
   };
 
   const SCENE_TO_SUPPORT_VISUALS = {
@@ -44,19 +44,6 @@
     granville_scene: ['puddle_reflections'],
     north_shore_scene: ['mountain_mist_layers'],
     waterfront_scene: ['ocean_surface_shimmer', 'seabus_silhouette']
-  };
-
-  const VISUAL_CAPS = {
-    scene: 1,
-    atmosphere: 1,
-    landmark: 1,
-    modifier: 3
-  };
-
-  const AUDIO_CAPS = {
-    bed: 1,
-    movement: 2,
-    accent: 2
   };
 
   function applyLayerLinking(audioLayers, visualLayers, isLinked) {
@@ -160,40 +147,26 @@
   }
 
 
-  function enforceLayerCaps(input) {
-    if (!input || !input.checked) return;
-    const name = input.name;
-    const group = String(input.dataset.layerGroup || '').trim();
-    if (!group) return;
-
-    const caps = name === 'visual_layers[]' ? VISUAL_CAPS : (name === 'audio_layers[]' ? AUDIO_CAPS : null);
-    if (!caps || !Object.prototype.hasOwnProperty.call(caps, group)) return;
-
-    const groupBoxes = Array.from(form.querySelectorAll(`input[name="${name}"][data-layer-group="${group}"]`));
-    const checked = groupBoxes.filter((box) => box.checked);
-    if (checked.length <= caps[group]) return;
-
-    input.checked = false;
-    setStatus(`Too many ${group} modules selected (max ${caps[group]}).`);
-  }
-
-  function attachLayerCapHandlers() {
-    if (!form) return;
-    const boxes = form.querySelectorAll('input[name="audio_layers[]"], input[name="visual_layers[]"]');
-    boxes.forEach((box) => {
-      box.addEventListener('change', () => enforceLayerCaps(box));
-    });
-  }
-
   function renderData(data) {
     const concept = document.getElementById('asmr-concept');
     const beats = document.getElementById('asmr-beats');
+    const storyBeats = document.getElementById('asmr-story-beats');
     const prompts = document.getElementById('asmr-video-prompts');
     const edit = document.getElementById('asmr-edit-notes');
     const note = document.getElementById('asmr-presentation');
     const recipe = document.getElementById('asmr-sound-json');
 
     if (concept) concept.textContent = `${data.title} (${data.runtime_seconds}s) — ${data.hook}\n${data.concept_summary}`;
+    if (storyBeats) {
+      storyBeats.innerHTML = '';
+      (Array.isArray(data.story_beats) ? data.story_beats : []).forEach((beat) => {
+        const li = document.createElement('li');
+        const t0 = Number(beat.t0 || 0).toFixed(1);
+        const t1 = Number(beat.t1 || 0).toFixed(1);
+        li.textContent = `${t0}s–${t1}s · ${beat.beat || 'Beat'} — ${beat.intent || ''}`.trim();
+        storyBeats.appendChild(li);
+      });
+    }
     toList(beats, data.sync_points || []);
     toList(prompts, data.style_tags || []);
     if (edit) {
@@ -512,7 +485,6 @@
     });
   }
 
-  attachLayerCapHandlers();
 
   window.addEventListener('resize', function () { if (visuals) visuals.resize(); });
 })();

--- a/js/asmr-visual-engine.js
+++ b/js/asmr-visual-engine.js
@@ -14,7 +14,9 @@
     'skytrain_track', 'skytrain_pass_visual', 'bus_pass_visual',
     'northshore_mountain_ridge', 'mountain_mist_layers',
     'rain_streaks', 'puddle_reflections',
-    'science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'lions_gate_bridge', 'bc_place_dome', 'port_cranes', 'gastown_scene', 'granville_scene', 'north_shore_scene', 'waterfront_scene', 'clear_cold_shimmer', 'ocean_surface_shimmer', 'seabus_silhouette'
+    'science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'lions_gate_bridge', 'bc_place_dome', 'port_cranes',
+    'planetarium_dome', 'starfield_projection', 'constellation_lines', 'canada_place_sails',
+    'gastown_scene', 'granville_scene', 'north_shore_scene', 'waterfront_scene', 'clear_cold_shimmer', 'ocean_surface_shimmer', 'seabus_silhouette'
   ];
 
   function clamp(value, min, max) {
@@ -296,7 +298,7 @@
     }
 
     drawSceneLayers(ctx, width, height, t, normalized, overlays) {
-      const landmarkTypes = ['science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'lions_gate_bridge', 'bc_place_dome', 'port_cranes', 'gastown_clock_silhouette', 'seabus_silhouette', 'waterfront_scene'];
+      const landmarkTypes = ['science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'lions_gate_bridge', 'bc_place_dome', 'port_cranes', 'planetarium_dome', 'starfield_projection', 'canada_place_sails', 'gastown_clock_silhouette', 'seabus_silhouette', 'waterfront_scene'];
       const atmosphereTypes = ['rain_streaks', 'snow_drift', 'harbor_mist', 'mountain_mist_layers', 'puddle_reflections', 'volumetric_fog', 'clear_cold_shimmer'];
       const weirdness = this.parseWeirdnessLevel();
       const weirdNorm = (weirdness - 1) / 9;
@@ -311,6 +313,8 @@
 
       const hasLandmark = activeEvents.some((item) => landmarkTypes.includes(item.event.visual_type));
       if (hasLandmark) distortion *= 0.6;
+      const hasPlanetarium = activeEvents.some((item) => ['planetarium_dome', 'starfield_projection'].includes(item.event.visual_type));
+      if (hasPlanetarium) distortion *= 0.5;
 
       this.drawBaseChamber(ctx, width, height, t, normalized);
 
@@ -972,6 +976,81 @@
           ctx.moveTo(x - 2, y + h * 0.035);
           ctx.lineTo(x - 24, y + h * 0.052);
           ctx.stroke();
+          break;
+        }
+
+
+        case 'planetarium_dome': {
+          const cx = w * 0.5;
+          const cy = h * 0.74;
+          const r = Math.min(w, h) * 0.28;
+          ctx.fillStyle = `rgba(14,22,40,${0.2 + intensity * 0.18})`;
+          ctx.beginPath();
+          ctx.arc(cx, cy, r, Math.PI, 0);
+          ctx.lineTo(cx + r, cy + 18);
+          ctx.lineTo(cx - r, cy + 18);
+          ctx.closePath();
+          ctx.fill();
+          ctx.strokeStyle = `rgba(160,198,236,${0.2 + intensity * 0.24})`;
+          ctx.lineWidth = 2;
+          for (let i = 1; i <= 5; i += 1) {
+            ctx.beginPath();
+            ctx.arc(cx, cy, r * (i / 5), Math.PI, 0);
+            ctx.stroke();
+          }
+          for (let i = -4; i <= 4; i += 1) {
+            const x = cx + (i * r / 5);
+            ctx.beginPath();
+            ctx.moveTo(x, cy + 2);
+            ctx.lineTo(cx, cy - r + 6);
+            ctx.stroke();
+          }
+          break;
+        }
+        case 'starfield_projection': {
+          const cx = w * 0.5;
+          const cy = h * 0.72;
+          const r = Math.min(w, h) * 0.27;
+          ctx.strokeStyle = `rgba(110,180,255,${0.08 + intensity * 0.16})`;
+          for (let i = 0; i < 6; i += 1) {
+            ctx.beginPath();
+            ctx.arc(cx, cy, r * (0.35 + i * 0.1), Math.PI + 0.14, -0.14);
+            ctx.stroke();
+          }
+          ctx.fillStyle = `rgba(188,226,255,${0.22 + intensity * 0.24})`;
+          for (let i = 0; i < 42; i += 1) {
+            const px = cx + Math.sin(i * 2.1 + normalized * 2.8) * (r * (0.18 + (i % 6) * 0.12));
+            const py = cy - Math.abs(Math.cos(i * 1.7 + normalized * 2.1)) * (r * (0.2 + (i % 5) * 0.13));
+            ctx.fillRect(px, py, 1.5, 1.5);
+          }
+          break;
+        }
+        case 'constellation_lines': {
+          ctx.strokeStyle = `rgba(170,214,255,${0.08 + intensity * 0.13})`;
+          ctx.lineWidth = 1;
+          const pts = [[0.32,0.24],[0.38,0.2],[0.45,0.25],[0.52,0.19],[0.58,0.24],[0.64,0.2]];
+          ctx.beginPath();
+          pts.forEach((pt, idx) => {
+            const x = w * pt[0]; const y = h * pt[1];
+            if (idx === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+            ctx.moveTo(x, y); ctx.arc(x, y, 1.3, 0, Math.PI * 2);
+          });
+          ctx.stroke();
+          break;
+        }
+        case 'canada_place_sails': {
+          const y = h * 0.58;
+          ctx.strokeStyle = `rgba(196,220,238,${0.2 + intensity * 0.2})`;
+          ctx.lineWidth = 2;
+          for (let i = 0; i < 5; i += 1) {
+            const x = w * (0.34 + i * 0.07);
+            ctx.beginPath();
+            ctx.moveTo(x, y);
+            ctx.lineTo(x + w * 0.04, y - h * 0.09);
+            ctx.lineTo(x + w * 0.08, y);
+            ctx.closePath();
+            ctx.stroke();
+          }
           break;
         }
 

--- a/page-asmr-lab.php
+++ b/page-asmr-lab.php
@@ -33,29 +33,35 @@ get_header();
         <div class="asmr-motif-group">
           <h3>Core Modules</h3>
           <div class="asmr-motif-grid">
-            <label><input type="checkbox" name="audio_layers[]" value="rain_ambience" data-layer-group="bed" /> rain ambience bed</label>
-            <label><input type="checkbox" name="audio_layers[]" value="ocean_waves" data-layer-group="bed" checked /> ocean waves bed</label>
-            <label><input type="checkbox" name="audio_layers[]" value="wind_gust" data-layer-group="bed" /> wind gust</label>
-            <label><input type="checkbox" name="audio_layers[]" value="footsteps" data-layer-group="movement" /> footsteps</label>
-            <label><input type="checkbox" name="audio_layers[]" value="skytrain_pass" data-layer-group="movement" /> SkyTrain pass</label>
-            <label><input type="checkbox" name="audio_layers[]" value="seabus_horn" data-layer-group="movement" checked /> SeaBus horn</label>
-            <label><input type="checkbox" name="audio_layers[]" value="crowd_murmur" data-layer-group="accent" /> crowd murmur</label>
-            <label><input type="checkbox" name="audio_layers[]" value="steam_clock" data-layer-group="accent" /> steam clock</label>
-            <label><input type="checkbox" name="audio_layers[]" value="bike_bell" data-layer-group="accent" /> bike bell</label>
-            <label><input type="checkbox" name="audio_layers[]" value="crosswalk_chirp" data-layer-group="accent" /> crosswalk chirp</label>
+            <label><input type="checkbox" name="audio_layers[]" value="rain_ambience" /> rain ambience bed</label>
+            <label><input type="checkbox" name="audio_layers[]" value="ocean_waves" checked /> ocean waves bed</label>
+            <label><input type="checkbox" name="audio_layers[]" value="wind_gust" /> wind gust</label>
+            <label><input type="checkbox" name="audio_layers[]" value="footsteps" /> footsteps</label>
+            <label><input type="checkbox" name="audio_layers[]" value="skytrain_pass" /> SkyTrain pass</label>
+            <label><input type="checkbox" name="audio_layers[]" value="seabus_horn" checked /> SeaBus horn</label>
+            <label><input type="checkbox" name="audio_layers[]" value="crowd_murmur" /> crowd murmur</label>
+            <label><input type="checkbox" name="audio_layers[]" value="steam_clock" /> steam clock</label>
+            <label><input type="checkbox" name="audio_layers[]" value="bike_bell" /> bike bell</label>
+            <label><input type="checkbox" name="audio_layers[]" value="crosswalk_chirp" /> crosswalk chirp</label>
+            <label><input type="checkbox" name="audio_layers[]" value="gastown_clock_whistle" /> Gastown clock toot</label>
+            <label><input type="checkbox" name="audio_layers[]" value="church_bells" /> church bells</label>
+            <label><input type="checkbox" name="audio_layers[]" value="harbour_noon_horn" /> harbour noon horn</label>
+            <label><input type="checkbox" name="audio_layers[]" value="nine_oclock_gun" /> 9 O'Clock Gun boom</label>
+            <label><input type="checkbox" name="audio_layers[]" value="planetarium_hum" /> planetarium hum</label>
+            <label><input type="checkbox" name="audio_layers[]" value="planetarium_chime" /> planetarium chime</label>
           </div>
         </div>
         <details class="asmr-motif-more">
           <summary>More modules</summary>
           <div class="asmr-motif-group">
             <div class="asmr-motif-grid">
-              <label><input type="checkbox" name="audio_layers[]" value="gulls_distant" data-layer-group="accent" /> distant gulls</label>
-              <label><input type="checkbox" name="audio_layers[]" value="compass_tap" data-layer-group="accent" /> compass tap</label>
-              <label><input type="checkbox" name="audio_layers[]" value="skateboard_roll" data-layer-group="movement" /> skateboard roll</label>
-              <label><input type="checkbox" name="audio_layers[]" value="siren_distant" data-layer-group="accent" /> distant siren</label>
-              <label><input type="checkbox" name="audio_layers[]" value="laughter_burst" data-layer-group="accent" /> laughter burst</label>
-              <label><input type="checkbox" name="audio_layers[]" value="bus_pass" data-layer-group="movement" /> bus pass</label>
-              <label><input type="checkbox" name="audio_layers[]" value="car_horn_short" data-layer-group="accent" /> car horn short</label>
+              <label><input type="checkbox" name="audio_layers[]" value="gulls_distant" /> distant gulls</label>
+              <label><input type="checkbox" name="audio_layers[]" value="compass_tap" /> compass tap</label>
+              <label><input type="checkbox" name="audio_layers[]" value="skateboard_roll" /> skateboard roll</label>
+              <label><input type="checkbox" name="audio_layers[]" value="siren_distant" /> distant siren</label>
+              <label><input type="checkbox" name="audio_layers[]" value="laughter_burst" /> laughter burst</label>
+              <label><input type="checkbox" name="audio_layers[]" value="bus_pass" /> bus pass</label>
+              <label><input type="checkbox" name="audio_layers[]" value="car_horn_short" /> car horn short</label>
             </div>
           </div>
         </details>
@@ -66,34 +72,38 @@ get_header();
         <div class="asmr-motif-group">
           <h3>Core Modules</h3>
           <div class="asmr-motif-grid">
-            <label><input type="checkbox" name="visual_layers[]" value="rain_streaks" data-layer-group="atmosphere" /> rain streaks</label>
-            <label><input type="checkbox" name="visual_layers[]" value="snow_drift" data-layer-group="atmosphere" /> snow drift</label>
-            <label><input type="checkbox" name="visual_layers[]" value="harbor_mist" data-layer-group="atmosphere" checked /> harbor mist</label>
-            <label><input type="checkbox" name="visual_layers[]" value="gastown_scene" data-layer-group="scene" /> Gastown scene</label>
-            <label><input type="checkbox" name="visual_layers[]" value="granville_scene" data-layer-group="scene" /> Granville scene</label>
-            <label><input type="checkbox" name="visual_layers[]" value="north_shore_scene" data-layer-group="scene" /> North Shore scene</label>
-            <label><input type="checkbox" name="visual_layers[]" value="waterfront_scene" data-layer-group="scene" checked /> Waterfront scene</label>
-            <label><input type="checkbox" name="visual_layers[]" value="science_world_dome" data-layer-group="landmark" /> Science World dome</label>
-            <label><input type="checkbox" name="visual_layers[]" value="chinatown_gate" data-layer-group="landmark" /> Chinatown gate</label>
-            <label><input type="checkbox" name="visual_layers[]" value="lions_gate_bridge" data-layer-group="landmark" checked /> Lions Gate Bridge</label>
-            <label><input type="checkbox" name="visual_layers[]" value="puddle_reflections" data-layer-group="modifier" /> puddle reflections</label>
-            <label><input type="checkbox" name="visual_layers[]" value="neon_sign_flicker" data-layer-group="modifier" /> neon sign flicker</label>
-            <label><input type="checkbox" name="visual_layers[]" value="scanline_field" data-layer-group="modifier" /> scanline field</label>
-            <label><input type="checkbox" name="visual_layers[]" value="skytrain_pass_visual" data-layer-group="modifier" /> SkyTrain pass visual</label>
-            <label><input type="checkbox" name="visual_layers[]" value="ocean_surface_shimmer" data-layer-group="modifier" checked /> ocean surface shimmer</label>
-            <label><input type="checkbox" name="visual_layers[]" value="seabus_silhouette" data-layer-group="modifier" checked /> SeaBus silhouette</label>
+            <label><input type="checkbox" name="visual_layers[]" value="rain_streaks" /> rain streaks</label>
+            <label><input type="checkbox" name="visual_layers[]" value="snow_drift" /> snow drift</label>
+            <label><input type="checkbox" name="visual_layers[]" value="harbor_mist" checked /> harbor mist</label>
+            <label><input type="checkbox" name="visual_layers[]" value="gastown_scene" /> Gastown scene</label>
+            <label><input type="checkbox" name="visual_layers[]" value="granville_scene" /> Granville scene</label>
+            <label><input type="checkbox" name="visual_layers[]" value="north_shore_scene" /> North Shore scene</label>
+            <label><input type="checkbox" name="visual_layers[]" value="waterfront_scene" checked /> Waterfront scene</label>
+            <label><input type="checkbox" name="visual_layers[]" value="science_world_dome" /> Science World dome</label>
+            <label><input type="checkbox" name="visual_layers[]" value="chinatown_gate" /> Chinatown gate</label>
+            <label><input type="checkbox" name="visual_layers[]" value="lions_gate_bridge" checked /> Lions Gate Bridge</label>
+            <label><input type="checkbox" name="visual_layers[]" value="planetarium_dome" /> Planetarium dome</label>
+            <label><input type="checkbox" name="visual_layers[]" value="starfield_projection" /> starfield projection</label>
+            <label><input type="checkbox" name="visual_layers[]" value="puddle_reflections" /> puddle reflections</label>
+            <label><input type="checkbox" name="visual_layers[]" value="neon_sign_flicker" /> neon sign flicker</label>
+            <label><input type="checkbox" name="visual_layers[]" value="scanline_field" /> scanline field</label>
+            <label><input type="checkbox" name="visual_layers[]" value="skytrain_pass_visual" /> SkyTrain pass visual</label>
+            <label><input type="checkbox" name="visual_layers[]" value="ocean_surface_shimmer" checked /> ocean surface shimmer</label>
+            <label><input type="checkbox" name="visual_layers[]" value="seabus_silhouette" checked /> SeaBus silhouette</label>
           </div>
         </div>
         <details class="asmr-motif-more">
           <summary>More modules</summary>
           <div class="asmr-motif-group">
             <div class="asmr-motif-grid">
-              <label><input type="checkbox" name="visual_layers[]" value="clear_cold_shimmer" data-layer-group="atmosphere" /> clear cold shimmer</label>
-              <label><input type="checkbox" name="visual_layers[]" value="gastown_clock_silhouette" data-layer-group="landmark" /> Gastown clock</label>
-              <label><input type="checkbox" name="visual_layers[]" value="english_bay_inukshuk" data-layer-group="landmark" /> English Bay inukshuk</label>
-              <label><input type="checkbox" name="visual_layers[]" value="maritime_museum_sailroof" data-layer-group="landmark" /> Maritime Museum sail roof</label>
-              <label><input type="checkbox" name="visual_layers[]" value="bc_place_dome" data-layer-group="landmark" /> BC Place dome</label>
-              <label><input type="checkbox" name="visual_layers[]" value="port_cranes" data-layer-group="landmark" /> Port cranes</label>
+              <label><input type="checkbox" name="visual_layers[]" value="clear_cold_shimmer" /> clear cold shimmer</label>
+              <label><input type="checkbox" name="visual_layers[]" value="gastown_clock_silhouette" /> Gastown clock</label>
+              <label><input type="checkbox" name="visual_layers[]" value="english_bay_inukshuk" /> English Bay inukshuk</label>
+              <label><input type="checkbox" name="visual_layers[]" value="maritime_museum_sailroof" /> Maritime Museum sail roof</label>
+              <label><input type="checkbox" name="visual_layers[]" value="bc_place_dome" /> BC Place dome</label>
+              <label><input type="checkbox" name="visual_layers[]" value="port_cranes" /> Port cranes</label>
+              <label><input type="checkbox" name="visual_layers[]" value="constellation_lines" /> constellation lines</label>
+              <label><input type="checkbox" name="visual_layers[]" value="canada_place_sails" /> Canada Place sails</label>
               <label><input type="checkbox" name="visual_layers[]" value="glitch_flash" data-layer-group="modifier" /> glitch flash</label>
               <label><input type="checkbox" name="visual_layers[]" value="signal_bars" data-layer-group="modifier" /> signal bars</label>
               <label><input type="checkbox" name="visual_layers[]" value="chromatic_veil" data-layer-group="modifier" /> chromatic veil</label>
@@ -108,7 +118,6 @@ get_header();
       </fieldset>
 
       <label class="asmr-link-toggle"><input type="checkbox" name="link_av" checked /> Link sound + visual for selected motifs</label>
-      <p class="asmr-link-tip">Tip: Fewer modules = clearer scenes. Try 1 scene + 1 atmosphere + 1 signature.</p>
       <div class="asmr-actions">
         <button type="submit" class="pixel-button">Generate ASMR Package</button>
         <button type="button" id="asmr-qa-preset" class="pixel-button secondary">Load QA Preset</button>
@@ -139,6 +148,7 @@ get_header();
 
     <section id="asmr-results" class="asmr-results" hidden>
       <article class="asmr-card"><h2>Concept</h2><p id="asmr-concept"></p></article>
+      <article class="asmr-card"><h2>Story Beats</h2><ol id="asmr-story-beats"></ol></article>
       <article class="asmr-card"><h2>Sync Points</h2><ol id="asmr-beats"></ol></article>
       <article class="asmr-card"><h2>Style Tags</h2><ul id="asmr-video-prompts"></ul></article>
       <article class="asmr-card"><h2>Edit Rhythm</h2><p id="asmr-edit-notes"></p></article>


### PR DESCRIPTION
### Motivation
- Remove confusing category cap/auto-uncheck behavior so the motif-rack is fully permissive and every option remains selectable. 
- Improve Vancouver-specific identity by introducing signature audio cues and a Planetarium visual motif so generated packages feel more place-specific while retaining the lo‑fi/CRT aesthetic. 
- Push more structure to the OpenAI generation step so outputs include a clear narrative arc (`story_beats`) and required cues for readable A/V anchoring. 

### Description
- Removed all checkbox cap/overlap/auto-uncheck logic from the client and payload flow while preserving conservative AV linking; updated `js/asmr-lab.js` to no longer enforce caps and to render `story_beats` in the results panel. (files: `js/asmr-lab.js`, `page-asmr-lab.php`) 
- Exposed new UI options for Vancouver/Planetarium motifs and removed the tip text that suggested “fewer modules”; added a Story Beats card to results. (file: `page-asmr-lab.php`, `assets/css/asmr-lab.css`) 
- Added new procedural audio engines and registrations: `gastown_clock_whistle`, `church_bells`, `harbour_noon_horn`, `nine_oclock_gun`, `planetarium_hum`, and `planetarium_chime`, and implemented their synthesis shapes in `js/asmr-foley-engine.js`. 
- Added new visual motif types and canvas renderers: `planetarium_dome`, `starfield_projection`, `constellation_lines`, and `canada_place_sails`, and tuned visual layering/readability in `js/asmr-visual-engine.js`. 
- Updated backend allowlists, maps and deterministic injection so selected Vancouver motifs are guaranteed to appear early (and not duplicated if already scheduled), and mapped audio↔visual pairs for new motifs. (file: `functions.php`) 
- Strengthened the OpenAI system prompt in `functions.php` with a concise Vancouver sound-palette guide, hardcoded `story_mode: true`, and required `logline` + `story_beats` in the strict JSON contract; added sanitization/validation for those fields. (file: `functions.php`) 

### Testing
- Ran `php -l functions.php` with no syntax errors reported. (passed) 
- Ran `node --check js/asmr-lab.js`, `node --check js/asmr-foley-engine.js`, and `node --check js/asmr-visual-engine.js` with no syntax errors reported. (all passed) 
- Attempted a Playwright page capture of the updated page, but the local web endpoint returned `ERR_EMPTY_RESPONSE` in this environment so UI rendering validation was not possible here. (failed due to unreachable local server)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0a3a97c8c832eb45d44e8bfeffc9b)