### PR TITLE
Remove planetarium audio, stage visual motifs, and refine Vancouver sound engines

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -912,8 +912,6 @@ function se_get_asmr_allowed_engines() {
         'church_bells',
         'harbour_noon_horn',
         'nine_oclock_gun',
-        'planetarium_hum',
-        'planetarium_chime',
     );
 }
 
@@ -1213,7 +1211,7 @@ function se_get_asmr_audio_layers_allowed() {
         'footsteps', 'footsteps_snow_mode', 'rain_ambience', 'wind_gust', 'crowd_murmur', 'laughter_burst',
         'skytrain_pass', 'bus_pass', 'car_horn_short', 'steam_clock',
         'seabus_horn', 'ocean_waves', 'gulls_distant', 'crosswalk_chirp', 'compass_tap', 'bike_bell', 'skateboard_roll', 'siren_distant',
-        'gastown_clock_whistle', 'church_bells', 'harbour_noon_horn', 'nine_oclock_gun', 'planetarium_hum', 'planetarium_chime'
+        'gastown_clock_whistle', 'church_bells', 'harbour_noon_horn', 'nine_oclock_gun'
     );
 }
 
@@ -1232,15 +1230,11 @@ function se_get_asmr_visual_layers_allowed() {
 
 function se_get_asmr_visual_to_audio_map() {
     return array(
-        'ocean_surface_shimmer' => array( 'ocean_waves' ),
-        'waterfront_scene' => array( 'ocean_waves' ),
         'seabus_silhouette' => array( 'seabus_horn' ),
         'skytrain_pass_visual' => array( 'skytrain_pass' ),
         'bus_pass_visual' => array( 'bus_pass' ),
         'rain_streaks' => array( 'rain_ambience' ),
         'gastown_scene' => array( 'gastown_clock_whistle' ),
-        'planetarium_dome' => array( 'planetarium_hum' ),
-        'starfield_projection' => array( 'planetarium_chime' ),
     );
 }
 
@@ -1273,8 +1267,6 @@ function se_get_asmr_mapped_visual_layers_from_audio( $audio_layers ) {
         'gastown_clock_whistle' => 'gastown_clock_silhouette',
         'church_bells' => 'constellation_lines',
         'harbour_noon_horn' => 'waterfront_scene',
-        'planetarium_hum' => 'planetarium_dome',
-        'planetarium_chime' => 'starfield_projection',
         'ocean_waves' => 'ocean_surface_shimmer',
         'seabus_horn' => 'seabus_silhouette',
     );
@@ -1331,11 +1323,56 @@ function se_get_asmr_motif_brief( $payload ) {
     return implode( ' ', $parts );
 }
 
+function se_stage_selected_visual_motifs( $visual_layers, $runtime, $story_beats ) {
+    $windows = array(
+        'opening' => array( 't0' => 0.0, 't1' => $runtime * 0.25 ),
+        'arrival' => array( 't0' => $runtime * 0.25, 't1' => $runtime * 0.5 ),
+        'lift' => array( 't0' => $runtime * 0.5, 't1' => $runtime * 0.75 ),
+        'resolve' => array( 't0' => $runtime * 0.75, 't1' => $runtime ),
+    );
+
+    $scenes = array( 'gastown_scene', 'granville_scene', 'north_shore_scene', 'waterfront_scene' );
+    $atmosphere = array( 'rain_streaks', 'snow_drift', 'harbor_mist', 'clear_cold_shimmer', 'ocean_surface_shimmer' );
+    $landmarks = array( 'gastown_clock_silhouette', 'science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'lions_gate_bridge', 'bc_place_dome', 'port_cranes', 'planetarium_dome', 'starfield_projection', 'constellation_lines', 'canada_place_sails', 'seabus_silhouette' );
+    $transit = array( 'skytrain_pass_visual', 'skytrain_track', 'bus_pass_visual', 'seabus_silhouette' );
+
+    $selected = array_values( array_unique( array_values( array_filter( array_map( 'sanitize_key', (array) $visual_layers ) ) ) ) );
+    $opening = array();
+    foreach ( $selected as $token ) {
+        if ( empty( $opening ) && in_array( $token, $scenes, true ) ) { $opening[] = $token; continue; }
+        if ( 0 === count( array_intersect( $opening, $atmosphere ) ) && in_array( $token, $atmosphere, true ) ) { $opening[] = $token; continue; }
+        if ( 0 === count( array_intersect( $opening, $landmarks ) ) && in_array( $token, $landmarks, true ) ) { $opening[] = $token; continue; }
+    }
+
+    $remaining = array_values( array_diff( $selected, $opening ) );
+    $arrival = array_slice( $remaining, 0, min( 2, count( $remaining ) ) );
+    $remaining = array_values( array_diff( $remaining, $arrival ) );
+
+    $lift = array_values( array_intersect( $remaining, $transit ) );
+    if ( empty( $lift ) && ! empty( $remaining ) ) { $lift[] = $remaining[0]; }
+    if ( count( $lift ) > 2 ) { $lift = array_slice( $lift, 0, 2 ); }
+    $remaining = array_values( array_diff( $remaining, $lift ) );
+
+    $resolve = array();
+    if ( ! empty( $remaining ) ) {
+        $resolve[] = $remaining[0];
+    } elseif ( ! empty( $opening ) ) {
+        $resolve[] = $opening[0];
+    }
+
+    return array(
+        'opening' => $opening,
+        'arrival' => $arrival,
+        'lift' => $lift,
+        'resolve' => $resolve,
+        'windows' => $windows,
+    );
+}
+
 function se_inject_asmr_vancouver_anchors( $decoded, $payload ) {
     $link_av = ! array_key_exists( 'link_av', $payload ) || ! empty( $payload['link_av'] );
     $audio_layers = array_values( array_filter( array_map( 'sanitize_key', (array) ( $payload['audio_layers'] ?? array() ) ) ) );
     $visual_layers = array_values( array_filter( array_map( 'sanitize_key', (array) ( $payload['visual_layers'] ?? array() ) ) ) );
-
     if ( empty( $audio_layers ) && empty( $visual_layers ) ) {
         return $decoded;
     }
@@ -1346,13 +1383,10 @@ function se_inject_asmr_vancouver_anchors( $decoded, $payload ) {
                 continue;
             }
             foreach ( $mapped_audio as $audio_token ) {
-                if ( 'footsteps_snow_mode' === $audio_token ) {
-                    if ( in_array( 'footsteps', $audio_layers, true ) ) {
-                        $audio_layers[] = 'footsteps_snow_mode';
-                    }
-                } else {
-                    $audio_layers[] = $audio_token;
+                if ( 'footsteps_snow_mode' === $audio_token && ! in_array( 'footsteps', $audio_layers, true ) ) {
+                    continue;
                 }
+                $audio_layers[] = $audio_token;
             }
         }
         $audio_layers = array_values( array_unique( $audio_layers ) );
@@ -1366,155 +1400,103 @@ function se_inject_asmr_vancouver_anchors( $decoded, $payload ) {
     }
 
     $runtime = max( 10, min( 30, floatval( $decoded['runtime_seconds'] ?? 20 ) ) );
-    $audio = array();
-    $visual = array();
+    $audio = is_array( $decoded['audio_events'] ?? null ) ? $decoded['audio_events'] : array();
+    $visual = is_array( $decoded['visual_events'] ?? null ) ? $decoded['visual_events'] : array();
+    $story_beats = is_array( $decoded['story_beats'] ?? null ) ? $decoded['story_beats'] : array();
 
-    $scene_or_landmark = array(
-        'gastown_scene', 'granville_scene', 'north_shore_scene', 'gastown_clock_silhouette', 'science_world_dome',
-        'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'lions_gate_bridge', 'bc_place_dome', 'port_cranes', 'waterfront_scene', 'seabus_silhouette',
-        'planetarium_dome', 'starfield_projection', 'canada_place_sails'
+    $has_audio = static function( $events, $engine, $t0, $t1 ) {
+        foreach ( $events as $event ) {
+            $time = floatval( $event['time'] ?? -1 );
+            if ( ( $event['engine'] ?? '' ) === $engine && $time >= $t0 && $time <= $t1 ) {
+                return true;
+            }
+        }
+        return false;
+    };
+    $has_visual = static function( $events, $token, $t0, $t1 ) {
+        foreach ( $events as $event ) {
+            $time = floatval( $event['time'] ?? -1 );
+            if ( ( $event['visual_type'] ?? '' ) === $token && $time >= $t0 && $time <= $t1 ) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    $audio_defaults = array(
+        'rain_ambience' => array( 'engine' => 'rain_close', 'time' => 0.02, 'duration' => max( 7.5, $runtime * 0.78 ), 'intensity' => 0.48, 'params' => array(), 'sync_role' => 'repair_rain_bed' ),
+        'ocean_waves' => array( 'engine' => 'ocean_waves', 'time' => 0.02, 'duration' => max( 8.2, $runtime * 0.82 ), 'intensity' => 0.45, 'params' => array( 'fade_out' => 3.0, 'foam' => 0.35 ), 'sync_role' => 'repair_ocean_bed' ),
+        'seabus_horn' => array( 'engine' => 'seabus_horn', 'time' => $runtime * 0.56, 'duration' => 2.2, 'intensity' => 0.36, 'params' => array( 'attack' => 0.28, 'release' => 1.8 ), 'sync_role' => 'repair_seabus_horn' ),
+        'gastown_clock_whistle' => array( 'engine' => 'gastown_clock_whistle', 'time' => $runtime * 0.34, 'duration' => 2.4, 'intensity' => 0.46, 'params' => array( 'breathy' => 0.72, 'vibrato' => 0.46 ), 'sync_role' => 'repair_gastown_whistle' ),
+        'church_bells' => array( 'engine' => 'church_bells', 'time' => $runtime * 0.62, 'duration' => 5.2, 'intensity' => 0.3, 'params' => array( 'decay' => 5.4, 'brightness' => 0.26 ), 'sync_role' => 'repair_church_bells' ),
+        'harbour_noon_horn' => array( 'engine' => 'harbour_noon_horn', 'time' => $runtime * 0.46, 'duration' => 4.6, 'intensity' => 0.42, 'params' => array( 'attack' => 0.42, 'release' => 3.1, 'wobble' => 0.05 ), 'sync_role' => 'repair_harbour_horn' ),
     );
 
     foreach ( $audio_layers as $layer ) {
-        if ( 'footsteps' === $layer || 'footsteps_snow_mode' === $layer ) {
-            $engine = in_array( 'footsteps_snow_mode', $audio_layers, true ) ? 'footsteps_snow' : 'footsteps_wet';
-            for ( $i = 0; $i < 3; $i++ ) {
-                $audio[] = array( 'time' => 0.7 + ( $i * ( $runtime * 0.14 ) ), 'duration' => 0.18, 'engine' => $engine, 'intensity' => 0.5, 'params' => array(), 'sync_role' => 'footstep_anchor' );
+        if ( ! isset( $audio_defaults[ $layer ] ) ) {
+            continue;
+        }
+        $event = $audio_defaults[ $layer ];
+        if ( ! $has_audio( $audio, $event['engine'], max( 0, $event['time'] - 1.0 ), min( $runtime, $event['time'] + 1.0 ) ) ) {
+            $audio[] = $event;
+        }
+    }
+
+    $staged = se_stage_selected_visual_motifs( $visual_layers, $runtime, $story_beats );
+    $windows = $staged['windows'];
+    foreach ( array( 'opening', 'arrival', 'lift', 'resolve' ) as $beat ) {
+        $tokens = $staged[ $beat ] ?? array();
+        $window = $windows[ $beat ];
+        $count = count( $tokens );
+        if ( 0 === $count ) {
+            continue;
+        }
+        foreach ( array_values( $tokens ) as $idx => $token ) {
+            if ( $has_visual( $visual, $token, $window['t0'], $window['t1'] ) ) {
+                continue;
             }
-        } elseif ( 'rain_ambience' === $layer ) {
-            $audio[] = array( 'time' => 0.02, 'duration' => max( 7.5, $runtime * 0.78 ), 'engine' => 'rain_close', 'intensity' => 0.5, 'params' => array(), 'sync_role' => 'rain_bed' );
-        } elseif ( 'wind_gust' === $layer ) {
-            $audio[] = array( 'time' => $runtime * 0.22, 'duration' => min( 3.8, $runtime * 0.24 ), 'engine' => 'cold_air_hush', 'intensity' => 0.44, 'params' => array(), 'sync_role' => 'wind_gust' );
-        } elseif ( 'crowd_murmur' === $layer ) {
-            $audio[] = array( 'time' => 0.9, 'duration' => 2.4, 'engine' => 'crowd_murmur', 'intensity' => 0.38, 'params' => array(), 'sync_role' => 'crowd_anchor' );
-        } elseif ( 'laughter_burst' === $layer ) {
-            $audio[] = array( 'time' => $runtime * 0.42, 'duration' => 0.34, 'engine' => 'laughter_burst', 'intensity' => 0.5, 'params' => array(), 'sync_role' => 'laughter_anchor' );
-        } elseif ( 'skytrain_pass' === $layer ) {
-            $mid = $runtime * 0.52;
-            $audio[] = array( 'time' => $mid, 'duration' => 2.1, 'engine' => 'skytrain_pass', 'intensity' => 0.62, 'params' => array(), 'sync_role' => 'skytrain_anchor' );
-        } elseif ( 'bus_pass' === $layer ) {
-            $audio[] = array( 'time' => $runtime * 0.3, 'duration' => 1.8, 'engine' => 'bus_idle', 'intensity' => 0.44, 'params' => array(), 'sync_role' => 'bus_anchor' );
-        } elseif ( 'car_horn_short' === $layer ) {
-            $audio[] = array( 'time' => $runtime * 0.64, 'duration' => 0.2, 'engine' => 'car_horn_short', 'intensity' => 0.48, 'params' => array(), 'sync_role' => 'horn_anchor' );
-        } elseif ( 'steam_clock' === $layer ) {
-            $audio[] = array( 'time' => 0.52, 'duration' => 1.1, 'engine' => 'steam_clock_burst', 'intensity' => 0.62, 'params' => array(), 'sync_role' => 'steam_clock_toggle' );
-        } elseif ( 'gastown_clock_whistle' === $layer ) {
-            $audio[] = array( 'time' => 0.54, 'duration' => 1.25, 'engine' => 'gastown_clock_whistle', 'intensity' => 0.64, 'params' => array(), 'sync_role' => 'gastown_clock_whistle' );
-        } elseif ( 'church_bells' === $layer ) {
-            $audio[] = array( 'time' => $runtime * 0.48, 'duration' => max( 4.0, min( 6.5, $runtime * 0.28 ) ), 'engine' => 'church_bells', 'intensity' => 0.34, 'params' => array( 'decay' => 5.2, 'brightness' => 0.3 ), 'sync_role' => 'church_bells' );
-        } elseif ( 'harbour_noon_horn' === $layer ) {
-            $audio[] = array( 'time' => $runtime * 0.34, 'duration' => max( 3.2, min( 5.0, $runtime * 0.24 ) ), 'engine' => 'harbour_noon_horn', 'intensity' => 0.44, 'params' => array( 'attack' => 0.35, 'release' => 2.2, 'wobble' => 0.08 ), 'sync_role' => 'harbour_noon_horn' );
-        } elseif ( 'nine_oclock_gun' === $layer ) {
-            $audio[] = array( 'time' => $runtime * 0.74, 'duration' => 1.2, 'engine' => 'nine_oclock_gun', 'intensity' => 0.46, 'params' => array(), 'sync_role' => 'nine_oclock_gun' );
-        } elseif ( 'planetarium_hum' === $layer ) {
-            $audio[] = array( 'time' => 0.05, 'duration' => max( 6.2, $runtime * 0.72 ), 'engine' => 'planetarium_hum', 'intensity' => 0.32, 'params' => array(), 'sync_role' => 'planetarium_hum' );
-        } elseif ( 'planetarium_chime' === $layer ) {
-            $audio[] = array( 'time' => $runtime * 0.41, 'duration' => 0.42, 'engine' => 'planetarium_chime', 'intensity' => 0.26, 'params' => array(), 'sync_role' => 'planetarium_chime' );
-        } elseif ( 'seabus_horn' === $layer ) {
-            $audio[] = array( 'time' => $runtime * 0.32, 'duration' => 1.8, 'engine' => 'seabus_horn', 'intensity' => 0.36, 'params' => array(), 'sync_role' => 'seabus_horn' );
-        } elseif ( 'gulls_distant' === $layer ) {
-            $audio[] = array( 'time' => 0.48, 'duration' => 2.2, 'engine' => 'gulls_distant', 'intensity' => 0.34, 'params' => array(), 'sync_role' => 'gulls_distant' );
-        } elseif ( 'crosswalk_chirp' === $layer ) {
-            $audio[] = array( 'time' => $runtime * 0.56, 'duration' => 0.85, 'engine' => 'crosswalk_chirp', 'intensity' => 0.32, 'params' => array(), 'sync_role' => 'crosswalk_chirp' );
-        } elseif ( 'compass_tap' === $layer ) {
-            $audio[] = array( 'time' => $runtime * 0.46, 'duration' => 0.2, 'engine' => 'compass_tap', 'intensity' => 0.3, 'params' => array(), 'sync_role' => 'compass_tap' );
-        } elseif ( 'bike_bell' === $layer ) {
-            $audio[] = array( 'time' => $runtime * 0.38, 'duration' => 0.38, 'engine' => 'bike_bell', 'intensity' => 0.34, 'params' => array(), 'sync_role' => 'bike_bell' );
-        } elseif ( 'skateboard_roll' === $layer ) {
-            $audio[] = array( 'time' => $runtime * 0.28, 'duration' => 1.6, 'engine' => 'skateboard_roll', 'intensity' => 0.38, 'params' => array(), 'sync_role' => 'skateboard_roll' );
-        } elseif ( 'siren_distant' === $layer ) {
-            $audio[] = array( 'time' => $runtime * 0.62, 'duration' => 1.8, 'engine' => 'siren_distant', 'intensity' => 0.28, 'params' => array(), 'sync_role' => 'siren_distant' );
-        }
-    }
-
-    foreach ( $visual_layers as $visual_type ) {
-        if ( in_array( $visual_type, array( 'rain_streaks', 'snow_drift', 'harbor_mist', 'clear_cold_shimmer' ), true ) ) {
-            $visual[] = array( 'time' => 0.0, 'duration' => max( 4.0, $runtime * 0.56 ), 'visual_type' => $visual_type, 'intensity' => 0.52, 'params' => array(), 'sync_role' => 'atmosphere_bed' );
-            continue;
-        }
-        if ( 'skytrain_pass_visual' === $visual_type ) {
-            $mid = $runtime * 0.52;
-            $visual[] = array( 'time' => $mid - 0.2, 'duration' => 2.4, 'visual_type' => 'skytrain_pass_visual', 'intensity' => 0.66, 'params' => array(), 'sync_role' => 'skytrain_visual' );
-            $visual[] = array( 'time' => $mid - 0.25, 'duration' => 2.5, 'visual_type' => 'skytrain_track', 'intensity' => 0.56, 'params' => array(), 'sync_role' => 'skytrain_track' );
-            continue;
-        }
-        if ( 'bus_pass_visual' === $visual_type ) {
-            $visual[] = array( 'time' => $runtime * 0.3, 'duration' => 2.0, 'visual_type' => 'bus_pass_visual', 'intensity' => 0.6, 'params' => array(), 'sync_role' => 'bus_visual' );
-            continue;
-        }
-        if ( in_array( $visual_type, array( 'gastown_scene', 'granville_scene', 'north_shore_scene', 'waterfront_scene' ), true ) ) {
-            $visual[] = array( 'time' => 0.18, 'duration' => min( 3.2, $runtime * 0.22 ), 'visual_type' => $visual_type, 'intensity' => 0.7, 'params' => array(), 'sync_role' => 'scene_anchor' );
-            $visual[] = array( 'time' => $runtime * 0.44, 'duration' => min( 2.4, $runtime * 0.2 ), 'visual_type' => $visual_type, 'intensity' => 0.58, 'params' => array(), 'sync_role' => 'scene_recur' );
-            continue;
-        }
-        if ( in_array( $visual_type, array( 'planetarium_dome', 'starfield_projection', 'constellation_lines', 'canada_place_sails' ), true ) ) {
-            $visual[] = array( 'time' => 0.16, 'duration' => min( 4.8, $runtime * 0.4 ), 'visual_type' => $visual_type, 'intensity' => 0.66, 'params' => array(), 'sync_role' => 'planetarium_landmark_anchor' );
-            if ( 'planetarium_dome' === $visual_type ) {
-                $visual[] = array( 'time' => 0.42, 'duration' => min( 3.4, $runtime * 0.28 ), 'visual_type' => 'starfield_projection', 'intensity' => 0.54, 'params' => array(), 'sync_role' => 'planetarium_projection_follow' );
+            $slot = ( $idx + 1 ) / ( $count + 1 );
+            $time = $window['t0'] + ( $window['t1'] - $window['t0'] ) * $slot;
+            if ( 'opening' === $beat && 0 === $idx ) {
+                $time = min( 0.48, max( 0.12, $time ) );
             }
-            continue;
-        }
-        $visual[] = array( 'time' => 0.14, 'duration' => min( 5.2, $runtime * 0.36 ), 'visual_type' => $visual_type, 'intensity' => 0.6, 'params' => array(), 'sync_role' => 'visual_motif_toggle' );
-    }
-
-    $has_scene_or_landmark = false;
-    foreach ( $visual_layers as $token ) {
-        if ( in_array( $token, $scene_or_landmark, true ) ) {
-            $has_scene_or_landmark = true;
-            break;
+            $visual[] = array(
+                'time' => round( $time, 3 ),
+                'duration' => min( max( 1.8, $runtime * 0.2 ), $runtime * 0.34 ),
+                'visual_type' => $token,
+                'intensity' => ( 'resolve' === $beat ) ? 0.5 : 0.62,
+                'params' => array(),
+                'sync_role' => 'repair_' . $beat . '_motif',
+            );
         }
     }
 
-
-    if ( in_array( 'ocean_waves', $audio_layers, true ) ) {
-        $audio[] = array( 'time' => 0.02, 'duration' => max( 8.0, $runtime * 0.85 ), 'engine' => 'ocean_waves', 'intensity' => 0.5, 'params' => array( 'fade_out' => 2.8, 'foam' => 0.5 ), 'sync_role' => 'ocean_wave_anchor' );
-    }
-
-    if ( in_array( 'ocean_surface_shimmer', $visual_layers, true ) ) {
-        $visual[] = array( 'time' => 0.0, 'duration' => max( 5.6, $runtime * 0.68 ), 'visual_type' => 'ocean_surface_shimmer', 'intensity' => 0.62, 'params' => array(), 'sync_role' => 'waterfront_shimmer_anchor' );
-    }
-
-    if ( in_array( 'seabus_silhouette', $visual_layers, true ) ) {
-        $visual[] = array( 'time' => 0.5, 'duration' => min( 4.4, $runtime * 0.3 ), 'visual_type' => 'seabus_silhouette', 'intensity' => 0.62, 'params' => array(), 'sync_role' => 'seabus_silhouette_anchor' );
-    }
-
-    if ( $has_scene_or_landmark ) {
+    $scene_or_landmark = array(
+        'gastown_scene', 'granville_scene', 'north_shore_scene', 'waterfront_scene', 'gastown_clock_silhouette', 'science_world_dome',
+        'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'lions_gate_bridge', 'bc_place_dome', 'port_cranes', 'seabus_silhouette',
+        'planetarium_dome', 'starfield_projection', 'constellation_lines', 'canada_place_sails'
+    );
+    $selected_scene_landmarks = array_values( array_intersect( $visual_layers, $scene_or_landmark ) );
+    if ( ! empty( $selected_scene_landmarks ) ) {
         $already_early = false;
         foreach ( $visual as $event ) {
-            if ( in_array( $event['visual_type'], $scene_or_landmark, true ) && floatval( $event['time'] ) <= 0.6 ) {
+            if ( in_array( $event['visual_type'] ?? '', $selected_scene_landmarks, true ) && floatval( $event['time'] ?? 99 ) <= 0.6 ) {
                 $already_early = true;
                 break;
             }
         }
         if ( ! $already_early ) {
-            $fallback = 'gastown_clock_silhouette';
-            foreach ( $visual_layers as $token ) {
-                if ( in_array( $token, $scene_or_landmark, true ) ) {
-                    $fallback = $token;
-                    break;
-                }
-            }
-            $visual[] = array( 'time' => 0.24, 'duration' => min( 2.6, $runtime * 0.2 ), 'visual_type' => $fallback, 'intensity' => 0.66, 'params' => array(), 'sync_role' => 'early_readability_anchor' );
+            $visual[] = array( 'time' => 0.32, 'duration' => min( 2.6, $runtime * 0.2 ), 'visual_type' => $selected_scene_landmarks[0], 'intensity' => 0.66, 'params' => array(), 'sync_role' => 'early_readability_anchor' );
         }
     }
 
-    usort(
-        $audio,
-        static function( $a, $b ) {
-            return (float) $a['time'] <=> (float) $b['time'];
-        }
-    );
-    usort(
-        $visual,
-        static function( $a, $b ) {
-            return (float) $a['time'] <=> (float) $b['time'];
-        }
-    );
+    usort( $audio, static function( $a, $b ) { return (float) ( $a['time'] ?? 0 ) <=> (float) ( $b['time'] ?? 0 ); } );
+    usort( $visual, static function( $a, $b ) { return (float) ( $a['time'] ?? 0 ) <=> (float) ( $b['time'] ?? 0 ); } );
 
-    $decoded['style_tags'] = array_values( array_unique( array_merge( array( 'retro_arcade_crt' ), $audio_layers, $visual_layers ) ) );
+    $decoded['style_tags'] = array_values( array_unique( array_merge( (array) ( $decoded['style_tags'] ?? array() ), array( 'retro_arcade_crt' ), $audio_layers, $visual_layers ) ) );
     $decoded['audio_events'] = $audio;
     $decoded['visual_events'] = $visual;
-    $decoded['presentation_note'] = 'Motif-rack composition with conservative A/V pairing and first-frame readability anchors.';
+    $decoded['presentation_note'] = 'Motif-repair injection: OpenAI composes the story arc, deterministic pass only ensures selected motif presence and readability.';
     return $decoded;
 }
 
@@ -1730,12 +1712,13 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
         . 'Return ONE strict JSON object and no markdown. '
         . 'Use exactly and only these top-level keys: title, runtime_seconds, hook, concept_summary, logline, story_beats, style_tags, audio_events, visual_events, sync_points, end_card, edit_rhythm, presentation_note. '
         . 'audio_events objects must include: time, duration, engine, intensity, params, sync_role. '
-        . 'ASMR timing rules: bed layers (ocean_waves, rain_close, rain_roof, planetarium_hum, crowd_murmur, harbor_fog_bed) should usually run 60-100% of runtime_seconds with soft fades. '
+        . 'ASMR timing rules: bed layers (ocean_waves, rain_close, rain_roof, crowd_murmur, harbor_fog_bed) should usually run 60-100% of runtime_seconds with soft fades. '
         . 'Horns and bells should be sustained and calming with typical durations between 2.5-6.0s, slow attack, and long release. '
         . 'Avoid tiny durations under 0.5s except intentional micro-textures; prioritize long calming layers. '
         . 'params must always be a JSON object (use {} when none) and never an array. '
         . 'visual_events objects must include: time, duration, visual_type, intensity, params, sync_role. '
         . 'sync_points objects must include: time, cue, importance. story_beats must be an array of exactly 4 objects with: t0, t1, beat, intent (Opening, Arrival, Ritual Lift, Resolve). '
+        . 'Compose this as a calm ASMR soundscape with a narrative arc. Beds should run long. Signature cues should be sparse and sustained. Avoid rapid-fire event stacking. Distribute reveals across the full runtime. If multiple landmarks/scenes are selected, choose one primary reveal per beat rather than showing all of them at once. '
         . 'end_card must include: use_end_card, text, reveal_style. '
         . 'edit_rhythm must include: pacing_note, silence_strategy, release_strategy. '
         . 'Only use these engine names: ' . $allowed_engines . '. '
@@ -1753,9 +1736,10 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
         . 'sync_points must map to real event moments and reinforce audio-visual unity, especially in the first 3 seconds. '
         . 'When motif tokens imply a place, ground the package in concrete materials, atmospheric lighting, and local acoustics. '
         . 'Prompt interpretation priority: selected visual motifs > selected audio motifs > named object > mood adjectives. '
+        . 'Do not schedule all selected motifs in the first quarter. Distribute selected motifs across the full runtime. Prefer one dominant reveal at a time. If planetarium visuals are selected, use only visual motifs and no planetarium sound motif. '
         . 'For Gastown/Vancouver scenes, favor steam clock cues, harbor fog bed, amber streetlamp halos, wet cobblestone reflections, brick facade texture, neon-on-wet shimmer, and winter hush pacing where relevant. '
- . 'Vancouver sound palette guide: gastown_clock_whistle=steam whistle toot, iconic Gastown clock, breathy warm; church_bells=distant cathedral bells, warm decay; harbour_noon_horn=harbour ship horn at noon, low and foggy; ocean_waves=waterfront waves, soft swell; skytrain_pass=SkyTrain whoosh and rail hum; seabus_horn=short ferry foghorn; planetarium_hum=quiet dome room tone; planetarium_chime=tiny sparkle chime; nine_oclock_gun=low ceremonial boom. '
-        . 'When using signature engines (harbour_noon_horn, gastown_clock_whistle, church_bells, ocean_waves, planetarium_hum), include optional shaping params when meaningful so synthesis can be tuned per scene. '
+ . 'Vancouver sound palette guide: gastown_clock_whistle=steam whistle toot, iconic Gastown clock, breathy warm and sustained; church_bells=distant cathedral bells with long warm decay; harbour_noon_horn=harbour ship horn at noon, low and foggy with gentle bloom; ocean_waves=waterfront waves, soft wide bed with smooth fade; skytrain_pass=SkyTrain whoosh and rail hum; seabus_horn=short soft ferry foghorn; nine_oclock_gun=low ceremonial boom. '
+        . 'When using signature engines (harbour_noon_horn, gastown_clock_whistle, church_bells, ocean_waves, seabus_horn), include optional shaping params when meaningful so synthesis can be tuned per scene. '
         . 'Avoid generic abstract output when prompts include specific motif or geography terms. '
         . 'The result should feel like an authored short sensory micro-film, not a debug demo. '
         . 'Every beat transition must be marked by a signature cue pair (audio + visual) from selected motifs when story_mode is true. Do not include prose outside JSON.';

--- a/js/asmr-foley-engine.js
+++ b/js/asmr-foley-engine.js
@@ -11,12 +11,12 @@
     'harbor_fog_bed', 'metal_resonance', 'snow_muffle', 'city_electrical_hum',
     'footsteps_wet', 'footsteps_snow', 'rain_close', 'rain_roof', 'puddle_splash',
     'crowd_murmur', 'laughter_burst', 'skytrain_pass', 'bus_idle', 'car_horn_short', 'seabus_horn', 'ocean_waves', 'gulls_distant', 'crosswalk_chirp', 'compass_tap', 'bike_bell', 'skateboard_roll', 'siren_distant',
-    'gastown_clock_whistle', 'church_bells', 'harbour_noon_horn', 'nine_oclock_gun', 'planetarium_hum', 'planetarium_chime'
+    'gastown_clock_whistle', 'church_bells', 'harbour_noon_horn', 'nine_oclock_gun'
   ];
 
   const BED_ENGINES = new Set([
     'ocean_waves', 'rain_close', 'rain_roof', 'harbor_fog_bed', 'city_electrical_hum',
-    'planetarium_hum', 'crowd_murmur', 'filtered_noise_wash', 'low_hum'
+    'crowd_murmur', 'filtered_noise_wash', 'low_hum'
   ]);
 
   function clamp(value, min, max) {
@@ -390,8 +390,8 @@
           this.scheduleTone(ctx, destination, atTime + 0.04, duration * 0.7, { from: p.from || 700, to: p.to || 1060, peak: 0.008 + intensity * 0.018, type: 'triangle', pan: -0.2 });
           break;
         case 'harbor_fog_bed':
-          this.scheduleTone(ctx, destination, atTime, duration, { from: p.from || 74, to: p.to || 66, peak: 0.03 + intensity * 0.055, type: 'sine' });
-          this.scheduleNoise(ctx, destination, atTime, duration, { freq: p.freq || 620, q: 0.45, peak: 0.016 + intensity * 0.034, filterType: 'lowpass', pan: 0 });
+          this.scheduleTone(ctx, destination, atTime, duration, { from: p.from || 74, to: p.to || 66, peak: 0.024 + intensity * 0.04, type: 'sine', env: { attack: 0.55, hold: duration * 0.5, release: 2.2, tail: 0.4 } });
+          this.scheduleNoise(ctx, destination, atTime, duration, { freq: p.freq || 620, q: 0.45, peak: 0.012 + intensity * 0.024, filterType: 'lowpass', pan: 0, env: { attack: 0.5, hold: duration * 0.48, release: 2.0, tail: 0.35 } });
           break;
         case 'metal_resonance':
           this.scheduleTone(ctx, destination, atTime, Math.max(0.12, duration * 0.5), { from: p.from || 980, to: p.to || 340, peak: 0.02 + intensity * 0.04, type: 'triangle', pan: 0.22 });
@@ -418,7 +418,7 @@
         case 'rain_close':
         case 'rain_roof': {
           const roof = event.engine === 'rain_roof';
-          this.scheduleNoise(ctx, destination, atTime, duration, { freq: roof ? 2600 : 3200, q: 0.9, peak: 0.018 + intensity * 0.04, filterType: 'highpass', pan: 0.02 });
+          this.scheduleNoise(ctx, destination, atTime, duration, { freq: roof ? 2600 : 3200, q: 0.9, peak: 0.015 + intensity * 0.03, filterType: 'highpass', pan: 0.02, env: { attack: 0.4, hold: duration * 0.48, release: 1.6, tail: 0.3 } });
           const drops = Math.max(6, Math.min(36, Math.round(duration * (roof ? 4 : 7) * (0.7 + intensity))));
           for (let i = 0; i < drops; i += 1) {
             const dt = (i / drops) * duration;
@@ -431,9 +431,9 @@
           this.scheduleTone(ctx, destination, atTime + 0.02, Math.max(0.09, duration * 0.5), { from: 220, to: 110, peak: 0.008 + intensity * 0.018, type: 'triangle', pan: 0.1 });
           break;
         case 'crowd_murmur':
-          this.scheduleNoise(ctx, destination, atTime, duration, { freq: 520, q: 0.65, peak: 0.02 + intensity * 0.032, filterType: 'bandpass', pan: -0.1 });
-          this.scheduleNoise(ctx, destination, atTime + 0.03, duration * 0.95, { freq: 880, q: 0.8, peak: 0.014 + intensity * 0.024, filterType: 'bandpass', pan: 0.12 });
-          this.scheduleTone(ctx, destination, atTime, duration * 0.85, { from: 190, to: 240, peak: 0.004 + intensity * 0.012, type: 'sine', pan: 0.04 });
+          this.scheduleNoise(ctx, destination, atTime, duration, { freq: 520, q: 0.65, peak: 0.014 + intensity * 0.024, filterType: 'bandpass', pan: -0.1, env: { attack: 0.45, hold: duration * 0.5, release: 1.8, tail: 0.35 } });
+          this.scheduleNoise(ctx, destination, atTime + 0.03, duration * 0.95, { freq: 880, q: 0.8, peak: 0.01 + intensity * 0.018, filterType: 'bandpass', pan: 0.12, env: { attack: 0.4, hold: duration * 0.46, release: 1.7, tail: 0.3 } });
+          this.scheduleTone(ctx, destination, atTime, duration * 0.85, { from: 190, to: 240, peak: 0.003 + intensity * 0.01, type: 'sine', pan: 0.04, env: { attack: 0.45, hold: duration * 0.42, release: 1.6, tail: 0.3 } });
           break;
         case 'laughter_burst':
           this.scheduleTone(ctx, destination, atTime, Math.max(0.12, duration * 0.7), { from: 280, to: 420, peak: 0.012 + intensity * 0.022, type: 'triangle', pan: 0.2 });
@@ -465,27 +465,21 @@
 
 
         case 'seabus_horn': {
-          const f0 = Number(p.f0 || 86);
-          const attack = clamp(Number(p.attack || 0.24), 0.12, 0.6);
-          const release = clamp(Number(p.release || 1.8), 1, 3.2);
-          const wobble = clamp(Number(p.wobble || 0.06), 0, 0.2);
-          const drift = clamp(Number(p.drift || 0.012), 0, 0.04);
-          const bright = clamp(Number(p.brightness || 0.28), 0, 1);
+          const f0 = Number(p.f0 || 82);
+          const attack = clamp(Number(p.attack || 0.26), 0.14, 0.5);
+          const release = clamp(Number(p.release || 1.6), 1.1, 2.6);
+          const wobble = clamp(Number(p.wobble || 0.04), 0, 0.12);
           this.scheduleTone(ctx, destination, atTime, duration, {
-            from: f0 * (1 + drift), to: f0 * (0.985 - drift), peak: 0.012 + intensity * 0.018, type: 'sine', pan: -0.05,
-            env: { attack, hold: duration * 0.34, release, tail: 0.4 }
+            from: f0 * 1.01, to: f0 * (0.985 - wobble * 0.15), peak: 0.01 + intensity * 0.015, type: 'sine', pan: -0.04,
+            env: { attack, hold: duration * 0.36, release, tail: 0.45 }
           });
-          this.scheduleTone(ctx, destination, atTime + 0.02, duration * 0.95, {
-            from: f0 * 2.02 * (1 + drift * 0.5), to: f0 * 2.0, peak: (0.005 + intensity * 0.01) * (0.5 + bright * 0.9), type: 'triangle', pan: 0.06,
-            env: { attack: attack * 0.9, hold: duration * 0.3, release: release * 0.9, tail: 0.35 }
+          this.scheduleTone(ctx, destination, atTime + 0.02, duration * 0.92, {
+            from: f0 * 1.98, to: f0 * 1.95, peak: 0.004 + intensity * 0.008, type: 'triangle', pan: 0.05,
+            env: { attack: attack * 0.9, hold: duration * 0.28, release: release * 0.9, tail: 0.36 }
           });
-          this.scheduleTone(ctx, destination, atTime + 0.04, duration * 0.9, {
-            from: f0 * 3.01, to: f0 * (3.01 - wobble * 0.8), peak: (0.002 + intensity * 0.005) * (0.4 + bright), type: 'sine', pan: 0.03,
-            env: { attack: attack * 0.8, hold: duration * 0.2, release: release * 0.8, tail: 0.3 }
-          });
-          this.scheduleNoise(ctx, destination, atTime + 0.02, duration * 0.82, {
-            freq: 360, q: 0.74, peak: 0.002 + intensity * 0.005, filterType: 'bandpass', pan: 0.01,
-            env: { attack: attack * 0.9, hold: duration * 0.26, release: release * 0.75, tail: 0.25 }
+          this.scheduleNoise(ctx, destination, atTime + 0.03, duration * 0.78, {
+            freq: 320, q: 0.7, peak: 0.0016 + intensity * 0.0035, filterType: 'bandpass', pan: 0.01,
+            env: { attack: attack, hold: duration * 0.24, release: release * 0.7, tail: 0.24 }
           });
           break;
         }
@@ -495,6 +489,7 @@
           const fadeOut = clamp(Number(p.fade_out || 2.8), 2.2, 3.2);
           const calmTailStart = atTime + Math.max(0.2, duration - fadeOut);
           const swells = Math.max(2, Math.round(duration * swellRate));
+          const noFoamAfter = atTime + duration - 1.25;
 
           this.scheduleNoise(ctx, destination, atTime, duration, {
             freq: 240, q: 0.52, peak: 0.009 + intensity * 0.017, filterType: 'bandpass', pan: -0.16,
@@ -506,14 +501,14 @@
           });
 
           for (let i = 0; i < swells; i += 1) {
-            const dt = (i / Math.max(1, swells - 1)) * Math.max(0.2, duration - 1.2);
+            const dt = (i / Math.max(1, swells - 1)) * Math.max(0.2, duration - 3.0);
             const swellAt = atTime + dt;
             const tailFactor = swellAt >= calmTailStart ? Math.max(0.25, (atTime + duration - swellAt) / Math.max(0.4, fadeOut)) : 1;
             this.scheduleTone(ctx, destination, swellAt, 1.35, {
               from: 62, to: 53, peak: (0.003 + intensity * 0.008) * tailFactor, type: 'sine', pan: (i % 2 ? 0.1 : -0.08),
-              env: { attack: 0.3, hold: 0.42, release: 1.5, tail: 0.3 }
+              env: { attack: 0.3, hold: 0.42, release: 1.4, tail: 0.25 }
             });
-            if (foam > 0.05 && (swellAt + 0.25) < (atTime + duration - 0.8)) {
+            if (foam > 0.05 && (swellAt + 0.25) < noFoamAfter) {
               this.scheduleNoise(ctx, destination, swellAt + 0.25, 0.34, {
                 freq: 1900, q: 1.05, peak: (0.0015 + intensity * 0.0045) * foam * tailFactor, filterType: 'highpass', pan: (i % 2 ? -0.12 : 0.12),
                 env: { attack: 0.05, hold: 0.08, release: 0.55, tail: 0.15 }
@@ -560,80 +555,63 @@
           break;
 
         case 'gastown_clock_whistle': {
-          const f0 = clamp(Number(p.f0 || 540), 520, 560);
-          const interval = clamp(Number(p.interval || 1.06), 1.02, 1.14);
-          const attack = clamp(Number(p.attack || 0.18), 0.1, 0.5);
-          const release = clamp(Number(p.release || 1.8), 1, 3.2);
-          const breathy = clamp(Number(p.breathy ?? 0.7), 0, 1);
-          const vibrato = clamp(Number(p.vibrato ?? 0.55), 0, 1);
-          const bend = 1 + (0.028 + vibrato * 0.02);
+          const f0 = clamp(Number(p.f0 || 536), 500, 570);
+          const interval = clamp(Number(p.interval || 1.045), 1.02, 1.09);
+          const attack = clamp(Number(p.attack || 0.16), 0.12, 0.22);
+          const release = clamp(Number(p.release || 2.3), 1.8, 3.0);
+          const breathy = clamp(Number(p.breathy ?? 0.72), 0.6, 0.85);
+          const vibrato = clamp(Number(p.vibrato ?? 0.45), 0.35, 0.55);
+          const bend = 1.018 + vibrato * 0.02;
           this.scheduleNoise(ctx, destination, atTime, duration, {
-            freq: 1700, q: 0.8, peak: (0.004 + intensity * 0.01) * (0.35 + breathy), filterType: 'bandpass', pan: 0.03,
-            env: { attack: attack * 0.7, hold: duration * 0.28, release: release * 0.9, tail: 0.25 }
+            freq: 1200, q: 0.7, peak: (0.004 + intensity * 0.009) * breathy, filterType: 'bandpass', pan: 0.02,
+            env: { attack: attack * 0.75, hold: duration * 0.34, release: release * 0.95, tail: 0.3 }
           });
-          this.scheduleNoise(ctx, destination, atTime + 0.02, duration * 0.95, {
-            freq: 980, q: 0.6, peak: (0.003 + intensity * 0.007) * breathy, filterType: 'lowpass', pan: -0.02,
-            env: { attack: attack * 0.9, hold: duration * 0.3, release: release * 0.8, tail: 0.2 }
+          this.scheduleTone(ctx, destination, atTime, duration, {
+            from: f0 * bend, to: f0, peak: 0.01 + intensity * 0.018, type: 'sine', pan: -0.04,
+            env: { attack, hold: duration * 0.36, release, tail: 0.45 }
           });
-          this.scheduleTone(ctx, destination, atTime + 0.02, duration * 0.9, {
-            from: f0 * bend, to: f0 * (1 + vibrato * 0.006), peak: 0.011 + intensity * 0.018, type: 'triangle', pan: -0.06,
-            env: { attack, hold: duration * 0.33, release, tail: 0.35 }
-          });
-          this.scheduleTone(ctx, destination, atTime + 0.05, duration * 0.88, {
-            from: (f0 * interval) * (1 + vibrato * 0.018), to: f0 * interval, peak: 0.008 + intensity * 0.013, type: 'sine', pan: 0.07,
-            env: { attack: attack * 1.1, hold: duration * 0.3, release: release * 0.95, tail: 0.35 }
+          this.scheduleTone(ctx, destination, atTime + 0.02, duration * 0.96, {
+            from: (f0 * interval) * bend, to: (f0 * interval), peak: 0.008 + intensity * 0.014, type: 'triangle', pan: 0.06,
+            env: { attack: attack * 0.95, hold: duration * 0.34, release: release * 0.92, tail: 0.4 }
           });
           break;
         }
         case 'church_bells': {
-          const root = Number(p.root || 392);
-          const decay = clamp(Number(p.decay || 4.5), 2.5, 7.5);
-          const brightness = clamp(Number(p.brightness || 0.35), 0, 1);
-          const drift = clamp(Number(p.drift || 0.01), 0, 0.04);
-          const partials = [
-            { r: 1.0, amp: 1.0, pan: -0.12, d: 1.0, type: 'sine' },
-            { r: 2.7, amp: 0.62, pan: 0.14, d: 0.82, type: 'triangle' },
-            { r: 5.8, amp: 0.4, pan: -0.18, d: 0.68, type: 'sine' },
-            { r: 8.9, amp: 0.24, pan: 0.2, d: 0.54, type: 'triangle' }
-          ];
-          partials.forEach((part, i) => {
-            this.scheduleTone(ctx, destination, atTime + i * 0.01, Math.max(duration, decay * part.d), {
-              from: root * part.r * (1 + drift),
-              to: root * part.r * (0.62 - drift * 0.5),
-              peak: (0.004 + intensity * 0.012) * part.amp * (0.65 + brightness * 0.7),
-              type: part.type,
-              pan: part.pan,
-              env: { attack: 0.22 + i * 0.03, hold: 0.5, release: decay * part.d, tail: 0.65 }
+          const root = clamp(Number(p.root || 328), 280, 380);
+          const decay = clamp(Number(p.decay || 5.4), 4.5, 6.5);
+          const brightness = clamp(Number(p.brightness || 0.26), 0.12, 0.45);
+          const partials = [1.0, 1.47, 2.11, 2.79];
+          partials.forEach((ratio, i) => {
+            this.scheduleTone(ctx, destination, atTime + i * 0.02, Math.max(duration, decay), {
+              from: root * ratio, to: root * ratio * 0.68,
+              peak: (0.003 + intensity * 0.01) * (1 - i * 0.16), type: i % 2 ? 'triangle' : 'sine', pan: -0.14 + i * 0.1,
+              env: { attack: 0.22 + i * 0.03, hold: 0.5, release: decay * (0.82 - i * 0.1), tail: 0.8 }
             });
           });
           this.scheduleNoise(ctx, destination, atTime + 0.03, Math.max(duration, decay * 0.9), {
-            freq: 1800 + brightness * 1000, q: 0.6, peak: 0.0015 + intensity * 0.004, filterType: 'lowpass', pan: 0,
-            env: { attack: 0.14, hold: 0.4, release: decay * 0.75, tail: 0.4 }
+            freq: 1300 + brightness * 700, q: 0.55, peak: 0.0012 + intensity * 0.0028, filterType: 'lowpass', pan: 0,
+            env: { attack: 0.18, hold: 0.44, release: decay * 0.7, tail: 0.45 }
           });
           break;
         }
         case 'harbour_noon_horn': {
-          const f0 = Number(p.f0 || 74);
-          const attack = clamp(Number(p.attack || 0.35), 0.15, 0.7);
-          const release = clamp(Number(p.release || 2.2), 1.2, 4.8);
-          const wobble = clamp(Number(p.wobble || 0.07), 0, 0.2);
-          const drift = clamp(Number(p.drift || 0.015), 0, 0.04);
-          const brightness = clamp(Number(p.brightness || 0.35), 0, 1);
-          this.scheduleTone(ctx, destination, atTime, duration, {
-            from: f0 * (1 + drift), to: f0 * (0.97 - drift * 0.4), peak: 0.012 + intensity * 0.02, type: 'sine', pan: -0.02,
-            env: { attack, hold: duration * 0.38, release, tail: 0.6 }
+          const f0 = Number(p.f0 || 72);
+          const attack = clamp(Number(p.attack || 0.42), 0.35, 0.55);
+          const release = clamp(Number(p.release || 3.0), 2.2, 4.0);
+          const wobble = clamp(Number(p.wobble || 0.05), 0, 0.12);
+          const drift = clamp(Number(p.drift || 0.01), 0, 0.025);
+          const brightness = clamp(Number(p.brightness || 0.2), 0, 0.35);
+          const partials = [1, 2.01, 2.98];
+          partials.forEach((r, i) => {
+            this.scheduleTone(ctx, destination, atTime + i * 0.018, duration, {
+              from: f0 * r * (1 + drift), to: f0 * r * (0.985 - wobble * 0.05),
+              peak: (0.01 + intensity * 0.018) * (0.95 - i * 0.28), type: i === 0 ? 'sine' : 'triangle', pan: -0.04 + i * 0.08,
+              env: { attack: attack * (1 + i * 0.06), hold: duration * 0.36, release: release * (0.95 - i * 0.08), tail: 0.55 }
+            });
           });
-          this.scheduleTone(ctx, destination, atTime + 0.015, duration * 0.96, {
-            from: f0 * 2.01 * (1 + wobble * 0.03), to: f0 * 2.0, peak: (0.006 + intensity * 0.012) * (0.55 + brightness), type: 'triangle', pan: -0.08,
-            env: { attack: attack * 0.85, hold: duration * 0.3, release: release * 0.92, tail: 0.5 }
-          });
-          this.scheduleTone(ctx, destination, atTime + 0.03, duration * 0.9, {
-            from: f0 * 3.02, to: f0 * (2.95 - wobble * 0.2), peak: (0.003 + intensity * 0.007) * (0.35 + brightness), type: 'sine', pan: 0.06,
-            env: { attack: attack * 0.8, hold: duration * 0.24, release: release * 0.8, tail: 0.45 }
-          });
-          this.scheduleNoise(ctx, destination, atTime + 0.04, duration * 0.86, {
-            freq: 320, q: 0.68, peak: (0.002 + intensity * 0.005) * (0.45 + brightness), filterType: 'bandpass', pan: 0.03,
-            env: { attack: attack * 0.9, hold: duration * 0.25, release: release * 0.72, tail: 0.3 }
+          this.scheduleNoise(ctx, destination, atTime + 0.03, duration * 0.86, {
+            freq: 290 + brightness * 180, q: 0.66, peak: 0.0018 + intensity * 0.0035, filterType: 'bandpass', pan: 0.02,
+            env: { attack: attack * 0.95, hold: duration * 0.28, release: release * 0.75, tail: 0.3 }
           });
           break;
         }
@@ -641,36 +619,6 @@
           this.scheduleNoise(ctx, destination, atTime, Math.max(0.2, duration * 0.4), { freq: 220, q: 0.65, peak: 0.018 + intensity * 0.03, filterType: 'lowpass', pan: -0.03 });
           this.scheduleTone(ctx, destination, atTime, Math.max(0.28, duration * 0.55), { from: 54, to: 40, peak: 0.02 + intensity * 0.032, type: 'sine', pan: 0.02 });
           this.scheduleNoise(ctx, destination, atTime + 0.06, Math.max(0.25, duration * 0.45), { freq: 880, q: 0.8, peak: 0.005 + intensity * 0.01, filterType: 'bandpass', pan: 0.06 });
-          break;
-        }
-        case 'planetarium_hum': {
-          this.scheduleTone(ctx, destination, atTime, duration, {
-            from: 88, to: 94, peak: 0.007 + intensity * 0.013, type: 'sine', pan: -0.02,
-            env: { attack: 0.35, hold: duration * 0.44, release: 2, tail: 0.5 }
-          });
-          this.scheduleTone(ctx, destination, atTime + 0.04, duration * 0.96, {
-            from: 126, to: 121, peak: 0.003 + intensity * 0.007, type: 'triangle', pan: 0.04,
-            env: { attack: 0.3, hold: duration * 0.35, release: 1.8, tail: 0.35 }
-          });
-          this.scheduleNoise(ctx, destination, atTime, duration, {
-            freq: 740, q: 0.52, peak: 0.003 + intensity * 0.009, filterType: 'lowpass', pan: 0.02,
-            env: { attack: 0.4, hold: duration * 0.42, release: 2.1, tail: 0.4 }
-          });
-          break;
-        }
-        case 'planetarium_chime': {
-          this.scheduleTone(ctx, destination, atTime, Math.max(0.16, duration * 0.75), {
-            from: 932, to: 690, peak: 0.004 + intensity * 0.008, type: 'triangle', pan: 0.08,
-            env: { attack: 0.08, hold: 0.18, release: 1.4, tail: 0.2 }
-          });
-          this.scheduleTone(ctx, destination, atTime + 0.04, Math.max(0.14, duration * 0.68), {
-            from: 1188, to: 860, peak: 0.003 + intensity * 0.006, type: 'sine', pan: -0.07,
-            env: { attack: 0.07, hold: 0.16, release: 1.2, tail: 0.2 }
-          });
-          this.scheduleNoise(ctx, destination, atTime + 0.03, Math.max(0.15, duration * 0.6), {
-            freq: 2600, q: 1.1, peak: 0.001 + intensity * 0.0025, filterType: 'bandpass', pan: 0,
-            env: { attack: 0.05, hold: 0.08, release: 0.9, tail: 0.15 }
-          });
           break;
         }
 
@@ -705,7 +653,7 @@
       if (e === 'seabus_horn') return 2.2;
       if (e === 'church_bells') return 4.8;
       if (e === 'gastown_clock_whistle') return 2.1;
-      if (e === 'planetarium_hum' || BED_ENGINES.has(e)) return 2.4;
+      if (BED_ENGINES.has(e)) return 2.8;
       return 0.8;
     }
 

--- a/js/asmr-lab.js
+++ b/js/asmr-lab.js
@@ -26,8 +26,6 @@
 
 
   const LINKED_VISUAL_TO_AUDIO = {
-    ocean_surface_shimmer: ['ocean_waves'],
-    waterfront_scene: ['ocean_waves'],
     seabus_silhouette: ['seabus_horn'],
     rain_streaks: ['rain_ambience'],
     skytrain_pass_visual: ['skytrain_pass'],
@@ -35,7 +33,6 @@
   };
 
   const OPTIONAL_LINK_AUDIO = {
-    waterfront_scene: ['ocean_waves'],
     gastown_scene: ['gastown_clock_whistle']
   };
 

--- a/page-asmr-lab.php
+++ b/page-asmr-lab.php
@@ -47,8 +47,6 @@ get_header();
             <label><input type="checkbox" name="audio_layers[]" value="church_bells" /> church bells</label>
             <label><input type="checkbox" name="audio_layers[]" value="harbour_noon_horn" /> harbour noon horn</label>
             <label><input type="checkbox" name="audio_layers[]" value="nine_oclock_gun" /> 9 O'Clock Gun boom</label>
-            <label><input type="checkbox" name="audio_layers[]" value="planetarium_hum" /> planetarium hum</label>
-            <label><input type="checkbox" name="audio_layers[]" value="planetarium_chime" /> planetarium chime</label>
           </div>
         </div>
         <details class="asmr-motif-more">


### PR DESCRIPTION
### Motivation
- Eliminate inappropriate planetarium audio and accidental ocean audio coupling so visuals can remain visual-only and ocean sound only appears when explicitly selected. 
- Stop the early “all motifs” burst that flattens story arcs and instead stage selected visual motifs across story beats to preserve narrative pacing. 
- Make Vancouver signature sounds more recognizably local and ASMR-friendly by improving the actual browser synth recipes for horns, bells, and beds. 

### Description
- Removed planetarium audio tokens (`planetarium_hum`, `planetarium_chime`) from the UI, allowlists, visual→audio maps, OpenAI prompt guidance, and the foley engine, while keeping planetarium visuals (`planetarium_dome`, `starfield_projection`, `constellation_lines`) visual-only; changes in `page-asmr-lab.php`, `functions.php`, and `js/asmr-foley-engine.js`. 
- Stopped automatic ocean audio coupling by removing mappings that added `ocean_waves` from `ocean_surface_shimmer` / `waterfront_scene` in both frontend linking (`js/asmr-lab.js`) and backend maps (`functions.php`), so `ocean_waves` is present only when selected in `audio_layers[]`. 
- Replaced the aggressive deterministic injection with a repair-oriented, beat-aware staging helper `se_stage_selected_visual_motifs($visual_layers, $runtime, $story_beats)` and updated `se_inject_asmr_vancouver_anchors` to dedupe against OpenAI output and inject only missing motifs into four windows (Opening / Arrival / Lift / Resolve), ensuring one readable scene/landmark appears early (t ≤ 0.6s). (All changes in `functions.php`.) 
- Updated the OpenAI `system_prompt` to request a calm ASMR arc, longer beds, sparse sustained signature cues, distribution of reveals across runtime, and explicit planetarium-visual-only behavior. (`functions.php`) 
- Improved synth recipes and bed behavior in `js/asmr-foley-engine.js` to make signature Vancouver sounds longer/softer and more ASMR: revised `gastown_clock_whistle`, `harbour_noon_horn`, `church_bells`, `seabus_horn`, smoothed `ocean_waves` tail/foam behavior, and tuned envelopes/tails for bed-like engines. 

### Testing
- Ran `node --check js/asmr-lab.js` and it passed with no syntax errors. 
- Ran `node --check js/asmr-foley-engine.js` and it passed with no syntax errors. 
- Ran `php -l functions.php` and `php -l page-asmr-lab.php` and both returned no syntax errors. 
- Attempted a UI capture via Playwright (to validate front-end rendering) but `http://localhost:8080` returned `ERR_EMPTY_RESPONSE`, so the runtime endpoint was unreachable and the screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0b005eae0832e82318ab39179973e)