### PR TITLE
Refactor ASMR visual atlas, debug provenance, and plan/render alignment

### DIFF
--- a/assets/css/asmr-lab.css
+++ b/assets/css/asmr-lab.css
@@ -42,3 +42,13 @@
 
 .asmr-card ol{margin:.2rem 0 .2rem 1.15rem;padding:0}
 .asmr-card ol li{margin:.25rem 0;line-height:1.45}
+
+.asmr-debug-atlas{margin-top:1rem;border:1px solid #33437f;border-radius:8px;padding:.8rem;background:#0c1226}
+.asmr-debug-atlas summary{cursor:pointer;color:#9ec0ff;font-size:.9rem}
+.asmr-debug-copy{font-size:.8rem;color:#b8ccff}
+.asmr-debug-actions{display:flex;gap:.7rem;align-items:center;flex-wrap:wrap;margin:.6rem 0}
+.asmr-debug-toggle{display:flex;align-items:center;gap:.45rem;font-size:.8rem}
+.asmr-visual-atlas-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(230px,1fr));gap:.6rem}
+.asmr-atlas-card{border:1px solid #2f3f73;border-radius:8px;background:#0a1022;padding:.55rem}
+.asmr-atlas-card h4{margin:.1rem 0 .25rem;color:#c6dcff;font-size:.86rem}
+.asmr-atlas-card p{margin:.15rem 0;font-size:.76rem;line-height:1.35}

--- a/functions.php
+++ b/functions.php
@@ -172,6 +172,7 @@ function se_enqueue_asmr_lab_assets() {
             array(
                 'endpoint' => esc_url_raw( rest_url( 'se/v1/asmr-generate' ) ),
                 'nonce'    => wp_create_nonce( 'wp_rest' ),
+                'visualRegistry' => se_get_asmr_visual_registry(),
             )
         );
     }
@@ -915,54 +916,100 @@ function se_get_asmr_allowed_engines() {
     );
 }
 
-function se_get_asmr_visual_types() {
-    return array(
-        'scanline_field', 'pixel_grid_pulse', 'wireframe_horizon', 'radial_bloom', 'particle_trail',
-        'glitch_flash', 'waveform_ring', 'macro_texture_drift', 'signal_bars', 'text_reveal',
-        'volumetric_fog', 'glass_refraction', 'halo_glyphs', 'cathedral_beam', 'monolith_silhouette',
-        'starfield_drift', 'orbiting_shards', 'pulse_orb', 'energy_column', 'refraction_ripple',
-        'chromatic_veil', 'terminal_runes', 'snow_drift', 'amber_halo', 'wet_reflection_shimmer',
-        'brick_shadow_drift', 'steam_plume_column', 'clock_face_reveal', 'harbor_mist',
-        'neon_wet_reflections', 'winter_particulate_depth',
-        'gastown_clock_silhouette', 'cobblestone_perspective', 'brick_wall_parallax', 'streetlamp_halo_row',
-        'granville_neon_marquee', 'neon_sign_flicker', 'traffic_light_glow',
-        'skytrain_track', 'skytrain_pass_visual', 'bus_pass_visual',
-        'northshore_mountain_ridge', 'mountain_mist_layers',
-        'rain_streaks', 'puddle_reflections',
-        'science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof',
-        'lions_gate_bridge', 'bc_place_dome', 'port_cranes',
-        'planetarium_dome', 'starfield_projection', 'constellation_lines', 'canada_place_sails',
-        'gastown_scene', 'granville_scene', 'north_shore_scene', 'waterfront_scene', 'clear_cold_shimmer', 'ocean_surface_shimmer', 'seabus_silhouette', 'gull_silhouettes',
+function se_get_asmr_visual_registry() {
+    static $registry = null;
+    if ( null !== $registry ) {
+        return $registry;
+    }
+
+    $registry = array(
+        array( 'id' => 'scanline_field', 'label' => 'Scanline Field', 'category' => 'support', 'priority' => 'support', 'description' => 'CRT line drift overlay.', 'expected_shape' => 'horizontal scan lines', 'renderer' => 'drawScanlineField', 'intensity_min' => 0.08, 'intensity_max' => 0.4, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'pixel_grid_pulse', 'label' => 'Pixel Grid Pulse', 'category' => 'support', 'priority' => 'support', 'description' => 'Retro pixel grid pulse.', 'expected_shape' => 'small grid cells', 'renderer' => 'drawPixelGridPulse', 'intensity_min' => 0.1, 'intensity_max' => 0.35, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'wireframe_horizon', 'label' => 'Wireframe Horizon', 'category' => 'scene', 'priority' => 'support', 'description' => 'Perspective horizon lines.', 'expected_shape' => 'vanishing horizon fan', 'renderer' => 'drawWireframeHorizon', 'intensity_min' => 0.15, 'intensity_max' => 0.45, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'radial_bloom', 'label' => 'Radial Bloom', 'category' => 'atmosphere', 'priority' => 'support', 'description' => 'Soft center bloom.', 'expected_shape' => 'radial glow', 'renderer' => 'drawRadialBloom', 'intensity_min' => 0.15, 'intensity_max' => 0.45, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'particle_trail', 'label' => 'Particle Trail', 'category' => 'motion', 'priority' => 'support', 'description' => 'Moving particle points.', 'expected_shape' => 'drifting dots', 'renderer' => 'drawParticleTrail', 'intensity_min' => 0.2, 'intensity_max' => 0.6, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'glitch_flash', 'label' => 'Glitch Flash', 'category' => 'support', 'priority' => 'support', 'description' => 'Brief digital glitch streaks.', 'expected_shape' => 'horizontal flashes', 'renderer' => 'drawGlitchFlash', 'intensity_min' => 0.05, 'intensity_max' => 0.25, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'waveform_ring', 'label' => 'Waveform Ring', 'category' => 'motion', 'priority' => 'support', 'description' => 'Oscillating ring pulse.', 'expected_shape' => 'wobble ring', 'renderer' => 'drawWaveformRing', 'intensity_min' => 0.15, 'intensity_max' => 0.5, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'macro_texture_drift', 'label' => 'Macro Texture Drift', 'category' => 'texture', 'priority' => 'support', 'description' => 'Linear texture drift.', 'expected_shape' => 'short bars', 'renderer' => 'drawMacroTextureDrift', 'intensity_min' => 0.12, 'intensity_max' => 0.35, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'signal_bars', 'label' => 'Signal Bars', 'category' => 'support', 'priority' => 'support', 'description' => 'Diagnostic signal meter bars.', 'expected_shape' => 'small stacked bars', 'renderer' => 'drawSignalBars', 'intensity_min' => 0.05, 'intensity_max' => 0.2, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'text_reveal', 'label' => 'Text Reveal', 'category' => 'support', 'priority' => 'support', 'description' => 'Short terminal text reveal.', 'expected_shape' => 'single text block', 'renderer' => 'drawTextReveal', 'intensity_min' => 0.15, 'intensity_max' => 0.5, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'volumetric_fog', 'label' => 'Volumetric Fog', 'category' => 'atmosphere', 'priority' => 'support', 'description' => 'Layered fog drift.', 'expected_shape' => 'horizontal haze bands', 'renderer' => 'drawVolumetricFog', 'intensity_min' => 0.2, 'intensity_max' => 0.6, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'glass_refraction', 'label' => 'Glass Refraction', 'category' => 'texture', 'priority' => 'support', 'description' => 'Refraction contour lines.', 'expected_shape' => 'curved refractive lines', 'renderer' => 'drawGlassRefraction', 'intensity_min' => 0.15, 'intensity_max' => 0.5, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'halo_glyphs', 'label' => 'Halo Glyphs', 'category' => 'atmosphere', 'priority' => 'support', 'description' => 'Arc glyph halos.', 'expected_shape' => 'partial circular arcs', 'renderer' => 'drawHaloGlyphs', 'intensity_min' => 0.15, 'intensity_max' => 0.5, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'cathedral_beam', 'label' => 'Cathedral Beam', 'category' => 'atmosphere', 'priority' => 'support', 'description' => 'Focused light beam.', 'expected_shape' => 'vertical cone beam', 'renderer' => 'drawCathedralBeam', 'intensity_min' => 0.15, 'intensity_max' => 0.45, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'monolith_silhouette', 'label' => 'Monolith Silhouette', 'category' => 'scene', 'priority' => 'hero', 'description' => 'Large central monolith.', 'expected_shape' => 'single tall slab', 'renderer' => 'drawMonolithSilhouette', 'intensity_min' => 0.25, 'intensity_max' => 0.75, 'opening_hero' => true, 'support_only' => false ),
+        array( 'id' => 'starfield_drift', 'label' => 'Starfield Drift', 'category' => 'atmosphere', 'priority' => 'support', 'description' => 'Sparse moving stars.', 'expected_shape' => 'small drifting stars', 'renderer' => 'drawStarfieldDrift', 'intensity_min' => 0.08, 'intensity_max' => 0.3, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'orbiting_shards', 'label' => 'Orbiting Shards', 'category' => 'motion', 'priority' => 'support', 'description' => 'Orbiting shard fragments.', 'expected_shape' => 'angular orbit points', 'renderer' => 'drawOrbitingShards', 'intensity_min' => 0.15, 'intensity_max' => 0.5, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'pulse_orb', 'label' => 'Pulse Orb', 'category' => 'motion', 'priority' => 'support', 'description' => 'Core pulse orb.', 'expected_shape' => 'pulsing circle', 'renderer' => 'drawPulseOrb', 'intensity_min' => 0.2, 'intensity_max' => 0.58, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'energy_column', 'label' => 'Energy Column', 'category' => 'motion', 'priority' => 'support', 'description' => 'Energy column pulse.', 'expected_shape' => 'soft vertical beam', 'renderer' => 'drawEnergyColumn', 'intensity_min' => 0.2, 'intensity_max' => 0.55, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'refraction_ripple', 'label' => 'Refraction Ripple', 'category' => 'texture', 'priority' => 'support', 'description' => 'Ripple distortion rings.', 'expected_shape' => 'ripple circles', 'renderer' => 'drawRefractionRipple', 'intensity_min' => 0.15, 'intensity_max' => 0.45, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'chromatic_veil', 'label' => 'Chromatic Veil', 'category' => 'support', 'priority' => 'support', 'description' => 'Chromatic split veil.', 'expected_shape' => 'subtle RGB haze', 'renderer' => 'drawChromaticVeil', 'intensity_min' => 0.06, 'intensity_max' => 0.2, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'terminal_runes', 'label' => 'Terminal Runes', 'category' => 'texture', 'priority' => 'support', 'description' => 'Arcade rune marks.', 'expected_shape' => 'tiny glyph strokes', 'renderer' => 'drawTerminalRunes', 'intensity_min' => 0.1, 'intensity_max' => 0.35, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'snow_drift', 'label' => 'Snow Drift', 'category' => 'atmosphere', 'priority' => 'support', 'description' => 'Snow particles drifting.', 'expected_shape' => 'falling dots', 'renderer' => 'drawSnowDrift', 'intensity_min' => 0.25, 'intensity_max' => 0.7, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'amber_halo', 'label' => 'Amber Halo', 'category' => 'atmosphere', 'priority' => 'support', 'description' => 'Warm streetlight halos.', 'expected_shape' => 'amber glow circles', 'renderer' => 'drawAmberHalo', 'intensity_min' => 0.15, 'intensity_max' => 0.4, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'wet_reflection_shimmer', 'label' => 'Wet Reflection Shimmer', 'category' => 'texture', 'priority' => 'support', 'description' => 'Wet streak reflections.', 'expected_shape' => 'vertical reflection strips', 'renderer' => 'drawWetReflectionShimmer', 'intensity_min' => 0.15, 'intensity_max' => 0.45, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'brick_shadow_drift', 'label' => 'Brick Shadow Drift', 'category' => 'texture', 'priority' => 'support', 'description' => 'Brick shadow texture.', 'expected_shape' => 'brick-like side blocks', 'renderer' => 'drawBrickShadowDrift', 'intensity_min' => 0.12, 'intensity_max' => 0.38, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'steam_plume_column', 'label' => 'Steam Plume Column', 'category' => 'atmosphere', 'priority' => 'support', 'description' => 'Steam column plume.', 'expected_shape' => 'soft column mist', 'renderer' => 'drawSteamPlumeColumn', 'intensity_min' => 0.18, 'intensity_max' => 0.5, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'clock_face_reveal', 'label' => 'Clock Face Reveal', 'category' => 'landmark', 'priority' => 'hero', 'description' => 'Clock face reveal motif.', 'expected_shape' => 'round clock face', 'renderer' => 'drawClockFaceReveal', 'intensity_min' => 0.25, 'intensity_max' => 0.7, 'opening_hero' => true, 'support_only' => false ),
+        array( 'id' => 'harbor_mist', 'label' => 'Harbor Mist', 'category' => 'atmosphere', 'priority' => 'support', 'description' => 'Harbor fog sheet.', 'expected_shape' => 'layered mist rows', 'renderer' => 'drawHarborMist', 'intensity_min' => 0.2, 'intensity_max' => 0.6, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'neon_wet_reflections', 'label' => 'Neon Wet Reflections', 'category' => 'texture', 'priority' => 'support', 'description' => 'Neon wet pavement texture.', 'expected_shape' => 'glowing vertical puddles', 'renderer' => 'drawNeonWetReflections', 'intensity_min' => 0.2, 'intensity_max' => 0.55, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'winter_particulate_depth', 'label' => 'Winter Particulate Depth', 'category' => 'atmosphere', 'priority' => 'support', 'description' => 'Depth snow particles.', 'expected_shape' => 'layered snow points', 'renderer' => 'drawWinterParticulateDepth', 'intensity_min' => 0.2, 'intensity_max' => 0.62, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'gastown_clock_silhouette', 'label' => 'Gastown Clock', 'category' => 'landmark', 'priority' => 'hero', 'description' => 'Steam clock silhouette.', 'expected_shape' => 'clock post + face', 'renderer' => 'drawGastownClockSilhouette', 'intensity_min' => 0.35, 'intensity_max' => 0.8, 'opening_hero' => true, 'support_only' => false ),
+        array( 'id' => 'cobblestone_perspective', 'label' => 'Cobblestone Perspective', 'category' => 'texture', 'priority' => 'support', 'description' => 'Cobblestone lane texture.', 'expected_shape' => 'ground grid stones', 'renderer' => 'drawCobblestonePerspective', 'intensity_min' => 0.18, 'intensity_max' => 0.45, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'brick_wall_parallax', 'label' => 'Brick Wall Parallax', 'category' => 'texture', 'priority' => 'support', 'description' => 'Brick facade sides.', 'expected_shape' => 'left/right brick blocks', 'renderer' => 'drawBrickWallParallax', 'intensity_min' => 0.18, 'intensity_max' => 0.45, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'streetlamp_halo_row', 'label' => 'Streetlamp Halo Row', 'category' => 'atmosphere', 'priority' => 'support', 'description' => 'Streetlamp halo row.', 'expected_shape' => 'four halo circles', 'renderer' => 'drawStreetlampHaloRow', 'intensity_min' => 0.18, 'intensity_max' => 0.48, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'granville_neon_marquee', 'label' => 'Granville Neon Marquee', 'category' => 'scene', 'priority' => 'support', 'description' => 'Neon marquee slabs.', 'expected_shape' => 'vertical neon panels', 'renderer' => 'drawGranvilleNeonMarquee', 'intensity_min' => 0.18, 'intensity_max' => 0.48, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'neon_sign_flicker', 'label' => 'Neon Sign Flicker', 'category' => 'scene', 'priority' => 'support', 'description' => 'Neon strip flicker.', 'expected_shape' => 'horizontal neon bars', 'renderer' => 'drawNeonSignFlicker', 'intensity_min' => 0.18, 'intensity_max' => 0.5, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'traffic_light_glow', 'label' => 'Traffic Light Glow', 'category' => 'scene', 'priority' => 'support', 'description' => 'Traffic signal glow.', 'expected_shape' => 'three light halos', 'renderer' => 'drawTrafficLightGlow', 'intensity_min' => 0.15, 'intensity_max' => 0.45, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'skytrain_track', 'label' => 'SkyTrain Track', 'category' => 'motion', 'priority' => 'support', 'description' => 'Elevated track lines.', 'expected_shape' => 'dual horizontal track', 'renderer' => 'drawSkytrainTrack', 'intensity_min' => 0.2, 'intensity_max' => 0.55, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'skytrain_pass_visual', 'label' => 'SkyTrain Pass', 'category' => 'motion', 'priority' => 'hero', 'description' => 'SkyTrain car pass-through.', 'expected_shape' => 'moving train block', 'renderer' => 'drawSkytrainPassVisual', 'intensity_min' => 0.25, 'intensity_max' => 0.7, 'opening_hero' => true, 'support_only' => false ),
+        array( 'id' => 'bus_pass_visual', 'label' => 'Bus Pass', 'category' => 'motion', 'priority' => 'support', 'description' => 'Bus pass-through.', 'expected_shape' => 'moving bus block', 'renderer' => 'drawBusPassVisual', 'intensity_min' => 0.2, 'intensity_max' => 0.6, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'northshore_mountain_ridge', 'label' => 'North Shore Ridge', 'category' => 'scene', 'priority' => 'support', 'description' => 'North Shore mountain ridge.', 'expected_shape' => 'mountain silhouette ridge', 'renderer' => 'drawNorthshoreMountainRidge', 'intensity_min' => 0.22, 'intensity_max' => 0.62, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'mountain_mist_layers', 'label' => 'Mountain Mist Layers', 'category' => 'atmosphere', 'priority' => 'support', 'description' => 'Mist bands for mountain scene.', 'expected_shape' => 'layered mist bands', 'renderer' => 'drawMountainMistLayers', 'intensity_min' => 0.18, 'intensity_max' => 0.5, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'rain_streaks', 'label' => 'Rain Streaks', 'category' => 'atmosphere', 'priority' => 'support', 'description' => 'Diagonal rain lines.', 'expected_shape' => 'falling streaks', 'renderer' => 'drawRainStreaks', 'intensity_min' => 0.2, 'intensity_max' => 0.6, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'puddle_reflections', 'label' => 'Puddle Reflections', 'category' => 'texture', 'priority' => 'support', 'description' => 'Puddle neon reflections.', 'expected_shape' => 'vertical reflection pools', 'renderer' => 'drawPuddleReflections', 'intensity_min' => 0.18, 'intensity_max' => 0.5, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'science_world_dome', 'label' => 'Science World Dome', 'category' => 'landmark', 'priority' => 'hero', 'description' => 'Geodesic dome silhouette with lattice.', 'expected_shape' => 'dome arc + triangle lattice', 'renderer' => 'drawScienceWorldDome', 'intensity_min' => 0.35, 'intensity_max' => 0.85, 'opening_hero' => true, 'support_only' => false ),
+        array( 'id' => 'chinatown_gate', 'label' => 'Chinatown Gate', 'category' => 'landmark', 'priority' => 'hero', 'description' => 'Chinatown gate profile.', 'expected_shape' => 'two pillars + layered roof', 'renderer' => 'drawChinatownGate', 'intensity_min' => 0.3, 'intensity_max' => 0.8, 'opening_hero' => true, 'support_only' => false ),
+        array( 'id' => 'english_bay_inukshuk', 'label' => 'English Bay Inukshuk', 'category' => 'landmark', 'priority' => 'hero', 'description' => 'Stacked stone Inukshuk reveal.', 'expected_shape' => 'base + torso + arm stone + head', 'renderer' => 'drawEnglishBayInukshuk', 'intensity_min' => 0.35, 'intensity_max' => 0.88, 'opening_hero' => true, 'support_only' => false ),
+        array( 'id' => 'maritime_museum_sailroof', 'label' => 'Maritime Museum Sail Roof', 'category' => 'landmark', 'priority' => 'hero', 'description' => 'Sail roof gesture.', 'expected_shape' => 'arched sail roof line', 'renderer' => 'drawMaritimeMuseumSailroof', 'intensity_min' => 0.28, 'intensity_max' => 0.8, 'opening_hero' => true, 'support_only' => false ),
+        array( 'id' => 'lions_gate_bridge', 'label' => 'Lions Gate Bridge', 'category' => 'landmark', 'priority' => 'hero', 'description' => 'Suspension bridge silhouette with two towers, deck, top cable arc, and suspenders.', 'expected_shape' => 'two towers + deck + hanging cable lines', 'renderer' => 'drawLionsGateBridge', 'intensity_min' => 0.35, 'intensity_max' => 0.9, 'opening_hero' => true, 'support_only' => false ),
+        array( 'id' => 'bc_place_dome', 'label' => 'BC Place Dome', 'category' => 'landmark', 'priority' => 'hero', 'description' => 'Stadium dome spoked silhouette.', 'expected_shape' => 'low dome with radial spokes', 'renderer' => 'drawBCPlaceDome', 'intensity_min' => 0.3, 'intensity_max' => 0.8, 'opening_hero' => true, 'support_only' => false ),
+        array( 'id' => 'port_cranes', 'label' => 'Port Cranes', 'category' => 'landmark', 'priority' => 'hero', 'description' => 'Container crane row.', 'expected_shape' => 'angular crane arms', 'renderer' => 'drawPortCranes', 'intensity_min' => 0.28, 'intensity_max' => 0.75, 'opening_hero' => true, 'support_only' => false ),
+        array( 'id' => 'planetarium_dome', 'label' => 'Planetarium Dome', 'category' => 'landmark', 'priority' => 'hero', 'description' => 'Smooth observatory dome.', 'expected_shape' => 'smooth dome + low base', 'renderer' => 'drawPlanetariumDome', 'intensity_min' => 0.3, 'intensity_max' => 0.82, 'opening_hero' => true, 'support_only' => false ),
+        array( 'id' => 'starfield_projection', 'label' => 'Starfield Projection', 'category' => 'landmark', 'priority' => 'hero', 'description' => 'Planetarium star projection.', 'expected_shape' => 'dome projection arcs + stars', 'renderer' => 'drawStarfieldProjection', 'intensity_min' => 0.25, 'intensity_max' => 0.75, 'opening_hero' => true, 'support_only' => false ),
+        array( 'id' => 'constellation_lines', 'label' => 'Constellation Lines', 'category' => 'atmosphere', 'priority' => 'support', 'description' => 'Constellation line overlay.', 'expected_shape' => 'tiny connected stars', 'renderer' => 'drawConstellationLines', 'intensity_min' => 0.12, 'intensity_max' => 0.35, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'canada_place_sails', 'label' => 'Canada Place Sails', 'category' => 'landmark', 'priority' => 'hero', 'description' => 'Canada Place sail peaks.', 'expected_shape' => 'triangular sail peaks', 'renderer' => 'drawCanadaPlaceSails', 'intensity_min' => 0.28, 'intensity_max' => 0.78, 'opening_hero' => true, 'support_only' => false ),
+        array( 'id' => 'gastown_scene', 'label' => 'Gastown Scene', 'category' => 'scene', 'priority' => 'hero', 'description' => 'Gastown scene background stack.', 'expected_shape' => 'brick + cobblestone + clock support', 'renderer' => 'drawGastownScene', 'intensity_min' => 0.28, 'intensity_max' => 0.76, 'opening_hero' => true, 'support_only' => false ),
+        array( 'id' => 'granville_scene', 'label' => 'Granville Scene', 'category' => 'scene', 'priority' => 'hero', 'description' => 'Granville neon street scene.', 'expected_shape' => 'neon facades + reflections', 'renderer' => 'drawGranvilleScene', 'intensity_min' => 0.28, 'intensity_max' => 0.76, 'opening_hero' => true, 'support_only' => false ),
+        array( 'id' => 'north_shore_scene', 'label' => 'North Shore Scene', 'category' => 'scene', 'priority' => 'hero', 'description' => 'North Shore ridge and mist scene.', 'expected_shape' => 'ridge horizon + mist', 'renderer' => 'drawNorthShoreScene', 'intensity_min' => 0.3, 'intensity_max' => 0.8, 'opening_hero' => true, 'support_only' => false ),
+        array( 'id' => 'waterfront_scene', 'label' => 'Waterfront Scene', 'category' => 'scene', 'priority' => 'hero', 'description' => 'Waterfront horizon and harbor support.', 'expected_shape' => 'waterline + distant structures', 'renderer' => 'drawWaterfrontScene', 'intensity_min' => 0.28, 'intensity_max' => 0.8, 'opening_hero' => true, 'support_only' => false ),
+        array( 'id' => 'clear_cold_shimmer', 'label' => 'Clear Cold Shimmer', 'category' => 'atmosphere', 'priority' => 'support', 'description' => 'Cold air shimmer.', 'expected_shape' => 'soft cool haze', 'renderer' => 'drawClearColdShimmer', 'intensity_min' => 0.15, 'intensity_max' => 0.45, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'ocean_surface_shimmer', 'label' => 'Ocean Surface Shimmer', 'category' => 'texture', 'priority' => 'support', 'description' => 'Ocean highlight shimmer.', 'expected_shape' => 'horizontal sparkle strips', 'renderer' => 'drawOceanSurfaceShimmer', 'intensity_min' => 0.18, 'intensity_max' => 0.52, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'seabus_silhouette', 'label' => 'SeaBus Silhouette', 'category' => 'landmark', 'priority' => 'hero', 'description' => 'SeaBus vessel silhouette.', 'expected_shape' => 'low ferry hull', 'renderer' => 'drawSeabusSilhouette', 'intensity_min' => 0.28, 'intensity_max' => 0.76, 'opening_hero' => true, 'support_only' => false ),
+        array( 'id' => 'gull_silhouettes', 'label' => 'Gull Silhouettes', 'category' => 'motion', 'priority' => 'support', 'description' => 'Subtle gull V silhouettes.', 'expected_shape' => '2-4 small V arcs', 'renderer' => 'drawGullSilhouettes', 'intensity_min' => 0.06, 'intensity_max' => 0.2, 'opening_hero' => false, 'support_only' => true ),
     );
+
+    return $registry;
+}
+
+function se_get_asmr_visual_types() {
+    return array_values( array_map( static function( $item ) { return $item['id']; }, se_get_asmr_visual_registry() ) );
 }
 
 function se_get_asmr_visual_hero_types() {
-    return array(
-        'gastown_scene', 'granville_scene', 'north_shore_scene', 'waterfront_scene',
-        'gastown_clock_silhouette', 'science_world_dome', 'chinatown_gate', 'english_bay_inukshuk',
-        'maritime_museum_sailroof', 'lions_gate_bridge', 'bc_place_dome', 'port_cranes',
-        'planetarium_dome', 'starfield_projection', 'canada_place_sails', 'seabus_silhouette',
-        'skytrain_pass_visual',
-    );
+    return array_values( array_map( static function( $item ) { return $item['id']; }, array_filter( se_get_asmr_visual_registry(), static function( $item ) { return 'hero' === ( $item['priority'] ?? '' ) && empty( $item['support_only'] ); } ) ) );
 }
 
 function se_get_asmr_visual_landmark_types() {
-    return array(
-        'gastown_clock_silhouette', 'science_world_dome', 'chinatown_gate', 'english_bay_inukshuk',
-        'maritime_museum_sailroof', 'lions_gate_bridge', 'bc_place_dome', 'port_cranes',
-        'planetarium_dome', 'starfield_projection', 'canada_place_sails', 'seabus_silhouette',
-    );
+    return array_values( array_map( static function( $item ) { return $item['id']; }, array_filter( se_get_asmr_visual_registry(), static function( $item ) { return 'landmark' === ( $item['category'] ?? '' ); } ) ) );
 }
 
 function se_get_asmr_visual_scene_types() {
-    return array( 'gastown_scene', 'granville_scene', 'north_shore_scene', 'waterfront_scene' );
+    return array_values( array_map( static function( $item ) { return $item['id']; }, array_filter( se_get_asmr_visual_registry(), static function( $item ) { return 'scene' === ( $item['category'] ?? '' ); } ) ) );
 }
 
 function se_get_asmr_visual_support_types() {
-    return array(
-        'scanline_field', 'signal_bars', 'chromatic_veil', 'pixel_grid_pulse', 'starfield_drift',
-        'wet_reflection_shimmer', 'neon_wet_reflections', 'gull_silhouettes',
-    );
+    return array_values( array_map( static function( $item ) { return $item['id']; }, array_filter( se_get_asmr_visual_registry(), static function( $item ) { return ! empty( $item['support_only'] ); } ) ) );
 }
 
 function se_get_asmr_semantic_cues( $payload ) {
@@ -1572,7 +1619,7 @@ function se_restrict_generation_plan_to_selected_motifs( $plan, $audio_layers, $
     $selected_audio = array_values( array_unique( array_map( 'sanitize_key', (array) $audio_layers ) ) );
     $selected_visual = array_values( array_unique( array_map( 'sanitize_key', (array) $visual_layers ) ) );
 
-    $visual_slots = array( 'primary_scene', 'landmark', 'motion' );
+    $visual_slots = array( 'primary_scene', 'landmark', 'motion', 'resolve_landmark' );
     foreach ( $visual_slots as $slot ) {
         $candidate = sanitize_key( $plan['visual_plan'][ $slot ] ?? '' );
         $plan['visual_plan'][ $slot ] = in_array( $candidate, $selected_visual, true ) ? $candidate : '';
@@ -1593,6 +1640,9 @@ function se_restrict_generation_plan_to_selected_motifs( $plan, $audio_layers, $
 
     if ( empty( $plan['visual_plan']['landmark'] ) || ! in_array( $plan['visual_plan']['landmark'], $selected_landmarks, true ) ) {
         $plan['visual_plan']['landmark'] = ! empty( $selected_landmarks ) ? $selected_landmarks[0] : '';
+    }
+    if ( empty( $plan['visual_plan']['resolve_landmark'] ) || ! in_array( $plan['visual_plan']['resolve_landmark'], $selected_landmarks, true ) ) {
+        $plan['visual_plan']['resolve_landmark'] = ! empty( $selected_landmarks ) ? end( $selected_landmarks ) : '';
     }
 
     if ( ! empty( $selected_landmarks ) && empty( $plan['visual_plan']['primary_scene'] ) && 1 === count( $selected_landmarks ) ) {
@@ -1644,6 +1694,71 @@ function se_build_asmr_style_tags( $decoded, $base_tags = array() ) {
     return array_values( array_unique( array_merge( $base, $broad, $hero ) ) );
 }
 
+function se_validate_visual_timeline_matches_plan( $plan, $visual_events ) {
+    $visual_plan = is_array( $plan['visual_plan'] ?? null ) ? $plan['visual_plan'] : array();
+    $events = is_array( $visual_events ) ? $visual_events : array();
+
+    $primary_scene = sanitize_key( $visual_plan['primary_scene'] ?? '' );
+    $landmark = sanitize_key( $visual_plan['landmark'] ?? '' );
+    $motion = sanitize_key( $visual_plan['motion'] ?? '' );
+    $resolve_landmark = sanitize_key( $visual_plan['resolve_landmark'] ?? '' );
+
+    $hero_types = se_get_asmr_visual_hero_types();
+    $support_types = se_get_asmr_visual_support_types();
+
+    $count_type = static function( $token ) use ( $events ) {
+        if ( ! $token ) return 0;
+        return count( array_filter( $events, static function( $event ) use ( $token ) { return sanitize_key( $event['visual_type'] ?? '' ) === $token; } ) );
+    };
+
+    $repairs = array();
+    if ( $primary_scene && 0 === $count_type( $primary_scene ) ) {
+        $repairs[] = array( 'time' => 0.2, 'duration' => 4.8, 'visual_type' => $primary_scene, 'intensity' => 0.76, 'params' => array(), 'sync_role' => 'repair_primary_scene' );
+    }
+    if ( $landmark && 0 === $count_type( $landmark ) ) {
+        $repairs[] = array( 'time' => 9.4, 'duration' => 4.8, 'visual_type' => $landmark, 'intensity' => 0.82, 'params' => array(), 'sync_role' => 'repair_landmark_hero' );
+    }
+    if ( $motion && 0 === $count_type( $motion ) ) {
+        $repairs[] = array( 'time' => 10.2, 'duration' => 3.4, 'visual_type' => $motion, 'intensity' => 0.4, 'params' => array(), 'sync_role' => 'repair_motion' );
+    }
+    if ( $resolve_landmark && 0 === $count_type( $resolve_landmark ) ) {
+        $repairs[] = array( 'time' => 15.3, 'duration' => 4.1, 'visual_type' => $resolve_landmark, 'intensity' => 0.78, 'params' => array(), 'sync_role' => 'repair_resolve_landmark' );
+    }
+
+    $with_repairs = array_merge( $events, $repairs );
+
+    $beat_windows = array(
+        array( 'label' => 'Opening', 't0' => 0.0, 't1' => 5.0 ),
+        array( 'label' => 'Arrival', 't0' => 5.0, 't1' => 10.0 ),
+        array( 'label' => 'Lift', 't0' => 10.0, 't1' => 15.0 ),
+        array( 'label' => 'Resolve', 't0' => 15.0, 't1' => 20.5 ),
+    );
+
+    foreach ( $beat_windows as $beat ) {
+        $beat_events = array_values( array_filter( $with_repairs, static function( $event ) use ( $beat ) {
+            $time = floatval( $event['time'] ?? 0 );
+            return $time >= $beat['t0'] && $time < $beat['t1'];
+        } ) );
+        $hero_count = count( array_filter( $beat_events, static function( $event ) use ( $hero_types ) {
+            return in_array( sanitize_key( $event['visual_type'] ?? '' ), $hero_types, true );
+        } ) );
+        $support_count = count( array_filter( $beat_events, static function( $event ) use ( $support_types ) {
+            return in_array( sanitize_key( $event['visual_type'] ?? '' ), $support_types, true );
+        } ) );
+
+        if ( $support_count > ( $hero_count * 2 + 2 ) && ! empty( $beat_events ) ) {
+            foreach ( $with_repairs as $idx => $event ) {
+                if ( floatval( $event['time'] ?? 0 ) >= $beat['t0'] && floatval( $event['time'] ?? 0 ) < $beat['t1'] && in_array( sanitize_key( $event['visual_type'] ?? '' ), $support_types, true ) ) {
+                    $with_repairs[ $idx ]['intensity'] = min( 0.18, floatval( $event['intensity'] ?? 0.2 ) );
+                }
+            }
+        }
+    }
+
+    usort( $with_repairs, static function( $a, $b ) { return (float) $a['time'] <=> (float) $b['time']; } );
+    return $with_repairs;
+}
+
 function se_compile_visual_events_from_plan( $plan, $runtime ) {
     $runtime = max( 10, min( 30, floatval( $runtime ) ) );
     $hero_types = se_get_asmr_visual_hero_types();
@@ -1656,56 +1771,46 @@ function se_compile_visual_events_from_plan( $plan, $runtime ) {
     $motion = sanitize_key( $visual_plan['motion'] ?? '' );
     $texture = sanitize_key( $visual_plan['texture'] ?? '' );
     $overlay = sanitize_key( $visual_plan['overlay_family'] ?? '' );
+    $resolve_landmark = sanitize_key( $visual_plan['resolve_landmark'] ?? '' );
+
+    if ( ! $resolve_landmark ) {
+        $resolve_landmark = $landmark;
+    }
 
     $events = array();
-    $opening_hero = $primary_scene && in_array( $primary_scene, $hero_types, true ) ? $primary_scene : '';
-    if ( ! $opening_hero && $landmark && in_array( $landmark, $hero_types, true ) ) {
-        $opening_hero = $landmark;
-    }
-    $arrival_hero = '';
-    if ( $landmark && in_array( $landmark, $hero_types, true ) && $landmark !== $opening_hero ) {
-        $arrival_hero = $landmark;
-    } elseif ( $primary_scene && in_array( $primary_scene, $hero_types, true ) && $primary_scene !== $opening_hero ) {
-        $arrival_hero = $primary_scene;
-    }
 
     if ( $atmosphere ) {
-        $events[] = array( 'time' => 0.0, 'duration' => min( $runtime - 0.2, 7.6 ), 'visual_type' => $atmosphere, 'intensity' => 0.34, 'params' => array(), 'sync_role' => 'opening_atmosphere' );
-    }
-    if ( $opening_hero ) {
-        $events[] = array( 'time' => 0.2, 'duration' => 5.4, 'visual_type' => $opening_hero, 'intensity' => 0.7, 'params' => array(), 'sync_role' => 'opening_scene' );
-    }
-    if ( $overlay && in_array( $overlay, $support_types, true ) ) {
-        $events[] = array( 'time' => 0.4, 'duration' => 3.2, 'visual_type' => $overlay, 'intensity' => 0.1, 'params' => array(), 'sync_role' => 'opening_support' );
+        $events[] = array( 'time' => 0.0, 'duration' => min( $runtime - 0.2, 7.6 ), 'visual_type' => $atmosphere, 'intensity' => 0.3, 'params' => array(), 'sync_role' => 'opening_atmosphere' );
     }
 
-    // Arrival: introduce the other hero, otherwise motion.
-    if ( $arrival_hero ) {
-        $events[] = array( 'time' => 4.6, 'duration' => 4.2, 'visual_type' => $arrival_hero, 'intensity' => 0.72, 'params' => array(), 'sync_role' => 'arrival_landmark' );
-    } elseif ( $motion ) {
-        $events[] = array( 'time' => 5.0, 'duration' => 3.6, 'visual_type' => $motion, 'intensity' => 0.5, 'params' => array(), 'sync_role' => 'arrival_motion' );
-    }
-
-    // Lift: strongest reveal.
-    if ( $landmark && in_array( $landmark, $hero_types, true ) ) {
-        $events[] = array( 'time' => 9.4, 'duration' => 5.0, 'visual_type' => $landmark, 'intensity' => 0.82, 'params' => array(), 'sync_role' => 'lift_reveal' );
-    }
-    if ( $motion ) {
-        $events[] = array( 'time' => 10.2, 'duration' => 3.4, 'visual_type' => $motion, 'intensity' => 0.46, 'params' => array(), 'sync_role' => 'lift_motion' );
-    }
-    if ( $texture ) {
-        $events[] = array( 'time' => 10.0, 'duration' => 4.0, 'visual_type' => $texture, 'intensity' => 0.3, 'params' => array(), 'sync_role' => 'lift_texture' );
-    }
-
-    // Resolve: simplify, no new landmark.
     if ( $primary_scene && in_array( $primary_scene, $hero_types, true ) ) {
-        $events[] = array( 'time' => 15.2, 'duration' => 4.3, 'visual_type' => $primary_scene, 'intensity' => 0.48, 'params' => array(), 'sync_role' => 'resolve_return' );
-    } elseif ( $atmosphere ) {
-        $events[] = array( 'time' => 15.4, 'duration' => 4.1, 'visual_type' => $atmosphere, 'intensity' => 0.28, 'params' => array(), 'sync_role' => 'resolve_bed' );
+        $events[] = array( 'time' => 0.2, 'duration' => 5.2, 'visual_type' => $primary_scene, 'intensity' => 0.76, 'params' => array(), 'sync_role' => 'opening_scene_hero' );
     }
 
-    usort( $events, static function( $a, $b ) { return (float) $a['time'] <=> (float) $b['time']; } );
-    return $events;
+    if ( $overlay && in_array( $overlay, $support_types, true ) ) {
+        $events[] = array( 'time' => 0.4, 'duration' => 3.2, 'visual_type' => $overlay, 'intensity' => 0.08, 'params' => array(), 'sync_role' => 'opening_support' );
+    }
+
+    if ( $landmark && in_array( $landmark, $hero_types, true ) ) {
+        $events[] = array( 'time' => 5.0, 'duration' => 4.2, 'visual_type' => $landmark, 'intensity' => 0.78, 'params' => array(), 'sync_role' => 'arrival_landmark_hero' );
+        $events[] = array( 'time' => 9.4, 'duration' => 5.0, 'visual_type' => $landmark, 'intensity' => 0.86, 'params' => array(), 'sync_role' => 'lift_landmark_hero' );
+    }
+
+    if ( $motion ) {
+        $events[] = array( 'time' => 10.2, 'duration' => 3.4, 'visual_type' => $motion, 'intensity' => 0.42, 'params' => array(), 'sync_role' => 'lift_motion' );
+    }
+
+    if ( $texture ) {
+        $events[] = array( 'time' => 10.0, 'duration' => 4.0, 'visual_type' => $texture, 'intensity' => 0.2, 'params' => array(), 'sync_role' => 'lift_texture' );
+    }
+
+    if ( $resolve_landmark && in_array( $resolve_landmark, $hero_types, true ) ) {
+        $events[] = array( 'time' => 15.2, 'duration' => 4.3, 'visual_type' => $resolve_landmark, 'intensity' => 0.74, 'params' => array(), 'sync_role' => 'resolve_landmark_hero' );
+    } elseif ( $primary_scene && in_array( $primary_scene, $hero_types, true ) ) {
+        $events[] = array( 'time' => 15.2, 'duration' => 4.3, 'visual_type' => $primary_scene, 'intensity' => 0.58, 'params' => array(), 'sync_role' => 'resolve_return' );
+    }
+
+    return se_validate_visual_timeline_matches_plan( $plan, $events );
 }
 
 function se_compile_audio_events_from_plan( $plan, $runtime ) {

--- a/js/asmr-lab.js
+++ b/js/asmr-lab.js
@@ -19,11 +19,17 @@
   const modeToggle = document.getElementById('asmr-playback-mode');
   const videoSupportEl = document.getElementById('asmr-video-support');
   const canvas = document.getElementById('asmr-visual-canvas');
+  const atlasGridEl = document.getElementById('asmr-visual-atlas-grid');
+  const previewCurrentHeroBtn = document.getElementById('asmr-preview-current-hero');
+  const provenanceToggle = document.getElementById('asmr-debug-provenance-toggle');
 
   const engine = new window.AsmrFoleyEngine();
   const visuals = window.AsmrVisualEngine ? new window.AsmrVisualEngine(canvas) : null;
   let lastPayload = null;
   let currentPackage = null;
+  const visualRegistry = (window.seAsmrLab && Array.isArray(window.seAsmrLab.visualRegistry) && window.seAsmrLab.visualRegistry.length)
+    ? window.seAsmrLab.visualRegistry
+    : (window.ASMR_VISUAL_REGISTRY || []);
 
 
   const LINKED_VISUAL_TO_AUDIO = {
@@ -135,6 +141,7 @@
     const edit = document.getElementById('asmr-edit-notes');
     const note = document.getElementById('asmr-presentation');
     const recipe = document.getElementById('asmr-sound-json');
+    const planVisualSummary = document.getElementById('asmr-plan-visual-summary');
 
     if (concept) concept.textContent = `${data.title} (${data.runtime_seconds}s) — ${data.hook}
 ${data.concept_summary}`;
@@ -172,6 +179,27 @@ ${data.concept_summary}`;
       });
     }
 
+
+    if (planVisualSummary) {
+      const vPlan = (data.generation_plan && data.generation_plan.visual_plan) || {};
+      const heroEvents = (Array.isArray(data.visual_events) ? data.visual_events : []).filter((event) => {
+        const entry = visualRegistry.find((item) => item.id === event.visual_type);
+        return entry && entry.priority === 'hero';
+      }).map((event) => event.visual_type);
+      const planned = [vPlan.primary_scene, vPlan.landmark, vPlan.motion].filter(Boolean);
+      const mismatch = planned.some((id) => !heroEvents.includes(id));
+      const rows = [
+        `Primary scene: ${vPlan.primary_scene || '—'}`,
+        `Landmark: ${vPlan.landmark || '—'}`,
+        `Motion: ${vPlan.motion || '—'}`,
+        `Atmosphere: ${vPlan.atmosphere || '—'}`,
+        `Compiled hero events: ${heroEvents.length ? Array.from(new Set(heroEvents)).join(', ') : '—'}`
+      ];
+      if (mismatch && provenanceToggle && provenanceToggle.checked) {
+        rows.push('⚠️ Debug warning: planned hero visual(s) missing from compiled hero event list.');
+      }
+      toList(planVisualSummary, rows);
+    }
     toList(beats, data.sync_points || []);
     toList(prompts, data.style_tags || []);
     if (edit) {
@@ -218,6 +246,39 @@ ${data.concept_summary}`;
       audio_layers: linked.audio_layers,
       visual_layers: linked.visual_layers
     });
+  }
+
+
+  function renderVisualAtlas() {
+    if (!atlasGridEl) return;
+    atlasGridEl.innerHTML = '';
+    visualRegistry.forEach((item) => {
+      const card = document.createElement('article');
+      card.className = 'asmr-atlas-card';
+      card.innerHTML = `<h4>${item.label}</h4><p><code>${item.id}</code></p><p>${item.category} • ${item.priority}</p><p>${item.description}</p><p><strong>Expected:</strong> ${item.expected_shape}</p>`;
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'pixel-button tiny secondary';
+      btn.textContent = 'Preview motif';
+      btn.addEventListener('click', () => {
+        if (!visuals) return;
+        visuals.previewVisualType(item.id, 3.2);
+      });
+      card.appendChild(btn);
+      atlasGridEl.appendChild(card);
+    });
+  }
+
+  async function previewCurrentHeroVisuals() {
+    if (!currentPackage || !visuals) return;
+    const vPlan = (currentPackage.generation_plan && currentPackage.generation_plan.visual_plan) || {};
+    const queue = [vPlan.primary_scene, vPlan.landmark, vPlan.motion]
+      .filter(Boolean)
+      .filter((value, index, arr) => arr.indexOf(value) === index);
+    for (let i = 0; i < queue.length; i += 1) {
+      visuals.previewVisualType(queue[i], 2.8);
+      await new Promise((resolve) => window.setTimeout(resolve, 3100));
+    }
   }
 
   async function requestGeneration(payload) {
@@ -495,6 +556,25 @@ ${data.concept_summary}`;
       } catch (err) {
         if (audioFeedback) audioFeedback.textContent = err.message || 'Video export failed in this browser.';
       }
+    });
+  }
+
+
+  if (visuals) {
+    visuals.setDebugOptions({ enabled: false, showProvenance: false });
+  }
+  renderVisualAtlas();
+
+  if (provenanceToggle) {
+    provenanceToggle.addEventListener('change', () => {
+      if (visuals) visuals.setDebugOptions({ enabled: provenanceToggle.checked, showProvenance: provenanceToggle.checked });
+      if (currentPackage && visuals) visuals.seek(0);
+    });
+  }
+
+  if (previewCurrentHeroBtn) {
+    previewCurrentHeroBtn.addEventListener('click', async () => {
+      await previewCurrentHeroVisuals();
     });
   }
 

--- a/js/asmr-visual-engine.js
+++ b/js/asmr-visual-engine.js
@@ -1,23 +1,81 @@
 (function (window) {
   'use strict';
 
-  const VISUAL_TYPES = [
-    'scanline_field', 'pixel_grid_pulse', 'wireframe_horizon', 'radial_bloom', 'particle_trail',
-    'glitch_flash', 'waveform_ring', 'macro_texture_drift', 'signal_bars', 'text_reveal',
-    'volumetric_fog', 'glass_refraction', 'halo_glyphs', 'cathedral_beam', 'monolith_silhouette',
-    'starfield_drift', 'orbiting_shards', 'pulse_orb', 'energy_column', 'refraction_ripple',
-    'chromatic_veil', 'terminal_runes', 'snow_drift', 'amber_halo', 'wet_reflection_shimmer',
-    'brick_shadow_drift', 'steam_plume_column', 'clock_face_reveal', 'harbor_mist',
-    'neon_wet_reflections', 'winter_particulate_depth',
-    'gastown_clock_silhouette', 'cobblestone_perspective', 'brick_wall_parallax', 'streetlamp_halo_row',
-    'granville_neon_marquee', 'neon_sign_flicker', 'traffic_light_glow',
-    'skytrain_track', 'skytrain_pass_visual', 'bus_pass_visual',
-    'northshore_mountain_ridge', 'mountain_mist_layers',
-    'rain_streaks', 'puddle_reflections',
-    'science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'lions_gate_bridge', 'bc_place_dome', 'port_cranes',
-    'planetarium_dome', 'starfield_projection', 'constellation_lines', 'canada_place_sails',
-    'gastown_scene', 'granville_scene', 'north_shore_scene', 'waterfront_scene', 'clear_cold_shimmer', 'ocean_surface_shimmer', 'seabus_silhouette', 'gull_silhouettes'
+  const VISUAL_REGISTRY = [
+    { id: 'scanline_field', label: 'Scanline Field', category: 'support', priority: 'support', description: 'CRT line drift overlay.', expected_shape: 'horizontal scan lines', renderer: 'drawScanlineField', intensity: [0.08, 0.4], openingHero: false, supportOnly: true },
+    { id: 'pixel_grid_pulse', label: 'Pixel Grid Pulse', category: 'support', priority: 'support', description: 'Retro pixel grid pulse.', expected_shape: 'small grid cells', renderer: 'drawPixelGridPulse', intensity: [0.1, 0.35], openingHero: false, supportOnly: true },
+    { id: 'wireframe_horizon', label: 'Wireframe Horizon', category: 'scene', priority: 'support', description: 'Perspective horizon lines.', expected_shape: 'vanishing horizon fan', renderer: 'drawWireframeHorizon', intensity: [0.15, 0.45], openingHero: false, supportOnly: true },
+    { id: 'radial_bloom', label: 'Radial Bloom', category: 'atmosphere', priority: 'support', description: 'Soft center bloom.', expected_shape: 'radial glow', renderer: 'drawRadialBloom', intensity: [0.15, 0.45], openingHero: false, supportOnly: true },
+    { id: 'particle_trail', label: 'Particle Trail', category: 'motion', priority: 'support', description: 'Moving particle points.', expected_shape: 'drifting dots', renderer: 'drawParticleTrail', intensity: [0.2, 0.6], openingHero: false, supportOnly: true },
+    { id: 'glitch_flash', label: 'Glitch Flash', category: 'support', priority: 'support', description: 'Brief digital glitch streaks.', expected_shape: 'horizontal flashes', renderer: 'drawGlitchFlash', intensity: [0.05, 0.25], openingHero: false, supportOnly: true },
+    { id: 'waveform_ring', label: 'Waveform Ring', category: 'motion', priority: 'support', description: 'Oscillating ring pulse.', expected_shape: 'wobble ring', renderer: 'drawWaveformRing', intensity: [0.15, 0.5], openingHero: false, supportOnly: true },
+    { id: 'macro_texture_drift', label: 'Macro Texture Drift', category: 'texture', priority: 'support', description: 'Linear texture drift.', expected_shape: 'short bars', renderer: 'drawMacroTextureDrift', intensity: [0.12, 0.35], openingHero: false, supportOnly: true },
+    { id: 'signal_bars', label: 'Signal Bars', category: 'support', priority: 'support', description: 'Diagnostic signal meter bars.', expected_shape: 'small stacked bars', renderer: 'drawSignalBars', intensity: [0.05, 0.2], openingHero: false, supportOnly: true },
+    { id: 'text_reveal', label: 'Text Reveal', category: 'support', priority: 'support', description: 'Short terminal text reveal.', expected_shape: 'single text block', renderer: 'drawTextReveal', intensity: [0.15, 0.5], openingHero: false, supportOnly: true },
+    { id: 'volumetric_fog', label: 'Volumetric Fog', category: 'atmosphere', priority: 'support', description: 'Layered fog drift.', expected_shape: 'horizontal haze bands', renderer: 'drawVolumetricFog', intensity: [0.2, 0.6], openingHero: false, supportOnly: true },
+    { id: 'glass_refraction', label: 'Glass Refraction', category: 'texture', priority: 'support', description: 'Refraction contour lines.', expected_shape: 'curved refractive lines', renderer: 'drawGlassRefraction', intensity: [0.15, 0.5], openingHero: false, supportOnly: true },
+    { id: 'halo_glyphs', label: 'Halo Glyphs', category: 'atmosphere', priority: 'support', description: 'Arc glyph halos.', expected_shape: 'partial circular arcs', renderer: 'drawHaloGlyphs', intensity: [0.15, 0.5], openingHero: false, supportOnly: true },
+    { id: 'cathedral_beam', label: 'Cathedral Beam', category: 'atmosphere', priority: 'support', description: 'Focused light beam.', expected_shape: 'vertical cone beam', renderer: 'drawCathedralBeam', intensity: [0.15, 0.45], openingHero: false, supportOnly: true },
+    { id: 'monolith_silhouette', label: 'Monolith Silhouette', category: 'scene', priority: 'hero', description: 'Large central monolith.', expected_shape: 'single tall slab', renderer: 'drawMonolithSilhouette', intensity: [0.25, 0.75], openingHero: true, supportOnly: false },
+    { id: 'starfield_drift', label: 'Starfield Drift', category: 'atmosphere', priority: 'support', description: 'Sparse moving stars.', expected_shape: 'small drifting stars', renderer: 'drawStarfieldDrift', intensity: [0.08, 0.3], openingHero: false, supportOnly: true },
+    { id: 'orbiting_shards', label: 'Orbiting Shards', category: 'motion', priority: 'support', description: 'Orbiting shard fragments.', expected_shape: 'angular orbit points', renderer: 'drawOrbitingShards', intensity: [0.15, 0.5], openingHero: false, supportOnly: true },
+    { id: 'pulse_orb', label: 'Pulse Orb', category: 'motion', priority: 'support', description: 'Core pulse orb.', expected_shape: 'pulsing circle', renderer: 'drawPulseOrb', intensity: [0.2, 0.58], openingHero: false, supportOnly: true },
+    { id: 'energy_column', label: 'Energy Column', category: 'motion', priority: 'support', description: 'Energy column pulse.', expected_shape: 'soft vertical beam', renderer: 'drawEnergyColumn', intensity: [0.2, 0.55], openingHero: false, supportOnly: true },
+    { id: 'refraction_ripple', label: 'Refraction Ripple', category: 'texture', priority: 'support', description: 'Ripple distortion rings.', expected_shape: 'ripple circles', renderer: 'drawRefractionRipple', intensity: [0.15, 0.45], openingHero: false, supportOnly: true },
+    { id: 'chromatic_veil', label: 'Chromatic Veil', category: 'support', priority: 'support', description: 'Chromatic split veil.', expected_shape: 'subtle RGB haze', renderer: 'drawChromaticVeil', intensity: [0.06, 0.2], openingHero: false, supportOnly: true },
+    { id: 'terminal_runes', label: 'Terminal Runes', category: 'texture', priority: 'support', description: 'Arcade rune marks.', expected_shape: 'tiny glyph strokes', renderer: 'drawTerminalRunes', intensity: [0.1, 0.35], openingHero: false, supportOnly: true },
+    { id: 'snow_drift', label: 'Snow Drift', category: 'atmosphere', priority: 'support', description: 'Snow particles drifting.', expected_shape: 'falling dots', renderer: 'drawSnowDrift', intensity: [0.25, 0.7], openingHero: false, supportOnly: true },
+    { id: 'amber_halo', label: 'Amber Halo', category: 'atmosphere', priority: 'support', description: 'Warm streetlight halos.', expected_shape: 'amber glow circles', renderer: 'drawAmberHalo', intensity: [0.15, 0.4], openingHero: false, supportOnly: true },
+    { id: 'wet_reflection_shimmer', label: 'Wet Reflection Shimmer', category: 'texture', priority: 'support', description: 'Wet streak reflections.', expected_shape: 'vertical reflection strips', renderer: 'drawWetReflectionShimmer', intensity: [0.15, 0.45], openingHero: false, supportOnly: true },
+    { id: 'brick_shadow_drift', label: 'Brick Shadow Drift', category: 'texture', priority: 'support', description: 'Brick shadow texture.', expected_shape: 'brick-like side blocks', renderer: 'drawBrickShadowDrift', intensity: [0.12, 0.38], openingHero: false, supportOnly: true },
+    { id: 'steam_plume_column', label: 'Steam Plume Column', category: 'atmosphere', priority: 'support', description: 'Steam column plume.', expected_shape: 'soft column mist', renderer: 'drawSteamPlumeColumn', intensity: [0.18, 0.5], openingHero: false, supportOnly: true },
+    { id: 'clock_face_reveal', label: 'Clock Face Reveal', category: 'landmark', priority: 'hero', description: 'Clock face reveal motif.', expected_shape: 'round clock face', renderer: 'drawClockFaceReveal', intensity: [0.25, 0.7], openingHero: true, supportOnly: false },
+    { id: 'harbor_mist', label: 'Harbor Mist', category: 'atmosphere', priority: 'support', description: 'Harbor fog sheet.', expected_shape: 'layered mist rows', renderer: 'drawHarborMist', intensity: [0.2, 0.6], openingHero: false, supportOnly: true },
+    { id: 'neon_wet_reflections', label: 'Neon Wet Reflections', category: 'texture', priority: 'support', description: 'Neon wet pavement texture.', expected_shape: 'glowing vertical puddles', renderer: 'drawNeonWetReflections', intensity: [0.2, 0.55], openingHero: false, supportOnly: true },
+    { id: 'winter_particulate_depth', label: 'Winter Particulate Depth', category: 'atmosphere', priority: 'support', description: 'Depth snow particles.', expected_shape: 'layered snow points', renderer: 'drawWinterParticulateDepth', intensity: [0.2, 0.62], openingHero: false, supportOnly: true },
+    { id: 'gastown_clock_silhouette', label: 'Gastown Clock', category: 'landmark', priority: 'hero', description: 'Steam clock silhouette.', expected_shape: 'clock post + face', renderer: 'drawGastownClockSilhouette', intensity: [0.35, 0.8], openingHero: true, supportOnly: false },
+    { id: 'cobblestone_perspective', label: 'Cobblestone Perspective', category: 'texture', priority: 'support', description: 'Cobblestone lane texture.', expected_shape: 'ground grid stones', renderer: 'drawCobblestonePerspective', intensity: [0.18, 0.45], openingHero: false, supportOnly: true },
+    { id: 'brick_wall_parallax', label: 'Brick Wall Parallax', category: 'texture', priority: 'support', description: 'Brick facade sides.', expected_shape: 'left/right brick blocks', renderer: 'drawBrickWallParallax', intensity: [0.18, 0.45], openingHero: false, supportOnly: true },
+    { id: 'streetlamp_halo_row', label: 'Streetlamp Halo Row', category: 'atmosphere', priority: 'support', description: 'Streetlamp halo row.', expected_shape: 'four halo circles', renderer: 'drawStreetlampHaloRow', intensity: [0.18, 0.48], openingHero: false, supportOnly: true },
+    { id: 'granville_neon_marquee', label: 'Granville Neon Marquee', category: 'scene', priority: 'support', description: 'Neon marquee slabs.', expected_shape: 'vertical neon panels', renderer: 'drawGranvilleNeonMarquee', intensity: [0.18, 0.48], openingHero: false, supportOnly: true },
+    { id: 'neon_sign_flicker', label: 'Neon Sign Flicker', category: 'scene', priority: 'support', description: 'Neon strip flicker.', expected_shape: 'horizontal neon bars', renderer: 'drawNeonSignFlicker', intensity: [0.18, 0.5], openingHero: false, supportOnly: true },
+    { id: 'traffic_light_glow', label: 'Traffic Light Glow', category: 'scene', priority: 'support', description: 'Traffic signal glow.', expected_shape: 'three light halos', renderer: 'drawTrafficLightGlow', intensity: [0.15, 0.45], openingHero: false, supportOnly: true },
+    { id: 'skytrain_track', label: 'SkyTrain Track', category: 'motion', priority: 'support', description: 'Elevated track lines.', expected_shape: 'dual horizontal track', renderer: 'drawSkytrainTrack', intensity: [0.2, 0.55], openingHero: false, supportOnly: true },
+    { id: 'skytrain_pass_visual', label: 'SkyTrain Pass', category: 'motion', priority: 'hero', description: 'SkyTrain car pass-through.', expected_shape: 'moving train block', renderer: 'drawSkytrainPassVisual', intensity: [0.25, 0.7], openingHero: true, supportOnly: false },
+    { id: 'bus_pass_visual', label: 'Bus Pass', category: 'motion', priority: 'support', description: 'Bus pass-through.', expected_shape: 'moving bus block', renderer: 'drawBusPassVisual', intensity: [0.2, 0.6], openingHero: false, supportOnly: true },
+    { id: 'northshore_mountain_ridge', label: 'North Shore Ridge', category: 'scene', priority: 'support', description: 'North Shore mountain ridge.', expected_shape: 'mountain silhouette ridge', renderer: 'drawNorthshoreMountainRidge', intensity: [0.22, 0.62], openingHero: false, supportOnly: true },
+    { id: 'mountain_mist_layers', label: 'Mountain Mist Layers', category: 'atmosphere', priority: 'support', description: 'Mist bands for mountain scene.', expected_shape: 'layered mist bands', renderer: 'drawMountainMistLayers', intensity: [0.18, 0.5], openingHero: false, supportOnly: true },
+    { id: 'rain_streaks', label: 'Rain Streaks', category: 'atmosphere', priority: 'support', description: 'Diagonal rain lines.', expected_shape: 'falling streaks', renderer: 'drawRainStreaks', intensity: [0.2, 0.6], openingHero: false, supportOnly: true },
+    { id: 'puddle_reflections', label: 'Puddle Reflections', category: 'texture', priority: 'support', description: 'Puddle neon reflections.', expected_shape: 'vertical reflection pools', renderer: 'drawPuddleReflections', intensity: [0.18, 0.5], openingHero: false, supportOnly: true },
+    { id: 'science_world_dome', label: 'Science World Dome', category: 'landmark', priority: 'hero', description: 'Geodesic dome silhouette with lattice.', expected_shape: 'dome arc + triangle lattice', renderer: 'drawScienceWorldDome', intensity: [0.35, 0.85], openingHero: true, supportOnly: false },
+    { id: 'chinatown_gate', label: 'Chinatown Gate', category: 'landmark', priority: 'hero', description: 'Chinatown gate profile.', expected_shape: 'two pillars + layered roof', renderer: 'drawChinatownGate', intensity: [0.3, 0.8], openingHero: true, supportOnly: false },
+    { id: 'english_bay_inukshuk', label: 'English Bay Inukshuk', category: 'landmark', priority: 'hero', description: 'Stacked stone Inukshuk reveal.', expected_shape: 'base + torso + arm stone + head', renderer: 'drawEnglishBayInukshuk', intensity: [0.35, 0.88], openingHero: true, supportOnly: false },
+    { id: 'maritime_museum_sailroof', label: 'Maritime Museum Sail Roof', category: 'landmark', priority: 'hero', description: 'Sail roof gesture.', expected_shape: 'arched sail roof line', renderer: 'drawMaritimeMuseumSailroof', intensity: [0.28, 0.8], openingHero: true, supportOnly: false },
+    { id: 'lions_gate_bridge', label: 'Lions Gate Bridge', category: 'landmark', priority: 'hero', description: 'Suspension bridge silhouette with two towers, deck, top cable arc, and suspenders.', expected_shape: 'two towers + deck + hanging cable lines', renderer: 'drawLionsGateBridge', intensity: [0.35, 0.9], openingHero: true, supportOnly: false },
+    { id: 'bc_place_dome', label: 'BC Place Dome', category: 'landmark', priority: 'hero', description: 'Stadium dome spoked silhouette.', expected_shape: 'low dome with radial spokes', renderer: 'drawBCPlaceDome', intensity: [0.3, 0.8], openingHero: true, supportOnly: false },
+    { id: 'port_cranes', label: 'Port Cranes', category: 'landmark', priority: 'hero', description: 'Container crane row.', expected_shape: 'angular crane arms', renderer: 'drawPortCranes', intensity: [0.28, 0.75], openingHero: true, supportOnly: false },
+    { id: 'planetarium_dome', label: 'Planetarium Dome', category: 'landmark', priority: 'hero', description: 'Smooth observatory dome.', expected_shape: 'smooth dome + low base', renderer: 'drawPlanetariumDome', intensity: [0.3, 0.82], openingHero: true, supportOnly: false },
+    { id: 'starfield_projection', label: 'Starfield Projection', category: 'landmark', priority: 'hero', description: 'Planetarium star projection.', expected_shape: 'dome projection arcs + stars', renderer: 'drawStarfieldProjection', intensity: [0.25, 0.75], openingHero: true, supportOnly: false },
+    { id: 'constellation_lines', label: 'Constellation Lines', category: 'atmosphere', priority: 'support', description: 'Constellation line overlay.', expected_shape: 'tiny connected stars', renderer: 'drawConstellationLines', intensity: [0.12, 0.35], openingHero: false, supportOnly: true },
+    { id: 'canada_place_sails', label: 'Canada Place Sails', category: 'landmark', priority: 'hero', description: 'Canada Place sail peaks.', expected_shape: 'triangular sail peaks', renderer: 'drawCanadaPlaceSails', intensity: [0.28, 0.78], openingHero: true, supportOnly: false },
+    { id: 'gastown_scene', label: 'Gastown Scene', category: 'scene', priority: 'hero', description: 'Gastown scene background stack.', expected_shape: 'brick + cobblestone + clock support', renderer: 'drawGastownScene', intensity: [0.28, 0.76], openingHero: true, supportOnly: false },
+    { id: 'granville_scene', label: 'Granville Scene', category: 'scene', priority: 'hero', description: 'Granville neon street scene.', expected_shape: 'neon facades + reflections', renderer: 'drawGranvilleScene', intensity: [0.28, 0.76], openingHero: true, supportOnly: false },
+    { id: 'north_shore_scene', label: 'North Shore Scene', category: 'scene', priority: 'hero', description: 'North Shore ridge and mist scene.', expected_shape: 'ridge horizon + mist', renderer: 'drawNorthShoreScene', intensity: [0.3, 0.8], openingHero: true, supportOnly: false },
+    { id: 'waterfront_scene', label: 'Waterfront Scene', category: 'scene', priority: 'hero', description: 'Waterfront horizon and harbor support.', expected_shape: 'waterline + distant structures', renderer: 'drawWaterfrontScene', intensity: [0.28, 0.8], openingHero: true, supportOnly: false },
+    { id: 'clear_cold_shimmer', label: 'Clear Cold Shimmer', category: 'atmosphere', priority: 'support', description: 'Cold air shimmer.', expected_shape: 'soft cool haze', renderer: 'drawClearColdShimmer', intensity: [0.15, 0.45], openingHero: false, supportOnly: true },
+    { id: 'ocean_surface_shimmer', label: 'Ocean Surface Shimmer', category: 'texture', priority: 'support', description: 'Ocean highlight shimmer.', expected_shape: 'horizontal sparkle strips', renderer: 'drawOceanSurfaceShimmer', intensity: [0.18, 0.52], openingHero: false, supportOnly: true },
+    { id: 'seabus_silhouette', label: 'SeaBus Silhouette', category: 'landmark', priority: 'hero', description: 'SeaBus vessel silhouette.', expected_shape: 'low ferry hull', renderer: 'drawSeabusSilhouette', intensity: [0.28, 0.76], openingHero: true, supportOnly: false },
+    { id: 'gull_silhouettes', label: 'Gull Silhouettes', category: 'motion', priority: 'support', description: 'Subtle gull V silhouettes.', expected_shape: '2-4 small V arcs', renderer: 'drawGullSilhouettes', intensity: [0.06, 0.2], openingHero: false, supportOnly: true }
   ];
+
+  const VISUAL_TYPES = VISUAL_REGISTRY.map((item) => item.id);
+  const VISUAL_REGISTRY_MAP = VISUAL_REGISTRY.reduce((acc, item) => { acc[item.id] = item; return acc; }, {});
+  const VISUAL_CATEGORY = VISUAL_REGISTRY.reduce((acc, item) => {
+    if (!acc[item.category]) acc[item.category] = [];
+    acc[item.category].push(item.id);
+    return acc;
+  }, {});
+  const SUPPORT_OVERLAY_TYPES = ['scanline_field', 'chromatic_veil', 'signal_bars', 'pixel_grid_pulse', 'glitch_flash', 'starfield_drift'];
 
   function clamp(value, min, max) {
     return Math.min(max, Math.max(min, value));
@@ -38,6 +96,51 @@
       this.clockOffset = 0;
       this.currentTime = 0;
       this.lowResTarget = null;
+      this.debugOptions = { enabled: false, showProvenance: false };
+      this.debugFrameState = null;
+      this.previewTimeout = null;
+    }
+
+
+    getVisualRegistry() {
+      return VISUAL_REGISTRY.slice();
+    }
+
+    setDebugOptions(options) {
+      this.debugOptions = Object.assign({}, this.debugOptions, options || {});
+    }
+
+    buildSingleVisualTimeline(visualType, runtime) {
+      const clampedRuntime = clamp(Number(runtime || 3.2), 2.5, 6);
+      return {
+        runtime: clampedRuntime,
+        visualEvents: [{
+          time: 0,
+          duration: clampedRuntime,
+          visual_type: visualType,
+          intensity: 0.85,
+          params: {},
+          sync_role: 'debug_single_preview'
+        }],
+        syncPoints: [],
+        endCard: { use_end_card: false },
+        title: 'Visual Debug Preview',
+        renderProfile: this.resolveRenderProfile({ style_tags: [] })
+      };
+    }
+
+    previewVisualType(visualType, runtimeSeconds) {
+      if (!VISUAL_REGISTRY_MAP[visualType]) return false;
+      if (this.previewTimeout) {
+        window.clearTimeout(this.previewTimeout);
+        this.previewTimeout = null;
+      }
+      this.loadTimeline(this.buildSingleVisualTimeline(visualType, runtimeSeconds || 3.2));
+      this.play(0);
+      this.previewTimeout = window.setTimeout(() => {
+        this.stop();
+      }, Math.round((runtimeSeconds || 3.2) * 1000));
+      return true;
     }
 
     setCanvas(canvas) {
@@ -269,11 +372,11 @@
     }
 
     drawSceneLayers(ctx, width, height, t, normalized, overlays) {
-      const landmarkTypes = ['science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof', 'lions_gate_bridge', 'bc_place_dome', 'port_cranes', 'planetarium_dome', 'starfield_projection', 'canada_place_sails', 'gastown_clock_silhouette', 'seabus_silhouette', 'waterfront_scene'];
-      const sceneTypes = ['gastown_scene', 'granville_scene', 'north_shore_scene', 'waterfront_scene'];
-      const atmosphereTypes = ['rain_streaks', 'snow_drift', 'harbor_mist', 'mountain_mist_layers', 'puddle_reflections', 'volumetric_fog', 'clear_cold_shimmer'];
-      const motionTypes = ['skytrain_track', 'skytrain_pass_visual', 'bus_pass_visual', 'particle_trail', 'waveform_ring'];
-      const supportOverlays = ['scanline_field', 'chromatic_veil', 'signal_bars', 'pixel_grid_pulse', 'glitch_flash', 'starfield_drift'];
+      const landmarkTypes = VISUAL_CATEGORY.landmark || [];
+      const sceneTypes = VISUAL_CATEGORY.scene || [];
+      const atmosphereTypes = VISUAL_CATEGORY.atmosphere || [];
+      const motionTypes = VISUAL_CATEGORY.motion || [];
+      const supportOverlays = SUPPORT_OVERLAY_TYPES;
       const weirdness = this.parseWeirdnessLevel();
       const weirdNorm = (weirdness - 1) / 9;
       let distortion = 0.04 + (0.18 - 0.04) * weirdNorm;
@@ -298,36 +401,40 @@
 
       this.drawBaseChamber(ctx, width, height, t, normalized);
 
-      activeEvents.filter((item) => atmosphereTypes.includes(item.event.visual_type)).forEach((item) => {
-        const intensity = Math.max(0.05, Math.min(1, Number(item.event.intensity || 0.5)));
-        this.drawEvent(ctx, item.event, item.progress, intensity, width, height, normalized);
-      });
+      const drawByType = (predicate, dampenSupport) => {
+        activeEvents.filter(predicate).forEach((item) => {
+          let intensity = Math.max(0.05, Math.min(1, Number(item.event.intensity || 0.5)));
+          if (dampenSupport && hasHeroVisual) intensity *= 0.18;
+          this.drawEvent(ctx, item.event, item.progress, intensity, width, height, normalized);
+        });
+      };
 
-      activeEvents.filter((item) => landmarkTypes.includes(item.event.visual_type) || sceneTypes.includes(item.event.visual_type)).forEach((item) => {
-        const intensity = Math.max(0.05, Math.min(1, Number(item.event.intensity || 0.5)));
-        this.drawEvent(ctx, item.event, item.progress, intensity, width, height, normalized);
-      });
-
-      activeEvents.filter((item) => motionTypes.includes(item.event.visual_type)).forEach((item) => {
-        const intensity = Math.max(0.05, Math.min(1, Number(item.event.intensity || 0.5)));
-        this.drawEvent(ctx, item.event, item.progress, intensity, width, height, normalized);
-      });
-
-      activeEvents.filter((item) => !atmosphereTypes.includes(item.event.visual_type)
+      drawByType((item) => atmosphereTypes.includes(item.event.visual_type), false);
+      drawByType((item) => landmarkTypes.includes(item.event.visual_type) || sceneTypes.includes(item.event.visual_type), false);
+      drawByType((item) => motionTypes.includes(item.event.visual_type), hasHeroVisual);
+      drawByType((item) => !atmosphereTypes.includes(item.event.visual_type)
           && !landmarkTypes.includes(item.event.visual_type)
           && !sceneTypes.includes(item.event.visual_type)
           && !motionTypes.includes(item.event.visual_type)
-          && !supportOverlays.includes(item.event.visual_type)).forEach((item) => {
-        const intensity = Math.max(0.05, Math.min(1, Number(item.event.intensity || 0.5)));
-        this.drawEvent(ctx, item.event, item.progress, intensity, width, height, normalized);
-      });
+          && !supportOverlays.includes(item.event.visual_type), false);
 
       activeEvents.filter((item) => supportOverlays.includes(item.event.visual_type)).forEach((item) => {
         if (item.event.visual_type !== activeSupportType) return;
         let intensity = Math.max(0.05, Math.min(1, Number(item.event.intensity || 0.5)));
-        if (hasHeroVisual) intensity *= 0.12;
+        if (hasHeroVisual) intensity *= 0.1;
         this.drawEvent(ctx, item.event, item.progress, intensity, width, height, normalized);
       });
+
+      this.debugFrameState = {
+        activeVisualTypes: activeEvents.map((item) => item.event.visual_type),
+        heroVisualTypes: activeEvents
+          .filter((item) => (VISUAL_REGISTRY_MAP[item.event.visual_type] && VISUAL_REGISTRY_MAP[item.event.visual_type].priority === 'hero'))
+          .map((item) => item.event.visual_type),
+        supportVisualTypes: activeEvents
+          .filter((item) => (VISUAL_REGISTRY_MAP[item.event.visual_type] && VISUAL_REGISTRY_MAP[item.event.visual_type].priority !== 'hero'))
+          .map((item) => item.event.visual_type),
+        beatLabel: this.getBeatLabelAtTime(t)
+      };
 
       if (distortion > 0) {
         ctx.save();
@@ -369,10 +476,44 @@
         this.drawSceneLayers(ctx, width, height, t, normalized, true);
       }
 
+      this.drawDebugProvenance(ctx, width, height);
+
       if (this.timeline.endCard && this.timeline.endCard.use_end_card && t > runtime - 1.6) {
         const p = Math.max(0, Math.min(1, (t - (runtime - 1.6)) / 1.4));
         this.drawEndCard(ctx, this.timeline.endCard, p, width, height);
       }
+    }
+
+
+    getBeatLabelAtTime(t) {
+      const runtime = this.timeline ? Number(this.timeline.runtime || 20) : 20;
+      const beats = [
+        { label: 'Opening', t0: 0, t1: runtime * 0.25 },
+        { label: 'Arrival', t0: runtime * 0.25, t1: runtime * 0.5 },
+        { label: 'Lift', t0: runtime * 0.5, t1: runtime * 0.75 },
+        { label: 'Resolve', t0: runtime * 0.75, t1: runtime + 0.001 }
+      ];
+      const current = beats.find((beat) => t >= beat.t0 && t < beat.t1);
+      return current ? current.label : 'Opening';
+    }
+
+    drawDebugProvenance(ctx, w, h) {
+      if (!this.debugOptions || !this.debugOptions.enabled || !this.debugOptions.showProvenance || !this.debugFrameState) return;
+      const lines = [
+        `Beat: ${this.debugFrameState.beatLabel}`,
+        `Hero: ${(this.debugFrameState.heroVisualTypes || []).join(', ') || '—'}`,
+        `Support: ${(this.debugFrameState.supportVisualTypes || []).join(', ') || '—'}`,
+        `Active: ${(this.debugFrameState.activeVisualTypes || []).join(', ') || '—'}`
+      ];
+      ctx.save();
+      ctx.fillStyle = 'rgba(3,10,24,0.78)';
+      ctx.fillRect(8, 8, w * 0.5, 16 + lines.length * 13);
+      ctx.fillStyle = '#b8dcff';
+      ctx.font = '11px monospace';
+      lines.forEach((line, idx) => {
+        ctx.fillText(line, 14, 22 + idx * 13);
+      });
+      ctx.restore();
     }
 
     drawBaseChamber(ctx, w, h, t, normalized) {
@@ -839,23 +980,26 @@
         }
         case 'science_world_dome': {
           const cx = w * 0.5;
-          const cy = h * 0.72;
-          const r = Math.min(w, h) * 0.24;
-          ctx.strokeStyle = `rgba(180,210,230,${0.32 + intensity * 0.34})`;
+          const cy = h * 0.74;
+          const r = Math.min(w, h) * 0.25;
+          ctx.strokeStyle = `rgba(188,220,240,${0.34 + intensity * 0.36})`;
           ctx.lineWidth = 2;
           ctx.beginPath();
           ctx.arc(cx, cy, r, Math.PI, 0);
           ctx.stroke();
-          for (let i = 1; i < 5; i += 1) {
+          for (let i = 1; i <= 5; i += 1) {
+            const ratio = i / 6;
             ctx.beginPath();
-            ctx.arc(cx, cy, r * (i / 5), Math.PI, 0);
+            ctx.arc(cx, cy, r * ratio, Math.PI, 0);
             ctx.stroke();
           }
-          for (let i = -4; i <= 4; i += 1) {
-            const x1 = cx + i * (r / 4);
+          for (let ring = 1; ring <= 4; ring += 1) {
+            const ry = r * (ring / 5);
+            const rx = Math.sqrt(Math.max(0.01, (r * r) - (ry * ry)));
+            const y = cy - ry;
             ctx.beginPath();
-            ctx.moveTo(x1, cy);
-            ctx.lineTo(cx, cy - r);
+            ctx.moveTo(cx - rx, y);
+            ctx.lineTo(cx + rx, y);
             ctx.stroke();
           }
           break;
@@ -873,19 +1017,23 @@
           break;
         }
         case 'english_bay_inukshuk': {
-          const alpha = 0.3 + intensity * 0.5;
+          const alpha = 0.45 + intensity * 0.42;
           const x = w * 0.5;
-          const y = h * 0.62;
+          const y = h * 0.68;
           const scale = Math.min(w, h);
-          ctx.fillStyle = `rgba(196,206,220,${alpha})`;
-          ctx.strokeStyle = `rgba(220,236,248,${Math.min(0.9, alpha + 0.2)})`;
+          ctx.fillStyle = `rgba(198,210,224,${alpha})`;
+          ctx.strokeStyle = `rgba(230,240,250,${Math.min(0.95, alpha + 0.2)})`;
           ctx.lineWidth = Math.max(2, scale * 0.006);
-          ctx.fillRect(x - scale * 0.04, y - scale * 0.16, scale * 0.08, scale * 0.18);
-          ctx.fillRect(x - scale * 0.1, y - scale * 0.1, scale * 0.2, scale * 0.05);
-          ctx.fillRect(x - scale * 0.025, y - scale * 0.22, scale * 0.05, scale * 0.05);
-          ctx.fillRect(x - scale * 0.06, y + scale * 0.02, scale * 0.12, scale * 0.05);
-          ctx.strokeRect(x - scale * 0.04, y - scale * 0.16, scale * 0.08, scale * 0.18);
-          ctx.strokeRect(x - scale * 0.1, y - scale * 0.1, scale * 0.2, scale * 0.05);
+          const stones = [
+            [x - scale * 0.09, y, scale * 0.18, scale * 0.05],
+            [x - scale * 0.038, y - scale * 0.16, scale * 0.076, scale * 0.16],
+            [x - scale * 0.13, y - scale * 0.12, scale * 0.26, scale * 0.045],
+            [x - scale * 0.03, y - scale * 0.22, scale * 0.06, scale * 0.045]
+          ];
+          stones.forEach((stone) => {
+            ctx.fillRect(stone[0], stone[1], stone[2], stone[3]);
+            ctx.strokeRect(stone[0], stone[1], stone[2], stone[3]);
+          });
           break;
         }
         case 'maritime_museum_sailroof': {
@@ -943,7 +1091,8 @@
           ctx.moveTo(0, horizon);
           ctx.lineTo(w, horizon);
           ctx.stroke();
-          this.drawEvent(ctx, { visual_type: 'port_cranes', params: {}, intensity: intensity * 0.58 }, p, intensity, w, h, normalized);
+          // Audit note: removed dominant port crane bars from generic waterfront scene helper to avoid mystery landmark-like columns.
+          this.drawEvent(ctx, { visual_type: 'gull_silhouettes', params: {}, intensity: Math.min(0.2, intensity * 0.25) }, p, intensity, w, h, normalized);
           this.drawEvent(ctx, { visual_type: 'ocean_surface_shimmer', params: {}, intensity: intensity * 0.78 }, p, intensity, w, h, normalized);
           const glow = ctx.createLinearGradient(0, horizon - 40, 0, horizon + 80);
           glow.addColorStop(0, `rgba(255,140,210,${0.06 + intensity * 0.08})`);
@@ -983,29 +1132,24 @@
 
         case 'planetarium_dome': {
           const cx = w * 0.5;
-          const cy = h * 0.74;
-          const r = Math.min(w, h) * 0.28;
-          ctx.fillStyle = `rgba(14,22,40,${0.2 + intensity * 0.18})`;
+          const cy = h * 0.75;
+          const r = Math.min(w, h) * 0.24;
+          ctx.fillStyle = `rgba(18,28,48,${0.34 + intensity * 0.24})`;
           ctx.beginPath();
           ctx.arc(cx, cy, r, Math.PI, 0);
-          ctx.lineTo(cx + r, cy + 18);
-          ctx.lineTo(cx - r, cy + 18);
+          ctx.lineTo(cx + r, cy + h * 0.03);
+          ctx.lineTo(cx - r, cy + h * 0.03);
           ctx.closePath();
           ctx.fill();
-          ctx.strokeStyle = `rgba(160,198,236,${0.2 + intensity * 0.24})`;
+          ctx.strokeStyle = `rgba(164,202,238,${0.28 + intensity * 0.25})`;
           ctx.lineWidth = 2;
-          for (let i = 1; i <= 5; i += 1) {
-            ctx.beginPath();
-            ctx.arc(cx, cy, r * (i / 5), Math.PI, 0);
-            ctx.stroke();
-          }
-          for (let i = -4; i <= 4; i += 1) {
-            const x = cx + (i * r / 5);
-            ctx.beginPath();
-            ctx.moveTo(x, cy + 2);
-            ctx.lineTo(cx, cy - r + 6);
-            ctx.stroke();
-          }
+          ctx.beginPath();
+          ctx.arc(cx, cy, r, Math.PI, 0);
+          ctx.stroke();
+          ctx.beginPath();
+          ctx.moveTo(cx - r * 0.95, cy + h * 0.03);
+          ctx.lineTo(cx + r * 0.95, cy + h * 0.03);
+          ctx.stroke();
           break;
         }
         case 'starfield_projection': {
@@ -1056,17 +1200,17 @@
         }
 
         case 'lions_gate_bridge': {
-          const deckY = h * 0.58;
+          const deckY = h * 0.6;
           const leftTowerX = w * 0.34;
           const rightTowerX = w * 0.66;
           const towerTop = h * 0.28;
-          const towerBottom = h * 0.58;
-          ctx.strokeStyle = `rgba(190,220,238,${0.28 + intensity * 0.34})`;
-          ctx.lineWidth = 2;
+          const towerBottom = deckY;
+          ctx.strokeStyle = `rgba(198,224,240,${0.36 + intensity * 0.34})`;
+          ctx.lineWidth = 2.2;
 
           ctx.beginPath();
-          ctx.moveTo(w * 0.16, deckY);
-          ctx.lineTo(w * 0.84, deckY);
+          ctx.moveTo(w * 0.14, deckY);
+          ctx.lineTo(w * 0.86, deckY);
           ctx.stroke();
 
           ctx.beginPath();
@@ -1076,16 +1220,24 @@
           ctx.lineTo(rightTowerX, towerTop);
           ctx.stroke();
 
-          const cableLift = 0.05 + intensity * 0.03;
           ctx.beginPath();
-          ctx.moveTo(w * 0.2, deckY - h * 0.01);
-          ctx.bezierCurveTo(w * 0.3, deckY - h * cableLift, w * 0.7, deckY - h * cableLift, w * 0.8, deckY - h * 0.01);
+          ctx.moveTo(leftTowerX - w * 0.02, towerTop + h * 0.01);
+          ctx.lineTo(leftTowerX + w * 0.02, towerTop + h * 0.01);
+          ctx.moveTo(rightTowerX - w * 0.02, towerTop + h * 0.01);
+          ctx.lineTo(rightTowerX + w * 0.02, towerTop + h * 0.01);
           ctx.stroke();
 
-          const suspenders = 10;
+          const cableLift = 0.08 + intensity * 0.035;
+          ctx.beginPath();
+          ctx.moveTo(w * 0.16, deckY);
+          ctx.bezierCurveTo(w * 0.3, deckY - h * cableLift, w * 0.7, deckY - h * cableLift, w * 0.84, deckY);
+          ctx.stroke();
+
+          const suspenders = 14;
           for (let i = 0; i <= suspenders; i += 1) {
-            const x = w * (0.24 + (i / suspenders) * 0.52);
-            const topY = deckY - h * (0.01 + Math.sin((i / suspenders) * Math.PI) * cableLift);
+            const x = w * (0.18 + (i / suspenders) * 0.64);
+            const curveP = (x - w * 0.16) / (w * 0.68);
+            const topY = deckY - h * (Math.sin(Math.PI * curveP) * cableLift);
             ctx.beginPath();
             ctx.moveTo(x, topY);
             ctx.lineTo(x, deckY);
@@ -1167,7 +1319,7 @@
         case 'gull_silhouettes': {
           ctx.strokeStyle = `rgba(214,232,244,${0.1 + intensity * 0.12})`;
           ctx.lineWidth = 1.6;
-          const gulls = 2 + Math.round(intensity * 2);
+          const gulls = 2 + Math.round(Math.min(0.2, intensity) * 10);
           for (let i = 0; i < gulls; i += 1) {
             const gx = w * (0.2 + i * 0.2) + Math.sin(normalized * 2 + i) * 18;
             const gy = h * (0.18 + (i % 2) * 0.06) + Math.cos(normalized * 1.5 + i) * 6;
@@ -1292,4 +1444,5 @@
   }
 
   window.AsmrVisualEngine = AsmrVisualEngine;
+  window.ASMR_VISUAL_REGISTRY = VISUAL_REGISTRY;
 })(window);

--- a/page-asmr-lab.php
+++ b/page-asmr-lab.php
@@ -141,6 +141,18 @@ get_header();
       <p id="asmr-audio-feedback" class="asmr-audio-feedback" aria-live="polite"></p>
     </section>
 
+
+
+    <details class="asmr-debug-atlas" id="asmr-visual-debug-atlas">
+      <summary>Visual Debug Atlas</summary>
+      <p class="asmr-debug-copy">Inspect each visual motif in isolation and verify hero/support provenance without running generation.</p>
+      <div class="asmr-debug-actions">
+        <button type="button" id="asmr-preview-current-hero" class="pixel-button secondary">Preview current hero visuals</button>
+        <label class="asmr-debug-toggle"><input type="checkbox" id="asmr-debug-provenance-toggle" /> Show render provenance overlay</label>
+      </div>
+      <div id="asmr-visual-atlas-grid" class="asmr-visual-atlas-grid"></div>
+    </details>
+
     <section class="asmr-visual-preview" aria-label="Visual preview canvas">
       <canvas id="asmr-visual-canvas" width="960" height="540"></canvas>
     </section>
@@ -151,6 +163,7 @@ get_header();
       <article class="asmr-card"><h2>Sync Points</h2><ol id="asmr-beats"></ol></article>
       <article class="asmr-card"><h2>Style Tags</h2><ul id="asmr-video-prompts"></ul></article>
       <article class="asmr-card"><h2>Active Generation Plan</h2><ul id="asmr-active-plan"></ul></article>
+      <article class="asmr-card"><h2>Plan → Visual Summary</h2><ul id="asmr-plan-visual-summary"></ul></article>
       <article class="asmr-card"><h2>Edit Rhythm</h2><p id="asmr-edit-notes"></p></article>
       <article class="asmr-card"><h2>Presentation Note</h2><p id="asmr-presentation"></p></article>
       <article class="asmr-card"><h2>Timeline JSON</h2>


### PR DESCRIPTION
### Motivation
- Reduce visual trust issues by making every visual motif auditable and traceable from UI selection to renderer output. 
- Ensure hero landmarks (e.g. Lions Gate Bridge, English Bay Inukshuk) render recognizably and are not drowned by support layers or mystery vertical bars. 
- Provide developer tools to inspect motifs in isolation and validate that the compiled timeline matches the generation plan.

### Description
- Introduced a canonical visual registry/atlas in the renderer (`js/asmr-visual-engine.js`) and server (`functions.php`) containing metadata for each visual id (id, label, category, priority, description, expected_shape, renderer, intensity range, openingHero/supportOnly) and exposed it to the frontend via localized script data. 
- Added UI debug tools: a collapsible “Visual Debug Atlas” with per-motif cards and a “Preview motif” button, a “Preview current hero visuals” flow, and a provenance toggle; corresponding UI wiring lives in `page-asmr-lab.php`, `js/asmr-lab.js` and styles in `assets/css/asmr-lab.css`. 
- Extended the visual engine with registry helpers and preview APIs (`getVisualRegistry`, `previewVisualType`, `setDebugOptions`) and refactored draw flow to use registry categories (hero/scene/atmosphere/motion/support) so scene support is dampened when hero visuals are active; also added an optional provenance overlay that reports active visual_types, hero/support classification, and current beat label. 
- Audited and rebuilt key renderers to improve recognizability and suppress problem shapes: `lions_gate_bridge` (explicit towers/deck/cables/suspenders), `english_bay_inukshuk` (chunky stacked stones), `science_world_dome` (geodesic/lattice cues), `planetarium_dome` (smooth observatory profile), and reduced dominant bars by removing the generic `port_cranes` insertion from `waterfront_scene` (now a subtle support). 
- Strengthened plan-to-render alignment: added `se_validate_visual_timeline_matches_plan($plan, $visual_events)` and flow changes so `se_compile_visual_events_from_plan` respects `resolve_landmark`, injects/repairs missing hero events, and dampens excessive support intensity per beat; changed plan sanitization to include `resolve_landmark` and derive allowlists from the canonical registry.

### Testing
- `node --check js/asmr-visual-engine.js` — passed. 
- `node --check js/asmr-lab.js` — passed. 
- `php -l functions.php` — passed. 
- `php -l page-asmr-lab.php` — passed. 
- Attempted an automated Playwright screenshot of the running page but the local web server was not available (HTTP `ERR_EMPTY_RESPONSE`), so UI runtime screenshots were not captured in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0ce764590832eb4c9344b7ab5d859)