### PR TITLE
Add hero Steam Clock, wedge massing and facade-profile driven Gastown world data

### DIFF
--- a/assets/world/gastown-water-street.json
+++ b/assets/world/gastown-water-street.json
@@ -1,21 +1,31 @@
 {
-  "routeId": "gastown_water_street_slice_v2",
+  "routeId": "gastown_water_street_slice_v3_hero_facades",
   "meta": {
     "title": "Waterfront Station to Steam Clock Corridor",
     "units": "meters-ish",
-    "source": "hand-shaped corridor prototype aligned to the 601 W Cordova to 305 Water St walk",
-    "lastBuild": "2026-03-14T09:49:57.803Z",
+    "source": "offline-shaped corridor prototype aligned to 601 W Cordova → 305 Water St, seeded with civic layout cues and heritage facade references",
+    "lastBuild": "2026-03-14T10:07:49.982Z",
     "buildNotes": [
       "Runtime geometry is compact and static; no live map APIs.",
-      "Prepared for future ingestion of offline City of Vancouver streets/buildings + optional OSM route alignment.",
-      "Corridor includes walk bounds, street and sidewalk zones, building masses, and landmark anchors."
+      "Prepared for offline City of Vancouver footprints/streets/ROW widths + optional OSM route alignment.",
+      "Supports hero_landmarks + facade_profiles to prioritize recognizability over photoreal detail.",
+      "Scaffold ready for manually curated heritage references and screenshot-backed style metadata."
     ],
     "importManifest": {
       "inputs": {
         "cityOfVancouver": {
           "buildingFootprints": "data/cov/buildings.geojson",
           "streetCenterlines": "data/cov/streets.geojson",
-          "intersections": "data/cov/intersections.geojson"
+          "intersections": "data/cov/intersections.geojson",
+          "rightOfWayWidths": "data/cov/right-of-way-widths.geojson"
+        },
+        "gastownHeritageOptional": {
+          "register": "data/heritage/gastown-register.geojson",
+          "styleReferenceNotes": "data/heritage/gastown-style-notes.json"
+        },
+        "referenceLibraryOptional": {
+          "curatedNotes": "data/reference/gastown-curated-notes.json",
+          "screenshotIndex": "data/reference/gastown-screenshots.json"
         },
         "osmOptional": {
           "routeAlignment": "data/osm/waterfront-to-steam-clock.geojson"
@@ -26,8 +36,9 @@
         "2) normalize projection to local meters-ish XY frame",
         "3) simplify centerline and derive walk corridor polygon",
         "4) split surfaces into street + sidewalk polygons",
-        "5) fit building masses from footprint blocks",
-        "6) write compact runtime JSON (no external dependencies)"
+        "5) fit building masses from footprint blocks + choose facade profile presets",
+        "6) attach hero landmark metadata and priority weighting",
+        "7) write compact runtime JSON (no external dependencies)"
       ]
     }
   },
@@ -363,7 +374,32 @@
       "depth": 20,
       "height": 18,
       "tone": "stoneMuted",
-      "yaw": 0.02
+      "yaw": 0.02,
+      "facade_profile": "warehouse_commercial_front",
+      "roofline_type": "flat",
+      "storefront_rhythm": {
+        "bay_pattern": "wide_module",
+        "base_band": 0.12,
+        "upper_rows": 3
+      },
+      "window_bay_count": 3,
+      "material_palette": {
+        "primary": "stoneMuted",
+        "accent": "brickDark",
+        "trim": "stoneMuted"
+      },
+      "awning_presence": false,
+      "cornice_emphasis": 0.35,
+      "building_style": [
+        "warehouse",
+        "commercial_block"
+      ],
+      "mass_inset": 0.97,
+      "reference_name": null,
+      "reference_address": null,
+      "style_notes": null,
+      "silhouette_notes": null,
+      "landmark_priority": "supporting"
     },
     {
       "id": "station-frontage-b",
@@ -373,7 +409,32 @@
       "depth": 10,
       "height": 15,
       "tone": "stoneMuted",
-      "yaw": -0.08
+      "yaw": -0.08,
+      "facade_profile": "warehouse_commercial_front",
+      "roofline_type": "flat",
+      "storefront_rhythm": {
+        "bay_pattern": "wide_module",
+        "base_band": 0.12,
+        "upper_rows": 3
+      },
+      "window_bay_count": 3,
+      "material_palette": {
+        "primary": "stoneMuted",
+        "accent": "brickDark",
+        "trim": "stoneMuted"
+      },
+      "awning_presence": false,
+      "cornice_emphasis": 0.35,
+      "building_style": [
+        "warehouse",
+        "commercial_block"
+      ],
+      "mass_inset": 0.97,
+      "reference_name": null,
+      "reference_address": null,
+      "style_notes": null,
+      "silhouette_notes": null,
+      "landmark_priority": "supporting"
     },
     {
       "id": "water-north-01",
@@ -383,7 +444,32 @@
       "depth": 11,
       "height": 17,
       "tone": "brickWarm",
-      "yaw": -0.2
+      "yaw": -0.2,
+      "facade_profile": "victorian_storefront_row",
+      "roofline_type": "stepped",
+      "storefront_rhythm": {
+        "bay_pattern": "narrow_retail",
+        "base_band": 0.2,
+        "upper_rows": 2
+      },
+      "window_bay_count": 5,
+      "material_palette": {
+        "primary": "brickDark",
+        "accent": "brickWarm",
+        "trim": "stoneMuted"
+      },
+      "awning_presence": true,
+      "cornice_emphasis": 0.8,
+      "building_style": [
+        "storefront_row",
+        "victorian"
+      ],
+      "mass_inset": 0.93,
+      "reference_name": null,
+      "reference_address": null,
+      "style_notes": null,
+      "silhouette_notes": null,
+      "landmark_priority": "supporting"
     },
     {
       "id": "water-north-02",
@@ -393,7 +479,32 @@
       "depth": 10,
       "height": 16,
       "tone": "brickDark",
-      "yaw": -0.3
+      "yaw": -0.3,
+      "facade_profile": "victorian_storefront_row",
+      "roofline_type": "stepped",
+      "storefront_rhythm": {
+        "bay_pattern": "narrow_retail",
+        "base_band": 0.2,
+        "upper_rows": 2
+      },
+      "window_bay_count": 5,
+      "material_palette": {
+        "primary": "brickDark",
+        "accent": "brickWarm",
+        "trim": "stoneMuted"
+      },
+      "awning_presence": true,
+      "cornice_emphasis": 0.8,
+      "building_style": [
+        "storefront_row",
+        "victorian"
+      ],
+      "mass_inset": 0.93,
+      "reference_name": null,
+      "reference_address": null,
+      "style_notes": null,
+      "silhouette_notes": null,
+      "landmark_priority": "supporting"
     },
     {
       "id": "water-north-03",
@@ -403,7 +514,32 @@
       "depth": 11,
       "height": 20,
       "tone": "brickWarm",
-      "yaw": -0.38
+      "yaw": -0.38,
+      "facade_profile": "gastown_heritage_masonry",
+      "roofline_type": "flat_cornice",
+      "storefront_rhythm": {
+        "bay_pattern": "tight_regular",
+        "base_band": 0.17,
+        "upper_rows": 3
+      },
+      "window_bay_count": 4,
+      "material_palette": {
+        "primary": "brickWarm",
+        "accent": "stoneMuted",
+        "trim": "stoneMuted"
+      },
+      "awning_presence": true,
+      "cornice_emphasis": 0.7,
+      "building_style": [
+        "heritage_low_rise",
+        "masonry"
+      ],
+      "mass_inset": 0.93,
+      "reference_name": null,
+      "reference_address": null,
+      "style_notes": null,
+      "silhouette_notes": null,
+      "landmark_priority": "supporting"
     },
     {
       "id": "water-north-04",
@@ -413,7 +549,32 @@
       "depth": 10,
       "height": 18,
       "tone": "stoneMuted",
-      "yaw": -0.42
+      "yaw": -0.42,
+      "facade_profile": "gastown_heritage_masonry",
+      "roofline_type": "flat_cornice",
+      "storefront_rhythm": {
+        "bay_pattern": "tight_regular",
+        "base_band": 0.17,
+        "upper_rows": 3
+      },
+      "window_bay_count": 4,
+      "material_palette": {
+        "primary": "brickWarm",
+        "accent": "stoneMuted",
+        "trim": "stoneMuted"
+      },
+      "awning_presence": true,
+      "cornice_emphasis": 0.7,
+      "building_style": [
+        "heritage_low_rise",
+        "masonry"
+      ],
+      "mass_inset": 0.93,
+      "reference_name": null,
+      "reference_address": null,
+      "style_notes": null,
+      "silhouette_notes": null,
+      "landmark_priority": "supporting"
     },
     {
       "id": "water-south-01",
@@ -423,7 +584,32 @@
       "depth": 14,
       "height": 18,
       "tone": "brickDark",
-      "yaw": -0.18
+      "yaw": -0.18,
+      "facade_profile": "gastown_heritage_masonry",
+      "roofline_type": "flat_cornice",
+      "storefront_rhythm": {
+        "bay_pattern": "tight_regular",
+        "base_band": 0.17,
+        "upper_rows": 3
+      },
+      "window_bay_count": 4,
+      "material_palette": {
+        "primary": "brickWarm",
+        "accent": "stoneMuted",
+        "trim": "stoneMuted"
+      },
+      "awning_presence": true,
+      "cornice_emphasis": 0.7,
+      "building_style": [
+        "heritage_low_rise",
+        "masonry"
+      ],
+      "mass_inset": 0.93,
+      "reference_name": null,
+      "reference_address": null,
+      "style_notes": null,
+      "silhouette_notes": null,
+      "landmark_priority": "supporting"
     },
     {
       "id": "water-south-02",
@@ -433,7 +619,32 @@
       "depth": 12,
       "height": 16,
       "tone": "brickWarm",
-      "yaw": -0.26
+      "yaw": -0.26,
+      "facade_profile": "gastown_heritage_masonry",
+      "roofline_type": "flat_cornice",
+      "storefront_rhythm": {
+        "bay_pattern": "tight_regular",
+        "base_band": 0.17,
+        "upper_rows": 3
+      },
+      "window_bay_count": 4,
+      "material_palette": {
+        "primary": "brickWarm",
+        "accent": "stoneMuted",
+        "trim": "stoneMuted"
+      },
+      "awning_presence": true,
+      "cornice_emphasis": 0.7,
+      "building_style": [
+        "heritage_low_rise",
+        "masonry"
+      ],
+      "mass_inset": 0.93,
+      "reference_name": null,
+      "reference_address": null,
+      "style_notes": null,
+      "silhouette_notes": null,
+      "landmark_priority": "supporting"
     },
     {
       "id": "water-south-03",
@@ -443,7 +654,32 @@
       "depth": 12,
       "height": 19,
       "tone": "stoneMuted",
-      "yaw": -0.34
+      "yaw": -0.34,
+      "facade_profile": "warehouse_commercial_front",
+      "roofline_type": "flat",
+      "storefront_rhythm": {
+        "bay_pattern": "wide_module",
+        "base_band": 0.12,
+        "upper_rows": 3
+      },
+      "window_bay_count": 3,
+      "material_palette": {
+        "primary": "stoneMuted",
+        "accent": "brickDark",
+        "trim": "stoneMuted"
+      },
+      "awning_presence": false,
+      "cornice_emphasis": 0.35,
+      "building_style": [
+        "warehouse",
+        "commercial_block"
+      ],
+      "mass_inset": 0.97,
+      "reference_name": null,
+      "reference_address": null,
+      "style_notes": null,
+      "silhouette_notes": null,
+      "landmark_priority": "supporting"
     },
     {
       "id": "steam-corner-block",
@@ -453,7 +689,32 @@
       "depth": 13,
       "height": 17,
       "tone": "brickDark",
-      "yaw": -0.4
+      "yaw": -0.4,
+      "facade_profile": "victorian_storefront_row",
+      "roofline_type": "stepped",
+      "storefront_rhythm": {
+        "bay_pattern": "narrow_retail",
+        "base_band": 0.2,
+        "upper_rows": 2
+      },
+      "window_bay_count": 5,
+      "material_palette": {
+        "primary": "brickDark",
+        "accent": "brickWarm",
+        "trim": "stoneMuted"
+      },
+      "awning_presence": true,
+      "cornice_emphasis": 0.8,
+      "building_style": [
+        "storefront_row",
+        "victorian"
+      ],
+      "mass_inset": 0.93,
+      "reference_name": "Steam Clock corner commercial frontage",
+      "reference_address": "300 block Water St, Vancouver, BC",
+      "style_notes": "Historic storefront cadence with cornice band and awning rhythm.",
+      "silhouette_notes": "Mid-rise corner with active base and articulated parapet.",
+      "landmark_priority": "high"
     },
     {
       "id": "cambie-corner-wedge",
@@ -463,7 +724,54 @@
       "depth": 16,
       "height": 22,
       "tone": "brickWarm",
-      "yaw": -0.78
+      "yaw": -0.78,
+      "building_style": [
+        "angled_corner",
+        "masonry_commercial"
+      ],
+      "roofline_type": "angled_parapet",
+      "window_bay_count": 6,
+      "cornice_emphasis": 0.9,
+      "awning_presence": true,
+      "storefront_rhythm": {
+        "bay_pattern": "corner_emphasis",
+        "base_band": 0.18,
+        "upper_rows": 4
+      },
+      "material_palette": {
+        "primary": "brickWarm",
+        "accent": "stoneMuted",
+        "trim": "stoneMuted"
+      },
+      "footprint": [
+        {
+          "x": -5.8,
+          "z": -7.6
+        },
+        {
+          "x": 4.9,
+          "z": -4.7
+        },
+        {
+          "x": 6.2,
+          "z": 5.8
+        },
+        {
+          "x": -2.2,
+          "z": 7.4
+        },
+        {
+          "x": -6.4,
+          "z": 2.1
+        }
+      ],
+      "reference_name": "Wedge-lot Gastown corner typology",
+      "facade_profile": "wedge_corner_block",
+      "mass_inset": 0.93,
+      "reference_address": "Water St / Cambie edge, Vancouver, BC",
+      "style_notes": "Wedge-lot masonry corner inspired by Gastown split-edge blocks.",
+      "silhouette_notes": "Angled prow corner, stepped/angled roofline, strong cornice.",
+      "landmark_priority": "high"
     }
   ],
   "landmarks": [
@@ -640,5 +948,122 @@
       "landmarkGlow": 0.34,
       "rainVisibility": 1.05
     }
-  }
+  },
+  "facade_profiles": {
+    "gastown_heritage_masonry": {
+      "label": "Gastown heritage masonry",
+      "building_style": [
+        "heritage_low_rise",
+        "masonry"
+      ],
+      "roofline_type": "flat_cornice",
+      "storefront_rhythm": {
+        "bay_pattern": "tight_regular",
+        "base_band": 0.17,
+        "upper_rows": 3
+      },
+      "window_bay_count": 4,
+      "material_palette": {
+        "primary": "brickWarm",
+        "accent": "stoneMuted",
+        "trim": "stoneMuted"
+      },
+      "awning_presence": true,
+      "cornice_emphasis": 0.7,
+      "massing": "streetwall_continuous"
+    },
+    "victorian_storefront_row": {
+      "label": "Victorian storefront row",
+      "building_style": [
+        "storefront_row",
+        "victorian"
+      ],
+      "roofline_type": "stepped",
+      "storefront_rhythm": {
+        "bay_pattern": "narrow_retail",
+        "base_band": 0.2,
+        "upper_rows": 2
+      },
+      "window_bay_count": 5,
+      "material_palette": {
+        "primary": "brickDark",
+        "accent": "brickWarm",
+        "trim": "stoneMuted"
+      },
+      "awning_presence": true,
+      "cornice_emphasis": 0.8,
+      "massing": "narrow_bay_row"
+    },
+    "wedge_corner_block": {
+      "label": "Wedge/flatiron corner block",
+      "building_style": [
+        "angled_corner",
+        "masonry_commercial"
+      ],
+      "roofline_type": "angled_parapet",
+      "storefront_rhythm": {
+        "bay_pattern": "corner_emphasis",
+        "base_band": 0.18,
+        "upper_rows": 4
+      },
+      "window_bay_count": 6,
+      "material_palette": {
+        "primary": "brickWarm",
+        "accent": "stoneMuted",
+        "trim": "stoneMuted"
+      },
+      "awning_presence": true,
+      "cornice_emphasis": 0.9,
+      "massing": "wedge_flatiron"
+    },
+    "warehouse_commercial_front": {
+      "label": "Warehouse/commercial front",
+      "building_style": [
+        "warehouse",
+        "commercial_block"
+      ],
+      "roofline_type": "flat",
+      "storefront_rhythm": {
+        "bay_pattern": "wide_module",
+        "base_band": 0.12,
+        "upper_rows": 3
+      },
+      "window_bay_count": 3,
+      "material_palette": {
+        "primary": "stoneMuted",
+        "accent": "brickDark",
+        "trim": "stoneMuted"
+      },
+      "awning_presence": false,
+      "cornice_emphasis": 0.35,
+      "massing": "deep_block"
+    }
+  },
+  "hero_landmarks": [
+    {
+      "id": "steam-clock-hero",
+      "reference_name": "Gastown Steam Clock",
+      "reference_address": "305 Water St, Vancouver, BC",
+      "x": 34,
+      "z": -94,
+      "asset_type": "steam_clock",
+      "landmark_priority": "primary",
+      "style_notes": "Cast-iron Victorian clock body with visible steam pipes and capped roof.",
+      "silhouette_notes": "Tall base + clock body + round face + cap roof + side steam pipes.",
+      "ground_emphasis_radius": 3.8,
+      "facade_profile": null
+    },
+    {
+      "id": "water-cordova-flatiron-hero",
+      "reference_name": "Gastown wedge-lot corner massing",
+      "reference_address": "Water St / W Cordova split edge, Vancouver, BC",
+      "x": 47,
+      "z": -111,
+      "asset_type": "wedge_corner_block",
+      "landmark_priority": "secondary",
+      "style_notes": "Angled masonry corner with narrow prow facing split alignment.",
+      "silhouette_notes": "Flatiron-like wedge footprint and emphasized parapet corner.",
+      "facade_profile": null
+    }
+  ]
 }

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -128,6 +128,54 @@
     }
   }
 
+  const facadeProfilePresets = {
+    gastown_heritage_masonry: {
+      baseInset: 0.94,
+      windowRows: 3,
+      rooflineLift: 1.1,
+      storefrontBand: 0.16,
+      awningDepth: 1.05,
+      silhouetteLift: 0.8,
+    },
+    victorian_storefront_row: {
+      baseInset: 0.96,
+      windowRows: 2,
+      rooflineLift: 0.9,
+      storefrontBand: 0.18,
+      awningDepth: 1.2,
+      silhouetteLift: 0.6,
+    },
+    wedge_corner_block: {
+      baseInset: 0.95,
+      windowRows: 4,
+      rooflineLift: 1.6,
+      storefrontBand: 0.17,
+      awningDepth: 1.1,
+      silhouetteLift: 1.5,
+    },
+    warehouse_commercial_front: {
+      baseInset: 0.97,
+      windowRows: 3,
+      rooflineLift: 0.7,
+      storefrontBand: 0.12,
+      awningDepth: 0,
+      silhouetteLift: 0.4,
+    },
+  };
+
+  function paletteToColors(building) {
+    const profile = (state.world && state.world.facade_profiles && state.world.facade_profiles[building.facade_profile]) || {};
+    const palette = building.material_palette || profile.material_palette || {};
+    const primary = palette.primary || building.tone || 'brickDark';
+    const accent = palette.accent || 'stoneMuted';
+    const trim = palette.trim || 'stoneMuted';
+    return {
+      primary: toneToColor(primary),
+      accent: toneToColor(accent),
+      trim: toneToColor(trim),
+    };
+  }
+
   function toShape(points) {
     const shape = new THREE.Shape();
     points.forEach((point, index) => {
@@ -171,9 +219,24 @@
 
   function addBuildings(world) {
     world.buildings.forEach((b) => {
-      const geom = new THREE.BoxGeometry(b.width, b.height, b.depth);
+      const profilePreset = facadeProfilePresets[b.facade_profile] || facadeProfilePresets.gastown_heritage_masonry;
+      const colors = paletteToColors(b);
+      const massingInset = b.mass_inset || profilePreset.baseInset;
+      const shapePoints = Array.isArray(b.footprint) && b.footprint.length >= 3
+        ? b.footprint
+        : [
+          { x: -b.width / 2, z: -b.depth / 2 },
+          { x: b.width / 2, z: -b.depth / 2 },
+          { x: b.width / 2, z: b.depth / 2 },
+          { x: -b.width / 2, z: b.depth / 2 },
+        ];
+      const geom = new THREE.ExtrudeGeometry(new THREE.Shape(shapePoints.map((point) => new THREE.Vector2(point.x, point.z))), {
+        depth: b.height,
+        bevelEnabled: false,
+      });
+      geom.rotateX(-Math.PI / 2);
       const mat = new THREE.MeshStandardMaterial({
-        color: toneToColor(b.tone),
+        color: colors.primary,
         roughness: 0.8,
         metalness: 0.16,
         emissive: 0x11151f,
@@ -181,9 +244,61 @@
       });
       visualState.buildingMaterials.push(mat);
       const mesh = new THREE.Mesh(geom, mat);
-      mesh.position.set(b.x, b.height / 2, b.z);
+      mesh.scale.set(massingInset, 1, massingInset);
+      mesh.position.set(b.x, 0, b.z);
       mesh.rotation.y = b.yaw || 0;
       worldGroup.add(mesh);
+
+      const rooflineType = b.roofline_type || 'flat_cornice';
+      if (rooflineType !== 'flat') {
+        const roofHeight = Math.max(0.5, (b.cornice_emphasis || 0.2) * 2 + profilePreset.rooflineLift * 0.2);
+        const roofGeom = new THREE.CylinderGeometry((Math.max(b.width, b.depth) * 0.5) * 0.92, (Math.max(b.width, b.depth) * 0.5), roofHeight, 6);
+        const roofMat = new THREE.MeshStandardMaterial({ color: colors.trim, roughness: 0.78, metalness: 0.12 });
+        const roof = new THREE.Mesh(roofGeom, roofMat);
+        roof.position.set(b.x, b.height + roofHeight / 2, b.z);
+        roof.rotation.y = (b.yaw || 0) + (rooflineType === 'angled_parapet' ? 0.45 : 0);
+        if (rooflineType === 'stepped') {
+          roof.scale.set(0.7, 1, 1);
+        } else if (rooflineType === 'gable_shallow') {
+          roof.rotation.z = Math.PI / 2;
+          roof.scale.set(0.5, 1, 1.2);
+        }
+        worldGroup.add(roof);
+      }
+
+      const storefrontBandHeight = Math.max(1.4, b.height * ((b.storefront_rhythm && b.storefront_rhythm.base_band) || profilePreset.storefrontBand));
+      const storefront = new THREE.Mesh(
+        new THREE.BoxGeometry((b.width || 8) * 0.92, storefrontBandHeight, Math.max(2, (b.depth || 8) * 0.15)),
+        new THREE.MeshStandardMaterial({ color: colors.accent, roughness: 0.72, metalness: 0.1 })
+      );
+      storefront.position.set(b.x, storefrontBandHeight / 2 + 0.2, b.z + ((b.depth || 8) * 0.34));
+      storefront.rotation.y = b.yaw || 0;
+      worldGroup.add(storefront);
+
+      const bayCount = Math.max(2, Math.min(8, b.window_bay_count || 4));
+      const windowRows = Math.max(1, Math.min(5, (b.storefront_rhythm && b.storefront_rhythm.upper_rows) || profilePreset.windowRows));
+      const windowMat = new THREE.MeshStandardMaterial({ color: 0x1f2a38, emissive: 0x344d63, emissiveIntensity: 0.14, roughness: 0.42, metalness: 0.22 });
+      for (let row = 0; row < windowRows; row += 1) {
+        for (let bay = 0; bay < bayCount; bay += 1) {
+          const win = new THREE.Mesh(new THREE.PlaneGeometry((b.width || 8) / (bayCount + 1.2), (b.height || 12) / (windowRows * 4.3)), windowMat);
+          const xOffset = (((bay + 1) / (bayCount + 1)) - 0.5) * ((b.width || 8) * 0.78);
+          const yOffset = storefrontBandHeight + 1.4 + row * ((b.height - storefrontBandHeight - 2) / windowRows);
+          const depthOffset = (b.depth || 8) * 0.52;
+          win.position.set(b.x + xOffset * Math.cos(b.yaw || 0), yOffset, b.z + depthOffset * Math.cos((b.yaw || 0) - Math.PI / 2) + xOffset * Math.sin(b.yaw || 0));
+          win.rotation.y = b.yaw || 0;
+          worldGroup.add(win);
+        }
+      }
+
+      if (b.awning_presence || (profilePreset.awningDepth > 0.1)) {
+        const awning = new THREE.Mesh(
+          new THREE.BoxGeometry((b.width || 8) * 0.86, 0.3, Math.max(0.8, profilePreset.awningDepth)),
+          new THREE.MeshStandardMaterial({ color: colors.trim, roughness: 0.64, metalness: 0.08 })
+        );
+        awning.position.set(b.x, storefrontBandHeight + 0.6, b.z + ((b.depth || 8) * 0.45));
+        awning.rotation.y = b.yaw || 0;
+        worldGroup.add(awning);
+      }
 
       const edge = new THREE.LineSegments(
         new THREE.EdgesGeometry(geom),
@@ -192,6 +307,59 @@
       edge.position.copy(mesh.position);
       edge.rotation.y = mesh.rotation.y;
       worldGroup.add(edge);
+    });
+  }
+
+  function addHeroLandmarks(world) {
+    (world.hero_landmarks || []).forEach((hero) => {
+      if (hero.id === 'steam-clock-hero') {
+        const base = new THREE.Mesh(
+          new THREE.CylinderGeometry(1.1, 1.35, 3.2, 12),
+          new THREE.MeshStandardMaterial({ color: 0x4b3d34, roughness: 0.72, metalness: 0.08 })
+        );
+        base.position.set(hero.x, 1.6, hero.z);
+        worldGroup.add(base);
+
+        const body = new THREE.Mesh(
+          new THREE.BoxGeometry(1.35, 4.2, 1.35),
+          new THREE.MeshStandardMaterial({ color: 0x5d4b40, roughness: 0.66, metalness: 0.18 })
+        );
+        body.position.set(hero.x, 4.7, hero.z);
+        worldGroup.add(body);
+
+        const face = new THREE.Mesh(
+          new THREE.CircleGeometry(0.62, 24),
+          new THREE.MeshStandardMaterial({ color: 0xf0dfb2, emissive: 0x6b5b3d, emissiveIntensity: 0.36 })
+        );
+        face.position.set(hero.x + 0.68, 5.25, hero.z);
+        face.rotation.y = -Math.PI / 2;
+        worldGroup.add(face);
+
+        const cap = new THREE.Mesh(
+          new THREE.ConeGeometry(0.95, 1.1, 10),
+          new THREE.MeshStandardMaterial({ color: 0x2a2a30, roughness: 0.58, metalness: 0.34 })
+        );
+        cap.position.set(hero.x, 7.45, hero.z);
+        worldGroup.add(cap);
+
+        [-0.45, 0.45].forEach((offset) => {
+          const pipe = new THREE.Mesh(
+            new THREE.CylinderGeometry(0.08, 0.08, 1.5, 8),
+            new THREE.MeshStandardMaterial({ color: 0x78767d, roughness: 0.54, metalness: 0.58 })
+          );
+          pipe.position.set(hero.x + offset, 6.2, hero.z + 0.55);
+          pipe.rotation.x = Math.PI / 2.8;
+          worldGroup.add(pipe);
+        });
+
+        const plinth = new THREE.Mesh(
+          new THREE.CircleGeometry((hero.ground_emphasis_radius || 3.2), 28),
+          new THREE.MeshStandardMaterial({ color: 0x43392f, roughness: 0.84, metalness: 0.06 })
+        );
+        plinth.rotation.x = -Math.PI / 2;
+        plinth.position.set(hero.x, 0.15, hero.z);
+        worldGroup.add(plinth);
+      }
     });
   }
 
@@ -665,6 +833,7 @@
       state.world = await window.GastownWorldLoader.load(config.worldDataUrl);
       addGround(state.world);
       addBuildings(state.world);
+      addHeroLandmarks(state.world);
       addLandmarks(state.world);
       addDebugRoute(state.world);
       setupAudio(state.world);

--- a/js/gastown-world-loader.js
+++ b/js/gastown-world-loader.js
@@ -36,6 +36,23 @@
     assertPolygon(data.route.walkBounds, 'route.walkBounds');
     data.zones.street.forEach((zone, index) => assertPolygon(zone.polygon, 'zones.street[' + index + ']'));
     data.zones.sidewalk.forEach((zone, index) => assertPolygon(zone.polygon, 'zones.sidewalk[' + index + ']'));
+
+    if (data.hero_landmarks && !Array.isArray(data.hero_landmarks)) {
+      throw new Error('Gastown world data is malformed: hero_landmarks must be an array.');
+    }
+
+    if (data.facade_profiles && typeof data.facade_profiles !== 'object') {
+      throw new Error('Gastown world data is malformed: facade_profiles must be an object.');
+    }
+
+    data.buildings.forEach((building, index) => {
+      if (building.footprint) {
+        assertPolygon(building.footprint, 'buildings[' + index + '].footprint');
+      }
+      if (building.window_bay_count && typeof building.window_bay_count !== 'number') {
+        throw new Error('Gastown world data is malformed: buildings[' + index + '].window_bay_count must be numeric.');
+      }
+    });
   }
 
   window.GastownWorldLoader = {

--- a/scripts/build-gastown-world.js
+++ b/scripts/build-gastown-world.js
@@ -19,6 +19,15 @@ const importManifest = {
       buildingFootprints: 'data/cov/buildings.geojson',
       streetCenterlines: 'data/cov/streets.geojson',
       intersections: 'data/cov/intersections.geojson',
+      rightOfWayWidths: 'data/cov/right-of-way-widths.geojson',
+    },
+    gastownHeritageOptional: {
+      register: 'data/heritage/gastown-register.geojson',
+      styleReferenceNotes: 'data/heritage/gastown-style-notes.json',
+    },
+    referenceLibraryOptional: {
+      curatedNotes: 'data/reference/gastown-curated-notes.json',
+      screenshotIndex: 'data/reference/gastown-screenshots.json',
     },
     osmOptional: {
       routeAlignment: 'data/osm/waterfront-to-steam-clock.geojson',
@@ -29,10 +38,28 @@ const importManifest = {
     '2) normalize projection to local meters-ish XY frame',
     '3) simplify centerline and derive walk corridor polygon',
     '4) split surfaces into street + sidewalk polygons',
-    '5) fit building masses from footprint blocks',
-    '6) write compact runtime JSON (no external dependencies)',
+    '5) fit building masses from footprint blocks + choose facade profile presets',
+    '6) attach hero landmark metadata and priority weighting',
+    '7) write compact runtime JSON (no external dependencies)',
   ],
 };
+
+const referenceTemplate = {
+  reference_name: null,
+  reference_address: null,
+  style_notes: null,
+  silhouette_notes: null,
+  facade_profile: null,
+  landmark_priority: 'supporting',
+};
+
+function applyReferenceScaffold(entity) {
+  Object.keys(referenceTemplate).forEach((key) => {
+    if (!(key in entity)) {
+      entity[key] = referenceTemplate[key];
+    }
+  });
+}
 
 function run() {
   if (!fs.existsSync(worldPath)) {
@@ -44,10 +71,14 @@ function run() {
   world.meta.lastBuild = new Date().toISOString();
   world.meta.buildNotes = [
     'Runtime geometry is compact and static; no live map APIs.',
-    'Prepared for future ingestion of offline City of Vancouver streets/buildings + optional OSM route alignment.',
-    'Corridor includes walk bounds, street and sidewalk zones, building masses, and landmark anchors.',
+    'Prepared for offline City of Vancouver footprints/streets/ROW widths + optional OSM route alignment.',
+    'Supports hero_landmarks + facade_profiles to prioritize recognizability over photoreal detail.',
+    'Scaffold ready for manually curated heritage references and screenshot-backed style metadata.',
   ];
   world.meta.importManifest = importManifest;
+
+  (world.buildings || []).forEach((building) => applyReferenceScaffold(building));
+  (world.hero_landmarks || []).forEach((landmark) => applyReferenceScaffold(landmark));
 
   fs.writeFileSync(worldPath, JSON.stringify(world, null, 2) + '\n', 'utf8');
   process.stdout.write('Updated ' + path.relative(root, worldPath) + '\n');


### PR DESCRIPTION
### Motivation
- Make the Waterfront Station → Water Street → Steam Clock corridor read more like Gastown by introducing a small set of reference-driven hero assets and facade-driven building logic.
- Replace purely generic extruded boxes with lightweight, recognizably historic silhouettes (hero Steam Clock, wedge/flatiron corner, heritage storefront rows) while keeping runtime geometry compact and stylized.
- Prepare the build/import scaffold to accept offline civic/heritage reference data and per-building metadata for future manual ingestion and curated appearance notes.

### Description
- Add schema and data: introduce `facade_profiles` and `hero_landmarks` to `assets/world/gastown-water-street.json` and enrich building records with `facade_profile`, `building_style`, `roofline_type`, `storefront_rhythm`, `window_bay_count`, `material_palette`, `awning_presence`, `cornice_emphasis` and reference scaffold fields (`reference_name`, `reference_address`, `style_notes`, `silhouette_notes`, `landmark_priority`).
- Runtime rendering updates in `js/gastown-sim.js`: add `facadeProfilePresets` and `paletteToColors`, support polygonal `footprint` extrusion via `THREE.ExtrudeGeometry`, massing `mass_inset`, roofline variants, storefront base band, window-bay rhythm, awnings, and a hand-authored `addHeroLandmarks` renderer that creates a stacked Steam Clock (base, body, round face, cap and side steam pipes + ground plinth) and hooks it into init.
- World loader validation in `js/gastown-world-loader.js` now checks for the new `hero_landmarks` array, `facade_profiles` object and validates building `footprint` polygons and numeric `window_bay_count` values.
- Build-time scaffold `scripts/build-gastown-world.js` extended its `importManifest` (ROW widths, heritage/register/style notes, curated reference assets) and now injects a lightweight reference metadata template to buildings and hero landmarks to prepare for future offline ingestion.

### Testing
- Static checks: ran `node --check js/gastown-sim.js`, `node --check js/gastown-world-loader.js`, and `node --check scripts/build-gastown-world.js`, all succeeded. 
- Build-time run: executed `node scripts/build-gastown-world.js`, which updated `assets/world/gastown-water-street.json` successfully. 
- Integration tests: ran `npm test` and observed failures unrelated to these changes (pre-existing DOM test harness failures in `lousy-outages` tests: `anchor.parentNode.insertBefore is not a function`).
- Smoke capture: a browser screenshot of the simulator page was produced to visually validate the scene load (artifact: `artifacts/gastown-sim.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b532c6b7cc832e978691599501cb20)