### PR TITLE
Add Gastown simulator promo to homepage with retro CTA and styles

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -159,6 +159,14 @@ get_header();
         <a href="<?php echo esc_url(home_url('/asmr-lab/')); ?>" class="pixel-button asmr-lab-teaser__cta">Enter ASMR Lab</a>
     </section>
 
+    <section class="gastown-sim-teaser crt-block" aria-labelledby="gastown-sim-teaser-title">
+        <p class="gastown-sim-teaser__eyebrow pixel-font"><span class="gastown-sim-teaser__badge">New</span> In progress. Shipping weird little upgrades constantly.</p>
+        <h2 id="gastown-sim-teaser-title" class="pixel-font">New: Gastown First-Person Simulator</h2>
+        <p class="gastown-sim-teaser__description">A first-person Vancouver experiment inspired by the ASMR Lab and now mutating into a playable Gastown walk. Start near Waterfront Station and head toward Water Street and the Steam Clock.</p>
+        <p class="gastown-sim-teaser__microcopy">Getting tuned up often, sometimes daily. If the world looks haunted, hard refresh or hop into a private window and dive back in.</p>
+        <a href="<?php echo esc_url(home_url('/page-gastown-sim/')); ?>" class="pixel-button gastown-sim-teaser__cta">Enter Gastown</a>
+    </section>
+
     <section class="track-analyzer-feature">
         <h2 class="pixel-font">Track Analyzer</h2>
         <p class="pixel-font">Upload an MP3 and get instant feedback on your mix.</p>
@@ -169,6 +177,7 @@ get_header();
         <h2 id="creative-tool-links-title" class="pixel-font">Creative Tool Deck</h2>
         <p>Prefer crawl-first browsing? Jump straight to the public tool pages:</p>
         <ul>
+            <li><a href="<?php echo esc_url(home_url('/page-gastown-sim/')); ?>">Gastown First-Person Simulator</a> — first-person Vancouver prototype, currently in active daily-ish mutation mode.</li>
             <li><a href="<?php echo esc_url(home_url('/asmr-lab/')); ?>">ASMR Lab</a> — AI sensory ad concepts, tactile beat sheets, and retro-foley prompt kits.</li>
             <li><a href="<?php echo esc_url(home_url('/suzys-track-analyzer/')); ?>">Track Analyzer</a> — upload a mix and get fast AI feedback.</li>
             <li><a href="<?php echo esc_url(home_url('/riff-generator/')); ?>">Riff Generator</a> — generate guitar ideas in a retro experiment shell.</li>

--- a/style.css
+++ b/style.css
@@ -583,7 +583,8 @@ body::before {
     grid-template-columns: 1fr;
   }
 
-  .asmr-lab-teaser {
+  .asmr-lab-teaser,
+  .gastown-sim-teaser {
     text-align: center;
   }
 }
@@ -2080,6 +2081,60 @@ body {
 }
 
 .asmr-lab-teaser__cta {
+  margin-top: 14px;
+}
+
+
+.gastown-sim-teaser {
+  margin: 40px auto;
+  max-width: 860px;
+  padding: 24px 28px;
+  border-radius: 12px;
+  text-align: left;
+}
+
+.gastown-sim-teaser__eyebrow {
+  margin: 0 0 0.75rem;
+  font-size: 0.68rem;
+  letter-spacing: 1px;
+  color: var(--secondary-color);
+  text-transform: uppercase;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.gastown-sim-teaser__badge {
+  display: inline-block;
+  padding: 2px 7px;
+  border: 1px solid var(--secondary-color);
+  border-radius: 999px;
+  line-height: 1.2;
+  color: #031c12;
+  background: var(--secondary-color);
+  box-shadow: 0 0 8px rgba(0, 255, 170, 0.35);
+}
+
+.gastown-sim-teaser h2 {
+  margin: 0 0 0.8rem;
+  color: #b6ffd7;
+}
+
+.gastown-sim-teaser__description,
+.gastown-sim-teaser__microcopy {
+  margin: 0;
+  max-width: 65ch;
+  line-height: 1.7;
+  color: #e8ffee;
+}
+
+.gastown-sim-teaser__microcopy {
+  margin-top: 0.8rem;
+  color: #c9fbe0;
+}
+
+.gastown-sim-teaser__cta {
   margin-top: 14px;
 }
 


### PR DESCRIPTION
### Motivation
- Surface the new Gastown First-Person Simulator prominently on the homepage as a playful, in-progress experiment linked to the live page `/page-gastown-sim/`.
- Communicate that the prototype is updated frequently and may require a hard refresh/clearing cache, while keeping the site tone handmade/retro rather than corporate.

### Description
- Added a new reusable `gastown-sim-teaser` section to `page-home.php` immediately beneath the ASMR Lab teaser, including a small “New” badge, headline, supportive microcopy, and a single primary CTA linking to `/page-gastown-sim/` (`Enter Gastown`).
- Inserted a supporting list link to the simulator in the existing Creative Tool Deck for crawl-first discoverability.
- Added scoped CSS rules in `style.css` to match the site’s retro/CRT aesthetic (badge styling, heading color, copy, spacing, CTA margin) and included mobile alignment behavior next to the ASMR teaser.
- Kept markup compact and maintainable so the block can be moved or reused later without altering other homepage content.

### Testing
- Ran `php -l page-home.php` with no syntax errors reported (OK).
- Ran `php -l style.css` with no syntax errors reported (OK).
- Attempted a Playwright screenshot of a local server, but there was no running web server in this theme-only environment so browser capture could not be completed (skipped).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b55252e4b8832ea250b34bcd544cd2)