### PR TITLE
Refactor ASMR Lab debug UX into compact Visual & Sound Inspectors

### DIFF
--- a/assets/css/asmr-lab.css
+++ b/assets/css/asmr-lab.css
@@ -52,3 +52,31 @@
 .asmr-atlas-card{border:1px solid #2f3f73;border-radius:8px;background:#0a1022;padding:.55rem}
 .asmr-atlas-card h4{margin:.1rem 0 .25rem;color:#c6dcff;font-size:.86rem}
 .asmr-atlas-card p{margin:.15rem 0;font-size:.76rem;line-height:1.35}
+
+
+.asmr-inspector-shortcuts{display:flex;gap:.6rem;flex-wrap:wrap;margin-top:1rem}
+.asmr-debug-inspectors{margin-top:.8rem;border:1px solid #33437f;border-radius:8px;background:#0c1226;position:relative}
+.asmr-debug-inspectors summary{cursor:pointer;color:#9ec0ff;font-size:.9rem;padding:.75rem .8rem}
+.asmr-debug-inspectors[open]{padding:0 .8rem .8rem;max-height:min(75vh,820px);overflow:auto}
+.asmr-inspector-tabs{display:flex;gap:.45rem;margin:.4rem 0 .75rem}
+.asmr-inspector-tab{background:#101a38;border:1px solid #2f3f73;color:#bcd3ff;border-radius:6px;padding:.38rem .65rem;font-size:.78rem;cursor:pointer}
+.asmr-inspector-tab.is-active{background:#1c2c5f;color:#e6eeff}
+.asmr-inspector-panel{display:none}
+.asmr-inspector-panel.is-active{display:block}
+.asmr-inspector-layout{display:grid;grid-template-columns:minmax(0,1.2fr) minmax(260px,.8fr);gap:.75rem;align-items:start}
+.asmr-inspector-list{min-width:0}
+.asmr-inspector-search-label{font-size:.75rem;color:#9ec0ff;margin-bottom:.25rem;display:block}
+#asmr-visual-inspector-search,#asmr-sound-inspector-search{width:100%;background:#0a0d1c;color:#e6ecff;border:1px solid #33437f;border-radius:6px;padding:.5rem .6rem;margin-bottom:.6rem}
+.asmr-inspector-preview{position:sticky;top:.45rem;background:#0a1022;border:1px solid #2f3f73;border-radius:8px;padding:.6rem}
+.asmr-inspector-preview h3{margin:.1rem 0 .45rem;font-size:.86rem;color:#c6dcff}
+.asmr-inspector-meta{font-size:.74rem;color:#b8ccff;line-height:1.35;margin:.2rem 0 .45rem}
+.asmr-inspector-status{font-size:.8rem;color:#9ed4ff}
+#asmr-visual-debug-canvas{display:block;width:100%;height:auto;min-height:170px;background:linear-gradient(180deg,#060c1f,#0a142d 45%,#090f1f);border:1px solid #26396a;border-radius:6px}
+.asmr-inspector-preview-actions{display:flex;gap:.45rem;flex-wrap:wrap;margin-top:.5rem}
+.asmr-inspector-group{margin:.5rem 0}
+.asmr-inspector-group-title{margin:0 0 .35rem;font-size:.73rem;color:#8db0ff;text-transform:uppercase;letter-spacing:.04em}
+.asmr-atlas-card,.asmr-sound-card{border:1px solid #2f3f73;border-radius:7px;background:#0a1022;padding:.45rem .5rem;margin-bottom:.45rem}
+.asmr-atlas-card h4,.asmr-sound-card h4{margin:.05rem 0 .2rem;color:#c6dcff;font-size:.8rem}
+.asmr-atlas-card p,.asmr-sound-card p{margin:.12rem 0;font-size:.72rem;line-height:1.28}
+.asmr-atlas-card.is-hovered,.asmr-sound-card.is-hovered{border-color:#6b89d6;box-shadow:0 0 0 1px rgba(135,173,255,.24) inset}
+@media (max-width:860px){.asmr-inspector-layout{grid-template-columns:1fr}.asmr-inspector-preview{position:static}}

--- a/js/asmr-foley-engine.js
+++ b/js/asmr-foley-engine.js
@@ -14,6 +14,34 @@
     'gastown_clock_whistle', 'church_bells', 'harbour_noon_horn', 'nine_oclock_gun'
   ];
 
+
+
+  const SOUND_REGISTRY = [
+    { id: 'ocean_waves', label: 'Ocean Waves', category: 'bed', description: 'Layered coastal surf roll.', expected_sound: 'broad low-mid wave wash', preview_duration: 2.4 },
+    { id: 'rain_close', label: 'Rain Close', category: 'bed', description: 'Near-field rainfall texture.', expected_sound: 'fine bright rain hiss', preview_duration: 2.2 },
+    { id: 'rain_roof', label: 'Rain Roof', category: 'texture', description: 'Raindrops pattering on hard roof.', expected_sound: 'tight percussive rain taps', preview_duration: 2.2 },
+    { id: 'harbor_fog_bed', label: 'Harbor Fog Bed', category: 'ambience', description: 'Low harbor fog ambience.', expected_sound: 'distant foggy low wash', preview_duration: 2.6 },
+    { id: 'city_electrical_hum', label: 'City Electrical Hum', category: 'support', description: 'Urban electrical undercurrent.', expected_sound: 'steady warm transformer hum', preview_duration: 2.3 },
+    { id: 'crowd_murmur', label: 'Crowd Murmur', category: 'ambience', description: 'Far crowd movement layer.', expected_sound: 'soft speech-like wash', preview_duration: 2.1 },
+    { id: 'skytrain_pass', label: 'SkyTrain Pass', category: 'transit', description: 'Train pass-by sweep.', expected_sound: 'rising metallic transit whoosh', preview_duration: 2.4 },
+    { id: 'seabus_horn', label: 'SeaBus Horn', category: 'cue', description: 'Harbor horn cue.', expected_sound: 'broad resonant horn call', preview_duration: 2.8 },
+    { id: 'bus_idle', label: 'Bus Idle', category: 'transit', description: 'Bus stop engine idle texture.', expected_sound: 'mid-low engine rumble', preview_duration: 2.0 },
+    { id: 'car_horn_short', label: 'Car Horn Short', category: 'cue', description: 'Quick car horn punctuation.', expected_sound: 'short bright horn chirp', preview_duration: 1.6 },
+    { id: 'crosswalk_chirp', label: 'Crosswalk Chirp', category: 'cue', description: 'Pedestrian crossing indicator.', expected_sound: 'repeating digital chirp', preview_duration: 1.8 },
+    { id: 'bike_bell', label: 'Bike Bell', category: 'cue', description: 'Nearby bike bell strike.', expected_sound: 'small metallic ding', preview_duration: 1.6 },
+    { id: 'gulls_distant', label: 'Gulls Distant', category: 'ambience', description: 'Far gull calls above harbor.', expected_sound: 'sparse airy seagull calls', preview_duration: 2.2 },
+    { id: 'skateboard_roll', label: 'Skateboard Roll', category: 'transit', description: 'Wheel roll over pavement.', expected_sound: 'rolling rattle with soft clicks', preview_duration: 2.0 },
+    { id: 'siren_distant', label: 'Siren Distant', category: 'cue', description: 'Distant city siren pass.', expected_sound: 'muted warbling siren tail', preview_duration: 2.6 },
+    { id: 'gastown_clock_whistle', label: 'Steam Clock Whistle', category: 'cue', description: 'Gastown steam whistle burst.', expected_sound: 'airy whistle puff', preview_duration: 2.4 },
+    { id: 'church_bells', label: 'Church Bells', category: 'cue', description: 'Bell toll accents.', expected_sound: 'slow resonant metallic toll', preview_duration: 2.8 },
+    { id: 'harbour_noon_horn', label: 'Harbour Noon Horn', category: 'cue', description: 'Noon horn marker.', expected_sound: 'deep held horn tone', preview_duration: 2.8 },
+    { id: 'nine_oclock_gun', label: "9 O'Clock Gun", category: 'cue', description: 'Single ceremonial boom.', expected_sound: 'short low transient boom', preview_duration: 1.8 }
+  ];
+
+  const SOUND_REGISTRY_MAP = SOUND_REGISTRY.reduce((acc, item) => {
+    acc[item.id] = item;
+    return acc;
+  }, {});
   const BED_ENGINES = new Set([
     'ocean_waves', 'rain_close', 'rain_roof', 'harbor_fog_bed', 'city_electrical_hum',
     'crowd_murmur', 'filtered_noise_wash', 'low_hum'
@@ -657,6 +685,32 @@
       return 0.8;
     }
 
+
+    getSoundRegistry() {
+      return SOUND_REGISTRY.map((item) => ({ ...item, engine: item.id }));
+    }
+
+    async previewEngineById(engineId, options = {}) {
+      const normalizedId = String(engineId || '').trim();
+      if (!ENGINE_NAMES.includes(normalizedId)) {
+        throw new Error('Unsupported sound engine id: ' + normalizedId);
+      }
+      const meta = SOUND_REGISTRY_MAP[normalizedId] || {};
+      const runtime = clamp(Number(options.preview_duration || meta.preview_duration || 2.2), 1.5, 3);
+      const pkg = {
+        runtime_seconds: runtime,
+        audio_events: [{
+          time: 0,
+          duration: runtime,
+          intensity: clamp(Number(options.intensity || 0.62), 0.2, 0.95),
+          engine: normalizedId,
+          params: (options.params && typeof options.params === 'object') ? { ...options.params } : {},
+          sync_role: 'debug_sound_preview'
+        }]
+      };
+      return this.preview(pkg);
+    }
+
     validateRecipe(pkg) {
       if (!pkg || typeof pkg !== 'object') return false;
       if (!Array.isArray(pkg.audio_events)) return false;
@@ -744,5 +798,6 @@
     }
   }
 
+  window.ASMR_SOUND_REGISTRY = SOUND_REGISTRY;
   window.AsmrFoleyEngine = AsmrFoleyEngine;
 })(window);

--- a/js/asmr-lab.js
+++ b/js/asmr-lab.js
@@ -20,6 +20,19 @@
   const videoSupportEl = document.getElementById('asmr-video-support');
   const canvas = document.getElementById('asmr-visual-canvas');
   const atlasGridEl = document.getElementById('asmr-visual-atlas-grid');
+  const soundGridEl = document.getElementById('asmr-sound-inspector-grid');
+  const visualSearchEl = document.getElementById('asmr-visual-inspector-search');
+  const soundSearchEl = document.getElementById('asmr-sound-inspector-search');
+  const debugInspectorsEl = document.getElementById('asmr-debug-inspectors');
+  const visualMetaEl = document.getElementById('asmr-visual-inspector-meta');
+  const soundMetaEl = document.getElementById('asmr-sound-inspector-meta');
+  const soundStatusEl = document.getElementById('asmr-sound-inspector-status');
+  const visualDebugCanvas = document.getElementById('asmr-visual-debug-canvas');
+  const pinVisualPreviewBtn = document.getElementById('asmr-pin-visual-preview');
+  const stopVisualPreviewBtn = document.getElementById('asmr-stop-visual-preview');
+  const stopSoundPreviewBtn = document.getElementById('asmr-stop-sound-preview');
+  const inspectSelectedVisualsBtn = document.getElementById('asmr-inspect-selected-visuals');
+  const inspectSelectedSoundsBtn = document.getElementById('asmr-inspect-selected-sounds');
   const previewCurrentHeroBtn = document.getElementById('asmr-preview-current-hero');
   const provenanceToggle = document.getElementById('asmr-debug-provenance-toggle');
 
@@ -30,7 +43,22 @@
   const visualRegistry = (window.seAsmrLab && Array.isArray(window.seAsmrLab.visualRegistry) && window.seAsmrLab.visualRegistry.length)
     ? window.seAsmrLab.visualRegistry
     : (window.ASMR_VISUAL_REGISTRY || []);
+  const soundRegistry = (window.ASMR_SOUND_REGISTRY && Array.isArray(window.ASMR_SOUND_REGISTRY) && window.ASMR_SOUND_REGISTRY.length)
+    ? window.ASMR_SOUND_REGISTRY
+    : (typeof engine.getSoundRegistry === 'function' ? engine.getSoundRegistry() : []);
 
+  const inspectorState = {
+    activeTab: 'visual',
+    visualFilter: '',
+    soundFilter: '',
+    pinnedVisualId: null,
+    visualHoverTimer: null,
+    selectedVisualOnly: false,
+    selectedSoundOnly: false,
+    currentSoundId: null
+  };
+
+  const previewVisuals = window.AsmrVisualEngine ? new window.AsmrVisualEngine(visualDebugCanvas) : null;
 
   const LINKED_VISUAL_TO_AUDIO = {
     seabus_silhouette: ['seabus_horn'],
@@ -249,23 +277,134 @@ ${data.concept_summary}`;
   }
 
 
+
+  function groupByCategory(list) {
+    return list.reduce((acc, item) => {
+      const key = String(item.category || 'other');
+      if (!acc[key]) acc[key] = [];
+      acc[key].push(item);
+      return acc;
+    }, {});
+  }
+
+  function matchesFilter(item, needle) {
+    if (!needle) return true;
+    const text = [item.id, item.label, item.category, item.description, item.expected_shape, item.expected_sound, item.priority].filter(Boolean).join(' ').toLowerCase();
+    return text.includes(needle);
+  }
+
+  function getSelectedValues(name) {
+    if (!form) return [];
+    return Array.from(form.querySelectorAll(`input[name="${name}[]"]:checked`)).map((el) => el.value);
+  }
+
+  function updateVisualMeta(item, status) {
+    if (!visualMetaEl) return;
+    if (!item) {
+      visualMetaEl.textContent = 'Hover or focus a motif card to preview.';
+      return;
+    }
+    visualMetaEl.textContent = `${item.label} (${item.id}) • ${item.category} • ${item.priority || 'support'} • ${status || item.expected_shape || ''}`;
+  }
+
+  function updateSoundStatus(id, status, expected) {
+    if (soundStatusEl) soundStatusEl.textContent = status;
+    if (soundMetaEl) {
+      if (!id) soundMetaEl.textContent = 'Select a sound engine and click Preview sound.';
+      else soundMetaEl.textContent = `${id}${expected ? ' • ' + expected : ''}`;
+    }
+  }
+
+  function previewVisualItem(item, sourceCard) {
+    if (!item || !previewVisuals) return;
+    if (inspectorState.pinnedVisualId && inspectorState.pinnedVisualId !== item.id) return;
+    if (inspectorState.visualHoverTimer) window.clearTimeout(inspectorState.visualHoverTimer);
+    inspectorState.visualHoverTimer = window.setTimeout(() => {
+      if (!previewVisuals.previewVisualMotifById(item.id, { runtimeSeconds: 1.6 })) {
+        updateVisualMeta(item, 'renderer missing');
+        return;
+      }
+      updateVisualMeta(item, item.expected_shape || 'previewing');
+      Array.from(atlasGridEl.querySelectorAll('.asmr-atlas-card')).forEach((el) => el.classList.remove('is-hovered'));
+      if (sourceCard) sourceCard.classList.add('is-hovered');
+    }, 130);
+  }
+
   function renderVisualAtlas() {
     if (!atlasGridEl) return;
     atlasGridEl.innerHTML = '';
-    visualRegistry.forEach((item) => {
-      const card = document.createElement('article');
-      card.className = 'asmr-atlas-card';
-      card.innerHTML = `<h4>${item.label}</h4><p><code>${item.id}</code></p><p>${item.category} • ${item.priority}</p><p>${item.description}</p><p><strong>Expected:</strong> ${item.expected_shape}</p>`;
-      const btn = document.createElement('button');
-      btn.type = 'button';
-      btn.className = 'pixel-button tiny secondary';
-      btn.textContent = 'Preview motif';
-      btn.addEventListener('click', () => {
-        if (!visuals) return;
-        visuals.previewVisualType(item.id, 3.2);
+    const filterNeedle = String(inspectorState.visualFilter || '').trim().toLowerCase();
+    const selected = new Set(getSelectedValues('visual_layers'));
+    const base = visualRegistry.filter((item) => !inspectorState.selectedVisualOnly || selected.has(item.id));
+    const filtered = base.filter((item) => matchesFilter(item, filterNeedle));
+    const grouped = groupByCategory(filtered);
+    ['scene', 'landmark', 'atmosphere', 'motion', 'texture', 'support'].forEach((category) => {
+      if (!grouped[category] || !grouped[category].length) return;
+      const section = document.createElement('section');
+      section.className = 'asmr-inspector-group';
+      section.innerHTML = `<h4 class="asmr-inspector-group-title">${category}</h4>`;
+      grouped[category].forEach((item) => {
+        const card = document.createElement('article');
+        card.className = 'asmr-atlas-card';
+        card.tabIndex = 0;
+        card.dataset.id = item.id;
+        card.innerHTML = `<h4>${item.label}</h4><p><code>${item.id}</code></p><p>${item.description || ''}</p><p>${item.category} • ${item.priority}</p><p><strong>Expected:</strong> ${item.expected_shape || '—'}</p>`;
+        const pinBtn = document.createElement('button');
+        pinBtn.type = 'button';
+        pinBtn.className = 'pixel-button tiny secondary';
+        pinBtn.textContent = 'Pin preview';
+        pinBtn.addEventListener('click', () => {
+          inspectorState.pinnedVisualId = inspectorState.pinnedVisualId === item.id ? null : item.id;
+          if (pinVisualPreviewBtn) pinVisualPreviewBtn.setAttribute('aria-pressed', inspectorState.pinnedVisualId ? 'true' : 'false');
+          previewVisualItem(item, card);
+        });
+        card.appendChild(pinBtn);
+        card.addEventListener('mouseenter', () => previewVisualItem(item, card));
+        card.addEventListener('focus', () => previewVisualItem(item, card));
+        card.addEventListener('mouseleave', () => { if (!inspectorState.pinnedVisualId && previewVisuals) previewVisuals.cancelPreview(); });
+        section.appendChild(card);
       });
-      card.appendChild(btn);
-      atlasGridEl.appendChild(card);
+      atlasGridEl.appendChild(section);
+    });
+  }
+
+  function renderSoundInspector() {
+    if (!soundGridEl) return;
+    soundGridEl.innerHTML = '';
+    const filterNeedle = String(inspectorState.soundFilter || '').trim().toLowerCase();
+    const selected = new Set(getSelectedValues('audio_layers'));
+    const base = soundRegistry.filter((item) => !inspectorState.selectedSoundOnly || selected.has(item.id));
+    const filtered = base.filter((item) => matchesFilter(item, filterNeedle));
+    const grouped = groupByCategory(filtered);
+    ['bed', 'transit', 'cue', 'ambience', 'texture', 'support'].forEach((category) => {
+      if (!grouped[category] || !grouped[category].length) return;
+      const section = document.createElement('section');
+      section.className = 'asmr-inspector-group';
+      section.innerHTML = `<h4 class="asmr-inspector-group-title">${category}</h4>`;
+      grouped[category].forEach((item) => {
+        const card = document.createElement('article');
+        card.className = 'asmr-sound-card';
+        card.innerHTML = `<h4>${item.label}</h4><p><code>${item.id}</code></p><p>${item.description || ''}</p><p>${item.category}</p><p><strong>Expected:</strong> ${item.expected_sound || '—'}</p>`;
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'pixel-button tiny secondary';
+        btn.textContent = 'Preview sound';
+        btn.addEventListener('click', async () => {
+          transport.stopAll();
+          if (previewVisuals) previewVisuals.cancelPreview();
+          engine.stop();
+          try {
+            await engine.previewEngineById(item.id, { preview_duration: item.preview_duration || 2.2 });
+            inspectorState.currentSoundId = item.id;
+            updateSoundStatus(item.id, 'previewing', item.expected_sound);
+          } catch (err) {
+            updateSoundStatus(item.id, 'stopped', item.expected_sound);
+          }
+        });
+        card.appendChild(btn);
+        section.appendChild(card);
+      });
+      soundGridEl.appendChild(section);
     });
   }
 
@@ -276,11 +415,39 @@ ${data.concept_summary}`;
       .filter(Boolean)
       .filter((value, index, arr) => arr.indexOf(value) === index);
     for (let i = 0; i < queue.length; i += 1) {
-      visuals.previewVisualType(queue[i], 2.8);
+      if (previewVisuals) previewVisuals.previewVisualMotifById(queue[i], { runtimeSeconds: 1.8 });
       await new Promise((resolve) => window.setTimeout(resolve, 3100));
     }
   }
 
+
+
+  function setInspectorTab(tab) {
+    inspectorState.activeTab = tab === 'sound' ? 'sound' : 'visual';
+    document.querySelectorAll('.asmr-inspector-tab').forEach((btn) => {
+      const active = btn.dataset.tab === inspectorState.activeTab;
+      btn.classList.toggle('is-active', active);
+      btn.setAttribute('aria-selected', active ? 'true' : 'false');
+    });
+    document.querySelectorAll('.asmr-inspector-panel').forEach((panel) => {
+      const active = panel.dataset.panel === inspectorState.activeTab;
+      panel.classList.toggle('is-active', active);
+      panel.hidden = !active;
+    });
+  }
+
+  function openInspector(tab, selectedOnly) {
+    if (debugInspectorsEl) debugInspectorsEl.open = true;
+    if (tab === 'sound') {
+      inspectorState.selectedSoundOnly = !!selectedOnly;
+      setInspectorTab('sound');
+      renderSoundInspector();
+      return;
+    }
+    inspectorState.selectedVisualOnly = !!selectedOnly;
+    setInspectorTab('visual');
+    renderVisualAtlas();
+  }
   async function requestGeneration(payload) {
     setError('');
     setStatus('Generating synchronized sensory film package...');
@@ -524,6 +691,7 @@ ${data.concept_summary}`;
       transport.stopAll();
       if (visuals) visuals.stop();
       engine.stop();
+      if (previewVisuals) previewVisuals.cancelPreview();
       if (audioFeedback) audioFeedback.textContent = 'Playback stopped.';
     });
   }
@@ -560,10 +728,70 @@ ${data.concept_summary}`;
   }
 
 
+
+
+  document.querySelectorAll('.asmr-inspector-tab').forEach((btn) => {
+    btn.addEventListener('click', () => setInspectorTab(btn.dataset.tab));
+  });
+
+  if (visualSearchEl) {
+    visualSearchEl.addEventListener('input', () => {
+      inspectorState.visualFilter = visualSearchEl.value || '';
+      inspectorState.selectedVisualOnly = false;
+      renderVisualAtlas();
+    });
+  }
+
+  if (soundSearchEl) {
+    soundSearchEl.addEventListener('input', () => {
+      inspectorState.soundFilter = soundSearchEl.value || '';
+      inspectorState.selectedSoundOnly = false;
+      renderSoundInspector();
+    });
+  }
+
+  if (inspectSelectedVisualsBtn) {
+    inspectSelectedVisualsBtn.addEventListener('click', () => openInspector('visual', true));
+  }
+
+  if (inspectSelectedSoundsBtn) {
+    inspectSelectedSoundsBtn.addEventListener('click', () => openInspector('sound', true));
+  }
+
+  if (pinVisualPreviewBtn) {
+    pinVisualPreviewBtn.addEventListener('click', () => {
+      inspectorState.pinnedVisualId = null;
+      pinVisualPreviewBtn.setAttribute('aria-pressed', 'false');
+      if (previewVisuals) previewVisuals.cancelPreview();
+      updateVisualMeta(null, 'stopped');
+    });
+  }
+
+  if (stopVisualPreviewBtn) {
+    stopVisualPreviewBtn.addEventListener('click', () => {
+      inspectorState.pinnedVisualId = null;
+      if (pinVisualPreviewBtn) pinVisualPreviewBtn.setAttribute('aria-pressed', 'false');
+      if (previewVisuals) previewVisuals.cancelPreview();
+      updateVisualMeta(null, 'stopped');
+    });
+  }
+
+  if (stopSoundPreviewBtn) {
+    stopSoundPreviewBtn.addEventListener('click', () => {
+      engine.stop();
+      inspectorState.currentSoundId = null;
+      updateSoundStatus(null, 'stopped');
+    });
+  }
   if (visuals) {
     visuals.setDebugOptions({ enabled: false, showProvenance: false });
   }
+  if (previewVisuals) {
+    previewVisuals.setDebugOptions({ enabled: true, showProvenance: false });
+  }
   renderVisualAtlas();
+  renderSoundInspector();
+  setInspectorTab('visual');
 
   if (provenanceToggle) {
     provenanceToggle.addEventListener('change', () => {

--- a/js/asmr-visual-engine.js
+++ b/js/asmr-visual-engine.js
@@ -99,6 +99,7 @@
       this.debugOptions = { enabled: false, showProvenance: false };
       this.debugFrameState = null;
       this.previewTimeout = null;
+      this.previewToken = 0;
     }
 
 
@@ -110,37 +111,70 @@
       this.debugOptions = Object.assign({}, this.debugOptions, options || {});
     }
 
-    buildSingleVisualTimeline(visualType, runtime) {
-      const clampedRuntime = clamp(Number(runtime || 3.2), 2.5, 6);
+    buildSingleVisualTimeline(visualType, runtime, options = {}) {
+      const clampedRuntime = clamp(Number(runtime || 3.2), 1.2, 6);
+      const intensity = clamp(Number(options.intensity || 0.85), 0.1, 1);
+      const profileTags = Array.isArray(options.style_tags) ? options.style_tags : ['debug_preview'];
       return {
         runtime: clampedRuntime,
         visualEvents: [{
           time: 0,
           duration: clampedRuntime,
           visual_type: visualType,
-          intensity: 0.85,
-          params: {},
+          intensity,
+          params: {
+            debug_preview: true,
+            minimal_context: true,
+            ...(options.params && typeof options.params === 'object' ? options.params : {})
+          },
           sync_role: 'debug_single_preview'
         }],
         syncPoints: [],
         endCard: { use_end_card: false },
         title: 'Visual Debug Preview',
-        renderProfile: this.resolveRenderProfile({ style_tags: [] })
+        renderProfile: this.resolveRenderProfile({ style_tags: profileTags })
       };
     }
 
-    previewVisualType(visualType, runtimeSeconds) {
-      if (!VISUAL_REGISTRY_MAP[visualType]) return false;
+    previewVisualMotifById(visualType, options = {}) {
+      if (!VISUAL_REGISTRY_MAP[visualType]) {
+        if (this.debugOptions && this.debugOptions.enabled && window.console && typeof window.console.warn === 'function') {
+          window.console.warn('[ASMR] No visual renderer found for motif id:', visualType);
+        }
+        return false;
+      }
       if (this.previewTimeout) {
         window.clearTimeout(this.previewTimeout);
         this.previewTimeout = null;
       }
-      this.loadTimeline(this.buildSingleVisualTimeline(visualType, runtimeSeconds || 3.2));
+
+      const previewToken = this.previewToken + 1;
+      this.previewToken = previewToken;
+      const runtimeSeconds = clamp(Number(options.runtimeSeconds || 1.8), 1.2, 6);
+      const shouldAutoStop = options.autoStop !== false;
+
+      this.loadTimeline(this.buildSingleVisualTimeline(visualType, runtimeSeconds, options));
       this.play(0);
-      this.previewTimeout = window.setTimeout(() => {
-        this.stop();
-      }, Math.round((runtimeSeconds || 3.2) * 1000));
+      if (shouldAutoStop) {
+        this.previewTimeout = window.setTimeout(() => {
+          if (previewToken !== this.previewToken) return;
+          this.stop();
+        }, Math.round(runtimeSeconds * 1000));
+      }
       return true;
+    }
+
+    previewVisualType(visualType, runtimeSeconds) {
+      return this.previewVisualMotifById(visualType, { runtimeSeconds: runtimeSeconds || 3.2 });
+    }
+
+    cancelPreview() {
+      this.previewToken += 1;
+      if (this.previewTimeout) {
+        window.clearTimeout(this.previewTimeout);
+        this.previewTimeout = null;
+      }
+      this.stop();
     }
 
     setCanvas(canvas) {

--- a/page-asmr-lab.php
+++ b/page-asmr-lab.php
@@ -143,14 +143,58 @@ get_header();
 
 
 
-    <details class="asmr-debug-atlas" id="asmr-visual-debug-atlas">
-      <summary>Visual Debug Atlas</summary>
-      <p class="asmr-debug-copy">Inspect each visual motif in isolation and verify hero/support provenance without running generation.</p>
+    <div class="asmr-inspector-shortcuts">
+      <button type="button" id="asmr-inspect-selected-visuals" class="pixel-button secondary">Inspect selected visuals</button>
+      <button type="button" id="asmr-inspect-selected-sounds" class="pixel-button secondary">Inspect selected sounds</button>
+    </div>
+
+    <details class="asmr-debug-inspectors" id="asmr-debug-inspectors">
+      <summary>Debug Inspectors</summary>
       <div class="asmr-debug-actions">
         <button type="button" id="asmr-preview-current-hero" class="pixel-button secondary">Preview current hero visuals</button>
         <label class="asmr-debug-toggle"><input type="checkbox" id="asmr-debug-provenance-toggle" /> Show render provenance overlay</label>
       </div>
-      <div id="asmr-visual-atlas-grid" class="asmr-visual-atlas-grid"></div>
+      <div class="asmr-inspector-tabs" role="tablist" aria-label="Debug inspector tabs">
+        <button type="button" class="asmr-inspector-tab is-active" data-tab="visual" role="tab" aria-selected="true">Visual Inspector</button>
+        <button type="button" class="asmr-inspector-tab" data-tab="sound" role="tab" aria-selected="false">Sound Inspector</button>
+      </div>
+
+      <section class="asmr-inspector-panel is-active" data-panel="visual" role="tabpanel">
+        <div class="asmr-inspector-layout">
+          <div class="asmr-inspector-list">
+            <label for="asmr-visual-inspector-search" class="asmr-inspector-search-label">Search visual motifs</label>
+            <input id="asmr-visual-inspector-search" type="search" placeholder="Search by id, label, category..." />
+            <div id="asmr-visual-atlas-grid" class="asmr-visual-atlas-grid"></div>
+          </div>
+          <aside class="asmr-inspector-preview" aria-live="polite">
+            <h3>Visual Preview</h3>
+            <p id="asmr-visual-inspector-meta" class="asmr-inspector-meta">Hover or focus a motif card to preview.</p>
+            <canvas id="asmr-visual-debug-canvas" width="480" height="270"></canvas>
+            <div class="asmr-inspector-preview-actions">
+              <button type="button" id="asmr-pin-visual-preview" class="pixel-button tiny secondary" aria-pressed="false">Pin preview</button>
+              <button type="button" id="asmr-stop-visual-preview" class="pixel-button tiny secondary">Stop</button>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <section class="asmr-inspector-panel" data-panel="sound" role="tabpanel" hidden>
+        <div class="asmr-inspector-layout">
+          <div class="asmr-inspector-list">
+            <label for="asmr-sound-inspector-search" class="asmr-inspector-search-label">Search sound engines</label>
+            <input id="asmr-sound-inspector-search" type="search" placeholder="Search by id, label, category..." />
+            <div id="asmr-sound-inspector-grid" class="asmr-sound-inspector-grid"></div>
+          </div>
+          <aside class="asmr-inspector-preview" aria-live="polite">
+            <h3>Sound Preview</h3>
+            <p id="asmr-sound-inspector-meta" class="asmr-inspector-meta">Select a sound engine and click Preview sound.</p>
+            <p id="asmr-sound-inspector-status" class="asmr-inspector-status">stopped</p>
+            <div class="asmr-inspector-preview-actions">
+              <button type="button" id="asmr-stop-sound-preview" class="pixel-button tiny secondary">Stop</button>
+            </div>
+          </aside>
+        </div>
+      </section>
     </details>
 
     <section class="asmr-visual-preview" aria-label="Visual preview canvas">


### PR DESCRIPTION
### Motivation
- The existing Visual Debug Atlas produced a very long inline debug area that pushed the main preview/output far down the page and broke quick inspection flows.  
- Hover/preview interactions were forcing page scroll and preview plumbing was unreliable, making rapid QA painful.  
- A compact, searchable inspector for both visuals and sounds is needed so debug tooling is fast, local, and separate from the main generate/export path.  

### Description
- Replaced the inline atlas with a collapsed `Debug Inspectors` area in `page-asmr-lab.php` containing two tabs: `Visual Inspector` and `Sound Inspector`, plus shortcut buttons `Inspect selected visuals` and `Inspect selected sounds`.  
- Added compact inspector styles in `assets/css/asmr-lab.css` for tabbed panels, sticky preview sidebars, grouped lists, responsive stacking, and compact cards to dramatically reduce page height.  
- Implemented hover/focus-driven visual motif previewing in `js/asmr-lab.js` using a dedicated debug canvas and a small debounce (~130ms) to avoid churn, plus `Pin preview` and `Stop` controls so previews stay local to the inspector and do not scroll the page.  
- Updated `js/asmr-visual-engine.js` to add `previewVisualMotifById(id, options)`, safer single-motif timelines, preview token/cancel semantics, and debug warnings when a motif ID lacks a renderer to improve plumbing and avoid stale previews.  
- Added a `SOUND_REGISTRY` and `SOUND_REGISTRY_MAP` and API helpers `getSoundRegistry()` and `previewEngineById()` to `js/asmr-foley-engine.js`, exported as `window.ASMR_SOUND_REGISTRY`, to enable click-to-preview sound auditioning with safe short examples and an explicit stop control.  
- Wiring changes in `js/asmr-lab.js`: registry discovery for visuals and sounds, grouped searchable inspector rendering, hover/focus handlers that call the dedicated preview engine/canvas, preview cancellation on transport stop, and ensuring debug previews never leak into main export flows.  

### Testing
- Ran `node --check js/asmr-lab.js` and it reported no syntax errors (success).  
- Ran `node --check js/asmr-visual-engine.js` and it reported no syntax errors (success).  
- Ran `node --check js/asmr-foley-engine.js` and it reported no syntax errors (success).  
- Ran `php -l page-asmr-lab.php` and PHP lint passed (success).  
- Attempted an automated Playwright screenshot of `page-asmr-lab.php`, but the local web server did not respond in this environment (`ERR_EMPTY_RESPONSE`), so visual verification via browser snapshot was not produced (failure due to environment, not code).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0e2fd4078832eaffced5351c1a658)