### PR TITLE
Calm ASMR Lab layout with advanced inspector disclosure

### DIFF
--- a/assets/css/asmr-lab.css
+++ b/assets/css/asmr-lab.css
@@ -84,3 +84,40 @@
 #asmr-visual-preview-title .preview-tag{font-size:.74rem;color:#8fb2ff;font-weight:400;margin-left:.35rem}
 .asmr-atlas-card.is-pinned{border-color:#82a2ff;box-shadow:0 0 0 1px rgba(149,182,255,.34) inset}
 @media (max-width:860px){.asmr-inspector-layout{grid-template-columns:1fr}.asmr-inspector-preview{position:static}}
+
+
+/* Calmer hierarchy and progressive disclosure */
+.asmr-audio-controls{margin-top:1.2rem;padding:.75rem .8rem;background:#0b1124;border:1px solid #2e3d71;border-radius:8px}
+
+.asmr-advanced-panel{margin-top:1rem;border:1px solid #2f3f73;border-radius:8px;background:#0b1124}
+.asmr-advanced-panel summary{cursor:pointer;color:#9ec0ff;font-size:.88rem;padding:.7rem .85rem;list-style:none}
+.asmr-advanced-panel summary::-webkit-details-marker{display:none}
+.asmr-advanced-panel[open]{padding:0 .85rem .85rem}
+.asmr-advanced-intro{font-size:.74rem;color:#9ab6ef;opacity:.85;margin:.2rem 0 .75rem}
+.asmr-advanced-panel .asmr-inspector-shortcuts{margin-top:0;margin-bottom:.7rem;padding:.55rem;border:1px dashed #33437f;border-radius:7px;background:#0a1022}
+
+.asmr-debug-inspectors{margin-top:.5rem;background:#090f21}
+.asmr-debug-inspectors summary{font-size:.84rem;padding:.6rem .72rem;color:#8fb1ff}
+.asmr-debug-inspectors:not([open]){opacity:.86}
+
+.asmr-results{margin-top:1.25rem;background:#0b1125;border:1px solid #2f3f73;border-radius:10px;padding:.9rem}
+.asmr-results-header{display:flex;justify-content:space-between;align-items:center;gap:.8rem;flex-wrap:wrap;margin-bottom:.8rem}
+.asmr-results-header h2{margin:0;font-size:1rem;color:#9ec0ff}
+.asmr-results-tabs{display:flex;gap:.45rem;flex-wrap:wrap}
+.asmr-results-tab{background:#101a38;border:1px solid #2f3f73;color:#bcd3ff;border-radius:999px;padding:.34rem .72rem;font-size:.75rem;cursor:pointer}
+.asmr-results-tab.is-active{background:#1d2f63;color:#eff5ff;border-color:#5274d1}
+.asmr-results-panel{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:.7rem}
+.asmr-results-panel[hidden]{display:none}
+.asmr-card{padding:.65rem .72rem;background:#10162f}
+.asmr-card h3{margin:.08rem 0 .45rem;font-size:.85rem;color:#9ec0ff}
+.asmr-card p{margin:.28rem 0;line-height:1.5;font-size:.76rem}
+.asmr-card ul,.asmr-card ol{margin:.2rem 0 .2rem 1.05rem}
+.asmr-card li{margin:.2rem 0;line-height:1.4}
+.asmr-card-brief p + p{border-top:1px dashed #2d3f78;padding-top:.38rem}
+.asmr-card-json pre{max-height:300px;overflow:auto;background:#080d1b;padding:.7rem;border-radius:6px;border:1px solid #22315a}
+
+@media (max-width:760px){
+  .asmr-results{padding:.72rem}
+  .asmr-results-header h2{font-size:.92rem}
+  .asmr-results-tab{font-size:.72rem}
+}

--- a/js/asmr-lab.js
+++ b/js/asmr-lab.js
@@ -23,6 +23,7 @@
   const soundGridEl = document.getElementById('asmr-sound-inspector-grid');
   const visualSearchEl = document.getElementById('asmr-visual-inspector-search');
   const soundSearchEl = document.getElementById('asmr-sound-inspector-search');
+  const advancedPanelEl = document.getElementById('asmr-advanced-panel');
   const debugInspectorsEl = document.getElementById('asmr-debug-inspectors');
   const visualMetaEl = document.getElementById('asmr-visual-inspector-meta');
   const soundMetaEl = document.getElementById('asmr-sound-inspector-meta');
@@ -38,6 +39,8 @@
   const visualPreviewPanelEl = document.querySelector('[data-panel="visual"] .asmr-inspector-preview');
   const visualPreviewTitleEl = document.getElementById('asmr-visual-preview-title');
   const provenanceToggle = document.getElementById('asmr-debug-provenance-toggle');
+  const resultsTabButtons = document.querySelectorAll('.asmr-results-tab');
+  const resultsPanels = document.querySelectorAll('.asmr-results-panel');
 
   const engine = new window.AsmrFoleyEngine();
   const inspectorSoundEngine = new window.AsmrFoleyEngine();
@@ -266,6 +269,22 @@
   }
 
 
+
+
+  function setResultsTab(tab) {
+    const activeTab = tab === 'timeline' || tab === 'json' ? tab : 'overview';
+    resultsTabButtons.forEach((btn) => {
+      const active = btn.dataset.resultsTab === activeTab;
+      btn.classList.toggle('is-active', active);
+      btn.setAttribute('aria-selected', active ? 'true' : 'false');
+    });
+    resultsPanels.forEach((panel) => {
+      const active = panel.dataset.resultsPanel === activeTab;
+      panel.classList.toggle('is-active', active);
+      panel.hidden = !active;
+    });
+  }
+
   function renderData(data) {
     const concept = document.getElementById('asmr-concept');
     const beats = document.getElementById('asmr-beats');
@@ -341,6 +360,7 @@ ${data.concept_summary}`;
       edit.textContent = `${er.pacing_note || ''} ${er.silence_strategy || ''} ${er.release_strategy || ''}`.trim();
     }
     if (note) note.textContent = data.presentation_note || '';
+    setResultsTab('overview');
     if (recipe) recipe.textContent = JSON.stringify({ audio_events: data.audio_events, visual_events: data.visual_events, end_card: data.end_card }, null, 2);
 
     currentPackage = data;
@@ -657,6 +677,7 @@ ${data.concept_summary}`;
   }
 
   function openInspector(tab, selectedOnly) {
+    if (advancedPanelEl) advancedPanelEl.open = true;
     if (debugInspectorsEl) debugInspectorsEl.open = true;
     if (tab === 'sound') {
       inspectorState.selectedSoundOnly = !!selectedOnly;
@@ -955,6 +976,10 @@ ${data.concept_summary}`;
     btn.addEventListener('click', () => setInspectorTab(btn.dataset.tab));
   });
 
+  resultsTabButtons.forEach((btn) => {
+    btn.addEventListener('click', () => setResultsTab(btn.dataset.resultsTab));
+  });
+
 
   if (debugInspectorsEl) {
     debugInspectorsEl.addEventListener('toggle', () => {
@@ -1040,6 +1065,9 @@ ${data.concept_summary}`;
   if (previewVisuals) {
     previewVisuals.setDebugOptions({ enabled: true, showProvenance: false });
   }
+  if (advancedPanelEl) advancedPanelEl.open = false;
+  if (debugInspectorsEl) debugInspectorsEl.open = false;
+
   renderVisualAtlas();
   renderSoundInspector();
   setInspectorTab('visual');

--- a/page-asmr-lab.php
+++ b/page-asmr-lab.php
@@ -143,21 +143,25 @@ get_header();
 
 
 
-    <div class="asmr-inspector-shortcuts">
-      <button type="button" id="asmr-inspect-selected-visuals" class="pixel-button secondary">Inspect selected visuals</button>
-      <button type="button" id="asmr-inspect-selected-sounds" class="pixel-button secondary">Inspect selected sounds</button>
-    </div>
+    <details class="asmr-advanced-panel" id="asmr-advanced-panel">
+      <summary>Advanced / Inspect</summary>
+      <div class="asmr-advanced-intro">Power-user diagnostics, motif inspectors, and render debugging tools.</div>
 
-    <details class="asmr-debug-inspectors" id="asmr-debug-inspectors">
-      <summary>Debug Inspectors</summary>
-      <div class="asmr-debug-actions">
-        <button type="button" id="asmr-preview-current-hero" class="pixel-button secondary">Preview current hero visuals</button>
-        <label class="asmr-debug-toggle"><input type="checkbox" id="asmr-debug-provenance-toggle" /> Show render provenance overlay</label>
+      <div class="asmr-inspector-shortcuts">
+        <button type="button" id="asmr-inspect-selected-visuals" class="pixel-button secondary">Inspect selected visuals</button>
+        <button type="button" id="asmr-inspect-selected-sounds" class="pixel-button secondary">Inspect selected sounds</button>
       </div>
-      <div class="asmr-inspector-tabs" role="tablist" aria-label="Debug inspector tabs">
-        <button type="button" class="asmr-inspector-tab is-active" data-tab="visual" role="tab" aria-selected="true">Visual Inspector</button>
-        <button type="button" class="asmr-inspector-tab" data-tab="sound" role="tab" aria-selected="false">Sound Inspector</button>
-      </div>
+
+      <details class="asmr-debug-inspectors" id="asmr-debug-inspectors">
+        <summary>Debug Inspectors</summary>
+        <div class="asmr-debug-actions">
+          <button type="button" id="asmr-preview-current-hero" class="pixel-button secondary">Preview current hero visuals</button>
+          <label class="asmr-debug-toggle"><input type="checkbox" id="asmr-debug-provenance-toggle" /> Show render provenance overlay</label>
+        </div>
+        <div class="asmr-inspector-tabs" role="tablist" aria-label="Debug inspector tabs">
+          <button type="button" class="asmr-inspector-tab is-active" data-tab="visual" role="tab" aria-selected="true">Visual Inspector</button>
+          <button type="button" class="asmr-inspector-tab" data-tab="sound" role="tab" aria-selected="false">Sound Inspector</button>
+        </div>
 
       <section class="asmr-inspector-panel is-active" data-panel="visual" role="tabpanel">
         <div class="asmr-inspector-layout">
@@ -179,7 +183,7 @@ get_header();
         </div>
       </section>
 
-      <section class="asmr-inspector-panel" data-panel="sound" role="tabpanel" hidden>
+        <section class="asmr-inspector-panel" data-panel="sound" role="tabpanel" hidden>
         <div class="asmr-inspector-layout">
           <div class="asmr-inspector-list">
             <label for="asmr-sound-inspector-search" class="asmr-inspector-search-label">Search sound engines</label>
@@ -195,7 +199,8 @@ get_header();
             </div>
           </aside>
         </div>
-      </section>
+        </section>
+      </details>
     </details>
 
     <section class="asmr-visual-preview" aria-label="Visual preview canvas">
@@ -203,20 +208,30 @@ get_header();
     </section>
 
     <section id="asmr-results" class="asmr-results" hidden>
-      <article class="asmr-card"><h2>Concept</h2><p id="asmr-concept"></p></article>
-      <article class="asmr-card"><h2>Story Beats</h2><ol id="asmr-story-beats"></ol></article>
-      <article class="asmr-card"><h2>Sync Points</h2><ol id="asmr-beats"></ol></article>
-      <article class="asmr-card"><h2>Style Tags</h2><ul id="asmr-video-prompts"></ul></article>
-      <article class="asmr-card"><h2>Active Generation Plan</h2><ul id="asmr-active-plan"></ul></article>
-      <article class="asmr-card"><h2>Plan → Visual Summary</h2><ul id="asmr-plan-visual-summary"></ul></article>
-      <article class="asmr-card"><h2>Edit Rhythm</h2><p id="asmr-edit-notes"></p></article>
-      <article class="asmr-card"><h2>Presentation Note</h2><p id="asmr-presentation"></p></article>
-      <article class="asmr-card"><h2>Timeline JSON</h2>
-        <details>
-          <summary>View JSON package</summary>
-          <pre id="asmr-sound-json"></pre>
-        </details>
-      </article>
+      <header class="asmr-results-header">
+        <h2>Generation Results</h2>
+        <div class="asmr-results-tabs" role="tablist" aria-label="Generation result sections">
+          <button type="button" class="asmr-results-tab is-active" data-results-tab="overview" role="tab" aria-selected="true">Overview</button>
+          <button type="button" class="asmr-results-tab" data-results-tab="timeline" role="tab" aria-selected="false">Timeline</button>
+          <button type="button" class="asmr-results-tab" data-results-tab="json" role="tab" aria-selected="false">JSON</button>
+        </div>
+      </header>
+
+      <section class="asmr-results-panel is-active" data-results-panel="overview" role="tabpanel">
+        <article class="asmr-card asmr-card-brief"><h3>Creative Brief</h3><p id="asmr-concept"></p><p id="asmr-edit-notes"></p><p id="asmr-presentation"></p></article>
+        <article class="asmr-card"><h3>Story Beats</h3><ol id="asmr-story-beats"></ol></article>
+        <article class="asmr-card"><h3>Style Tags</h3><ul id="asmr-video-prompts"></ul></article>
+      </section>
+
+      <section class="asmr-results-panel" data-results-panel="timeline" role="tabpanel" hidden>
+        <article class="asmr-card"><h3>Sync Points</h3><ol id="asmr-beats"></ol></article>
+        <article class="asmr-card"><h3>Active Plan</h3><ul id="asmr-active-plan"></ul></article>
+        <article class="asmr-card"><h3>Plan → Visual Summary</h3><ul id="asmr-plan-visual-summary"></ul></article>
+      </section>
+
+      <section class="asmr-results-panel" data-results-panel="json" role="tabpanel" hidden>
+        <article class="asmr-card asmr-card-json"><h3>Timeline Package JSON</h3><pre id="asmr-sound-json"></pre></article>
+      </section>
     </section>
   </section>
 </main>

--- a/style.css
+++ b/style.css
@@ -3497,3 +3497,18 @@ body.page-template-page-bio-php .bio-content {
 .footer-site-links a:focus {
   text-decoration: underline;
 }
+
+
+/* ASMR Lab page-level breathing room */
+.asmr-lab-page .asmr-lab-shell {
+  margin-top: 2.4rem;
+  margin-bottom: 2.8rem;
+}
+
+.asmr-lab-page .asmr-lab-primer {
+  margin-bottom: 1.2rem;
+}
+
+.asmr-lab-page .asmr-lab-form {
+  gap: 1rem;
+}


### PR DESCRIPTION
### Motivation
- The ASMR Lab UI was visually busy with creation controls, debug tools, playback, preview, and results all stacked together, making first load feel cluttered.
- Keep the core creator flow (duration, sound layers, visual motifs, link AV, generate) front-and-center while de-emphasizing advanced/debug tools by default.
- Make generated output easier to scan by converting many small result cards into a simpler segmented layout without removing any existing functionality.

### Description
- Wrapped inspector shortcuts and debug tooling inside a new collapsed-by-default `details.asmr-advanced-panel` so advanced controls are tucked away but still accessible; updated `page-asmr-lab.php` accordingly.
- Reworked the results area into tabbed/segmented panels (`Overview`, `Timeline`, `JSON`) and reduced repeated headings by grouping related content into fewer cards in `page-asmr-lab.php`.
- Added styles to `assets/css/asmr-lab.css` to soften hierarchy, style the advanced panel and result tabs, increase breathing room, and reduce visual density while preserving the retro arcade aesthetic.
- Implemented result tab state handling and progressive-disclosure behavior in `js/asmr-lab.js` by adding `setResultsTab`, wiring tab buttons, defaulting to `Overview` after render, and ensuring the advanced/debug panels are closed on initial load while keeping inspector shortcuts opening those panels when invoked.
- Small page-level spacing polish added to `style.css` for the ASMR Lab template to improve overall breathing room.

### Testing
- Ran PHP syntax check `php -l page-asmr-lab.php` which succeeded.
- Performed JS syntax check via `node -c js/asmr-lab.js` which returned without errors.
- Attempted a Playwright screenshot to visually validate the page, but the local server was not responding (`ERR_EMPTY_RESPONSE`), so no live render screenshot was produced.
- Changes were committed locally with a descriptive commit message and are ready for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b50bd07440832e8f3ae5849a17823c)