### PR TITLE
Reduce ASMR Lab motif stickiness and tighten compiler grounding

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1245,9 +1245,7 @@ function se_get_asmr_visual_to_audio_map() {
     return array(
         'seabus_silhouette' => array( 'seabus_horn' ),
         'skytrain_pass_visual' => array( 'skytrain_pass' ),
-        'bus_pass_visual' => array( 'bus_pass' ),
         'rain_streaks' => array( 'rain_ambience' ),
-        'gastown_scene' => array( 'gastown_clock_whistle' ),
     );
 }
 
@@ -1296,11 +1294,7 @@ function se_get_asmr_mapped_visual_layers_from_audio( $audio_layers ) {
 function se_get_asmr_vancouver_derived_payload( $payload ) {
     $audio_layers = array_values( array_filter( array_map( 'sanitize_key', (array) ( $payload['audio_layers'] ?? array() ) ) ) );
     $visual_layers = array_values( array_filter( array_map( 'sanitize_key', (array) ( $payload['visual_layers'] ?? array() ) ) ) );
-    if ( empty( $visual_layers ) ) {
-        $visual_layers = array( 'waterfront_scene', 'harbor_mist', 'ocean_surface_shimmer' );
-    }
-
-    $motif_line = implode( ' + ', $visual_layers );
+    $motif_line = empty( $visual_layers ) ? 'unselected motif rack' : implode( ' + ', $visual_layers );
     $foley_text = empty( $audio_layers ) ? 'soft civic ambience' : implode( ', ', $audio_layers );
     $payload['concept'] = sprintf( 'Vancouver Motif Stack: %s', $motif_line );
     $payload['object'] = 'city motif rack';
@@ -1403,14 +1397,8 @@ function se_inject_asmr_vancouver_anchors( $decoded, $payload ) {
             }
         }
         $audio_layers = array_values( array_unique( $audio_layers ) );
-        $visual_layers = array_values( array_unique( array_merge( $visual_layers, se_get_asmr_mapped_visual_layers_from_audio( $audio_layers ) ) ) );
     }
 
-    foreach ( se_get_asmr_scene_visual_support_map() as $scene => $support_visuals ) {
-        if ( in_array( $scene, $visual_layers, true ) ) {
-            $visual_layers = array_values( array_unique( array_merge( $visual_layers, $support_visuals ) ) );
-        }
-    }
 
     $runtime = max( 10, min( 30, floatval( $decoded['runtime_seconds'] ?? 20 ) ) );
     $audio = is_array( $decoded['audio_events'] ?? null ) ? $decoded['audio_events'] : array();
@@ -1506,7 +1494,7 @@ function se_inject_asmr_vancouver_anchors( $decoded, $payload ) {
     usort( $audio, static function( $a, $b ) { return (float) ( $a['time'] ?? 0 ) <=> (float) ( $b['time'] ?? 0 ); } );
     usort( $visual, static function( $a, $b ) { return (float) ( $a['time'] ?? 0 ) <=> (float) ( $b['time'] ?? 0 ); } );
 
-    $decoded['style_tags'] = array_values( array_unique( array_merge( (array) ( $decoded['style_tags'] ?? array() ), array( 'retro_arcade_crt' ), $audio_layers, $visual_layers ) ) );
+    $decoded['style_tags'] = se_build_asmr_style_tags( $decoded, array( 'retro_arcade_crt', 'beat_compiled' ) );
     $decoded['audio_events'] = $audio;
     $decoded['visual_events'] = $visual;
     $decoded['presentation_note'] = 'Motif-repair injection: OpenAI composes the story arc, deterministic pass only ensures selected motif presence and readability.';
@@ -1537,6 +1525,85 @@ function se_get_asmr_default_story_beats( $runtime ) {
     );
 }
 
+
+function se_pick_random_from_allowed( $candidates, $allowed ) {
+    $pool = array_values( array_intersect( array_map( 'sanitize_key', (array) $candidates ), array_map( 'sanitize_key', (array) $allowed ) ) );
+    if ( empty( $pool ) ) {
+        return '';
+    }
+    shuffle( $pool );
+    return $pool[0];
+}
+
+function se_restrict_generation_plan_to_selected_motifs( $plan, $audio_layers, $visual_layers ) {
+    $plan = is_array( $plan ) ? $plan : array();
+    $plan['visual_plan'] = is_array( $plan['visual_plan'] ?? null ) ? $plan['visual_plan'] : array();
+    $plan['audio_plan'] = is_array( $plan['audio_plan'] ?? null ) ? $plan['audio_plan'] : array();
+
+    $selected_audio = array_values( array_unique( array_map( 'sanitize_key', (array) $audio_layers ) ) );
+    $selected_visual = array_values( array_unique( array_map( 'sanitize_key', (array) $visual_layers ) ) );
+
+    $visual_slots = array( 'primary_scene', 'landmark', 'motion' );
+    foreach ( $visual_slots as $slot ) {
+        $candidate = sanitize_key( $plan['visual_plan'][ $slot ] ?? '' );
+        $plan['visual_plan'][ $slot ] = in_array( $candidate, $selected_visual, true ) ? $candidate : '';
+    }
+
+    foreach ( array( 'atmosphere', 'texture', 'overlay_family' ) as $slot ) {
+        $candidate = sanitize_key( $plan['visual_plan'][ $slot ] ?? '' );
+        $plan['visual_plan'][ $slot ] = in_array( $candidate, $selected_visual, true ) ? $candidate : '';
+    }
+
+    $hero_scene_pool = array_values( array_intersect( $selected_visual, se_get_asmr_visual_hero_types() ) );
+    if ( empty( $plan['visual_plan']['primary_scene'] ) ) {
+        $plan['visual_plan']['primary_scene'] = se_pick_random_from_allowed( $hero_scene_pool, $hero_scene_pool );
+    }
+    if ( empty( $plan['visual_plan']['landmark'] ) ) {
+        $plan['visual_plan']['landmark'] = se_pick_random_from_allowed( $hero_scene_pool, $hero_scene_pool );
+    }
+
+    $audio_slots = array( 'primary_bed', 'secondary_bed', 'transit_cue' );
+    foreach ( $audio_slots as $slot ) {
+        $candidate = sanitize_key( $plan['audio_plan'][ $slot ] ?? '' );
+        $plan['audio_plan'][ $slot ] = in_array( $candidate, $selected_audio, true ) ? $candidate : '';
+    }
+
+    $signature = array_slice( array_values( array_filter( array_map( 'sanitize_key', (array) ( $plan['audio_plan']['signature_cues'] ?? array() ) ) ) ), 0, 3 );
+    $plan['audio_plan']['signature_cues'] = array_values( array_intersect( $signature, $selected_audio ) );
+
+    if ( empty( $plan['audio_plan']['primary_bed'] ) && ! empty( $selected_audio ) ) {
+        $plan['audio_plan']['primary_bed'] = se_pick_random_from_allowed( $selected_audio, $selected_audio );
+    }
+
+    return $plan;
+}
+
+function se_build_asmr_style_tags( $decoded, $base_tags = array() ) {
+    $base = array_values( array_filter( array_map( 'sanitize_key', (array) $base_tags ) ) );
+    $existing = array_values( array_filter( array_map( 'sanitize_key', (array) ( $decoded['style_tags'] ?? array() ) ) ) );
+    $broad_allowed = array( 'atmospheric', 'cinematic', 'coastal', 'urban_night', 'retro_arcade_crt', 'beat_compiled' );
+    $broad = array_values( array_intersect( $existing, $broad_allowed ) );
+
+    $plan = is_array( $decoded['generation_plan'] ?? null ) ? $decoded['generation_plan'] : array();
+    $visual_plan = is_array( $plan['visual_plan'] ?? null ) ? $plan['visual_plan'] : array();
+    $audio_plan = is_array( $plan['audio_plan'] ?? null ) ? $plan['audio_plan'] : array();
+
+    $hero = array();
+    foreach ( array( 'primary_scene', 'landmark' ) as $slot ) {
+        $token = sanitize_key( $visual_plan[ $slot ] ?? '' );
+        if ( $token ) {
+            $hero[] = $token;
+        }
+    }
+    $primary_bed = sanitize_key( $audio_plan['primary_bed'] ?? '' );
+    if ( $primary_bed ) {
+        $hero[] = $primary_bed;
+    }
+
+    $hero = array_slice( array_values( array_unique( $hero ) ), 0, 2 );
+    return array_values( array_unique( array_merge( $base, $broad, $hero ) ) );
+}
+
 function se_compile_visual_events_from_plan( $plan, $runtime ) {
     $runtime = max( 10, min( 30, floatval( $runtime ) ) );
     $hero_types = se_get_asmr_visual_hero_types();
@@ -1551,9 +1618,6 @@ function se_compile_visual_events_from_plan( $plan, $runtime ) {
     $overlay = sanitize_key( $visual_plan['overlay_family'] ?? '' );
 
     $events = array();
-    if ( ! $primary_scene ) { $primary_scene = 'waterfront_scene'; }
-    if ( ! $atmosphere ) { $atmosphere = 'harbor_mist'; }
-    if ( ! $motion ) { $motion = 'gull_silhouettes'; }
     if ( $atmosphere ) {
         $events[] = array( 'time' => 0.0, 'duration' => min( $runtime - 0.2, 7.6 ), 'visual_type' => $atmosphere, 'intensity' => 0.34, 'params' => array(), 'sync_role' => 'opening_atmosphere' );
     }
@@ -1589,10 +1653,6 @@ function se_compile_visual_events_from_plan( $plan, $runtime ) {
         $events[] = array( 'time' => 15.4, 'duration' => 4.1, 'visual_type' => $atmosphere, 'intensity' => 0.28, 'params' => array(), 'sync_role' => 'resolve_bed' );
     }
 
-    if ( 'gull_silhouettes' === $motion ) {
-        $events[] = array( 'time' => 12.8, 'duration' => 2.4, 'visual_type' => 'gull_silhouettes', 'intensity' => 0.24, 'params' => array(), 'sync_role' => 'support_motion' );
-    }
-
     usort( $events, static function( $a, $b ) { return (float) $a['time'] <=> (float) $b['time']; } );
     return $events;
 }
@@ -1606,8 +1666,6 @@ function se_compile_audio_events_from_plan( $plan, $runtime ) {
     $signature_cues = array_slice( array_values( array_filter( array_map( 'sanitize_key', (array) ( $audio_plan['signature_cues'] ?? array() ) ) ) ), 0, 3 );
 
     $events = array();
-    if ( ! $primary_bed ) { $primary_bed = 'ocean_waves'; }
-    if ( empty( $signature_cues ) ) { $signature_cues = array( 'seabus_horn' ); }
     if ( $primary_bed ) {
         $events[] = array( 'time' => 0.0, 'duration' => min( $runtime - 0.1, 16.8 ), 'engine' => $primary_bed, 'intensity' => 0.4, 'params' => array( 'fade_out' => 2.6 ), 'sync_role' => 'primary_bed' );
     }
@@ -1779,7 +1837,7 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
         $legacy_audio_layers[] = $legacy_audio_map[ $token ] ?? $token;
     }
 
-    $link_av = ! array_key_exists( 'link_av', $params ) || filter_var( $params['link_av'], FILTER_VALIDATE_BOOLEAN );
+    $link_av = array_key_exists( 'link_av', $params ) ? filter_var( $params['link_av'], FILTER_VALIDATE_BOOLEAN ) : false;
     $audio_layers = array_values( array_intersect( $allowed_audio, array_map( 'sanitize_key', (array) ( $params['audio_layers'] ?? array() ) ) ) );
     if ( empty( $audio_layers ) && ! empty( $legacy_audio_layers ) ) {
         $audio_layers = array_values( array_intersect( $allowed_audio, $legacy_audio_layers ) );
@@ -1855,6 +1913,7 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
 
     $runtime = max( 10, min( 30, absint( $decoded['runtime_seconds'] ?? $payload['duration'] ) ) );
     $plan = is_array( $decoded['generation_plan'] ?? null ) ? $decoded['generation_plan'] : array();
+    $plan = se_restrict_generation_plan_to_selected_motifs( $plan, $audio_layers, $visual_layers );
 
     $decoded['title'] = sanitize_text_field( $decoded['title'] ?? 'ASMR Lab Sequence' );
     $decoded['runtime_seconds'] = $runtime;
@@ -1862,7 +1921,7 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
     $decoded['concept_summary'] = sanitize_text_field( $decoded['concept_summary'] ?? 'Disciplined beat-driven structure.' );
     $decoded['logline'] = sanitize_text_field( $decoded['logline'] ?? ( $plan['logline'] ?? '' ) );
     $decoded['story_beats'] = is_array( $decoded['story_beats'] ?? null ) && count( $decoded['story_beats'] ) === 4 ? $decoded['story_beats'] : se_get_asmr_default_story_beats( $runtime );
-    $decoded['style_tags'] = array_values( array_unique( array_filter( array_merge( (array) ( $decoded['style_tags'] ?? array() ), array( 'retro_arcade_crt', 'beat_compiled' ), $audio_layers, $visual_layers ) ) ) );
+    $decoded['style_tags'] = se_build_asmr_style_tags( array_merge( $decoded, array( 'generation_plan' => $plan ) ), array( 'retro_arcade_crt', 'beat_compiled' ) );
     $decoded['audio_events'] = se_compile_audio_events_from_plan( $plan, $runtime );
     $decoded['visual_events'] = se_compile_visual_events_from_plan( $plan, $runtime );
     $decoded['sync_points'] = array(

--- a/js/asmr-lab.js
+++ b/js/asmr-lab.js
@@ -6,6 +6,7 @@
 
   const form = document.getElementById('asmr-lab-form');
   const statusEl = document.getElementById('asmr-status');
+  const debugStatusEl = document.getElementById('asmr-debug-status');
   const errorEl = document.getElementById('asmr-error');
   const resultsEl = document.getElementById('asmr-results');
   const previewBtn = document.getElementById('asmr-preview');
@@ -28,19 +29,7 @@
   const LINKED_VISUAL_TO_AUDIO = {
     seabus_silhouette: ['seabus_horn'],
     rain_streaks: ['rain_ambience'],
-    skytrain_pass_visual: ['skytrain_pass'],
-    gastown_scene: ['gastown_clock_whistle']
-  };
-
-  const OPTIONAL_LINK_AUDIO = {
-    gastown_scene: ['gastown_clock_whistle']
-  };
-
-  const SCENE_TO_SUPPORT_VISUALS = {
-    gastown_scene: ['gastown_clock_silhouette'],
-    granville_scene: ['puddle_reflections'],
-    north_shore_scene: ['mountain_mist_layers'],
-    waterfront_scene: ['ocean_surface_shimmer', 'seabus_silhouette']
+    skytrain_pass_visual: ['skytrain_pass']
   };
 
   function applyLayerLinking(audioLayers, visualLayers, isLinked) {
@@ -50,15 +39,8 @@
       return { audio_layers: Array.from(audioSet), visual_layers: Array.from(visualSet) };
     }
 
-    Object.entries(SCENE_TO_SUPPORT_VISUALS).forEach(([sceneToken, supportVisuals]) => {
-      if (!visualSet.has(sceneToken)) return;
-      supportVisuals.slice(0, 2).forEach((visualToken) => visualSet.add(visualToken));
-    });
-
     Object.entries(LINKED_VISUAL_TO_AUDIO).forEach(([visualToken, audioTokens]) => {
       if (!visualSet.has(visualToken)) return;
-      const isOptional = Object.prototype.hasOwnProperty.call(OPTIONAL_LINK_AUDIO, visualToken);
-      if (isOptional && !isLinked) return;
       audioTokens.forEach((audioToken) => audioSet.add(audioToken));
     });
 
@@ -149,11 +131,13 @@
     const beats = document.getElementById('asmr-beats');
     const storyBeats = document.getElementById('asmr-story-beats');
     const prompts = document.getElementById('asmr-video-prompts');
+    const activePlan = document.getElementById('asmr-active-plan');
     const edit = document.getElementById('asmr-edit-notes');
     const note = document.getElementById('asmr-presentation');
     const recipe = document.getElementById('asmr-sound-json');
 
-    if (concept) concept.textContent = `${data.title} (${data.runtime_seconds}s) — ${data.hook}\n${data.concept_summary}`;
+    if (concept) concept.textContent = `${data.title} (${data.runtime_seconds}s) — ${data.hook}
+${data.concept_summary}`;
     if (storyBeats) {
       storyBeats.innerHTML = '';
       const labelOrder = ['Opening', 'Arrival', 'Lift', 'Resolve'];
@@ -165,19 +149,27 @@
         li.textContent = `${label} (${t0}s–${t1}s): ${beat.intent || beat.beat || ''}`.trim();
         storyBeats.appendChild(li);
       });
+    }
 
+    if (activePlan) {
+      activePlan.innerHTML = '';
       const plan = data.generation_plan || {};
       const vPlan = plan.visual_plan || {};
       const aPlan = plan.audio_plan || {};
-      const summary = [
+      const planRows = [
         `Primary scene: ${vPlan.primary_scene || '—'}`,
         `Landmark: ${vPlan.landmark || '—'}`,
+        `Motion: ${vPlan.motion || '—'}`,
+        `Primary bed: ${aPlan.primary_bed || '—'}`,
         `Signature cues: ${Array.isArray(aPlan.signature_cues) && aPlan.signature_cues.length ? aPlan.signature_cues.join(', ') : '—'}`
       ];
-      const li = document.createElement('li');
-      li.textContent = summary.join(' · ');
-      storyBeats.appendChild(li);
+      planRows.forEach((row) => {
+        const li = document.createElement('li');
+        li.textContent = row;
+        activePlan.appendChild(li);
+      });
     }
+
     toList(beats, data.sync_points || []);
     toList(prompts, data.style_tags || []);
     if (edit) {
@@ -200,6 +192,13 @@
     });
   }
 
+
+  function setDebugStatus(payload) {
+    if (!debugStatusEl) return;
+    const audioCount = Array.isArray(payload.audio_layers) ? payload.audio_layers.length : 0;
+    const visualCount = Array.isArray(payload.visual_layers) ? payload.visual_layers.length : 0;
+    debugStatusEl.textContent = `Selection snapshot: audio=${audioCount}, visual=${visualCount}, link_av=${payload.link_av ? 'on' : 'off'}`;
+  }
 
   function collectFormPayload() {
     const formData = new FormData(form);
@@ -411,6 +410,7 @@
     form.addEventListener('submit', async (event) => {
       event.preventDefault();
       lastPayload = collectFormPayload();
+      setDebugStatus(lastPayload);
       try { renderData(await requestGeneration(lastPayload)); }
       catch (err) { setError(err.message || 'Generation failed.'); setStatus(''); }
     });

--- a/page-asmr-lab.php
+++ b/page-asmr-lab.php
@@ -34,11 +34,11 @@ get_header();
           <h3>Core Modules</h3>
           <div class="asmr-motif-grid">
             <label><input type="checkbox" name="audio_layers[]" value="rain_ambience" /> rain ambience bed</label>
-            <label><input type="checkbox" name="audio_layers[]" value="ocean_waves" checked /> ocean waves bed</label>
+            <label><input type="checkbox" name="audio_layers[]" value="ocean_waves" /> ocean waves bed</label>
             <label><input type="checkbox" name="audio_layers[]" value="wind_gust" /> wind gust</label>
             <label><input type="checkbox" name="audio_layers[]" value="footsteps" /> footsteps</label>
             <label><input type="checkbox" name="audio_layers[]" value="skytrain_pass" /> SkyTrain pass</label>
-            <label><input type="checkbox" name="audio_layers[]" value="seabus_horn" checked /> SeaBus horn</label>
+            <label><input type="checkbox" name="audio_layers[]" value="seabus_horn" /> SeaBus horn</label>
             <label><input type="checkbox" name="audio_layers[]" value="crowd_murmur" /> crowd murmur</label>
             <label><input type="checkbox" name="audio_layers[]" value="steam_clock" /> steam clock</label>
             <label><input type="checkbox" name="audio_layers[]" value="bike_bell" /> bike bell</label>
@@ -72,22 +72,22 @@ get_header();
           <div class="asmr-motif-grid">
             <label><input type="checkbox" name="visual_layers[]" value="rain_streaks" /> rain streaks</label>
             <label><input type="checkbox" name="visual_layers[]" value="snow_drift" /> snow drift</label>
-            <label><input type="checkbox" name="visual_layers[]" value="harbor_mist" checked /> harbor mist</label>
+            <label><input type="checkbox" name="visual_layers[]" value="harbor_mist" /> harbor mist</label>
             <label><input type="checkbox" name="visual_layers[]" value="gastown_scene" /> Gastown scene</label>
             <label><input type="checkbox" name="visual_layers[]" value="granville_scene" /> Granville scene</label>
             <label><input type="checkbox" name="visual_layers[]" value="north_shore_scene" /> North Shore scene</label>
-            <label><input type="checkbox" name="visual_layers[]" value="waterfront_scene" checked /> Waterfront scene</label>
+            <label><input type="checkbox" name="visual_layers[]" value="waterfront_scene" /> Waterfront scene</label>
             <label><input type="checkbox" name="visual_layers[]" value="science_world_dome" /> Science World dome</label>
             <label><input type="checkbox" name="visual_layers[]" value="chinatown_gate" /> Chinatown gate</label>
-            <label><input type="checkbox" name="visual_layers[]" value="lions_gate_bridge" checked /> Lions Gate Bridge</label>
+            <label><input type="checkbox" name="visual_layers[]" value="lions_gate_bridge" /> Lions Gate Bridge</label>
             <label><input type="checkbox" name="visual_layers[]" value="planetarium_dome" /> Planetarium dome</label>
             <label><input type="checkbox" name="visual_layers[]" value="starfield_projection" /> starfield projection</label>
             <label><input type="checkbox" name="visual_layers[]" value="puddle_reflections" /> puddle reflections</label>
             <label><input type="checkbox" name="visual_layers[]" value="neon_sign_flicker" /> neon sign flicker</label>
             <label><input type="checkbox" name="visual_layers[]" value="scanline_field" /> scanline field</label>
             <label><input type="checkbox" name="visual_layers[]" value="skytrain_pass_visual" /> SkyTrain pass visual</label>
-            <label><input type="checkbox" name="visual_layers[]" value="ocean_surface_shimmer" checked /> ocean surface shimmer</label>
-            <label><input type="checkbox" name="visual_layers[]" value="seabus_silhouette" checked /> SeaBus silhouette</label>
+            <label><input type="checkbox" name="visual_layers[]" value="ocean_surface_shimmer" /> ocean surface shimmer</label>
+            <label><input type="checkbox" name="visual_layers[]" value="seabus_silhouette" /> SeaBus silhouette</label>
           </div>
         </div>
         <details class="asmr-motif-more">
@@ -115,13 +115,14 @@ get_header();
         </details>
       </fieldset>
 
-      <label class="asmr-link-toggle"><input type="checkbox" name="link_av" checked /> Link sound + visual for selected motifs</label>
+      <label class="asmr-link-toggle"><input type="checkbox" name="link_av" /> Link sound + visual for selected motifs</label>
       <div class="asmr-actions">
         <button type="submit" class="pixel-button">Generate ASMR Package</button>
         <button type="button" id="asmr-qa-preset" class="pixel-button secondary">Load QA Preset</button>
         <button type="button" id="asmr-sound-only" class="pixel-button secondary" disabled>Regenerate Sound Only</button>
       </div>
       <p id="asmr-status" class="asmr-status" role="status" aria-live="polite"></p>
+      <p id="asmr-debug-status" class="asmr-status asmr-debug-status" aria-live="polite"></p>
       <p id="asmr-error" class="asmr-error" role="alert" hidden></p>
     </form>
 
@@ -149,6 +150,7 @@ get_header();
       <article class="asmr-card"><h2>Story Beats</h2><ol id="asmr-story-beats"></ol></article>
       <article class="asmr-card"><h2>Sync Points</h2><ol id="asmr-beats"></ol></article>
       <article class="asmr-card"><h2>Style Tags</h2><ul id="asmr-video-prompts"></ul></article>
+      <article class="asmr-card"><h2>Active Generation Plan</h2><ul id="asmr-active-plan"></ul></article>
       <article class="asmr-card"><h2>Edit Rhythm</h2><p id="asmr-edit-notes"></p></article>
       <article class="asmr-card"><h2>Presentation Note</h2><p id="asmr-presentation"></p></article>
       <article class="asmr-card"><h2>Timeline JSON</h2>


### PR DESCRIPTION
### Motivation
- Address recurring waterfront/SeaBus/Lions Gate bias caused by sticky UI defaults, aggressive link coupling, and hardcoded compiler fallbacks so generations reflect current user selections and plan content. 
- Make `link_av` truly optional and ensure QA preset is explicit and isolated so normal page load is neutral.

### Description
- UI: removed `checked` from all `audio_layers[]` and `visual_layers[]` checkboxes and made `link_av` unchecked by default, kept `duration=20`, and added a debug line `#asmr-debug-status` plus an “Active Generation Plan” block `#asmr-active-plan` to the results. (`page-asmr-lab.php`)
- Frontend logic: weakened `applyLayerLinking()` to only add a tiny explicit visual→audio map (`seabus_silhouette`, `skytrain_pass_visual`, `rain_streaks`) and removed scene→support auto-expansion; added `setDebugStatus()` to display selected audio/visual counts and `link_av` state; render the active `generation_plan` summary after generation; QA preset remains button-triggered only. (`js/asmr-lab.js`)
- Server/compiler: removed hardcoded fallback motifs from `se_compile_visual_events_from_plan()` and `se_compile_audio_events_from_plan()` (no default `waterfront_scene`, `harbor_mist`, `gull_silhouettes`, `ocean_waves`, or `seabus_horn` substitutions), stopped automatic expansion of scene support visuals and aggressive audio/visual mapping, and made backend `link_av` default to false unless provided. (`functions.php`)
- Grounding & variation: added `se_restrict_generation_plan_to_selected_motifs($plan, $audio_layers, $visual_layers)` and lightweight randomization via `se_pick_random_from_allowed()` to ensure hero/audio slots come only from the current selected rack (and vary when multiple choices are selected). (`functions.php`)
- Style tags: replaced bulk-merging of selected layers into `style_tags` with `se_build_asmr_style_tags()` that outputs broad tone tags plus up to two hero motifs, preventing style_tags from becoming a full inventory dump. (`functions.php`)

### Testing
- Ran `node --check js/asmr-lab.js` and it returned no syntax errors. (success)
- Ran `php -l functions.php` and it returned no syntax errors. (success)
- Ran `php -l page-asmr-lab.php` and it returned no syntax errors. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0c5b8ad64832eb720ea3265fc78dd)