### PR TITLE
Stabilize ASMR inspector visual previews and controls

### DIFF
--- a/assets/css/asmr-lab.css
+++ b/assets/css/asmr-lab.css
@@ -79,4 +79,8 @@
 .asmr-atlas-card h4,.asmr-sound-card h4{margin:.05rem 0 .2rem;color:#c6dcff;font-size:.8rem}
 .asmr-atlas-card p,.asmr-sound-card p{margin:.12rem 0;font-size:.72rem;line-height:1.28}
 .asmr-atlas-card.is-hovered,.asmr-sound-card.is-hovered{border-color:#6b89d6;box-shadow:0 0 0 1px rgba(135,173,255,.24) inset}
+.asmr-inspector-preview.is-hover-active{border-color:#5c79c9;box-shadow:0 0 0 1px rgba(126,168,255,.22) inset}
+#asmr-visual-preview-title.is-previewing{color:#e2edff;text-shadow:0 0 10px rgba(128,188,255,.35)}
+#asmr-visual-preview-title .preview-tag{font-size:.74rem;color:#8fb2ff;font-weight:400;margin-left:.35rem}
+.asmr-atlas-card.is-pinned{border-color:#82a2ff;box-shadow:0 0 0 1px rgba(149,182,255,.34) inset}
 @media (max-width:860px){.asmr-inspector-layout{grid-template-columns:1fr}.asmr-inspector-preview{position:static}}

--- a/js/asmr-lab.js
+++ b/js/asmr-lab.js
@@ -30,13 +30,17 @@
   const visualDebugCanvas = document.getElementById('asmr-visual-debug-canvas');
   const pinVisualPreviewBtn = document.getElementById('asmr-pin-visual-preview');
   const stopVisualPreviewBtn = document.getElementById('asmr-stop-visual-preview');
+  const clearVisualPreviewBtn = document.getElementById('asmr-clear-visual-preview');
   const stopSoundPreviewBtn = document.getElementById('asmr-stop-sound-preview');
   const inspectSelectedVisualsBtn = document.getElementById('asmr-inspect-selected-visuals');
   const inspectSelectedSoundsBtn = document.getElementById('asmr-inspect-selected-sounds');
   const previewCurrentHeroBtn = document.getElementById('asmr-preview-current-hero');
+  const visualPreviewPanelEl = document.querySelector('[data-panel="visual"] .asmr-inspector-preview');
+  const visualPreviewTitleEl = document.getElementById('asmr-visual-preview-title');
   const provenanceToggle = document.getElementById('asmr-debug-provenance-toggle');
 
   const engine = new window.AsmrFoleyEngine();
+  const inspectorSoundEngine = new window.AsmrFoleyEngine();
   const visuals = window.AsmrVisualEngine ? new window.AsmrVisualEngine(canvas) : null;
   let lastPayload = null;
   let currentPackage = null;
@@ -45,7 +49,7 @@
     : (window.ASMR_VISUAL_REGISTRY || []);
   const soundRegistry = (window.ASMR_SOUND_REGISTRY && Array.isArray(window.ASMR_SOUND_REGISTRY) && window.ASMR_SOUND_REGISTRY.length)
     ? window.ASMR_SOUND_REGISTRY
-    : (typeof engine.getSoundRegistry === 'function' ? engine.getSoundRegistry() : []);
+    : (typeof inspectorSoundEngine.getSoundRegistry === 'function' ? inspectorSoundEngine.getSoundRegistry() : []);
 
   const inspectorState = {
     activeTab: 'visual',
@@ -55,7 +59,14 @@
     visualHoverTimer: null,
     selectedVisualOnly: false,
     selectedSoundOnly: false,
-    currentSoundId: null
+    currentSoundId: null,
+    hoveredVisualId: null,
+    focusedVisualId: null,
+    currentPreviewVisualId: null,
+    previewPanelHovered: false,
+    pendingCancelTimer: null,
+    visualPreviewState: 'stopped',
+    visualMode: 'hold'
   };
 
   const previewVisuals = window.AsmrVisualEngine ? new window.AsmrVisualEngine(visualDebugCanvas) : null;
@@ -298,35 +309,119 @@ ${data.concept_summary}`;
     return Array.from(form.querySelectorAll(`input[name="${name}[]"]:checked`)).map((el) => el.value);
   }
 
+  function updatePreviewPanelHeader(item) {
+    if (!visualPreviewTitleEl) return;
+    const tag = item ? ` <span class="preview-tag">${item.label} • ${item.priority || 'support'}</span>` : '';
+    visualPreviewTitleEl.innerHTML = `Visual Preview${tag}`;
+    visualPreviewTitleEl.classList.toggle('is-previewing', !!item);
+  }
+
   function updateVisualMeta(item, status) {
     if (!visualMetaEl) return;
     if (!item) {
       visualMetaEl.textContent = 'Hover or focus a motif card to preview.';
+      updatePreviewPanelHeader(null);
       return;
     }
-    visualMetaEl.textContent = `${item.label} (${item.id}) • ${item.category} • ${item.priority || 'support'} • ${status || item.expected_shape || ''}`;
+    updatePreviewPanelHeader(item);
+    const mode = inspectorState.visualMode || 'hold';
+    const state = inspectorState.visualPreviewState || 'stopped';
+    visualMetaEl.textContent = `${item.label} (${item.id}) • ${item.category} • ${item.priority || 'support'} • state:${state} • mode:${mode} • ${status || item.expected_shape || ''}`;
+  }
+
+  function clearPendingVisualCancel() {
+    if (inspectorState.pendingCancelTimer) {
+      window.clearTimeout(inspectorState.pendingCancelTimer);
+      inspectorState.pendingCancelTimer = null;
+    }
+  }
+
+  function isVisualInteractionActive() {
+    if (inspectorState.pinnedVisualId) return true;
+    return !!(inspectorState.hoveredVisualId || inspectorState.focusedVisualId || inspectorState.previewPanelHovered);
+  }
+
+  function refreshVisualCardStates() {
+    if (!atlasGridEl) return;
+    Array.from(atlasGridEl.querySelectorAll('.asmr-atlas-card')).forEach((el) => {
+      const id = el.dataset.id;
+      const isHovered = !!id && (id === inspectorState.hoveredVisualId || id === inspectorState.focusedVisualId || id === inspectorState.currentPreviewVisualId);
+      const isPinned = !!id && id === inspectorState.pinnedVisualId;
+      el.classList.toggle('is-hovered', isHovered);
+      el.classList.toggle('is-pinned', isPinned);
+    });
+    if (visualPreviewPanelEl) {
+      visualPreviewPanelEl.classList.toggle('is-hover-active', isVisualInteractionActive());
+    }
+  }
+
+  function scheduleVisualCancel() {
+    clearPendingVisualCancel();
+    inspectorState.pendingCancelTimer = window.setTimeout(() => {
+      if (isVisualInteractionActive()) return;
+      if (previewVisuals) previewVisuals.cancelPreview({ clearFrame: false, resetTime: false });
+      inspectorState.currentPreviewVisualId = null;
+      inspectorState.visualPreviewState = 'stopped';
+      refreshVisualCardStates();
+    }, 190);
+  }
+
+  function stopVisualPreviewMotion() {
+    if (!previewVisuals) return;
+    previewVisuals.cancelPreview({ clearFrame: false, resetTime: false });
+    inspectorState.visualPreviewState = 'stopped';
+    const item = visualRegistry.find((entry) => entry.id === inspectorState.currentPreviewVisualId) || null;
+    updateVisualMeta(item, item ? (item.expected_shape || 'stopped') : 'stopped');
+    refreshVisualCardStates();
+  }
+
+  function clearVisualPreview() {
+    if (!previewVisuals) return;
+    previewVisuals.cancelPreview({ clearFrame: true, resetTime: true });
+    inspectorState.hoveredVisualId = null;
+    inspectorState.focusedVisualId = null;
+    inspectorState.currentPreviewVisualId = null;
+    inspectorState.visualPreviewState = 'stopped';
+    clearPendingVisualCancel();
+    refreshVisualCardStates();
+    updateVisualMeta(null, 'stopped');
   }
 
   function updateSoundStatus(id, status, expected) {
     if (soundStatusEl) soundStatusEl.textContent = status;
     if (soundMetaEl) {
       if (!id) soundMetaEl.textContent = 'Select a sound engine and click Preview sound.';
-      else soundMetaEl.textContent = `${id}${expected ? ' • ' + expected : ''}`;
+      else soundMetaEl.textContent = `engine:${id}${expected ? ' • expected: ' + expected : ''}`;
     }
   }
 
-  function previewVisualItem(item, sourceCard) {
+  function previewVisualItem(item, sourceCard, mode) {
     if (!item || !previewVisuals) return;
     if (inspectorState.pinnedVisualId && inspectorState.pinnedVisualId !== item.id) return;
+    clearPendingVisualCancel();
     if (inspectorState.visualHoverTimer) window.clearTimeout(inspectorState.visualHoverTimer);
     inspectorState.visualHoverTimer = window.setTimeout(() => {
-      if (!previewVisuals.previewVisualMotifById(item.id, { runtimeSeconds: 1.6 })) {
-        updateVisualMeta(item, 'renderer missing');
+      const isPinned = inspectorState.pinnedVisualId === item.id;
+      const loopPreview = isPinned;
+      const holdLastFrame = !isPinned;
+      inspectorState.visualPreviewState = isPinned ? 'pinned' : (mode || 'hover');
+      inspectorState.visualMode = loopPreview ? 'loop' : (holdLastFrame ? 'hold' : 'oneshot');
+      if (!previewVisuals.previewVisualMotifById(item.id, {
+        runtimeSeconds: isPinned ? 2.2 : 1.8,
+        autoStop: !isPinned,
+        loopPreview,
+        holdLastFrame,
+        preserveFrameOnStop: true
+      })) {
+        inspectorState.visualPreviewState = 'stopped';
+        updateVisualMeta(item, 'Renderer missing');
         return;
       }
-      updateVisualMeta(item, item.expected_shape || 'previewing');
-      Array.from(atlasGridEl.querySelectorAll('.asmr-atlas-card')).forEach((el) => el.classList.remove('is-hovered'));
-      if (sourceCard) sourceCard.classList.add('is-hovered');
+      const report = typeof previewVisuals.getLastPreviewReport === 'function' ? previewVisuals.getLastPreviewReport() : null;
+      const status = report && report.warning ? report.warning : (item.expected_shape || 'previewing');
+      inspectorState.currentPreviewVisualId = item.id;
+      updateVisualMeta(item, status);
+      refreshVisualCardStates();
     }, 130);
   }
 
@@ -356,16 +451,37 @@ ${data.concept_summary}`;
         pinBtn.addEventListener('click', () => {
           inspectorState.pinnedVisualId = inspectorState.pinnedVisualId === item.id ? null : item.id;
           if (pinVisualPreviewBtn) pinVisualPreviewBtn.setAttribute('aria-pressed', inspectorState.pinnedVisualId ? 'true' : 'false');
-          previewVisualItem(item, card);
+          if (inspectorState.pinnedVisualId) {
+            previewVisualItem(item, card, 'pinned');
+          } else {
+            stopVisualPreviewMotion();
+          }
+          refreshVisualCardStates();
         });
         card.appendChild(pinBtn);
-        card.addEventListener('mouseenter', () => previewVisualItem(item, card));
-        card.addEventListener('focus', () => previewVisualItem(item, card));
-        card.addEventListener('mouseleave', () => { if (!inspectorState.pinnedVisualId && previewVisuals) previewVisuals.cancelPreview(); });
+        card.addEventListener('mouseenter', () => {
+          inspectorState.hoveredVisualId = item.id;
+          previewVisualItem(item, card, 'hover');
+        });
+        card.addEventListener('mouseleave', () => {
+          if (inspectorState.hoveredVisualId === item.id) inspectorState.hoveredVisualId = null;
+          scheduleVisualCancel();
+          refreshVisualCardStates();
+        });
+        card.addEventListener('focus', () => {
+          inspectorState.focusedVisualId = item.id;
+          previewVisualItem(item, card, 'hover');
+        });
+        card.addEventListener('blur', () => {
+          if (inspectorState.focusedVisualId === item.id) inspectorState.focusedVisualId = null;
+          scheduleVisualCancel();
+          refreshVisualCardStates();
+        });
         section.appendChild(card);
       });
       atlasGridEl.appendChild(section);
     });
+    refreshVisualCardStates();
   }
 
   function renderSoundInspector() {
@@ -390,11 +506,10 @@ ${data.concept_summary}`;
         btn.className = 'pixel-button tiny secondary';
         btn.textContent = 'Preview sound';
         btn.addEventListener('click', async () => {
-          transport.stopAll();
-          if (previewVisuals) previewVisuals.cancelPreview();
-          engine.stop();
+          inspectorSoundEngine.stop();
+          updateSoundStatus(item.id, 'previewing', item.expected_sound);
           try {
-            await engine.previewEngineById(item.id, { preview_duration: item.preview_duration || 2.2 });
+            await inspectorSoundEngine.previewEngineById(item.id, { preview_duration: item.preview_duration || 2.2 });
             inspectorState.currentSoundId = item.id;
             updateSoundStatus(item.id, 'previewing', item.expected_sound);
           } catch (err) {
@@ -691,7 +806,8 @@ ${data.concept_summary}`;
       transport.stopAll();
       if (visuals) visuals.stop();
       engine.stop();
-      if (previewVisuals) previewVisuals.cancelPreview();
+      inspectorSoundEngine.stop();
+      stopVisualPreviewMotion();
       if (audioFeedback) audioFeedback.textContent = 'Playback stopped.';
     });
   }
@@ -734,6 +850,29 @@ ${data.concept_summary}`;
     btn.addEventListener('click', () => setInspectorTab(btn.dataset.tab));
   });
 
+
+  if (debugInspectorsEl) {
+    debugInspectorsEl.addEventListener('toggle', () => {
+      if (!debugInspectorsEl.open) {
+        clearVisualPreview();
+      }
+    });
+  }
+
+
+  if (visualPreviewPanelEl) {
+    visualPreviewPanelEl.addEventListener('mouseenter', () => {
+      inspectorState.previewPanelHovered = true;
+      clearPendingVisualCancel();
+      refreshVisualCardStates();
+    });
+    visualPreviewPanelEl.addEventListener('mouseleave', () => {
+      inspectorState.previewPanelHovered = false;
+      scheduleVisualCancel();
+      refreshVisualCardStates();
+    });
+  }
+
   if (visualSearchEl) {
     visualSearchEl.addEventListener('input', () => {
       inspectorState.visualFilter = visualSearchEl.value || '';
@@ -762,8 +901,8 @@ ${data.concept_summary}`;
     pinVisualPreviewBtn.addEventListener('click', () => {
       inspectorState.pinnedVisualId = null;
       pinVisualPreviewBtn.setAttribute('aria-pressed', 'false');
-      if (previewVisuals) previewVisuals.cancelPreview();
-      updateVisualMeta(null, 'stopped');
+      stopVisualPreviewMotion();
+      refreshVisualCardStates();
     });
   }
 
@@ -771,14 +910,21 @@ ${data.concept_summary}`;
     stopVisualPreviewBtn.addEventListener('click', () => {
       inspectorState.pinnedVisualId = null;
       if (pinVisualPreviewBtn) pinVisualPreviewBtn.setAttribute('aria-pressed', 'false');
-      if (previewVisuals) previewVisuals.cancelPreview();
-      updateVisualMeta(null, 'stopped');
+      stopVisualPreviewMotion();
+    });
+  }
+
+  if (clearVisualPreviewBtn) {
+    clearVisualPreviewBtn.addEventListener('click', () => {
+      inspectorState.pinnedVisualId = null;
+      if (pinVisualPreviewBtn) pinVisualPreviewBtn.setAttribute('aria-pressed', 'false');
+      clearVisualPreview();
     });
   }
 
   if (stopSoundPreviewBtn) {
     stopSoundPreviewBtn.addEventListener('click', () => {
-      engine.stop();
+      inspectorSoundEngine.stop();
       inspectorState.currentSoundId = null;
       updateSoundStatus(null, 'stopped');
     });
@@ -792,6 +938,8 @@ ${data.concept_summary}`;
   renderVisualAtlas();
   renderSoundInspector();
   setInspectorTab('visual');
+  updateVisualMeta(null, "stopped");
+  updateSoundStatus(null, "stopped");
 
   if (provenanceToggle) {
     provenanceToggle.addEventListener('change', () => {

--- a/js/asmr-visual-engine.js
+++ b/js/asmr-visual-engine.js
@@ -100,6 +100,8 @@
       this.debugFrameState = null;
       this.previewTimeout = null;
       this.previewToken = 0;
+      this.playbackOptions = { loopPlayback: false };
+      this.lastPreviewReport = null;
     }
 
 
@@ -138,6 +140,12 @@
 
     previewVisualMotifById(visualType, options = {}) {
       if (!VISUAL_REGISTRY_MAP[visualType]) {
+        this.lastPreviewReport = {
+          motifId: visualType,
+          rendererMissing: true,
+          pipelineOk: false,
+          warning: 'Renderer missing'
+        };
         if (this.debugOptions && this.debugOptions.enabled && window.console && typeof window.console.warn === 'function') {
           window.console.warn('[ASMR] No visual renderer found for motif id:', visualType);
         }
@@ -152,15 +160,35 @@
       this.previewToken = previewToken;
       const runtimeSeconds = clamp(Number(options.runtimeSeconds || 1.8), 1.2, 6);
       const shouldAutoStop = options.autoStop !== false;
+      const holdLastFrame = options.holdLastFrame !== false;
+      const loopPreview = !!options.loopPreview;
+      const preserveFrameOnStop = options.preserveFrameOnStop !== false;
 
       this.loadTimeline(this.buildSingleVisualTimeline(visualType, runtimeSeconds, options));
-      this.play(0);
+      this.resize();
+      let pipelineOk = true;
+      try {
+        this.render(Math.min(0.25, Math.max(0.08, runtimeSeconds * 0.15)));
+      } catch (err) {
+        pipelineOk = false;
+      }
+      this.play(0, { loopPlayback: loopPreview });
       if (shouldAutoStop) {
         this.previewTimeout = window.setTimeout(() => {
           if (previewToken !== this.previewToken) return;
-          this.stop();
+          this.stop({
+            clearFrame: !(holdLastFrame && preserveFrameOnStop),
+            resetTime: false
+          });
         }, Math.round(runtimeSeconds * 1000));
       }
+      this.lastPreviewReport = {
+        motifId: visualType,
+        rendererMissing: false,
+        pipelineOk,
+        warning: pipelineOk ? '' : 'Rendered, but no visible motif detected',
+        mode: loopPreview ? 'loop' : (holdLastFrame ? 'hold' : 'oneshot')
+      };
       return true;
     }
 
@@ -168,13 +196,20 @@
       return this.previewVisualMotifById(visualType, { runtimeSeconds: runtimeSeconds || 3.2 });
     }
 
-    cancelPreview() {
+    cancelPreview(options = {}) {
       this.previewToken += 1;
       if (this.previewTimeout) {
         window.clearTimeout(this.previewTimeout);
         this.previewTimeout = null;
       }
-      this.stop();
+      this.stop({
+        clearFrame: options.clearFrame === true,
+        resetTime: options.resetTime !== false
+      });
+    }
+
+    getLastPreviewReport() {
+      return this.lastPreviewReport ? { ...this.lastPreviewReport } : null;
     }
 
     setCanvas(canvas) {
@@ -310,24 +345,28 @@
       this.timeline = this.normalizeVisualTimeline(pkg || {});
     }
 
-    play(clockOffset) {
+    play(clockOffset, options = {}) {
       if (!this.ctx || !this.timeline) return;
       this.stop();
       this.resize();
       this.clockOffset = Number(clockOffset || 0);
       this.startPerf = performance.now() - (this.clockOffset * 1000);
+      this.playbackOptions = {
+        loopPlayback: !!options.loopPlayback
+      };
       this.running = true;
       this.loop();
     }
 
-    stop() {
+    stop(options = {}) {
       this.running = false;
       if (this.rafId) {
         cancelAnimationFrame(this.rafId);
         this.rafId = null;
       }
-      this.currentTime = 0;
-      this.clearFrame();
+      this.playbackOptions = { loopPlayback: false };
+      if (options.resetTime !== false) this.currentTime = 0;
+      if (options.clearFrame !== false) this.clearFrame();
     }
 
     seek(seconds) {
@@ -349,6 +388,12 @@
       this.render(this.currentTime);
       const linger = this.timeline.endCard && this.timeline.endCard.use_end_card ? 1.25 : 1.75;
       if (this.currentTime >= this.timeline.runtime + linger) {
+        if (this.playbackOptions && this.playbackOptions.loopPlayback) {
+          this.startPerf = performance.now();
+          this.currentTime = 0;
+          this.rafId = requestAnimationFrame(this.loop.bind(this));
+          return;
+        }
         this.stop();
         return;
       }

--- a/page-asmr-lab.php
+++ b/page-asmr-lab.php
@@ -167,12 +167,13 @@ get_header();
             <div id="asmr-visual-atlas-grid" class="asmr-visual-atlas-grid"></div>
           </div>
           <aside class="asmr-inspector-preview" aria-live="polite">
-            <h3>Visual Preview</h3>
+            <h3 id="asmr-visual-preview-title">Visual Preview</h3>
             <p id="asmr-visual-inspector-meta" class="asmr-inspector-meta">Hover or focus a motif card to preview.</p>
             <canvas id="asmr-visual-debug-canvas" width="480" height="270"></canvas>
             <div class="asmr-inspector-preview-actions">
               <button type="button" id="asmr-pin-visual-preview" class="pixel-button tiny secondary" aria-pressed="false">Pin preview</button>
               <button type="button" id="asmr-stop-visual-preview" class="pixel-button tiny secondary">Stop</button>
+              <button type="button" id="asmr-clear-visual-preview" class="pixel-button tiny secondary">Clear preview</button>
             </div>
           </aside>
         </div>


### PR DESCRIPTION
### Motivation
- Hovering motif cards produced a short auto-stopped animation and `stop()` cleared the debug canvas, leaving the preview panel blank and fragile when moving the mouse between card and preview panel.
- The visual and sound debug inspectors needed clearer, isolated preview behavior (hold poster frames, optional looping, separate sound preview engine) and explicit user controls to avoid affecting main playback/export flows.

### Description
- Added debug preview session controls and reporting to `AsmrVisualEngine` in `js/asmr-visual-engine.js`: new options `loopPreview`, `holdLastFrame`, `preserveFrameOnStop`, immediate first-frame synchronous `render(...)` before animation, and `getLastPreviewReport()` for renderer/pipeline warnings; `stop()` and `cancelPreview()` now accept options to preserve the last frame instead of always clearing. (Files: `js/asmr-visual-engine.js`.)
- Updated inspector interaction in `js/asmr-lab.js` to treat the motif card + preview panel as a single hover zone, added `hoveredVisualId`, `previewPanelHovered`, `pendingCancelTimer`, delayed cancel (≈190ms), and functions `scheduleVisualCancel()`, `stopVisualPreviewMotion()`, `clearVisualPreview()` to control poster-frame vs clear behavior and to keep pinned previews looping. Pinned previews loop; hover previews render-and-hold. (File: `js/asmr-lab.js`.)
- Isolated sound inspector preview to a dedicated `inspectorSoundEngine` so inspector-level audio preview/stop does not interfere with the main `engine` used for playback/export, and improved sound status/meta messaging. (File: `js/asmr-lab.js`, `js/asmr-foley-engine.js` unchanged except validation.)
- Added explicit Clear preview UI and header polish: new `Clear preview` button and preview title ID in `page-asmr-lab.php`, and preview/pinned/hover CSS states in `assets/css/asmr-lab.css` to highlight previewing/pinned cards and the preview panel. (Files: `page-asmr-lab.php`, `assets/css/asmr-lab.css`.)

### Testing
- Syntax checks completed successfully: `node --check js/asmr-lab.js`, `node --check js/asmr-visual-engine.js`, and `node --check js/asmr-foley-engine.js` (all passed).
- PHP template lint succeeded with `php -l page-asmr-lab.php` (passed).
- Attempted a Playwright page capture to validate runtime UI, but there was no local web server responding in this environment (`Page.goto` failed with `ERR_EMPTY_RESPONSE`), so no live screenshot was produced; code-level checks and lints were used for validation instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0e9371e38832ea39d69c6cebfcb8c)