### PR TITLE
Rebuild Gastown simulator as a bounded Waterfront→Steam Clock corridor

### DIFF
--- a/assets/css/gastown-sim.css
+++ b/assets/css/gastown-sim.css
@@ -51,6 +51,7 @@
 }
 
 .gastown-sim-canvas {
+  position: relative;
   width: 100%;
   border-radius: 12px;
   overflow: hidden;
@@ -106,4 +107,25 @@
 .gastown-pointer-status {
   color: #bdd8ff;
   font-size: 0.92rem;
+}
+
+
+.gastown-route-debug-overlay {
+  position: absolute;
+  right: 0.75rem;
+  top: 0.75rem;
+  margin: 0;
+  max-width: min(360px, 45vw);
+  max-height: 52%;
+  overflow: auto;
+  white-space: pre-wrap;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.72rem;
+  line-height: 1.35;
+  color: #d4ecff;
+  background: rgba(7, 11, 18, 0.7);
+  border: 1px solid rgba(143, 182, 214, 0.4);
+  border-radius: 8px;
+  padding: 0.5rem 0.6rem;
+  pointer-events: none;
 }

--- a/assets/world/gastown-water-street.json
+++ b/assets/world/gastown-water-street.json
@@ -1,191 +1,522 @@
 {
-  "routeId": "gastown_water_street_slice_v1",
+  "routeId": "gastown_water_street_slice_v2",
   "meta": {
-    "title": "Waterfront to Steam Clock Corridor",
+    "title": "Waterfront Station to Steam Clock Corridor",
     "units": "meters-ish",
-    "source": "hand-authored prototype aligned to Gastown Water Street layout",
-    "lastBuild": "2026-03-14T09:25:33.833Z",
+    "source": "hand-shaped corridor prototype aligned to the 601 W Cordova to 305 Water St walk",
+    "lastBuild": "2026-03-14T09:49:57.803Z",
     "buildNotes": [
-      "Placeholder scaffold only.",
-      "Future: read offline GeoJSON / CSV exports from Open Data and OSM extracts.",
-      "Future: normalize centerline, landmark anchors, and facades into compact runtime format."
-    ]
+      "Runtime geometry is compact and static; no live map APIs.",
+      "Prepared for future ingestion of offline City of Vancouver streets/buildings + optional OSM route alignment.",
+      "Corridor includes walk bounds, street and sidewalk zones, building masses, and landmark anchors."
+    ],
+    "importManifest": {
+      "inputs": {
+        "cityOfVancouver": {
+          "buildingFootprints": "data/cov/buildings.geojson",
+          "streetCenterlines": "data/cov/streets.geojson",
+          "intersections": "data/cov/intersections.geojson"
+        },
+        "osmOptional": {
+          "routeAlignment": "data/osm/waterfront-to-steam-clock.geojson"
+        }
+      },
+      "pipeline": [
+        "1) load local civic/OSM exports (if present)",
+        "2) normalize projection to local meters-ish XY frame",
+        "3) simplify centerline and derive walk corridor polygon",
+        "4) split surfaces into street + sidewalk polygons",
+        "5) fit building masses from footprint blocks",
+        "6) write compact runtime JSON (no external dependencies)"
+      ]
+    }
   },
   "spawn": {
-    "x": 0,
+    "x": -10,
     "y": 1.7,
-    "z": 0,
-    "yaw": 0
+    "z": 8,
+    "yaw": -0.28
   },
-  "corridor": {
+  "route": {
+    "name": "Waterfront Station → Water Street → Steam Clock",
     "centerline": [
       {
-        "x": 0,
-        "z": 0
+        "id": "waterfront-station",
+        "label": "Waterfront Station Threshold",
+        "x": -10,
+        "z": 8
       },
       {
-        "x": 8,
-        "z": -26
+        "id": "cordova-to-water",
+        "label": "Cordova Edge / Water Entry",
+        "x": -4,
+        "z": -8
       },
       {
-        "x": 14,
-        "z": -54
+        "id": "water-west-block",
+        "label": "Water Street West Block",
+        "x": 6,
+        "z": -32
       },
       {
-        "x": 26,
-        "z": -85
+        "id": "water-mid-block",
+        "label": "Water Street Mid Block",
+        "x": 18,
+        "z": -58
+      },
+      {
+        "id": "steam-clock-approach",
+        "label": "Steam Clock Approach",
+        "x": 29,
+        "z": -83
+      },
+      {
+        "id": "steam-clock-node",
+        "label": "Steam Clock at Cambie",
+        "x": 34,
+        "z": -94
+      },
+      {
+        "id": "angled-split",
+        "label": "Angled/Split Street Edge",
+        "x": 45,
+        "z": -108
+      }
+    ],
+    "walkBounds": [
+      {
+        "x": -24,
+        "z": 17
+      },
+      {
+        "x": 2,
+        "z": 17
+      },
+      {
+        "x": 16,
+        "z": -10
+      },
+      {
+        "x": 31,
+        "z": -43
       },
       {
         "x": 44,
+        "z": -71
+      },
+      {
+        "x": 57,
+        "z": -95
+      },
+      {
+        "x": 61,
+        "z": -117
+      },
+      {
+        "x": 42,
+        "z": -130
+      },
+      {
+        "x": 20,
         "z": -112
+      },
+      {
+        "x": 7,
+        "z": -84
+      },
+      {
+        "x": -7,
+        "z": -53
+      },
+      {
+        "x": -18,
+        "z": -25
+      },
+      {
+        "x": -29,
+        "z": 2
       }
     ],
-    "halfWidth": 7.5,
-    "softBoundary": 10.5
+    "streetWidth": 10,
+    "sidewalkWidth": 4,
+    "softBoundary": 3,
+    "hardResetDistance": 14
+  },
+  "zones": {
+    "street": [
+      {
+        "id": "water-street-roadway",
+        "surface": "road",
+        "polygon": [
+          {
+            "x": -17,
+            "z": 13
+          },
+          {
+            "x": -2,
+            "z": 13
+          },
+          {
+            "x": 12,
+            "z": -16
+          },
+          {
+            "x": 24,
+            "z": -42
+          },
+          {
+            "x": 35,
+            "z": -66
+          },
+          {
+            "x": 46,
+            "z": -88
+          },
+          {
+            "x": 50,
+            "z": -107
+          },
+          {
+            "x": 37,
+            "z": -116
+          },
+          {
+            "x": 27,
+            "z": -98
+          },
+          {
+            "x": 16,
+            "z": -74
+          },
+          {
+            "x": 4,
+            "z": -47
+          },
+          {
+            "x": -7,
+            "z": -20
+          },
+          {
+            "x": -20,
+            "z": 8
+          }
+        ]
+      }
+    ],
+    "sidewalk": [
+      {
+        "id": "north-sidewalk",
+        "surface": "sidewalk",
+        "polygon": [
+          {
+            "x": -24,
+            "z": 17
+          },
+          {
+            "x": 2,
+            "z": 17
+          },
+          {
+            "x": 16,
+            "z": -10
+          },
+          {
+            "x": 31,
+            "z": -43
+          },
+          {
+            "x": 44,
+            "z": -71
+          },
+          {
+            "x": 57,
+            "z": -95
+          },
+          {
+            "x": 61,
+            "z": -117
+          },
+          {
+            "x": 52,
+            "z": -124
+          },
+          {
+            "x": 41,
+            "z": -106
+          },
+          {
+            "x": 30,
+            "z": -84
+          },
+          {
+            "x": 18,
+            "z": -57
+          },
+          {
+            "x": 7,
+            "z": -32
+          },
+          {
+            "x": -4,
+            "z": -5
+          },
+          {
+            "x": -15,
+            "z": 17
+          }
+        ]
+      },
+      {
+        "id": "south-sidewalk",
+        "surface": "sidewalk",
+        "polygon": [
+          {
+            "x": -20,
+            "z": 8
+          },
+          {
+            "x": -7,
+            "z": -20
+          },
+          {
+            "x": 4,
+            "z": -47
+          },
+          {
+            "x": 16,
+            "z": -74
+          },
+          {
+            "x": 27,
+            "z": -98
+          },
+          {
+            "x": 37,
+            "z": -116
+          },
+          {
+            "x": 42,
+            "z": -130
+          },
+          {
+            "x": 20,
+            "z": -112
+          },
+          {
+            "x": 7,
+            "z": -84
+          },
+          {
+            "x": -7,
+            "z": -53
+          },
+          {
+            "x": -18,
+            "z": -25
+          },
+          {
+            "x": -29,
+            "z": 2
+          }
+        ]
+      }
+    ]
   },
   "nodes": [
     {
       "id": "station-threshold",
       "label": "Waterfront Station Threshold",
-      "x": 0,
-      "z": -3
+      "x": -10,
+      "z": 8
     },
     {
-      "id": "mid-water-street",
-      "label": "Mid Water Street",
-      "x": 13,
-      "z": -53
+      "id": "water-entry",
+      "label": "Cordova to Water Street Entry",
+      "x": -3,
+      "z": -10
     },
     {
-      "id": "steam-clock-approach",
-      "label": "Steam Clock Approach",
-      "x": 24,
-      "z": -82
+      "id": "water-mid",
+      "label": "Water Street Mid Corridor",
+      "x": 18,
+      "z": -58
     },
     {
-      "id": "split-building-node",
-      "label": "Split / Angled Building Node",
-      "x": 41,
-      "z": -108
+      "id": "steam-clock",
+      "label": "Steam Clock Corner",
+      "x": 34,
+      "z": -94
+    },
+    {
+      "id": "split-wedge",
+      "label": "Angled/Split Block",
+      "x": 47,
+      "z": -111
     }
   ],
-  "buildingPlanes": [
+  "buildings": [
     {
-      "side": "left",
-      "x": -12,
-      "z": -10,
-      "width": 16,
-      "depth": 12,
-      "height": 17,
-      "tone": "brickDark"
+      "id": "station-frontage-a",
+      "x": -25,
+      "z": 3,
+      "width": 18,
+      "depth": 20,
+      "height": 18,
+      "tone": "stoneMuted",
+      "yaw": 0.02
     },
     {
-      "side": "right",
+      "id": "station-frontage-b",
+      "x": -6,
+      "z": 16,
+      "width": 16,
+      "depth": 10,
+      "height": 15,
+      "tone": "stoneMuted",
+      "yaw": -0.08
+    },
+    {
+      "id": "water-north-01",
       "x": 11,
-      "z": -16,
+      "z": -20,
       "width": 14,
       "depth": 11,
-      "height": 16,
-      "tone": "brickWarm"
+      "height": 17,
+      "tone": "brickWarm",
+      "yaw": -0.2
     },
     {
-      "side": "left",
-      "x": -7,
-      "z": -40,
-      "width": 17,
-      "depth": 12,
-      "height": 18,
-      "tone": "stoneMuted"
-    },
-    {
-      "side": "right",
-      "x": 18,
-      "z": -46,
-      "width": 15,
+      "id": "water-north-02",
+      "x": 22,
+      "z": -45,
+      "width": 16,
       "depth": 10,
       "height": 16,
-      "tone": "brickDark"
+      "tone": "brickDark",
+      "yaw": -0.3
     },
     {
-      "side": "left",
-      "x": -2,
+      "id": "water-north-03",
+      "x": 33,
       "z": -69,
-      "width": 19,
+      "width": 14,
+      "depth": 11,
+      "height": 20,
+      "tone": "brickWarm",
+      "yaw": -0.38
+    },
+    {
+      "id": "water-north-04",
+      "x": 45,
+      "z": -91,
+      "width": 12,
+      "depth": 10,
+      "height": 18,
+      "tone": "stoneMuted",
+      "yaw": -0.42
+    },
+    {
+      "id": "water-south-01",
+      "x": -23,
+      "z": -19,
+      "width": 18,
+      "depth": 14,
+      "height": 18,
+      "tone": "brickDark",
+      "yaw": -0.18
+    },
+    {
+      "id": "water-south-02",
+      "x": -12,
+      "z": -45,
+      "width": 16,
+      "depth": 12,
+      "height": 16,
+      "tone": "brickWarm",
+      "yaw": -0.26
+    },
+    {
+      "id": "water-south-03",
+      "x": 1,
+      "z": -73,
+      "width": 18,
       "depth": 12,
       "height": 19,
-      "tone": "brickWarm"
+      "tone": "stoneMuted",
+      "yaw": -0.34
     },
     {
-      "side": "right",
-      "x": 24,
-      "z": -76,
-      "width": 18,
+      "id": "steam-corner-block",
+      "x": 16,
+      "z": -97,
+      "width": 15,
       "depth": 13,
-      "height": 20,
-      "tone": "stoneMuted"
+      "height": 17,
+      "tone": "brickDark",
+      "yaw": -0.4
     },
     {
-      "side": "left",
-      "x": 8,
-      "z": -100,
-      "width": 20,
-      "depth": 13,
-      "height": 20,
-      "tone": "brickDark"
-    },
-    {
-      "side": "right",
-      "x": 40,
-      "z": -105,
-      "width": 18,
-      "depth": 11,
-      "height": 18,
-      "tone": "brickWarm"
+      "id": "cambie-corner-wedge",
+      "x": 50,
+      "z": -111,
+      "width": 13,
+      "depth": 16,
+      "height": 22,
+      "tone": "brickWarm",
+      "yaw": -0.78
     }
   ],
   "landmarks": [
     {
       "id": "steam-clock",
       "label": "Gastown Steam Clock",
-      "x": 29,
-      "z": -92,
-      "type": "clock"
+      "x": 34,
+      "z": -94,
+      "type": "clock",
+      "radius": 7
     },
     {
-      "id": "station-front",
-      "label": "Waterfront Entry Plaza",
-      "x": -2,
-      "z": 5,
-      "type": "station"
+      "id": "waterfront-entry",
+      "label": "Waterfront Station Entry",
+      "x": -11,
+      "z": 9,
+      "type": "station",
+      "radius": 8
     },
     {
-      "id": "angled-building",
-      "label": "Angled Building Wedge",
-      "x": 44,
+      "id": "split-building",
+      "label": "Split / Angled Street Wedge",
+      "x": 47,
       "z": -111,
-      "type": "split"
+      "type": "split",
+      "radius": 7
     }
   ],
+  "bounds": {
+    "edgeMessage": "You reached the route edge. Staying on the Water Street corridor.",
+    "resetMessage": "Returned to the last safe point on the route.",
+    "floorY": 0
+  },
   "audioZones": [
     {
       "id": "station-rumble",
-      "x": 2,
-      "z": -5,
+      "x": -8,
+      "z": 5,
       "radius": 24,
       "bed": "distant_transit"
     },
     {
       "id": "steam-clock-core",
-      "x": 29,
-      "z": -92,
-      "radius": 16,
+      "x": 34,
+      "z": -94,
+      "radius": 17,
       "bed": "steam_clock_mech"
     },
     {
       "id": "split-nightlife",
-      "x": 43,
-      "z": -108,
-      "radius": 19,
+      "x": 47,
+      "z": -111,
+      "radius": 20,
       "bed": "street_crowd"
     }
   ],

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -19,6 +19,7 @@
   const moodSelect = app.querySelector('[name="mood"]');
   const debugToggle = app.querySelector('[data-action="debug-toggle"]');
   const debugPanel = app.querySelector('[data-debug-panel]');
+  const routeDebugOverlay = app.querySelector('[data-route-debug-overlay]');
 
   const state = {
     world: null,
@@ -27,6 +28,8 @@
     yaw: 0,
     pitch: 0,
     velocity: new THREE.Vector3(),
+    lastSafePosition: new THREE.Vector3(),
+    debugEnabled: new URLSearchParams(window.location.search).get('gastownDebug') === '1',
     activeWeather: config.defaultWeather || 'rain',
     activeTimeOfDay: config.defaultTimeOfDay || 'night',
     activeMood: config.defaultMood || 'eerie',
@@ -38,6 +41,7 @@
     },
     barkTimer: null,
     clockTimer: null,
+    boundaryNoticeTimer: null,
   };
 
   const scene = new THREE.Scene();
@@ -61,7 +65,12 @@
   scene.add(fillLight);
 
   const rainGroup = new THREE.Group();
+  const worldGroup = new THREE.Group();
+  const debugGroup = new THREE.Group();
+  debugGroup.visible = state.debugEnabled;
+  scene.add(worldGroup);
   scene.add(rainGroup);
+  scene.add(debugGroup);
 
   const visualState = {
     currentWeather: null,
@@ -70,9 +79,10 @@
     roadMaterial: null,
     sidewalkMaterial: null,
     laneMaterial: null,
-    corridorGlowMaterial: null,
+    curbMaterial: null,
     buildingMaterials: [],
     landmarkVisuals: [],
+    groundMeshes: [],
   };
 
   function updateSize() {
@@ -87,6 +97,17 @@
     statusEl.textContent = text;
   }
 
+  function flashBoundaryStatus(text) {
+    setStatus(text);
+    if (state.boundaryNoticeTimer) {
+      clearTimeout(state.boundaryNoticeTimer);
+    }
+    state.boundaryNoticeTimer = setTimeout(() => {
+      if (!state.isRunning) return;
+      setStatus('Play mode active. Click scene for mouse look, then move with WASD / arrow keys.');
+    }, 1900);
+  }
+
   function setPointerStatus(text) {
     if (pointerStatusEl) {
       pointerStatusEl.textContent = text;
@@ -99,60 +120,57 @@
 
   function toneToColor(tone) {
     switch (tone) {
-      case 'brickWarm': return 0x5f3d33;
-      case 'stoneMuted': return 0x4a4f56;
+      case 'brickWarm': return 0x6a4638;
+      case 'stoneMuted': return 0x545b64;
       case 'brickDark':
       default:
         return 0x3f2a2a;
     }
   }
 
-  function addGround(world) {
-    const path = world.corridor.centerline;
-    let minX = path[0].x;
-    let maxX = path[0].x;
-    let minZ = path[0].z;
-    let maxZ = path[0].z;
+  function toShape(points) {
+    const shape = new THREE.Shape();
+    points.forEach((point, index) => {
+      if (index === 0) {
+        shape.moveTo(point.x, point.z);
+      } else {
+        shape.lineTo(point.x, point.z);
+      }
+    });
+    shape.closePath();
+    return shape;
+  }
 
-    path.forEach((point) => {
-      minX = Math.min(minX, point.x);
-      maxX = Math.max(maxX, point.x);
-      minZ = Math.min(minZ, point.z);
-      maxZ = Math.max(maxZ, point.z);
+  function createZoneMesh(points, material, y) {
+    const mesh = new THREE.Mesh(new THREE.ShapeGeometry(toShape(points)), material);
+    mesh.rotation.x = -Math.PI / 2;
+    mesh.position.y = y;
+    worldGroup.add(mesh);
+    visualState.groundMeshes.push(mesh);
+    return mesh;
+  }
+
+  function addGround(world) {
+    visualState.roadMaterial = new THREE.MeshStandardMaterial({ color: 0x232a33, roughness: 0.9, metalness: 0.14 });
+    visualState.sidewalkMaterial = new THREE.MeshStandardMaterial({ color: 0x34404a, roughness: 0.86, metalness: 0.08 });
+    visualState.curbMaterial = new THREE.MeshStandardMaterial({ color: 0x2a3139, roughness: 0.84, metalness: 0.12 });
+    visualState.laneMaterial = new THREE.LineBasicMaterial({ color: 0x698095, transparent: true, opacity: 0.42 });
+
+    world.zones.street.forEach((zone) => createZoneMesh(zone.polygon, visualState.roadMaterial, 0));
+    world.zones.sidewalk.forEach((zone) => createZoneMesh(zone.polygon, visualState.sidewalkMaterial, 0.12));
+
+    world.zones.street.forEach((zone) => {
+      const curb = createZoneMesh(zone.polygon, visualState.curbMaterial, 0.04);
+      curb.scale.set(1.01, 1.01, 1.01);
     });
 
-    const width = (maxX - minX) + 52;
-    const depth = (maxZ - minZ) + 78;
-    const centerX = (minX + maxX) / 2;
-    const centerZ = (minZ + maxZ) / 2 - 8;
-
-    visualState.roadMaterial = new THREE.MeshStandardMaterial({ color: 0x232a33, roughness: 0.9, metalness: 0.14 });
-    const street = new THREE.Mesh(new THREE.PlaneGeometry(width, depth), visualState.roadMaterial);
-    street.rotation.x = -Math.PI / 2;
-    street.position.set(centerX, 0, centerZ);
-    scene.add(street);
-
-    visualState.sidewalkMaterial = new THREE.MeshStandardMaterial({ color: 0x34404a, roughness: 0.88, metalness: 0.08 });
-    const sidewalk = new THREE.Mesh(new THREE.PlaneGeometry(width * 0.88, depth * 0.88), visualState.sidewalkMaterial);
-    sidewalk.rotation.x = -Math.PI / 2;
-    sidewalk.position.set(centerX, 0.015, centerZ);
-    scene.add(sidewalk);
-
-    visualState.laneMaterial = new THREE.MeshStandardMaterial({ color: 0x4f5f6e, roughness: 0.78, metalness: 0.2, transparent: true, opacity: 0.35 });
-    const laneBand = new THREE.Mesh(new THREE.PlaneGeometry(world.corridor.halfWidth * 2.1, depth * 0.84), visualState.laneMaterial);
-    laneBand.rotation.x = -Math.PI / 2;
-    laneBand.position.set(centerX + 2, 0.025, centerZ - 6);
-    scene.add(laneBand);
-
-    visualState.corridorGlowMaterial = new THREE.MeshStandardMaterial({ color: 0x8ea4b7, emissive: 0x0f1824, emissiveIntensity: 0.42, transparent: true, opacity: 0.2 });
-    const corridorGuide = new THREE.Mesh(new THREE.PlaneGeometry(world.corridor.halfWidth * 1.45, depth * 0.72), visualState.corridorGlowMaterial);
-    corridorGuide.rotation.x = -Math.PI / 2;
-    corridorGuide.position.set(centerX + 8, 0.03, centerZ - 14);
-    scene.add(corridorGuide);
+    const routePoints = world.route.centerline.map((point) => new THREE.Vector3(point.x, 0.14, point.z));
+    const line = new THREE.Line(new THREE.BufferGeometry().setFromPoints(routePoints), visualState.laneMaterial);
+    worldGroup.add(line);
   }
 
   function addBuildings(world) {
-    world.buildingPlanes.forEach((b) => {
+    world.buildings.forEach((b) => {
       const geom = new THREE.BoxGeometry(b.width, b.height, b.depth);
       const mat = new THREE.MeshStandardMaterial({
         color: toneToColor(b.tone),
@@ -164,14 +182,16 @@
       visualState.buildingMaterials.push(mat);
       const mesh = new THREE.Mesh(geom, mat);
       mesh.position.set(b.x, b.height / 2, b.z);
-      scene.add(mesh);
+      mesh.rotation.y = b.yaw || 0;
+      worldGroup.add(mesh);
 
       const edge = new THREE.LineSegments(
         new THREE.EdgesGeometry(geom),
         new THREE.LineBasicMaterial({ color: 0x6f8197, transparent: true, opacity: 0.28 })
       );
       edge.position.copy(mesh.position);
-      scene.add(edge);
+      edge.rotation.y = mesh.rotation.y;
+      worldGroup.add(edge);
     });
   }
 
@@ -179,23 +199,58 @@
     world.landmarks.forEach((landmark) => {
       const col = landmark.type === 'clock' ? 0xc8a460 : landmark.type === 'split' ? 0x7ea2c7 : 0x8793a1;
       const markerMaterial = new THREE.MeshStandardMaterial({ color: col, emissive: col, emissiveIntensity: 0.2 });
-      const marker = new THREE.Mesh(new THREE.CylinderGeometry(0.6, 0.6, 4, 10), markerMaterial);
-      marker.position.set(landmark.x, 2.1, landmark.z);
-      scene.add(marker);
+      const markerHeight = landmark.type === 'clock' ? 7.2 : 4.5;
+      const markerRadius = landmark.type === 'clock' ? 0.38 : 0.7;
+      const marker = new THREE.Mesh(new THREE.CylinderGeometry(markerRadius, markerRadius * 1.05, markerHeight, 12), markerMaterial);
+      marker.position.set(landmark.x, markerHeight / 2, landmark.z);
+      worldGroup.add(marker);
 
-      const haloMaterial = new THREE.MeshBasicMaterial({ color: col, transparent: true, opacity: 0.12 });
-      const halo = new THREE.Mesh(new THREE.SphereGeometry(2.1, 16, 16), haloMaterial);
-      halo.position.set(landmark.x, 2.5, landmark.z);
-      scene.add(halo);
+      const haloMaterial = new THREE.MeshBasicMaterial({ color: col, transparent: true, opacity: 0.1 });
+      const halo = new THREE.Mesh(new THREE.SphereGeometry((landmark.radius || 6) * 0.7, 16, 16), haloMaterial);
+      halo.position.set(landmark.x, 2.8, landmark.z);
+      worldGroup.add(halo);
 
       const reflectionMaterial = new THREE.MeshStandardMaterial({ color: col, emissive: 0x1b2533, emissiveIntensity: 0.45, transparent: true, opacity: 0.22, roughness: 0.55, metalness: 0.3 });
-      const reflection = new THREE.Mesh(new THREE.CircleGeometry(2.5, 24), reflectionMaterial);
+      const reflection = new THREE.Mesh(new THREE.CircleGeometry(landmark.radius || 2.7, 24), reflectionMaterial);
       reflection.rotation.x = -Math.PI / 2;
-      reflection.position.set(landmark.x, 0.05, landmark.z);
-      scene.add(reflection);
+      reflection.position.set(landmark.x, 0.11, landmark.z);
+      worldGroup.add(reflection);
 
       visualState.landmarkVisuals.push({ markerMaterial, haloMaterial, reflectionMaterial });
     });
+  }
+
+  function addDebugRoute(world) {
+    while (debugGroup.children.length) {
+      debugGroup.remove(debugGroup.children[0]);
+    }
+
+    const centerlinePoints = world.route.centerline.map((point) => new THREE.Vector3(point.x, 0.35, point.z));
+    const centerline = new THREE.Line(
+      new THREE.BufferGeometry().setFromPoints(centerlinePoints),
+      new THREE.LineBasicMaterial({ color: 0x8de7ff })
+    );
+    debugGroup.add(centerline);
+
+    const walkBoundPoints = world.route.walkBounds.map((point) => new THREE.Vector3(point.x, 0.33, point.z));
+    walkBoundPoints.push(new THREE.Vector3(world.route.walkBounds[0].x, 0.33, world.route.walkBounds[0].z));
+    const walkBoundLine = new THREE.Line(
+      new THREE.BufferGeometry().setFromPoints(walkBoundPoints),
+      new THREE.LineBasicMaterial({ color: 0xffa763 })
+    );
+    debugGroup.add(walkBoundLine);
+
+    world.nodes.forEach((node) => {
+      const marker = new THREE.Mesh(new THREE.SphereGeometry(0.45, 12, 12), new THREE.MeshBasicMaterial({ color: 0xd5f3ff }));
+      marker.position.set(node.x, 0.5, node.z);
+      debugGroup.add(marker);
+    });
+
+    if (routeDebugOverlay) {
+      const lines = world.route.centerline.map((point, index) => (index + 1) + '. ' + (point.label || point.id || ('node-' + index)) + ' [' + point.x + ', ' + point.z + ']');
+      routeDebugOverlay.textContent = lines.join('\n');
+      routeDebugOverlay.hidden = !state.debugEnabled;
+    }
   }
 
   function rebuildRain(intensity) {
@@ -218,10 +273,7 @@
     }
 
     geom.setAttribute('position', new THREE.BufferAttribute(points, 3));
-    const rain = new THREE.Points(
-      geom,
-      new THREE.PointsMaterial({ color: 0x9dc3db, size: 0.09, transparent: true, opacity: 0.7 })
-    );
+    const rain = new THREE.Points(geom, new THREE.PointsMaterial({ color: 0x9dc3db, size: 0.09, transparent: true, opacity: 0.7 }));
     rainGroup.add(rain);
   }
 
@@ -251,21 +303,61 @@
     return Math.hypot(point.x - px, point.z - pz);
   }
 
-  function clampToCorridor(position, corridor) {
-    let nearestDistance = Number.POSITIVE_INFINITY;
-    corridor.centerline.forEach((point, index) => {
-      if (!corridor.centerline[index + 1]) return;
-      nearestDistance = Math.min(nearestDistance, distanceToSegment(position, point, corridor.centerline[index + 1]));
-    });
+  function projectToSegment(point, a, b) {
+    const abx = b.x - a.x;
+    const abz = b.z - a.z;
+    const apx = point.x - a.x;
+    const apz = point.z - a.z;
+    const denominator = (abx * abx) + (abz * abz);
+    const t = denominator === 0 ? 0 : Math.max(0, Math.min(1, ((apx * abx) + (apz * abz)) / denominator));
+    return { x: a.x + (abx * t), z: a.z + (abz * t) };
+  }
 
-    if (nearestDistance <= corridor.softBoundary) {
+  function isPointInPolygon(point, polygon) {
+    let inside = false;
+    for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i, i += 1) {
+      const xi = polygon[i].x;
+      const zi = polygon[i].z;
+      const xj = polygon[j].x;
+      const zj = polygon[j].z;
+      const intersects = ((zi > point.z) !== (zj > point.z)) && (point.x < (((xj - xi) * (point.z - zi)) / ((zj - zi) || 0.00001)) + xi);
+      if (intersects) inside = !inside;
+    }
+    return inside;
+  }
+
+  function closestPointOnPolygon(point, polygon) {
+    let best = { x: polygon[0].x, z: polygon[0].z, distance: Number.POSITIVE_INFINITY };
+    polygon.forEach((node, index) => {
+      const next = polygon[(index + 1) % polygon.length];
+      const projected = projectToSegment(point, node, next);
+      const distance = Math.hypot(point.x - projected.x, point.z - projected.z);
+      if (distance < best.distance) {
+        best = { x: projected.x, z: projected.z, distance };
+      }
+    });
+    return best;
+  }
+
+  function enforceWorldBounds() {
+    const walkBounds = state.world.route.walkBounds;
+    const point = { x: player.position.x, z: player.position.z };
+    if (isPointInPolygon(point, walkBounds)) {
+      state.lastSafePosition.set(player.position.x, player.position.y, player.position.z);
       return;
     }
 
-    const heading = Math.atan2(corridor.centerline[corridor.centerline.length - 1].x - corridor.centerline[0].x, corridor.centerline[corridor.centerline.length - 1].z - corridor.centerline[0].z);
-    const nudge = 0.22;
-    position.x -= Math.sin(heading) * nudge;
-    position.z -= Math.cos(heading) * nudge;
+    const clamped = closestPointOnPolygon(point, walkBounds);
+    player.position.x = clamped.x;
+    player.position.z = clamped.z;
+
+    if (clamped.distance > state.world.route.hardResetDistance) {
+      player.position.copy(state.lastSafePosition.lengthSq() ? state.lastSafePosition : new THREE.Vector3(state.world.spawn.x, state.world.spawn.y, state.world.spawn.z));
+      flashBoundaryStatus((state.world.bounds && state.world.bounds.resetMessage) || 'Returned to the route.');
+      return;
+    }
+
+    flashBoundaryStatus((state.world.bounds && state.world.bounds.edgeMessage) || 'Stayed inside the route corridor.');
   }
 
   function updateNearestNode() {
@@ -289,8 +381,7 @@
     const base = (config.audioBaseUrl || '').replace(/\/$/, '');
     const src = (name) => [base + '/' + name + '.mp3', base + '/' + name + '.ogg'];
 
-    const ambientBeds = ['quiet_night', 'eerie_drones', 'nightlife_hum', 'commuter_mix'];
-    ambientBeds.forEach((id) => {
+    ['quiet_night', 'eerie_drones', 'nightlife_hum', 'commuter_mix'].forEach((id) => {
       state.sounds.beds[id] = new Howl({ src: src('beds/' + id), loop: true, volume: 0, html5: false });
     });
 
@@ -310,10 +401,6 @@
     const mood = state.world.moodPresets[state.activeMood] || state.world.moodPresets.eerie;
     const weather = state.world.weatherPresets[state.activeWeather] || state.world.weatherPresets.rain;
     const timeOfDay = state.world.timeOfDayPresets[state.activeTimeOfDay] || state.world.timeOfDayPresets.night;
-
-    visualState.currentMood = mood;
-    visualState.currentWeather = weather;
-    visualState.currentTime = timeOfDay;
 
     const weatherFogBoost = state.activeWeather === 'fog' ? 0.008 : state.activeWeather === 'rain' ? 0.003 : -0.001;
     const fogDensity = Math.max(0.004, (weather.fogDensity || 0.01) + (timeOfDay.fogBoost || 0) + weatherFogBoost);
@@ -342,14 +429,12 @@
     if (visualState.sidewalkMaterial) {
       visualState.sidewalkMaterial.color.set(timeOfDay.sidewalkColor || '#3a444f');
     }
+    if (visualState.curbMaterial) {
+      visualState.curbMaterial.color.set(timeOfDay.sidewalkColor || '#3a444f').multiplyScalar(0.74);
+    }
     if (visualState.laneMaterial) {
       visualState.laneMaterial.color.set(timeOfDay.laneColor || '#5d6a76');
       visualState.laneMaterial.opacity = 0.2 + ((timeOfDay.pathBrightness || 0.25) * 0.5);
-    }
-    if (visualState.corridorGlowMaterial) {
-      visualState.corridorGlowMaterial.color.set(timeOfDay.guideGlow || '#8da5bd');
-      visualState.corridorGlowMaterial.opacity = 0.14 + ((timeOfDay.pathBrightness || 0.25) * 0.35);
-      visualState.corridorGlowMaterial.emissiveIntensity = 0.28 + ((timeOfDay.pathBrightness || 0.25) * 0.42);
     }
 
     visualState.landmarkVisuals.forEach((landmarkVisual) => {
@@ -439,8 +524,9 @@
 
     player.position.x += state.velocity.x * delta;
     player.position.z += state.velocity.z * delta;
+    player.position.y = Math.max((state.world.bounds && state.world.bounds.floorY) || 0, 1.7);
 
-    clampToCorridor(player.position, state.world.corridor);
+    enforceWorldBounds();
     updateNearestNode();
     updateAudioZones();
   }
@@ -473,11 +559,20 @@
   function resetToStart() {
     const spawn = state.world.spawn || { x: 0, y: 1.7, z: 0, yaw: 0 };
     player.position.set(spawn.x, spawn.y, spawn.z);
+    state.lastSafePosition.copy(player.position);
     state.yaw = spawn.yaw || 0;
     state.pitch = 0;
     player.rotation.y = state.yaw;
     camera.rotation.x = 0;
-    setLandmark('Nearest landmark: Station threshold');
+    updateNearestNode();
+  }
+
+  function setDebugState(enabled) {
+    state.debugEnabled = enabled;
+    debugGroup.visible = enabled;
+    if (routeDebugOverlay) {
+      routeDebugOverlay.hidden = !enabled;
+    }
   }
 
   function startSim() {
@@ -539,12 +634,13 @@
     });
 
     debugToggle.addEventListener('click', () => {
-      const isOpen = debugPanel.hasAttribute('hidden');
-      if (isOpen) {
+      const open = debugPanel.hasAttribute('hidden');
+      if (open) {
         debugPanel.removeAttribute('hidden');
       } else {
         debugPanel.setAttribute('hidden', 'hidden');
       }
+      setDebugState(open);
     });
   }
 
@@ -570,6 +666,7 @@
       addGround(state.world);
       addBuildings(state.world);
       addLandmarks(state.world);
+      addDebugRoute(state.world);
       setupAudio(state.world);
       updateSize();
       applyTimeOfDay(state.activeTimeOfDay);
@@ -577,6 +674,10 @@
       applyWeather(state.activeWeather);
       resetToStart();
       attachEvents();
+      setDebugState(state.debugEnabled);
+      if (state.debugEnabled) {
+        debugPanel.removeAttribute('hidden');
+      }
       scheduleSteamClock();
       setStatus('Prototype ready. Press Start, click the scene, and use Esc to exit pointer lock.');
       setPointerStatus('Pointer unlocked. Click scene after Start to enter look mode.');

--- a/js/gastown-world-loader.js
+++ b/js/gastown-world-loader.js
@@ -16,10 +16,26 @@
     return data;
   }
 
+  function assertPolygon(points, label) {
+    if (!Array.isArray(points) || points.length < 3) {
+      throw new Error('Gastown world data is malformed: ' + label + ' requires at least 3 points.');
+    }
+  }
+
   function validateWorldData(data) {
-    if (!data || !Array.isArray(data.nodes) || !Array.isArray(data.buildingPlanes)) {
+    const hasRoute = data && data.route && Array.isArray(data.route.centerline);
+    const hasNodes = data && Array.isArray(data.nodes);
+    const hasBuildings = data && Array.isArray(data.buildings);
+    const hasStreetZones = data && data.zones && Array.isArray(data.zones.street);
+    const hasSidewalkZones = data && data.zones && Array.isArray(data.zones.sidewalk);
+
+    if (!hasRoute || !hasNodes || !hasBuildings || !hasStreetZones || !hasSidewalkZones) {
       throw new Error('Gastown world data is malformed.');
     }
+
+    assertPolygon(data.route.walkBounds, 'route.walkBounds');
+    data.zones.street.forEach((zone, index) => assertPolygon(zone.polygon, 'zones.street[' + index + ']'));
+    data.zones.sidewalk.forEach((zone, index) => assertPolygon(zone.polygon, 'zones.sidewalk[' + index + ']'));
   }
 
   window.GastownWorldLoader = {

--- a/page-gastown-sim.php
+++ b/page-gastown-sim.php
@@ -60,14 +60,17 @@ get_header();
     <p class="gastown-pointer-status" data-sim-pointer-status aria-live="polite">Pointer unlocked.</p>
     <p class="gastown-landmark" data-sim-landmark aria-live="polite">Nearest landmark: Station threshold</p>
 
-    <div class="gastown-sim-canvas" data-sim-canvas></div>
+    <div class="gastown-sim-canvas" data-sim-canvas>
+      <pre class="gastown-route-debug-overlay" data-route-debug-overlay hidden></pre>
+    </div>
 
     <section class="gastown-debug" data-debug-panel hidden>
       <h2>Debug notes</h2>
       <ul>
         <li>WASD or arrow keys for movement</li>
         <li>Mouse look while pointer is locked</li>
-        <li>Corridor clamp keeps player in playable route slice</li>
+        <li>Walk bounds clamp keeps the player in the playable corridor slice</li>
+        <li>Route debug can also be enabled with <code>?gastownDebug=1</code></li>
         <li>Audio zones: station rumble, steam clock core, split-building nightlife edge</li>
       </ul>
     </section>

--- a/scripts/build-gastown-world.js
+++ b/scripts/build-gastown-world.js
@@ -2,9 +2,9 @@
 
 /**
  * Build-time scaffold for generating assets/world/gastown-water-street.json
- * from offline exports sourced from City of Vancouver Open Data + OSM/Overpass.
+ * from offline exports sourced from City of Vancouver Open Data + optional OSM data.
  *
- * Runtime player deliberately does not call external map/data APIs.
+ * Runtime simulator deliberately does not call external map/data APIs.
  */
 
 const fs = require('fs');
@@ -13,9 +13,29 @@ const path = require('path');
 const root = path.resolve(__dirname, '..');
 const worldPath = path.join(root, 'assets', 'world', 'gastown-water-street.json');
 
+const importManifest = {
+  inputs: {
+    cityOfVancouver: {
+      buildingFootprints: 'data/cov/buildings.geojson',
+      streetCenterlines: 'data/cov/streets.geojson',
+      intersections: 'data/cov/intersections.geojson',
+    },
+    osmOptional: {
+      routeAlignment: 'data/osm/waterfront-to-steam-clock.geojson',
+    },
+  },
+  pipeline: [
+    '1) load local civic/OSM exports (if present)',
+    '2) normalize projection to local meters-ish XY frame',
+    '3) simplify centerline and derive walk corridor polygon',
+    '4) split surfaces into street + sidewalk polygons',
+    '5) fit building masses from footprint blocks',
+    '6) write compact runtime JSON (no external dependencies)',
+  ],
+};
+
 function run() {
-  const hasWorld = fs.existsSync(worldPath);
-  if (!hasWorld) {
+  if (!fs.existsSync(worldPath)) {
     throw new Error('Missing base world file at assets/world/gastown-water-street.json');
   }
 
@@ -23,10 +43,11 @@ function run() {
   world.meta = world.meta || {};
   world.meta.lastBuild = new Date().toISOString();
   world.meta.buildNotes = [
-    'Placeholder scaffold only.',
-    'Future: read offline GeoJSON / CSV exports from Open Data and OSM extracts.',
-    'Future: normalize centerline, landmark anchors, and facades into compact runtime format.'
+    'Runtime geometry is compact and static; no live map APIs.',
+    'Prepared for future ingestion of offline City of Vancouver streets/buildings + optional OSM route alignment.',
+    'Corridor includes walk bounds, street and sidewalk zones, building masses, and landmark anchors.',
   ];
+  world.meta.importManifest = importManifest;
 
   fs.writeFileSync(worldPath, JSON.stringify(world, null, 2) + '\n', 'utf8');
   process.stdout.write('Updated ' + path.relative(root, worldPath) + '\n');


### PR DESCRIPTION
### Motivation
- Replace the generic flat plane and floating boxes with a readable, route-shaped Gastown slice aligned to Waterfront Station → Water Street → Steam Clock so the simulator feels like a real corridor rather than an abstract box world. 
- Prevent players from drifting into empty space by adding explicit walk bounds and safe-position behavior. 
- Prepare the runtime world format and build scaffold to receive future offline City of Vancouver / OSM data while keeping the player entirely local and lightweight.

### Description
- Introduced a compact route-shaped runtime world schema in `assets/world/gastown-water-street.json` that includes `route.centerline`, `route.walkBounds`, `zones` (street/sidewalk polygons), `buildings`, `landmarks`, and `bounds` messaging. 
- Hardened world data validation in `js/gastown-world-loader.js` to require the new `route/zones/buildings` schema and added polygon assertions via `assertPolygon`. 
- Refactored the renderer in `js/gastown-sim.js` to draw polygonal street/sidewalk/curb meshes and corridor-aligned building masses and landmarks (replacing the single-plane approach), added `toShape`/`createZoneMesh` helpers, and grouped runtime geometry under `worldGroup`. 
- Implemented robust bounds enforcement: polygon containment checks (`isPointInPolygon`), closest-edge clamping (`closestPointOnPolygon`/`projectToSegment`), last-safe-position tracking, and a hard-reset fallback with brief status notices when edges are hit. 
- Added a lightweight route debug mode with centerline, walk-bounds and node markers plus an optional textual overlay (hidden by default, toggled with the debug button or `?gastownDebug=1`) and minimal template/CSS support (`page-gastown-sim.php`, `assets/css/gastown-sim.css`). 
- Updated the build scaffold `scripts/build-gastown-world.js` to include an `importManifest` and documented pipeline steps for future offline ingestion of City of Vancouver / OSM extracts while continuing to write a compact static JSON runtime.

### Testing
- `node --check js/gastown-world-loader.js` succeeded. 
- `node --check js/gastown-sim.js` succeeded. 
- `node --check scripts/build-gastown-world.js` and `node scripts/build-gastown-world.js` succeeded and updated `assets/world/gastown-water-street.json`. 
- `jq empty assets/world/gastown-water-street.json` validated the JSON and `php -l page-gastown-sim.php` reported no syntax errors. 
- Attempted a headless browser screenshot of `page-gastown-sim.php` but the local web server was not reachable (Playwright `ERR_EMPTY_RESPONSE`), so visual verification was not captured in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b52e1b3348832e927b88436f84c6a4)