### PR TITLE
Introduce Gastown Water Street route profile and route-driven composition

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -956,6 +956,12 @@ function se_get_asmr_visual_registry() {
         array( 'id' => 'neon_wet_reflections', 'label' => 'Neon Wet Reflections', 'category' => 'texture', 'priority' => 'support', 'description' => 'Neon wet pavement texture.', 'expected_shape' => 'glowing vertical puddles', 'renderer' => 'drawNeonWetReflections', 'intensity_min' => 0.2, 'intensity_max' => 0.55, 'opening_hero' => false, 'support_only' => true ),
         array( 'id' => 'winter_particulate_depth', 'label' => 'Winter Particulate Depth', 'category' => 'atmosphere', 'priority' => 'support', 'description' => 'Depth snow particles.', 'expected_shape' => 'layered snow points', 'renderer' => 'drawWinterParticulateDepth', 'intensity_min' => 0.2, 'intensity_max' => 0.62, 'opening_hero' => false, 'support_only' => true ),
         array( 'id' => 'gastown_clock_silhouette', 'label' => 'Gastown Clock', 'category' => 'landmark', 'priority' => 'hero', 'description' => 'Steam clock silhouette.', 'expected_shape' => 'tall steam clock with roof cap, round face, glass body, side pipes, and pedestal base', 'renderer' => 'drawGastownClockSilhouette', 'intensity_min' => 0.35, 'intensity_max' => 0.8, 'opening_hero' => true, 'support_only' => false ),
+        array( 'id' => 'steam_clock_approach', 'label' => 'Steam Clock Approach', 'category' => 'landmark', 'priority' => 'hero', 'description' => 'Steam clock reveal embedded in route movement.', 'expected_shape' => 'clock on left/right third inside corridor', 'renderer' => 'drawSteamClockApproach', 'intensity_min' => 0.3, 'intensity_max' => 0.82, 'opening_hero' => true, 'support_only' => false ),
+        array( 'id' => 'water_street_corridor', 'label' => 'Water Street Corridor', 'category' => 'scene', 'priority' => 'support', 'description' => 'Route-first Water Street corridor framing.', 'expected_shape' => 'off-center vanishing corridor with facades', 'renderer' => 'drawWaterStreetCorridor', 'intensity_min' => 0.22, 'intensity_max' => 0.62, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'station_threshold_glow', 'label' => 'Station Threshold Glow', 'category' => 'scene', 'priority' => 'support', 'description' => 'Waterfront threshold entry glow.', 'expected_shape' => 'station-edge glow with corridor entry', 'renderer' => 'drawStationThresholdGlow', 'intensity_min' => 0.2, 'intensity_max' => 0.56, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'angled_building_split', 'label' => 'Angled Building Split', 'category' => 'scene', 'priority' => 'support', 'description' => 'Street split with angled building node.', 'expected_shape' => 'forking curb lines and angled facade mass', 'renderer' => 'drawAngledBuildingSplit', 'intensity_min' => 0.18, 'intensity_max' => 0.6, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'lamp_rhythm_row', 'label' => 'Lamp Rhythm Row', 'category' => 'texture', 'priority' => 'support', 'description' => 'Rhythmic staggered lamp halos along route.', 'expected_shape' => 'receding off-center lamp cadence', 'renderer' => 'drawLampRhythmRow', 'intensity_min' => 0.12, 'intensity_max' => 0.4, 'opening_hero' => false, 'support_only' => true ),
+        array( 'id' => 'wet_cobble_axis', 'label' => 'Wet Cobble Axis', 'category' => 'texture', 'priority' => 'support', 'description' => 'Ground-plane reflective cobble motion axis.', 'expected_shape' => 'wet perspective axis with converging lines', 'renderer' => 'drawWetCobbleAxis', 'intensity_min' => 0.12, 'intensity_max' => 0.44, 'opening_hero' => false, 'support_only' => true ),
         array( 'id' => 'cobblestone_perspective', 'label' => 'Cobblestone Perspective', 'category' => 'texture', 'priority' => 'support', 'description' => 'Cobblestone lane texture.', 'expected_shape' => 'ground grid stones', 'renderer' => 'drawCobblestonePerspective', 'intensity_min' => 0.18, 'intensity_max' => 0.45, 'opening_hero' => false, 'support_only' => true ),
         array( 'id' => 'brick_wall_parallax', 'label' => 'Brick Wall Parallax', 'category' => 'texture', 'priority' => 'support', 'description' => 'Brick facade sides.', 'expected_shape' => 'left/right brick blocks', 'renderer' => 'drawBrickWallParallax', 'intensity_min' => 0.18, 'intensity_max' => 0.45, 'opening_hero' => false, 'support_only' => true ),
         array( 'id' => 'streetlamp_halo_row', 'label' => 'Streetlamp Halo Row', 'category' => 'atmosphere', 'priority' => 'support', 'description' => 'Streetlamp halo row.', 'expected_shape' => 'four halo circles', 'renderer' => 'drawStreetlampHaloRow', 'intensity_min' => 0.18, 'intensity_max' => 0.48, 'opening_hero' => false, 'support_only' => true ),
@@ -1033,7 +1039,7 @@ function se_get_asmr_semantic_cues( $payload ) {
     ) ) );
 
     $cue_map = array(
-        'gastown' => array( 'steam_clock', 'cobblestone', 'brick', 'amber', 'urban_night' ),
+        'gastown' => array( 'steam_clock', 'cobblestone', 'brick', 'amber', 'urban_night', 'water_street_route' ),
         'vancouver' => array( 'harbor', 'fog', 'coastal', 'urban_night' ),
         'steam clock' => array( 'steam_clock', 'metal', 'bell' ),
         'snow' => array( 'snow', 'winter_hush', 'cold_air' ),
@@ -1041,6 +1047,7 @@ function se_get_asmr_semantic_cues( $payload ) {
         'harbor fog' => array( 'harbor', 'fog' ),
         'amber' => array( 'amber', 'streetlamp' ),
         'streetlamp' => array( 'streetlamp', 'amber' ),
+        'water street' => array( 'water_street_route', 'corridor_traversal', 'first_person_unseen' ),
         'wet cobblestone' => array( 'wet_reflection', 'cobblestone' ),
         'cobblestone' => array( 'cobblestone' ),
         'brick' => array( 'brick' ),
@@ -1319,6 +1326,7 @@ function se_get_asmr_visual_layers_allowed() {
         'gastown_clock_silhouette', 'science_world_dome', 'chinatown_gate', 'english_bay_inukshuk', 'maritime_museum_sailroof',
         'lions_gate_bridge', 'bc_place_dome', 'port_cranes', 'planetarium_dome', 'starfield_projection', 'constellation_lines', 'canada_place_sails',
         'cobblestone_perspective', 'brick_wall_parallax', 'puddle_reflections', 'streetlamp_halo_row',
+        'water_street_corridor', 'station_threshold_glow', 'steam_clock_approach', 'angled_building_split', 'lamp_rhythm_row', 'wet_cobble_axis',
         'street_corridor_vanishing_point', 'curb_line_perspective', 'facade_plane_bands', 'awning_edge_rows',
         'heritage_window_grid', 'district_sign_columns', 'wet_reflection_axis', 'skyline_mask_lowrise',
         'skytrain_track', 'skytrain_pass_visual', 'bus_pass_visual',
@@ -1338,7 +1346,7 @@ function se_get_asmr_visual_to_audio_map() {
 
 function se_get_asmr_scene_visual_support_map() {
     return array(
-        'gastown_scene' => array( 'street_corridor_vanishing_point', 'curb_line_perspective', 'facade_plane_bands', 'heritage_window_grid', 'gastown_clock_silhouette', 'streetlamp_halo_row' ),
+        'gastown_scene' => array( 'water_street_corridor', 'station_threshold_glow', 'wet_cobble_axis', 'lamp_rhythm_row', 'steam_clock_approach', 'angled_building_split', 'gastown_clock_silhouette' ),
         'granville_scene' => array( 'street_corridor_vanishing_point', 'district_sign_columns', 'wet_reflection_axis', 'granville_neon_marquee', 'puddle_reflections' ),
         'north_shore_scene' => array( 'northshore_mountain_ridge', 'mountain_mist_layers', 'gull_silhouettes' ),
         'waterfront_scene' => array( 'ocean_surface_shimmer', 'seabus_silhouette', 'canada_place_sails', 'gull_silhouettes' ),
@@ -1361,8 +1369,8 @@ function se_get_asmr_mapped_visual_layers_from_audio( $audio_layers ) {
         'skytrain_pass' => 'skytrain_pass_visual',
         'bus_pass' => 'bus_pass_visual',
         'rain_ambience' => 'rain_streaks',
-        'steam_clock' => 'gastown_clock_silhouette',
-        'gastown_clock_whistle' => 'gastown_clock_silhouette',
+        'steam_clock' => 'steam_clock_approach',
+        'gastown_clock_whistle' => 'steam_clock_approach',
         'church_bells' => 'constellation_lines',
         'harbour_noon_horn' => 'waterfront_scene',
         'ocean_waves' => 'ocean_surface_shimmer',
@@ -1622,6 +1630,13 @@ function se_pick_random_from_allowed( $candidates, $allowed ) {
     return $pool[0];
 }
 
+
+function se_is_gastown_route_selection( $visual_layers ) {
+    $visual = array_values( array_unique( array_map( 'sanitize_key', (array) $visual_layers ) ) );
+    $route_tokens = array( 'gastown_scene', 'water_street_corridor', 'station_threshold_glow', 'steam_clock_approach', 'angled_building_split', 'lamp_rhythm_row', 'wet_cobble_axis' );
+    return count( array_intersect( $visual, $route_tokens ) ) >= 2;
+}
+
 function se_restrict_generation_plan_to_selected_motifs( $plan, $audio_layers, $visual_layers ) {
     $plan = is_array( $plan ) ? $plan : array();
     $plan['visual_plan'] = is_array( $plan['visual_plan'] ?? null ) ? $plan['visual_plan'] : array();
@@ -1662,6 +1677,28 @@ function se_restrict_generation_plan_to_selected_motifs( $plan, $audio_layers, $
 
     $overlay = sanitize_key( $plan['visual_plan']['overlay_family'] ?? '' );
     $plan['visual_plan']['overlay_family'] = in_array( $overlay, $selected_support, true ) ? $overlay : '';
+
+    if ( se_is_gastown_route_selection( $selected_visual ) ) {
+        if ( in_array( 'gastown_scene', $selected_visual, true ) ) {
+            $plan['visual_plan']['primary_scene'] = 'gastown_scene';
+        }
+        if ( in_array( 'steam_clock_approach', $selected_visual, true ) ) {
+            $plan['visual_plan']['landmark'] = 'steam_clock_approach';
+            $plan['visual_plan']['resolve_landmark'] = 'steam_clock_approach';
+        } elseif ( in_array( 'gastown_clock_silhouette', $selected_visual, true ) ) {
+            $plan['visual_plan']['landmark'] = 'gastown_clock_silhouette';
+            $plan['visual_plan']['resolve_landmark'] = 'gastown_clock_silhouette';
+        }
+        if ( in_array( 'water_street_corridor', $selected_visual, true ) ) {
+            $plan['visual_plan']['motion'] = 'water_street_corridor';
+        }
+        if ( in_array( 'wet_cobble_axis', $selected_visual, true ) ) {
+            $plan['visual_plan']['texture'] = 'wet_cobble_axis';
+        }
+        if ( in_array( 'lamp_rhythm_row', $selected_visual, true ) ) {
+            $plan['visual_plan']['overlay_family'] = 'lamp_rhythm_row';
+        }
+    }
 
     $audio_slots = array( 'primary_bed', 'secondary_bed', 'transit_cue' );
     foreach ( $audio_slots as $slot ) {
@@ -1789,36 +1826,56 @@ function se_compile_visual_events_from_plan( $plan, $runtime ) {
     }
 
     $events = array();
+    $route_params = array();
+    if ( se_is_gastown_route_selection( array( $primary_scene, $landmark, $motion, $texture, $overlay, $resolve_landmark ) ) || 'gastown_scene' === $primary_scene ) {
+        $route_params = array(
+            'route_id' => 'gastown_water_street_walk',
+            'pov' => 'first_person_unseen',
+            'movement' => 'forward_walk',
+            'framing' => 'off_center_landmark',
+            'corridor_bias' => 'strong',
+            'asymmetry_bias' => 'high',
+        );
+    }
 
     if ( $atmosphere ) {
-        $events[] = array( 'time' => 0.0, 'duration' => min( $runtime - 0.2, 7.6 ), 'visual_type' => $atmosphere, 'intensity' => 0.3, 'params' => array(), 'sync_role' => 'opening_atmosphere' );
+        $events[] = array( 'time' => 0.0, 'duration' => min( $runtime - 0.2, 7.6 ), 'visual_type' => $atmosphere, 'intensity' => 0.3, 'params' => $route_params, 'sync_role' => 'opening_atmosphere' );
     }
 
     if ( $primary_scene && in_array( $primary_scene, $hero_types, true ) ) {
-        $events[] = array( 'time' => 0.2, 'duration' => 5.2, 'visual_type' => $primary_scene, 'intensity' => 0.76, 'params' => array(), 'sync_role' => 'opening_scene_hero' );
+        $events[] = array( 'time' => 0.2, 'duration' => 5.2, 'visual_type' => $primary_scene, 'intensity' => 0.76, 'params' => $route_params, 'sync_role' => 'opening_scene_hero' );
     }
 
     if ( $overlay && in_array( $overlay, $support_types, true ) ) {
-        $events[] = array( 'time' => 0.4, 'duration' => 3.2, 'visual_type' => $overlay, 'intensity' => 0.08, 'params' => array(), 'sync_role' => 'opening_support' );
+        $events[] = array( 'time' => 0.4, 'duration' => 3.2, 'visual_type' => $overlay, 'intensity' => 0.08, 'params' => $route_params, 'sync_role' => 'opening_support' );
     }
 
     if ( $landmark && in_array( $landmark, $hero_types, true ) ) {
-        $events[] = array( 'time' => 5.0, 'duration' => 4.2, 'visual_type' => $landmark, 'intensity' => 0.78, 'params' => array(), 'sync_role' => 'arrival_landmark_hero' );
-        $events[] = array( 'time' => 9.4, 'duration' => 5.0, 'visual_type' => $landmark, 'intensity' => 0.86, 'params' => array(), 'sync_role' => 'lift_landmark_hero' );
+        $events[] = array( 'time' => 5.0, 'duration' => 4.2, 'visual_type' => $landmark, 'intensity' => 0.78, 'params' => $route_params, 'sync_role' => 'arrival_landmark_hero' );
+        $events[] = array( 'time' => 9.4, 'duration' => 5.0, 'visual_type' => $landmark, 'intensity' => 0.86, 'params' => $route_params, 'sync_role' => 'lift_landmark_hero' );
     }
 
     if ( $motion ) {
-        $events[] = array( 'time' => 10.2, 'duration' => 3.4, 'visual_type' => $motion, 'intensity' => 0.42, 'params' => array(), 'sync_role' => 'lift_motion' );
+        $events[] = array( 'time' => 10.2, 'duration' => 3.4, 'visual_type' => $motion, 'intensity' => 0.42, 'params' => $route_params, 'sync_role' => 'lift_motion' );
     }
 
     if ( $texture ) {
-        $events[] = array( 'time' => 10.0, 'duration' => 4.0, 'visual_type' => $texture, 'intensity' => 0.2, 'params' => array(), 'sync_role' => 'lift_texture' );
+        $events[] = array( 'time' => 10.0, 'duration' => 4.0, 'visual_type' => $texture, 'intensity' => 0.2, 'params' => $route_params, 'sync_role' => 'lift_texture' );
+    }
+
+
+    if ( ! empty( $route_params ) ) {
+        $events[] = array( 'time' => 0.0, 'duration' => 4.6, 'visual_type' => 'station_threshold_glow', 'intensity' => 0.42, 'params' => $route_params, 'sync_role' => 'route_start_threshold' );
+        $events[] = array( 'time' => 3.8, 'duration' => 6.1, 'visual_type' => 'water_street_corridor', 'intensity' => 0.58, 'params' => $route_params, 'sync_role' => 'route_mid_corridor' );
+        $events[] = array( 'time' => 8.4, 'duration' => 5.1, 'visual_type' => 'wet_cobble_axis', 'intensity' => 0.36, 'params' => $route_params, 'sync_role' => 'route_ground_motion' );
+        $events[] = array( 'time' => 12.1, 'duration' => 4.9, 'visual_type' => 'steam_clock_approach', 'intensity' => 0.76, 'params' => $route_params, 'sync_role' => 'route_clock_reveal' );
+        $events[] = array( 'time' => 15.1, 'duration' => 4.6, 'visual_type' => 'angled_building_split', 'intensity' => 0.54, 'params' => $route_params, 'sync_role' => 'route_end_split' );
     }
 
     if ( $resolve_landmark && in_array( $resolve_landmark, $hero_types, true ) ) {
-        $events[] = array( 'time' => 15.2, 'duration' => 4.3, 'visual_type' => $resolve_landmark, 'intensity' => 0.74, 'params' => array(), 'sync_role' => 'resolve_landmark_hero' );
+        $events[] = array( 'time' => 15.2, 'duration' => 4.3, 'visual_type' => $resolve_landmark, 'intensity' => 0.74, 'params' => $route_params, 'sync_role' => 'resolve_landmark_hero' );
     } elseif ( $primary_scene && in_array( $primary_scene, $hero_types, true ) ) {
-        $events[] = array( 'time' => 15.2, 'duration' => 4.3, 'visual_type' => $primary_scene, 'intensity' => 0.58, 'params' => array(), 'sync_role' => 'resolve_return' );
+        $events[] = array( 'time' => 15.2, 'duration' => 4.3, 'visual_type' => $primary_scene, 'intensity' => 0.58, 'params' => $route_params, 'sync_role' => 'resolve_return' );
     }
 
     return se_validate_visual_timeline_matches_plan( $plan, $events );
@@ -2117,6 +2174,48 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
         }
     }
 
+
+    $gastown_route_context = array();
+    if ( is_array( $params['gastown_route_context'] ?? null ) ) {
+        $raw_route = $params['gastown_route_context'];
+        $route_id = sanitize_key( $raw_route['route_id'] ?? '' );
+        if ( '' !== $route_id ) {
+            $gastown_route_context['route_id'] = $route_id;
+        }
+
+        if ( isset( $raw_route['district'] ) ) {
+            $district = sanitize_key( $raw_route['district'] );
+            if ( '' !== $district ) {
+                $gastown_route_context['district'] = $district;
+            }
+        }
+
+        if ( is_array( $raw_route['continuity'] ?? null ) ) {
+            $gastown_route_context['continuity'] = array(
+                'single_district' => ! empty( $raw_route['continuity']['single_district'] ),
+                'continuous_path' => ! empty( $raw_route['continuity']['continuous_path'] ),
+                'reveal_mode' => sanitize_key( $raw_route['continuity']['reveal_mode'] ?? '' ),
+                'disallow_unrelated_landmarks' => ! empty( $raw_route['continuity']['disallow_unrelated_landmarks'] ),
+            );
+        }
+
+        if ( is_array( $raw_route['camera_grammar'] ?? null ) ) {
+            $gastown_route_context['camera_grammar'] = array(
+                'pov' => sanitize_key( $raw_route['camera_grammar']['pov'] ?? '' ),
+                'movement' => sanitize_key( $raw_route['camera_grammar']['movement'] ?? '' ),
+                'framing' => sanitize_key( $raw_route['camera_grammar']['framing'] ?? '' ),
+                'corridor_bias' => sanitize_key( $raw_route['camera_grammar']['corridor_bias'] ?? '' ),
+                'asymmetry_bias' => sanitize_key( $raw_route['camera_grammar']['asymmetry_bias'] ?? '' ),
+            );
+        }
+
+        foreach ( array( 'waypoint_order', 'landmark_order' ) as $list_key ) {
+            if ( is_array( $raw_route[ $list_key ] ?? null ) ) {
+                $gastown_route_context[ $list_key ] = array_values( array_filter( array_map( 'sanitize_key', array_slice( $raw_route[ $list_key ], 0, 8 ) ) ) );
+            }
+        }
+    }
+
     $payload = array(
         'concept' => sanitize_text_field( $params['concept'] ?? '' ),
         'object' => sanitize_text_field( $params['object'] ?? '' ),
@@ -2149,6 +2248,9 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
     if ( ! empty( $vancouver_world_context ) ) {
         $payload['vancouver_world_context'] = $vancouver_world_context;
     }
+    if ( ! empty( $gastown_route_context ) ) {
+        $payload['gastown_route_context'] = $gastown_route_context;
+    }
 
     $allowed_engines = implode( ', ', se_get_asmr_allowed_engines() );
     $system_prompt = 'You are ASMR Lab. Return strict JSON only. Compose a disciplined 20-second cinematic beat plan first, not an event-dense timeline. '
@@ -2164,6 +2266,11 @@ function se_handle_asmr_generate( WP_REST_Request $req ) {
         . 'Default to end_card.use_end_card=false and keep text empty unless the user explicitly requests an end card. '
         . 'When vancouver_world_context is present, use it as soft grounding for scene specificity, texture, and landmark plausibility, while still prioritizing selected motifs and cinematic readability. '
         . 'Use it to make locations feel geographically anchored, avoid excessive verbatim reuse of raw labels, and never let it override motif constraints or story structure. '
+        . 'When gastown_route_context is present, treat the piece as a first-person unseen camera traversal down one connected corridor route. '
+        . 'Prioritize route scaffolding first and landmark second: start at the waterfront threshold, move through the brick/lamp/cobblestone corridor, reveal steam clock during approach, then resolve at the street split angled-building node. '
+        . 'Keep one district only, one continuous path, one reveal at a time, and do not jump to unrelated Vancouver landmarks. '
+        . 'Use camera grammar tokens from context (pov first_person_unseen, movement forward_walk/slow_glide, framing off_center_landmark, corridor_bias strong, asymmetry_bias medium/high). '
+        . 'Favor asymmetrical vanishing-point corridor framing with facades cropped into left/right edges, and avoid dead-center hero placement unless explicitly requested. '
         . 'Resolve must simplify and avoid introducing a new landmark. Keep one dominant reveal at a time.';
 
     $response = se_openai_chat(

--- a/js/asmr-lab.js
+++ b/js/asmr-lab.js
@@ -81,9 +81,58 @@
   };
 
   const SCENE_MOTIF_MAP = {
-    gastown: ['gastown_scene', 'gastown_clock_silhouette', 'cobblestone_perspective', 'brick_wall_parallax', 'streetlamp_halo_row', 'clock_face_reveal'],
+    gastown: ['gastown_scene', 'gastown_clock_silhouette', 'steam_clock_approach', 'water_street_corridor', 'station_threshold_glow', 'angled_building_split', 'lamp_rhythm_row', 'wet_cobble_axis', 'cobblestone_perspective', 'brick_wall_parallax', 'streetlamp_halo_row', 'clock_face_reveal'],
     granville: ['granville_scene', 'granville_neon_marquee', 'neon_sign_flicker', 'traffic_light_glow', 'neon_wet_reflections'],
     chinatown: ['chinatown_gate']
+  };
+
+
+  const GASTOWN_ROUTE_PROFILE = {
+    route_id: 'gastown_water_street_walk',
+    district: 'gastown',
+    continuity: {
+      single_district: true,
+      continuous_path: true,
+      reveal_mode: 'one_at_a_time',
+      disallow_unrelated_landmarks: true
+    },
+    camera_grammar: {
+      pov: 'first_person_unseen',
+      movement: 'forward_walk',
+      framing: 'off_center_landmark',
+      corridor_bias: 'strong',
+      asymmetry_bias: 'high'
+    },
+    waypoint_order: [
+      'waterfront_threshold',
+      'brick_lamp_cobblestone_corridor',
+      'steam_clock_approach',
+      'street_split_angled_building'
+    ],
+    landmark_order: [
+      'station_threshold_glow',
+      'water_street_corridor',
+      'steam_clock_approach',
+      'angled_building_split'
+    ],
+    facade_tendency_by_segment: [
+      { segment: 'waterfront_threshold', left: 'station_mass', right: 'brick_entry' },
+      { segment: 'brick_lamp_cobblestone_corridor', left: 'heritage_brick_dense', right: 'shopfront_neon_sparse' },
+      { segment: 'steam_clock_approach', left: 'compressed_facade_planes', right: 'clock_reveal_candidate' },
+      { segment: 'street_split_angled_building', left: 'receding_curb_line', right: 'angled_node_mass' }
+    ],
+    audio_traits_by_segment: [
+      { segment: 'waterfront_threshold', traits: ['distant_transit_hum', 'cold_air_hush'] },
+      { segment: 'brick_lamp_cobblestone_corridor', traits: ['footstep_cobble_texture', 'lamp_hum_rhythm'] },
+      { segment: 'steam_clock_approach', traits: ['steam_whistle_hint', 'metal_resonance_ping'] },
+      { segment: 'street_split_angled_building', traits: ['open_street_tail', 'reverb_decay_soft'] }
+    ],
+    visual_traits_by_segment: [
+      { segment: 'waterfront_threshold', motifs: ['station_threshold_glow', 'water_street_corridor'] },
+      { segment: 'brick_lamp_cobblestone_corridor', motifs: ['water_street_corridor', 'lamp_rhythm_row', 'wet_cobble_axis'] },
+      { segment: 'steam_clock_approach', motifs: ['steam_clock_approach', 'wet_cobble_axis'] },
+      { segment: 'street_split_angled_building', motifs: ['angled_building_split', 'water_street_corridor'] }
+    ]
   };
 
   const sceneSeedState = {
@@ -172,6 +221,33 @@
       scenes: sceneContexts,
       source: 'vancouver-scene-seeds',
       version: 1
+    };
+  }
+
+
+  function getGastownRouteContext(selectedVisuals) {
+    const selectedSet = new Set(Array.isArray(selectedVisuals) ? selectedVisuals : []);
+    const routeMotifs = ['gastown_scene', 'steam_clock_approach', 'water_street_corridor', 'station_threshold_glow', 'angled_building_split', 'lamp_rhythm_row', 'wet_cobble_axis', 'gastown_clock_silhouette'];
+    const routeSelected = routeMotifs.some((motif) => selectedSet.has(motif));
+    if (!routeSelected) return null;
+
+    const visualTraits = (GASTOWN_ROUTE_PROFILE.visual_traits_by_segment || []).map((segment) => ({
+      segment: segment.segment,
+      motifs: (segment.motifs || []).filter((motif) => selectedSet.has(motif) || motif === 'water_street_corridor' || motif === 'steam_clock_approach')
+    }));
+
+    return {
+      route_id: GASTOWN_ROUTE_PROFILE.route_id,
+      district: GASTOWN_ROUTE_PROFILE.district,
+      continuity: GASTOWN_ROUTE_PROFILE.continuity,
+      camera_grammar: GASTOWN_ROUTE_PROFILE.camera_grammar,
+      waypoint_order: GASTOWN_ROUTE_PROFILE.waypoint_order,
+      landmark_order: GASTOWN_ROUTE_PROFILE.landmark_order,
+      facade_tendency_by_segment: GASTOWN_ROUTE_PROFILE.facade_tendency_by_segment,
+      audio_traits_by_segment: GASTOWN_ROUTE_PROFILE.audio_traits_by_segment,
+      visual_traits_by_segment: visualTraits,
+      selected_route_motifs: Array.from(selectedSet).filter((token) => routeMotifs.includes(token)),
+      source: 'gastown-route-profile-v1'
     };
   }
 
@@ -399,12 +475,14 @@ ${data.concept_summary}`;
     const visualLayers = formData.getAll('visual_layers[]').map((item) => String(item || '').trim()).filter(Boolean);
     const linked = applyLayerLinking(audioLayers, visualLayers, linkAV);
 
-    const worldContext = getWorldContextForVisualSelection(linked.visual_layers);
+    const routeContext = getGastownRouteContext(linked.visual_layers);
+    const worldContext = routeContext ? null : getWorldContextForVisualSelection(linked.visual_layers);
 
     return Object.assign({}, base, {
       link_av: linkAV,
       audio_layers: linked.audio_layers,
       visual_layers: linked.visual_layers,
+      gastown_route_context: routeContext || undefined,
       vancouver_world_context: worldContext || undefined
     });
   }

--- a/js/asmr-visual-engine.js
+++ b/js/asmr-visual-engine.js
@@ -73,6 +73,12 @@
     { id: 'clear_cold_shimmer', label: 'Clear Cold Shimmer', category: 'atmosphere', priority: 'support', description: 'Cold air shimmer.', expected_shape: 'soft cool haze', renderer: 'drawClearColdShimmer', intensity: [0.15, 0.45], openingHero: false, supportOnly: true },
     { id: 'ocean_surface_shimmer', label: 'Ocean Surface Shimmer', category: 'texture', priority: 'support', description: 'Ocean highlight shimmer.', expected_shape: 'horizontal sparkle strips', renderer: 'drawOceanSurfaceShimmer', intensity: [0.18, 0.52], openingHero: false, supportOnly: true },
     { id: 'seabus_silhouette', label: 'SeaBus Silhouette', category: 'landmark', priority: 'hero', description: 'SeaBus vessel silhouette.', expected_shape: 'low ferry hull', renderer: 'drawSeabusSilhouette', intensity: [0.28, 0.76], openingHero: true, supportOnly: false },
+    { id: 'water_street_corridor', label: 'Water Street Corridor', category: 'scene', priority: 'support', description: 'Route-first Water Street corridor framing.', expected_shape: 'off-center vanishing corridor with facades', renderer: 'drawWaterStreetCorridor', intensity: [0.22, 0.62], openingHero: false, supportOnly: true },
+    { id: 'station_threshold_glow', label: 'Station Threshold Glow', category: 'scene', priority: 'support', description: 'Waterfront threshold entry glow.', expected_shape: 'station-edge glow with corridor entry', renderer: 'drawStationThresholdGlow', intensity: [0.2, 0.56], openingHero: false, supportOnly: true },
+    { id: 'steam_clock_approach', label: 'Steam Clock Approach', category: 'landmark', priority: 'hero', description: 'Steam clock reveal embedded in route movement.', expected_shape: 'clock on left/right third inside corridor', renderer: 'drawSteamClockApproach', intensity: [0.3, 0.82], openingHero: true, supportOnly: false },
+    { id: 'angled_building_split', label: 'Angled Building Split', category: 'scene', priority: 'support', description: 'Street split with angled building node.', expected_shape: 'forking curb lines and angled facade mass', renderer: 'drawAngledBuildingSplit', intensity: [0.18, 0.6], openingHero: false, supportOnly: true },
+    { id: 'lamp_rhythm_row', label: 'Lamp Rhythm Row', category: 'texture', priority: 'support', description: 'Rhythmic staggered lamp halos along route.', expected_shape: 'receding off-center lamp cadence', renderer: 'drawLampRhythmRow', intensity: [0.12, 0.4], openingHero: false, supportOnly: true },
+    { id: 'wet_cobble_axis', label: 'Wet Cobble Axis', category: 'texture', priority: 'support', description: 'Ground-plane reflective cobble motion axis.', expected_shape: 'wet perspective axis with converging lines', renderer: 'drawWetCobbleAxis', intensity: [0.12, 0.44], openingHero: false, supportOnly: true },
     { id: 'gull_silhouettes', label: 'Gull Silhouettes', category: 'motion', priority: 'support', description: 'Subtle gull V silhouettes.', expected_shape: '2-4 small V arcs', renderer: 'drawGullSilhouettes', intensity: [0.06, 0.2], openingHero: false, supportOnly: true }
   ];
 
@@ -326,7 +332,7 @@
     resolveRenderProfile(pkg) {
       const tags = (Array.isArray(pkg.style_tags) ? pkg.style_tags : []).map((t) => String(t || '').toLowerCase());
       const pixelMode = hasAnyTag(tags, ['pixel_art', '8bit', 'lowres_mode']);
-      const vancouverCue = hasAnyTag(tags, ['gastown', 'granville', 'chinatown', 'north_shore', 'waterfront', 'vancouver', 'snow', 'rain', 'fog', 'amber', 'neon', 'brick', 'cobblestone', 'mountains']);
+      const vancouverCue = hasAnyTag(tags, ['gastown', 'granville', 'chinatown', 'north_shore', 'waterfront', 'water_street', 'vancouver', 'snow', 'rain', 'fog', 'amber', 'neon', 'brick', 'cobblestone', 'mountains']);
       const theme = {
         bgTop: '#02050c',
         bgMid: '#070d1e',
@@ -346,7 +352,7 @@
         theme.fog = [122, 170, 215];
         theme.particles = [186, 220, 255];
       }
-      if (hasAnyTag(tags, ['gastown', 'amber', 'brick', 'cobblestone'])) {
+      if (hasAnyTag(tags, ['gastown', 'water_street', 'amber', 'brick', 'cobblestone'])) {
         theme.bgMid = '#211a21';
         theme.bgBottom = '#160f18';
         theme.amber = [255, 188, 110];
@@ -1000,7 +1006,11 @@
         }
 
         case 'gastown_clock_silhouette': {
-          const cx = w * 0.52;
+          const framing = String((p && p.framing) || '').toLowerCase();
+          const offCenter = (framing === 'off_center_landmark' || p.off_center_landmark === true);
+          const sideToken = String((p && p.clock_side) || '').toLowerCase();
+          const side = sideToken === 'right' ? 1 : (sideToken === 'left' ? -1 : ((Math.sin(normalized * 2.1) > 0) ? 1 : -1));
+          const cx = w * (offCenter ? (side > 0 ? 0.68 : 0.32) : 0.52);
           const baseY = h * 0.73;
           const faceY = h * 0.35;
           const faceR = Math.max(18, Math.min(w, h) * 0.07);
@@ -1131,7 +1141,9 @@
           break;
         }
         case 'street_corridor_vanishing_point': {
-          const vx = w * (0.48 + Math.sin(normalized * 1.1) * 0.03);
+          const asymmetry = String((p && p.asymmetry_bias) || '').toLowerCase();
+          const asymmetryShift = asymmetry === 'high' ? 0.09 : (asymmetry === 'medium' ? 0.05 : 0.03);
+          const vx = w * (0.48 + Math.sin(normalized * 1.1) * asymmetryShift);
           const vy = h * 0.34;
           const baseY = h * 0.98;
           ctx.strokeStyle = `rgba(122,170,220,${0.1 + intensity * 0.14})`;
@@ -1151,7 +1163,8 @@
           break;
         }
         case 'curb_line_perspective': {
-          const vx = w * 0.5;
+          const corridorBias = String((p && p.corridor_bias) || '').toLowerCase();
+          const vx = w * (corridorBias === 'strong' ? 0.48 : 0.5);
           const vy = h * 0.38;
           ctx.strokeStyle = `rgba(178,204,228,${0.12 + intensity * 0.16})`;
           ctx.lineWidth = Math.max(1.2, w * 0.0024);
@@ -1166,10 +1179,12 @@
           break;
         }
         case 'facade_plane_bands': {
+          const corridorBias = String((p && p.corridor_bias) || '').toLowerCase();
+          const baseFacade = corridorBias === 'strong' ? 0.3 : 0.26;
           const fade = 0.08 + intensity * 0.14;
           for (let i = 0; i < 7; i += 1) {
             const t = i / 7;
-            const leftW = w * (0.26 - t * 0.16);
+            const leftW = w * (baseFacade - t * 0.16);
             const rightW = leftW;
             const y = h * (0.18 + t * 0.58);
             const bandH = h * (0.085 - t * 0.04);
@@ -1382,14 +1397,68 @@
           break;
         }
         case 'gastown_scene': {
-          this.drawEvent(ctx, { visual_type: 'street_corridor_vanishing_point', params: {}, intensity: intensity * 0.58 }, p, intensity, w, h, normalized);
-          this.drawEvent(ctx, { visual_type: 'curb_line_perspective', params: {}, intensity: intensity * 0.52 }, p, intensity, w, h, normalized);
-          this.drawEvent(ctx, { visual_type: 'facade_plane_bands', params: {}, intensity: intensity * 0.56 }, p, intensity, w, h, normalized);
-          this.drawEvent(ctx, { visual_type: 'heritage_window_grid', params: {}, intensity: intensity * 0.5 }, p, intensity, w, h, normalized);
-          this.drawEvent(ctx, { visual_type: 'brick_wall_parallax', params: {}, intensity: intensity * 0.68 }, p, intensity, w, h, normalized);
-          this.drawEvent(ctx, { visual_type: 'cobblestone_perspective', params: {}, intensity: intensity * 0.74 }, p, intensity, w, h, normalized);
-          this.drawEvent(ctx, { visual_type: 'streetlamp_halo_row', params: {}, intensity: intensity * 0.64 }, p, intensity, w, h, normalized);
-          this.drawEvent(ctx, { visual_type: 'gastown_clock_silhouette', params: {}, intensity: intensity * 0.84 }, p, intensity, w, h, normalized);
+          const routeParams = Object.assign({}, p || {}, {
+            pov: (p && p.pov) || 'first_person_unseen',
+            movement: (p && p.movement) || 'forward_walk',
+            framing: (p && p.framing) || 'off_center_landmark',
+            corridor_bias: (p && p.corridor_bias) || 'strong',
+            asymmetry_bias: (p && p.asymmetry_bias) || 'high'
+          });
+          this.drawEvent(ctx, { visual_type: 'water_street_corridor', params: routeParams, intensity: intensity * 0.72 }, routeParams, intensity, w, h, normalized);
+          this.drawEvent(ctx, { visual_type: 'wet_cobble_axis', params: routeParams, intensity: intensity * 0.64 }, routeParams, intensity, w, h, normalized);
+          this.drawEvent(ctx, { visual_type: 'lamp_rhythm_row', params: routeParams, intensity: intensity * 0.56 }, routeParams, intensity, w, h, normalized);
+          this.drawEvent(ctx, { visual_type: 'steam_clock_approach', params: routeParams, intensity: intensity * 0.78 }, routeParams, intensity, w, h, normalized);
+          break;
+        }
+        case 'water_street_corridor': {
+          const routeParams = Object.assign({}, p || {}, { corridor_bias: 'strong', asymmetry_bias: 'high' });
+          this.drawEvent(ctx, { visual_type: 'street_corridor_vanishing_point', params: routeParams, intensity: intensity * 0.7 }, routeParams, intensity, w, h, normalized);
+          this.drawEvent(ctx, { visual_type: 'curb_line_perspective', params: routeParams, intensity: intensity * 0.62 }, routeParams, intensity, w, h, normalized);
+          this.drawEvent(ctx, { visual_type: 'facade_plane_bands', params: routeParams, intensity: intensity * 0.72 }, routeParams, intensity, w, h, normalized);
+          this.drawEvent(ctx, { visual_type: 'heritage_window_grid', params: routeParams, intensity: intensity * 0.56 }, routeParams, intensity, w, h, normalized);
+          this.drawEvent(ctx, { visual_type: 'brick_wall_parallax', params: routeParams, intensity: intensity * 0.62 }, routeParams, intensity, w, h, normalized);
+          break;
+        }
+        case 'station_threshold_glow': {
+          this.drawEvent(ctx, { visual_type: 'water_street_corridor', params: p || {}, intensity: intensity * 0.68 }, p, intensity, w, h, normalized);
+          const glow = ctx.createLinearGradient(0, h * 0.02, 0, h * 0.42);
+          glow.addColorStop(0, `rgba(162,196,236,${0.1 + intensity * 0.16})`);
+          glow.addColorStop(1, 'rgba(0,0,0,0)');
+          ctx.fillStyle = glow;
+          ctx.fillRect(0, 0, w, h * 0.44);
+          break;
+        }
+        case 'steam_clock_approach': {
+          this.drawEvent(ctx, { visual_type: 'water_street_corridor', params: p || {}, intensity: intensity * 0.54 }, p, intensity, w, h, normalized);
+          this.drawEvent(ctx, { visual_type: 'gastown_clock_silhouette', params: Object.assign({}, p || {}, { framing: 'off_center_landmark' }), intensity: intensity * 0.82 }, p, intensity, w, h, normalized);
+          break;
+        }
+        case 'angled_building_split': {
+          this.drawEvent(ctx, { visual_type: 'water_street_corridor', params: p || {}, intensity: intensity * 0.52 }, p, intensity, w, h, normalized);
+          ctx.fillStyle = `rgba(66,52,64,${0.14 + intensity * 0.16})`;
+          ctx.beginPath();
+          ctx.moveTo(w * 0.58, h * 0.26);
+          ctx.lineTo(w * 0.88, h * 0.22);
+          ctx.lineTo(w * 0.92, h * 0.76);
+          ctx.lineTo(w * 0.64, h * 0.8);
+          ctx.closePath();
+          ctx.fill();
+          ctx.strokeStyle = `rgba(188,174,154,${0.18 + intensity * 0.16})`;
+          ctx.lineWidth = 2;
+          ctx.beginPath();
+          ctx.moveTo(w * 0.46, h * 0.98);
+          ctx.lineTo(w * 0.56, h * 0.48);
+          ctx.lineTo(w * 0.7, h * 0.32);
+          ctx.stroke();
+          break;
+        }
+        case 'lamp_rhythm_row': {
+          this.drawEvent(ctx, { visual_type: 'streetlamp_halo_row', params: p || {}, intensity: intensity * 0.8 }, p, intensity, w, h, normalized);
+          break;
+        }
+        case 'wet_cobble_axis': {
+          this.drawEvent(ctx, { visual_type: 'cobblestone_perspective', params: p || {}, intensity: intensity * 0.72 }, p, intensity, w, h, normalized);
+          this.drawEvent(ctx, { visual_type: 'wet_reflection_axis', params: p || {}, intensity: intensity * 0.7 }, p, intensity, w, h, normalized);
           break;
         }
         case 'granville_scene': {


### PR DESCRIPTION
### Motivation
- Shift Gastown output from poster-like, symbolic scenes to a single connected first-person corridor traversal along Water Street with staged reveals (Waterfront → corridor → steam clock → angled building split). 
- Provide explicit camera grammar and route scaffolding so generated visuals prioritize movement, asymmetrical vanishing-point composition, and off-center landmark reveals rather than isolated landmarks.

### Description
- Add a lightweight `gastown_water_street_walk` route profile and a client-side `getGastownRouteContext` builder that returns waypoint order, landmark order, facade tendencies, and segment-level audio/visual traits in `js/asmr-lab.js`, and send it as `gastown_route_context` instead of broad city context when route motifs are selected. 
- Introduce new route motifs and textures in `js/asmr-visual-engine.js` (`water_street_corridor`, `station_threshold_glow`, `steam_clock_approach`, `angled_building_split`, `lamp_rhythm_row`, `wet_cobble_axis`) and refactor `gastown_scene` drawing to prefer corridor scaffolding, motion-carrying ground-plane cues, and off-center clock reveals controlled by camera-grammar params. 
- Add camera-grammar-aware composition controls (tokens: `pov`, `movement`, `framing`, `corridor_bias`, `asymmetry_bias`) that influence vanishing point, facade widths, and landmark placement in the visual engine so scenes read as first-person corridor traversal. 
- Extend server-side `functions.php` visual registry, allowed-visual lists, scene-support mappings, audio→visual mapping, and timeline compilation so route selections drive `visual_plan`/`motion`/`texture` choices, inject route-aware `params` into compiled `visual_events`, parse incoming `gastown_route_context`, and strengthen the prompt guidance to prefer single-district, continuous-path, one-reveal-at-a-time output. 

### Testing
- Ran `php -l functions.php` to verify PHP syntax and it returned no syntax errors. 
- Verified the modified JS files parse by running `node -e "new Function(require('fs').readFileSync('js/asmr-lab.js','utf8')); new Function(require('fs').readFileSync('js/asmr-visual-engine.js','utf8')); console.log('js ok')"` which succeeded. 
- Attempted a browser screenshot via Playwright to exercise the UI, but no local web server was reachable at `http://localhost:8080` (`ERR_EMPTY_RESPONSE`) so visual runtime validation couldn’t be captured in this environment. 
- No automated unit tests were present; changes were kept backward-compatible and lightweight to minimize risk to existing preview/export behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b512bda554832eaed44293052e5722)