### PR TITLE
Refactor ASMR Lab into route-based Gastown explorer/recorder prototype

### DIFF
--- a/assets/css/asmr-lab.css
+++ b/assets/css/asmr-lab.css
@@ -121,3 +121,19 @@
   .asmr-results-header h2{font-size:.92rem}
   .asmr-results-tab{font-size:.72rem}
 }
+.asmr-route-console{margin:0 0 1rem;padding:.8rem;border:1px solid #2f3f73;border-radius:10px;background:linear-gradient(180deg,#0d142c,#0b1123)}
+.asmr-route-console h2{margin:.1rem 0 .4rem;font-size:.92rem;color:#b7ccff}
+.asmr-route-intro{margin:.12rem 0 .65rem;color:#aec4f4;font-size:.78rem;line-height:1.45}
+.asmr-route-mode-switch{display:flex;gap:.45rem;flex-wrap:wrap;margin-bottom:.65rem}
+.asmr-mode-chip.is-active,.asmr-look-chip.is-active{border-color:#7ea1ff;box-shadow:0 0 0 1px rgba(126,161,255,.35) inset;background:#1a2a59;color:#f2f6ff}
+.asmr-route-nav{display:grid;grid-template-columns:auto 1fr auto;gap:.65rem;align-items:center;padding:.55rem;border:1px solid #293867;border-radius:8px;background:#0a1022}
+.asmr-route-node-meta h3{margin:.1rem 0;font-size:.88rem;color:#d3e0ff}
+.asmr-route-node-order,.asmr-route-node-id,.asmr-route-node-transition{margin:.1rem 0;font-size:.72rem;color:#9fb8eb}
+.asmr-look-controls{display:flex;align-items:center;gap:.4rem;flex-wrap:wrap;margin-top:.65rem}
+.asmr-look-label{font-size:.74rem;color:#9ec0ff}
+.asmr-advanced-fields{margin-top:.7rem}
+.asmr-advanced-fields>summary{padding:.55rem .65rem;background:#0a1022;border:1px dashed #31407a;border-radius:8px}
+.asmr-advanced-fields[open]{padding-bottom:.5rem}
+.asmr-advanced-fields[open]>summary{margin-bottom:.65rem}
+.asmr-layer-groups{margin-top:.55rem}
+@media (max-width:780px){.asmr-route-nav{grid-template-columns:1fr}.asmr-route-nav .pixel-button{width:100%}}

--- a/js/asmr-lab.js
+++ b/js/asmr-lab.js
@@ -41,6 +41,14 @@
   const provenanceToggle = document.getElementById('asmr-debug-provenance-toggle');
   const resultsTabButtons = document.querySelectorAll('.asmr-results-tab');
   const resultsPanels = document.querySelectorAll('.asmr-results-panel');
+  const modeChips = document.querySelectorAll('.asmr-mode-chip');
+  const lookChips = document.querySelectorAll('.asmr-look-chip');
+  const prevNodeBtn = document.getElementById('asmr-node-prev');
+  const nextNodeBtn = document.getElementById('asmr-node-next');
+  const nodeOrderEl = document.getElementById('asmr-route-node-order');
+  const nodeTitleEl = document.getElementById('asmr-route-node-title');
+  const nodeIdEl = document.getElementById('asmr-route-node-id');
+  const nodeTransitionEl = document.getElementById('asmr-route-node-transition');
 
   const engine = new window.AsmrFoleyEngine();
   const inspectorSoundEngine = new window.AsmrFoleyEngine();
@@ -267,11 +275,65 @@
   }
 
 
+  const ROUTE_PRESETS = {
+    gastown_water_street_walk: {
+      route_id: 'gastown_water_street_walk',
+      title: 'Gastown Water Street Walk',
+      nodes: [
+        {
+          id: 'station_threshold',
+          title: 'Station Threshold',
+          route_order: 1,
+          visual_layers: ['station_threshold_glow', 'water_street_corridor', 'street_corridor_vanishing_point'],
+          audio_layers: ['footsteps', 'skytrain_pass', 'crowd_murmur', 'wind_gust'],
+          look_bias: 'center',
+          transition_targets: ['water_street_corridor']
+        },
+        {
+          id: 'water_street_corridor',
+          title: 'Water Street Corridor',
+          route_order: 2,
+          visual_layers: ['water_street_corridor', 'wet_cobble_axis', 'lamp_rhythm_row', 'brick_wall_parallax'],
+          audio_layers: ['footsteps', 'crowd_murmur', 'bike_bell', 'crosswalk_chirp'],
+          look_bias: 'right',
+          transition_targets: ['steam_clock_approach']
+        },
+        {
+          id: 'steam_clock_approach',
+          title: 'Steam Clock Approach',
+          route_order: 3,
+          visual_layers: ['steam_clock_approach', 'gastown_clock_silhouette', 'water_street_corridor', 'streetlamp_halo_row'],
+          audio_layers: ['steam_clock', 'gastown_clock_whistle', 'footsteps', 'crowd_murmur'],
+          look_bias: 'left',
+          transition_targets: ['split_building_node']
+        },
+        {
+          id: 'split_building_node',
+          title: 'Split / Angled Building Node',
+          route_order: 4,
+          visual_layers: ['angled_building_split', 'water_street_corridor', 'cobblestone_perspective', 'lamp_rhythm_row'],
+          audio_layers: ['footsteps', 'wind_gust', 'crowd_murmur', 'car_horn_short'],
+          look_bias: 'center',
+          transition_targets: []
+        }
+      ]
+    }
+  };
+
   const QA_PRESET = {
     duration: '20',
     link_av: true,
-    audio_layers: ['ocean_waves', 'seabus_horn'],
-    visual_layers: ['waterfront_scene', 'harbor_mist', 'lions_gate_bridge', 'ocean_surface_shimmer']
+    route_preset: 'gastown_water_street_walk',
+    active_node: 'station_threshold',
+    look_bias: 'center'
+  };
+
+  const routeState = {
+    mode: 'compose',
+    routePresetId: 'gastown_water_street_walk',
+    currentNodeId: 'station_threshold',
+    lookBias: 'center',
+    traversal: ['station_threshold']
   };
 
   const transport = {
@@ -306,6 +368,127 @@
       li.textContent = typeof item === 'string' ? item : JSON.stringify(item);
       parent.appendChild(li);
     });
+  }
+
+  function getRoutePreset() {
+    return ROUTE_PRESETS[routeState.routePresetId] || ROUTE_PRESETS.gastown_water_street_walk;
+  }
+
+  function getRouteNode(nodeId) {
+    const route = getRoutePreset();
+    return (route.nodes || []).find((node) => node.id === nodeId) || route.nodes[0] || null;
+  }
+
+  function normalizeLookBias(value) {
+    return value === 'left' || value === 'right' ? value : 'center';
+  }
+
+  function setMode(mode) {
+    routeState.mode = mode === 'explore' || mode === 'record' ? mode : 'compose';
+    modeChips.forEach((chip) => {
+      const active = chip.dataset.asmrMode === routeState.mode;
+      chip.classList.toggle('is-active', active);
+      chip.setAttribute('aria-pressed', active ? 'true' : 'false');
+    });
+    if (audioFeedback) audioFeedback.textContent = `Mode: ${routeState.mode}.`;
+  }
+
+  function setLookBias(value) {
+    routeState.lookBias = normalizeLookBias(value);
+    if (form && form.elements.namedItem('look_bias')) form.elements.namedItem('look_bias').value = routeState.lookBias;
+    lookChips.forEach((chip) => {
+      const active = chip.dataset.lookBias === routeState.lookBias;
+      chip.classList.toggle('is-active', active);
+      chip.setAttribute('aria-pressed', active ? 'true' : 'false');
+    });
+  }
+
+  function syncNodeMeta() {
+    const route = getRoutePreset();
+    const nodes = route.nodes || [];
+    const idx = nodes.findIndex((node) => node.id === routeState.currentNodeId);
+    const node = idx >= 0 ? nodes[idx] : nodes[0];
+    if (!node) return;
+    routeState.currentNodeId = node.id;
+    if (form && form.elements.namedItem('active_node')) form.elements.namedItem('active_node').value = node.id;
+    if (!routeState.traversal.includes(node.id)) routeState.traversal.push(node.id);
+    if (nodeOrderEl) nodeOrderEl.textContent = `Node ${node.route_order || idx + 1} / ${nodes.length}`;
+    if (nodeTitleEl) nodeTitleEl.textContent = node.title || node.id;
+    if (nodeIdEl) nodeIdEl.textContent = node.id;
+    if (nodeTransitionEl) {
+      nodeTransitionEl.textContent = node.transition_targets && node.transition_targets.length
+        ? `Transitions to: ${node.transition_targets.join(', ')}`
+        : 'Transitions to: end of current route corridor';
+    }
+    if (prevNodeBtn) prevNodeBtn.disabled = idx <= 0;
+    if (nextNodeBtn) nextNodeBtn.disabled = idx < 0 || idx >= nodes.length - 1;
+    if (routeState.mode !== 'explore' && routeState.mode !== 'record') return;
+    const look = routeState.lookBias || node.look_bias || 'center';
+    const previewPkg = buildRoutePreviewPackage(node, look);
+    currentPackage = previewPkg;
+    if (visuals) {
+      visuals.loadTimeline(previewPkg);
+      visuals.seek(0);
+    }
+    [previewBtn, stopBtn, exportBtn, soundOnlyBtn, exportVideoBtn].forEach((b) => {
+      if (!b) return;
+      if (b === exportVideoBtn) b.disabled = !currentPackage || !videoSupport.canExport;
+      else b.disabled = !currentPackage;
+    });
+  }
+
+  function moveNode(delta) {
+    const route = getRoutePreset();
+    const nodes = route.nodes || [];
+    const idx = nodes.findIndex((node) => node.id === routeState.currentNodeId);
+    if (idx < 0) return;
+    const target = nodes[idx + delta];
+    if (!target) return;
+    routeState.currentNodeId = target.id;
+    if (!routeState.traversal.includes(target.id)) routeState.traversal.push(target.id);
+    setLookBias(target.look_bias || routeState.lookBias);
+    syncNodeMeta();
+    if (audioFeedback) audioFeedback.textContent = `Moved to ${target.title}.`;
+  }
+
+  function collectAdvancedSelections(name) {
+    return getSelectedValues(name).filter(Boolean);
+  }
+
+  function buildRoutePreviewPackage(node, lookBias) {
+    const runtime = Number((form && form.elements.namedItem('duration') && form.elements.namedItem('duration').value) || 20) || 20;
+    const look = normalizeLookBias(lookBias || node.look_bias || 'center');
+    const lookPan = look === 'left' ? -0.32 : (look === 'right' ? 0.32 : 0);
+    const visualEvents = (node.visual_layers || []).map((visualType) => ({
+      t: 0,
+      duration: runtime,
+      visual_type: visualType,
+      intensity: 0.72,
+      params: {
+        pov: 'first_person_unseen',
+        look_bias: look,
+        pan_bias: lookPan,
+        corridor_bias: 'strong',
+        asymmetry_bias: 'high',
+        route_id: routeState.routePresetId,
+        node_id: node.id
+      }
+    }));
+    return {
+      runtime_seconds: runtime,
+      route_preset: routeState.routePresetId,
+      route_mode: routeState.mode,
+      active_node: node.id,
+      look_bias: look,
+      traversal_nodes: routeState.traversal.slice(),
+      audio_layers: (node.audio_layers || []).slice(),
+      visual_layers: (node.visual_layers || []).slice(),
+      audio_events: [],
+      visual_events: visualEvents,
+      sync_points: [`Start: ${node.title}`, `Look: ${look}`, `Traverse: ${(node.transition_targets || []).join(', ') || 'route_end'}`],
+      style_tags: ['gastown', 'water_street', 'first_person', 'crt'],
+      creative_brief: `Route node preview for ${node.title}`
+    };
   }
 
   function getVideoSupport() {
@@ -461,7 +644,7 @@ ${data.concept_summary}`;
       ? payload.vancouver_world_context.scenes.length
       : 0;
     const sceneStatus = sceneSeedState.loaded ? `sceneSeeds=loaded:${sceneSeedState.total}` : 'sceneSeeds=offline';
-    debugStatusEl.textContent = `Selection snapshot: audio=${audioCount}, visual=${visualCount}, link_av=${payload.link_av ? 'on' : 'off'}, worldScenes=${worldScenes}, ${sceneStatus}`;
+    debugStatusEl.textContent = `Route snapshot: preset=${payload.route_preset || 'none'}, mode=${payload.route_mode || 'compose'}, node=${payload.active_node || 'station_threshold'}, look=${payload.look_bias || 'center'}, audio=${audioCount}, visual=${visualCount}, worldScenes=${worldScenes}, ${sceneStatus}`;
   }
 
   function collectFormPayload() {
@@ -470,16 +653,32 @@ ${data.concept_summary}`;
       duration: String(formData.get('duration') || '20')
     };
 
+    const node = getRouteNode(routeState.currentNodeId);
+    const nodeAudio = (node && Array.isArray(node.audio_layers)) ? node.audio_layers : [];
+    const nodeVisuals = (node && Array.isArray(node.visual_layers)) ? node.visual_layers : [];
+
     const linkAV = !!formData.get('link_av');
-    const audioLayers = formData.getAll('audio_layers[]').map((item) => String(item || '').trim()).filter(Boolean);
-    const visualLayers = formData.getAll('visual_layers[]').map((item) => String(item || '').trim()).filter(Boolean);
+    const audioLayers = Array.from(new Set(nodeAudio.concat(collectAdvancedSelections('audio_layers'))));
+    const visualLayers = Array.from(new Set(nodeVisuals.concat(collectAdvancedSelections('visual_layers'))));
     const linked = applyLayerLinking(audioLayers, visualLayers, linkAV);
 
-    const routeContext = getGastownRouteContext(linked.visual_layers);
-    const worldContext = routeContext ? null : getWorldContextForVisualSelection(linked.visual_layers);
+    const routeContext = getGastownRouteContext(linked.visual_layers) || {
+      route_id: routeState.routePresetId,
+      node_id: node ? node.id : 'station_threshold',
+      look_bias: routeState.lookBias,
+      route_mode: routeState.mode,
+      traversal_nodes: routeState.traversal.slice(),
+      source: 'gastown-route-preset-v2'
+    };
+    const worldContext = null;
 
     return Object.assign({}, base, {
       link_av: linkAV,
+      route_mode: routeState.mode,
+      route_preset: routeState.routePresetId,
+      active_node: node ? node.id : 'station_threshold',
+      look_bias: routeState.lookBias,
+      traversal_nodes: routeState.traversal.slice(),
       audio_layers: linked.audio_layers,
       visual_layers: linked.visual_layers,
       gastown_route_context: routeContext || undefined,
@@ -794,7 +993,16 @@ ${data.concept_summary}`;
     const fullMode = !modeToggle || modeToggle.value === 'audiovisual';
     if (visuals && fullMode) {
       visuals.loadTimeline(currentPackage);
-      visuals.seek(0); // meaningful first frame before audio transport start
+      visuals.seek(0);
+    }
+
+    if (routeState.mode === 'explore') {
+      if (visuals) {
+        visuals.play(0);
+        transport.registerStop(() => visuals.stop());
+      }
+      if (audioFeedback) audioFeedback.textContent = 'Explore preview playing (visual route look-through).';
+      return;
     }
 
     const playback = await engine.preview(currentPackage);
@@ -807,7 +1015,11 @@ ${data.concept_summary}`;
     }
     transport.registerStop(() => engine.stop());
 
-    if (audioFeedback) audioFeedback.textContent = fullMode ? 'Synchronized preview playing.' : 'Sound-only preview playing.';
+    if (audioFeedback) {
+      audioFeedback.textContent = routeState.mode === 'record'
+        ? 'Record mode preview playing.'
+        : (fullMode ? 'Synchronized preview playing.' : 'Sound-only preview playing.');
+    }
   }
 
   async function inspectRecordedBlob(blob) {
@@ -943,7 +1155,8 @@ ${data.concept_summary}`;
     const url = URL.createObjectURL(result.blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = `asmr-lab-film-1920x1080.${result.extension}`;
+    const sequenceTag = (routeState.traversal || []).join('-') || 'route';
+    a.download = `asmr-lab-${routeState.routePresetId}-${sequenceTag}-1920x1080.${result.extension}`;
     a.click();
     URL.revokeObjectURL(url);
 
@@ -981,7 +1194,13 @@ ${data.concept_summary}`;
         const field = form.elements.namedItem(key);
         if (field) field.value = value;
       });
-      setStatus('QA preset loaded (waterfront rack). Generate package to test ocean-linked motifs.');
+      routeState.routePresetId = QA_PRESET.route_preset || 'gastown_water_street_walk';
+      routeState.currentNodeId = QA_PRESET.active_node || 'station_threshold';
+      routeState.traversal = [routeState.currentNodeId];
+      setLookBias(QA_PRESET.look_bias || 'center');
+      setMode('compose');
+      syncNodeMeta();
+      setStatus('Route preset loaded for Gastown Water Street walk.');
       setError('');
     });
   }
@@ -1025,7 +1244,8 @@ ${data.concept_summary}`;
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
-        a.download = 'asmr-lab-preview.wav';
+        const sequenceTag = (routeState.traversal || []).join('-') || 'route';
+        a.download = `asmr-lab-${routeState.routePresetId}-${sequenceTag}.wav`;
         a.click();
         URL.revokeObjectURL(url);
         if (audioFeedback) audioFeedback.textContent = 'WAV export complete.';
@@ -1151,6 +1371,26 @@ ${data.concept_summary}`;
   setInspectorTab('visual');
   updateVisualMeta(null, "stopped");
   updateSoundStatus(null, "stopped");
+  setMode('compose');
+  setLookBias(routeState.lookBias);
+  syncNodeMeta();
+
+  modeChips.forEach((chip) => {
+    chip.addEventListener('click', () => {
+      setMode(chip.dataset.asmrMode);
+      syncNodeMeta();
+    });
+  });
+
+  lookChips.forEach((chip) => {
+    chip.addEventListener('click', () => {
+      setLookBias(chip.dataset.lookBias);
+      syncNodeMeta();
+    });
+  });
+
+  if (prevNodeBtn) prevNodeBtn.addEventListener('click', () => moveNode(-1));
+  if (nextNodeBtn) nextNodeBtn.addEventListener('click', () => moveNode(1));
 
   if (provenanceToggle) {
     provenanceToggle.addEventListener('change', () => {

--- a/page-asmr-lab.php
+++ b/page-asmr-lab.php
@@ -10,23 +10,58 @@ get_header();
     <header class="asmr-lab-header">
       <p class="asmr-kicker">Retro-futurist creative control room</p>
       <h1 class="asmr-title">ASMR Lab</h1>
-      <p class="asmr-intro">Compose short procedural sensory micro-films from a prompt. The lab outputs a strict audiovisual score you can perform directly in the browser.</p>
+      <p class="asmr-intro">Route-first Gastown prototype. Compose, explore, and record a first-person Water Street walk from the Waterfront threshold to the Steam Clock corridor and split-building node.</p>
     </header>
 
     <section class="asmr-lab-primer" aria-labelledby="asmr-lab-primer-title">
-      <h2 id="asmr-lab-primer-title">What ASMR Lab now performs</h2>
+      <h2 id="asmr-lab-primer-title">What this prototype now performs</h2>
       <ul>
-        <li><strong>Strict timeline JSON</strong> with synchronized audio + visual events.</li>
-        <li><strong>Procedural sound synthesis</strong> using browser-generated textures.</li>
-        <li><strong>Reactive CRT-inspired visuals</strong> driven by the same shared clock.</li>
-        <li><strong>Preview, stop, WAV export, and 1080p video export</strong> without leaving the control room.</li>
+        <li><strong>Compose mode</strong> for a single hardcoded route preset: <code>gastown_water_street_walk</code>.</li>
+        <li><strong>Explore mode</strong> with connected scene nodes and left/center/right look bias per node.</li>
+        <li><strong>Record mode</strong> aligned to your active route traversal sequence.</li>
+        <li><strong>CRT-styled playback + export</strong> via synchronized browser audio/visual engines.</li>
       </ul>
     </section>
 
     <form id="asmr-lab-form" class="asmr-lab-form" novalidate>
+      <section class="asmr-route-console" aria-labelledby="asmr-route-title">
+        <h2 id="asmr-route-title">Gastown Route Console</h2>
+        <p class="asmr-route-intro">Preset: <strong>gastown_water_street_walk</strong> (Waterfront Station threshold → Water Street corridor → Steam Clock approach → split / angled-building node).</p>
+        <div class="asmr-route-mode-switch" role="group" aria-label="ASMR Lab mode">
+          <button type="button" class="pixel-button secondary asmr-mode-chip is-active" data-asmr-mode="compose">Compose</button>
+          <button type="button" class="pixel-button secondary asmr-mode-chip" data-asmr-mode="explore">Explore</button>
+          <button type="button" class="pixel-button secondary asmr-mode-chip" data-asmr-mode="record">Record</button>
+        </div>
+
+        <div class="asmr-route-nav" aria-live="polite">
+          <button type="button" id="asmr-node-prev" class="pixel-button secondary">◀ Prev node</button>
+          <div class="asmr-route-node-meta">
+            <p id="asmr-route-node-order" class="asmr-route-node-order">Node 1 / 4</p>
+            <h3 id="asmr-route-node-title">Station Threshold</h3>
+            <p id="asmr-route-node-id" class="asmr-route-node-id">station_threshold</p>
+            <p id="asmr-route-node-transition" class="asmr-route-node-transition"></p>
+          </div>
+          <button type="button" id="asmr-node-next" class="pixel-button secondary">Next node ▶</button>
+        </div>
+
+        <div class="asmr-look-controls" role="group" aria-label="Look bias">
+          <span class="asmr-look-label">Look bias:</span>
+          <button type="button" class="pixel-button tiny secondary asmr-look-chip" data-look-bias="left">Look left</button>
+          <button type="button" class="pixel-button tiny secondary asmr-look-chip is-active" data-look-bias="center">Look center</button>
+          <button type="button" class="pixel-button tiny secondary asmr-look-chip" data-look-bias="right">Look right</button>
+        </div>
+
+        <input type="hidden" name="route_preset" value="gastown_water_street_walk" />
+        <input type="hidden" name="active_node" value="station_threshold" />
+        <input type="hidden" name="look_bias" value="center" />
+      </section>
+
       <div class="asmr-grid">
         <label>Duration (10-30 sec)<input type="number" name="duration" min="10" max="30" value="20" required /></label>
       </div>
+
+      <details class="asmr-advanced-fields">
+        <summary>Motif inspector (advanced override)</summary>
 
       <fieldset class="asmr-layer-grid asmr-layer-groups">
         <legend>Sound Layers</legend>
@@ -116,10 +151,11 @@ get_header();
       </fieldset>
 
       <label class="asmr-link-toggle"><input type="checkbox" name="link_av" /> Link sound + visual for selected motifs</label>
+      </details>
       <div class="asmr-actions">
-        <button type="submit" class="pixel-button">Generate ASMR Package</button>
-        <button type="button" id="asmr-qa-preset" class="pixel-button secondary">Load QA Preset</button>
-        <button type="button" id="asmr-sound-only" class="pixel-button secondary" disabled>Regenerate Sound Only</button>
+        <button type="submit" class="pixel-button">Generate Route Package</button>
+        <button type="button" id="asmr-qa-preset" class="pixel-button secondary">Load Route Preset</button>
+        <button type="button" id="asmr-sound-only" class="pixel-button secondary" disabled>Regenerate Route Audio</button>
       </div>
       <p id="asmr-status" class="asmr-status" role="status" aria-live="polite"></p>
       <p id="asmr-debug-status" class="asmr-status asmr-debug-status" aria-live="polite"></p>


### PR DESCRIPTION
### Motivation
- Replace the checkbox-heavy motif UX with a single-route, first-person exploration and recording prototype focused on Water Street in Gastown. 
- Provide a calmer CRT-styled UI that centers on route traversal, node-based previews, and simple record/export flows while keeping advanced motif controls accessible but de-emphasized.

### Description
- Introduced a route console UI and hidden route form fields in `page-asmr-lab.php` and collapsed motif controls into an advanced drawer to make the experience route-first (modes: `compose`, `explore`, `record`).
- Added a hardcoded route preset `gastown_water_street_walk` and node definitions (`station_threshold`, `water_street_corridor`, `steam_clock_approach`, `split_building_node`) with `title`, `route_order`, `visual_layers`, `audio_layers`, `look_bias`, and `transition_targets` in `js/asmr-lab.js`.
- Implemented route state management (`routeState`), node navigation (`prev/next`), look-bias chips, and `syncNodeMeta()`/`moveNode()` to update the active node and generate node-specific preview packages (`buildRoutePreviewPackage`).
- Updated payload collection to prioritize route-node stacks while still allowing advanced motif overrides, and added route metadata to generated payloads (`route_preset`, `active_node`, `look_bias`, `traversal_nodes`).
- Added lightweight Explore behavior that plays a first-person visual preview without changing audio flows, kept existing preview/export/record flows, and updated export filenames to include the route preset and traversal sequence.
- Added calmer route-console styling in `assets/css/asmr-lab.css` and updated primer/action copy to reflect route-focused language.

### Testing
- Ran PHP lint: `php -l page-asmr-lab.php` — succeeded.
- Syntax-checked JS: `node --check js/asmr-lab.js` — succeeded.
- Ran repository tests: `npm test` — observed failing tests in unrelated `lousy-outages` suites (integration/refresh-loop) that pre-existed and are not caused by these ASMR changes.
- Attempted a Playwright screenshot to validate rendering, but the Chromium process crashed in this environment (no screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b51843f12c832e8b1a85c795354afd)