### PR TITLE
Add arrow-key turning and clarify keyboard controls

### DIFF
--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -29,6 +29,7 @@
     world: null,
     isRunning: false,
     move: { forward: false, backward: false, left: false, right: false },
+    turn: { left: false, right: false },
     yaw: 0,
     pitch: 0,
     velocity: new THREE.Vector3(),
@@ -1267,8 +1268,15 @@
 
   function movePlayer(delta) {
     const speed = 9;
+    const turnSpeed = 1.85;
     const forward = Number(state.move.forward) - Number(state.move.backward);
     const strafe = Number(state.move.right) - Number(state.move.left);
+    const turning = Number(state.turn.right) - Number(state.turn.left);
+
+    if (turning !== 0) {
+      state.yaw -= turning * turnSpeed * delta;
+      player.rotation.y = state.yaw;
+    }
 
     const input = new THREE.Vector3(strafe, 0, -forward);
     if (input.lengthSq() > 1) {
@@ -1308,8 +1316,10 @@
   function setMoveKey(code, pressed) {
     if (code === 'KeyW' || code === 'ArrowUp') state.move.forward = pressed;
     if (code === 'KeyS' || code === 'ArrowDown') state.move.backward = pressed;
-    if (code === 'KeyA' || code === 'ArrowLeft') state.move.left = pressed;
-    if (code === 'KeyD' || code === 'ArrowRight') state.move.right = pressed;
+    if (code === 'KeyA') state.move.left = pressed;
+    if (code === 'KeyD') state.move.right = pressed;
+    if (code === 'ArrowLeft') state.turn.left = pressed;
+    if (code === 'ArrowRight') state.turn.right = pressed;
   }
 
   function resetToStart() {
@@ -1351,6 +1361,8 @@
     state.move.backward = false;
     state.move.left = false;
     state.move.right = false;
+    state.turn.left = false;
+    state.turn.right = false;
     if (document.pointerLockElement) {
       document.exitPointerLock();
     }
@@ -1402,6 +1414,8 @@
         state.move.backward = false;
         state.move.left = false;
         state.move.right = false;
+        state.turn.left = false;
+        state.turn.right = false;
         state.isRunning = false;
         setStatus('Paused. Pointer released. Click scene to resume look mode and movement.');
         setPointerStatus('Pointer released. Click scene to re-enter look mode.');

--- a/page-gastown-sim.php
+++ b/page-gastown-sim.php
@@ -50,7 +50,8 @@ get_header();
       <ul>
         <li><strong>Click scene</strong> to enter look mode</li>
         <li><strong>Mouse</strong> = look around</li>
-        <li><strong>W A S D / arrow keys</strong> = move</li>
+        <li><strong>W A S D</strong> = move / strafe</li>
+        <li><strong>Arrow keys</strong> = move forward/back + turn left/right</li>
         <li><strong>Esc</strong> = release pointer / pause</li>
       </ul>
     </section>
@@ -81,7 +82,8 @@ get_header();
     <section class="gastown-debug" data-debug-panel hidden>
       <h2>Debug notes</h2>
       <ul>
-        <li>WASD or arrow keys for movement</li>
+        <li>W/S + Arrow Up/Down move forward/back; A/D strafe</li>
+        <li>Arrow Left/Right turns the player heading</li>
         <li>Mouse look while pointer is locked</li>
         <li>Walk bounds clamp keeps the player in the playable corridor slice</li>
         <li>Route debug can also be enabled with <code>?gastownDebug=1</code></li>


### PR DESCRIPTION
### Motivation
- Keyboard-only navigation lacked a way to yaw/turn the player, making arrow keys feel incomplete compared to mouse look.
- Users expect arrow Left/Right to rotate orientation in a first-person walking simulator while mouse remains primary look control.
- Maintain consistent player heading so minimap and movement behave the same whether rotation comes from the mouse or keyboard.

### Description
- Added a new `turn` state (`state.turn`) and per-frame keyboard yaw integration in `movePlayer` so `ArrowLeft` / `ArrowRight` apply smooth turning via `state.yaw` while preserving mouse-driven yaw via the same state.
- Mapped keys in `setMoveKey` so `W/S` and `ArrowUp/ArrowDown` are forward/back, `A/D` are strafing, and `ArrowLeft`/`ArrowRight` toggle the new `turn.left`/`turn.right` flags; removed left/right arrow strafing.
- Cleared `turn` flags on `pauseSim` and when pointer lock is released so play/pause transitions remain consistent.
- Updated quick-help and debug text in `page-gastown-sim.php` to describe the new mapping (`Mouse = look`, `W A S D = move/strafe`, `Arrow keys = move + turn`, `Esc = release pointer`).

### Testing
- Ran `node --check js/gastown-sim.js` with no syntax errors reported.
- Ran `php -l page-gastown-sim.php` with no syntax errors reported.
- Attempted a headless browser screenshot to validate runtime behavior, but the local web app was unreachable in this environment (`ERR_EMPTY_RESPONSE`), so interactive validation could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b61be5f490832e98a87eabc865adae)