### PR TITLE
Click-to-enter play mode, morning default, and minimap heading fix

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -239,6 +239,7 @@ function se_enqueue_gastown_sim_assets() {
                 'audioBaseUrl'   => esc_url_raw( $uri . '/assets/audio/gastown' ),
                 'defaultWeather' => 'rain',
                 'defaultMood'    => 'eerie',
+                'defaultTimeOfDay' => 'morning',
             )
         );
     }

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -11,7 +11,6 @@
   const statusEl = app.querySelector('[data-sim-status]');
   const pointerStatusEl = app.querySelector('[data-sim-pointer-status]');
   const landmarkEl = app.querySelector('[data-sim-landmark]');
-  const startBtn = app.querySelector('[data-action="start"]');
   const pauseBtn = app.querySelector('[data-action="pause"]');
   const resetBtn = app.querySelector('[data-action="reset"]');
   const timeOfDaySelect = app.querySelector('[name="time-of-day"]');
@@ -34,7 +33,7 @@
     lastSafePosition: new THREE.Vector3(),
     debugEnabled: new URLSearchParams(window.location.search).get('gastownDebug') === '1',
     activeWeather: config.defaultWeather || 'rain',
-    activeTimeOfDay: config.defaultTimeOfDay || 'night',
+    activeTimeOfDay: config.defaultTimeOfDay || 'morning',
     activeMood: config.defaultMood || 'eerie',
     sounds: {
       beds: {},
@@ -115,7 +114,7 @@
     }
     state.boundaryNoticeTimer = setTimeout(() => {
       if (!state.isRunning) return;
-      setStatus('Play mode active. Click scene for mouse look, then move with WASD / arrow keys.');
+      setStatus('Play mode active. Mouse look and movement are live.');
     }, 1900);
   }
 
@@ -910,6 +909,8 @@
     const playerPoint = toMinimapPoint({ x: player.position.x, z: player.position.z }, metrics, pad);
     const heading = state.yaw;
     const dirLength = 16;
+    const headingX = -Math.sin(heading);
+    const headingY = -Math.cos(heading);
 
     ctx.fillStyle = '#f2f6ff';
     ctx.beginPath();
@@ -919,7 +920,8 @@
     ctx.fillStyle = 'rgba(133, 205, 245, 0.35)';
     ctx.beginPath();
     ctx.moveTo(playerPoint.x, playerPoint.y);
-    ctx.arc(playerPoint.x, playerPoint.y, dirLength, heading - 0.42, heading + 0.42);
+    const headingAngle = Math.atan2(headingY, headingX);
+    ctx.arc(playerPoint.x, playerPoint.y, dirLength, headingAngle - 0.42, headingAngle + 0.42);
     ctx.closePath();
     ctx.fill();
 
@@ -927,7 +929,7 @@
     ctx.lineWidth = 2;
     ctx.beginPath();
     ctx.moveTo(playerPoint.x, playerPoint.y);
-    ctx.lineTo(playerPoint.x + Math.sin(heading) * dirLength, playerPoint.y - Math.cos(heading) * dirLength);
+    ctx.lineTo(playerPoint.x + headingX * dirLength, playerPoint.y + headingY * dirLength);
     ctx.stroke();
   }
 
@@ -1131,9 +1133,16 @@
 
   function startSim() {
     state.isRunning = true;
-    setStatus('Play mode active. Click scene for mouse look, then move with WASD / arrow keys.');
+    setStatus('Play mode active. Mouse look and movement are live.');
     setPointerStatus('Pointer lock requested… press Esc any time to release.');
     lockPointer();
+  }
+
+  function enterPlayMode() {
+    if (state.isRunning && document.pointerLockElement === renderer.domElement) {
+      return;
+    }
+    startSim();
   }
 
   function pauseSim() {
@@ -1145,23 +1154,20 @@
     if (document.pointerLockElement) {
       document.exitPointerLock();
     }
-    setStatus('Paused. Click Start to continue walking the route.');
-    setPointerStatus('Pointer released. Press Start and click scene to re-enter look mode.');
+    setStatus('Paused. Click scene to resume look mode and movement.');
+    setPointerStatus('Pointer released. Click scene to re-enter look mode.');
   }
 
   function attachEvents() {
     window.addEventListener('resize', updateSize);
     renderer.domElement.addEventListener('click', () => {
-      if (state.isRunning) {
-        lockPointer();
-      }
+      enterPlayMode();
     });
     document.addEventListener('mousemove', onMouseMove);
 
     document.addEventListener('keydown', (event) => setMoveKey(event.code, true));
     document.addEventListener('keyup', (event) => setMoveKey(event.code, false));
 
-    startBtn.addEventListener('click', startSim);
     pauseBtn.addEventListener('click', pauseSim);
     resetBtn.addEventListener('click', resetToStart);
 
@@ -1180,8 +1186,8 @@
         state.move.left = false;
         state.move.right = false;
         state.isRunning = false;
-        setStatus('Pointer released. Play mode exited. Press Start to continue the walk.');
-        setPointerStatus('Pointer released. Press Start, then click scene to re-enter look mode.');
+        setStatus('Paused. Pointer released. Click scene to resume look mode and movement.');
+        setPointerStatus('Pointer released. Click scene to re-enter look mode.');
       } else {
         setPointerStatus('Pointer unlocked.');
       }
@@ -1236,8 +1242,8 @@
         debugPanel.removeAttribute('hidden');
       }
       scheduleSteamClock();
-      setStatus('Prototype ready. Press Start, click the scene, and use Esc to exit pointer lock.');
-      setPointerStatus('Pointer unlocked. Click scene after Start to enter look mode.');
+      setStatus('Prototype ready. Click scene to enter look mode and begin moving.');
+      setPointerStatus('Pointer unlocked. Click scene to enter look mode.');
       renderer.setAnimationLoop((time) => {
         const delta = Math.min(0.03, (time - (init.prevTime || time)) / 1000);
         init.prevTime = time;

--- a/page-gastown-sim.php
+++ b/page-gastown-sim.php
@@ -10,20 +10,19 @@ get_header();
     <header class="gastown-sim-header">
       <p class="gastown-sim-kicker">Prototype route: Waterfront Station → Water Street → Steam Clock</p>
       <h1>Gastown First-Person Simulator</h1>
-      <p class="gastown-sim-intro">A stylized, geographically grounded night walk through one focused Gastown slice. Click Start, lock the pointer, and walk the corridor.</p>
+      <p class="gastown-sim-intro">A stylized, geographically grounded Gastown walk through one focused corridor slice. Click into the scene, look around, and walk the route.</p>
     </header>
 
     <div class="gastown-controls" role="group" aria-label="Simulator controls">
-      <button type="button" class="pixel-button" data-action="start">Start</button>
       <button type="button" class="pixel-button secondary" data-action="pause">Pause</button>
       <button type="button" class="pixel-button secondary" data-action="reset">Reset to route start</button>
       <label>
         Time of day
         <select name="time-of-day">
-          <option value="morning">Morning</option>
+          <option value="morning" selected>Morning</option>
           <option value="afternoon">Afternoon</option>
           <option value="evening">Evening</option>
-          <option value="night" selected>Night</option>
+          <option value="night">Night</option>
         </select>
       </label>
       <label>
@@ -52,7 +51,7 @@ get_header();
         <li><strong>Click scene</strong> to enter look mode</li>
         <li><strong>Mouse</strong> = look around</li>
         <li><strong>W A S D / arrow keys</strong> = move</li>
-        <li><strong>Esc</strong> = release pointer / leave play mode</li>
+        <li><strong>Esc</strong> = release pointer / pause</li>
       </ul>
     </section>
 


### PR DESCRIPTION
### Motivation
- Improve first-person feel and reduce UI friction by removing the separate Start step and making the sim enter play on click. 
- Make the initial scene feel brighter by defaulting to morning on first load. 
- Fix the minimap heading so its wedge/line matches actual camera/player forward direction and avoids confusing reversed guidance.

### Description
- Removed the explicit Start button and updated intro/help copy to instruct users to click the scene to enter look/play mode (`page-gastown-sim.php`).
- Defaulted the time-of-day to `morning` in the UI select and in the localized simulator config (`page-gastown-sim.php`, `functions.php`, and `js/gastown-sim.js`).
- Reworked the entry/exit loop so clicking the WebGL canvas calls a new `enterPlayMode()` helper that starts the sim and requests pointer lock, and Esc/pointer unlock transitions to a paused idle state that can be resumed by clicking the scene (`js/gastown-sim.js`).
- Updated status/HUD copy to reflect the new behavior and keep the HUD minimal and clear (`js/gastown-sim.js` and `page-gastown-sim.php`).
- Corrected minimap heading math by mapping camera yaw to minimap X/Y vectors and using `Math.atan2` for the wedge/line drawing so the minimap arrow now aligns with world forward motion (`js/gastown-sim.js`).
- Preserved existing systems (minimap, weather, mood, movement, bounds/reset logic, pointer lock) and adjusted only entry/exit and display logic for clarity.

### Testing
- Ran `php -l page-gastown-sim.php` and the file passed linting successfully.
- Ran `php -l functions.php` and `node --check js/gastown-sim.js`, both of which succeeded with no syntax errors.
- Attempted an automated Playwright page capture to validate runtime behavior, but it failed due to no local web server available in the environment (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b55f267aac832e857e6ed894d7ac7c)