### PR TITLE
ASMR Lab — reframe as rebuild chamber and add optional lab narrator

### DIFF
--- a/assets/css/asmr-lab.css
+++ b/assets/css/asmr-lab.css
@@ -137,3 +137,59 @@
 .asmr-advanced-fields[open]>summary{margin-bottom:.65rem}
 .asmr-layer-groups{margin-top:.55rem}
 @media (max-width:780px){.asmr-route-nav{grid-template-columns:1fr}.asmr-route-nav .pixel-button{width:100%}}
+
+.asmr-rebuild-chamber{
+  margin:1rem 0 1.1rem;
+  padding:1rem;
+  border:1px solid #3a4f8a;
+  border-radius:10px;
+  background:radial-gradient(circle at top right, rgba(110,66,255,.22), rgba(11,17,36,.96) 45%), linear-gradient(180deg,#0b1124,#090f20 75%);
+  box-shadow:0 0 24px rgba(89,125,255,.18) inset;
+}
+.asmr-alert{
+  margin:0 0 .4rem;
+  font-size:.76rem;
+  color:#ffc87a;
+  text-transform:uppercase;
+  letter-spacing:.05em;
+}
+.asmr-rebuild-chamber h2{margin:.2rem 0 .55rem;color:#dce7ff}
+.asmr-rebuild-chamber p{margin:.34rem 0;color:#bdd0fb;line-height:1.55}
+.asmr-status-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(180px,1fr));
+  gap:.45rem;
+  margin:.75rem 0;
+}
+.asmr-status-grid p{
+  margin:0;
+  font-size:.76rem;
+  border:1px solid #324579;
+  border-radius:8px;
+  padding:.5rem .55rem;
+  background:#0a1124;
+}
+.asmr-lab-voice-panel{
+  margin-top:.7rem;
+  padding:.75rem;
+  border:1px dashed #4862a1;
+  border-radius:8px;
+  background:rgba(7,13,29,.82);
+}
+.asmr-lab-voice-status{margin:.55rem 0 0;font-size:.76rem;color:#9fc0ff}
+.asmr-cta-row{display:flex;gap:.5rem;flex-wrap:wrap;margin-top:.85rem}
+.asmr-legacy-console{
+  margin-top:.9rem;
+  border:1px solid #2f3f73;
+  border-radius:10px;
+  background:#090f20;
+}
+.asmr-legacy-console summary{
+  cursor:pointer;
+  list-style:none;
+  padding:.75rem .9rem;
+  color:#9dbdff;
+  font-size:.84rem;
+}
+.asmr-legacy-console summary::-webkit-details-marker{display:none}
+.asmr-legacy-console[open]{padding:0 .9rem .9rem}

--- a/js/asmr-lab.js
+++ b/js/asmr-lab.js
@@ -1,6 +1,65 @@
 (function () {
   'use strict';
 
+  function initLabNarrator() {
+    const trigger = document.getElementById('asmr-lab-voice-trigger');
+    const status = document.getElementById('asmr-lab-voice-status');
+    if (!trigger || !status) return;
+
+    const lines = [
+      'Lab status update. Yes, this prototype is under major development. No, pressing buttons harder will not speed it up.',
+      'ASMR Lab was the glitchy ancestor of the Gastown simulator. It did its job, then demanded a redesign.',
+      'Rebuild chamber active. Legacy code remains in containment. Interface recovery is in progress.',
+      'System note. Prototype unstable, story intact, vibes operational.'
+    ];
+
+    function speakMessage(text) {
+      if (!text || !('speechSynthesis' in window)) return false;
+
+      const synth = window.speechSynthesis;
+      const utterance = new SpeechSynthesisUtterance(text);
+
+      const pickVoice = () => {
+        const voices = synth.getVoices();
+        const preferred = voices.find((voice) =>
+          voice.name.includes('Google UK English Male') ||
+          voice.name.includes('Microsoft David') ||
+          /en/i.test(voice.lang)
+        );
+
+        utterance.voice = preferred || null;
+        utterance.rate = 0.92;
+        utterance.pitch = 0.84;
+        synth.cancel();
+        synth.speak(utterance);
+      };
+
+      const voices = synth.getVoices();
+      if (!voices || voices.length === 0) {
+        synth.addEventListener('voiceschanged', pickVoice, { once: true });
+      } else {
+        pickVoice();
+      }
+
+      return true;
+    }
+
+    trigger.addEventListener('click', () => {
+      const line = lines[Math.floor(Math.random() * lines.length)];
+      status.textContent = 'Lab narrator online…';
+
+      const supported = speakMessage(line);
+      if (!supported) {
+        status.textContent = line;
+        return;
+      }
+
+      status.textContent = `Lab narrator: "${line}"`;
+    });
+  }
+
+  initLabNarrator();
+
   const app = document.getElementById('asmr-lab-app');
   if (!app || !window.seAsmrLab) return;
 

--- a/page-asmr-lab.php
+++ b/page-asmr-lab.php
@@ -8,11 +8,33 @@ get_header();
 <main id="primary" class="content-area asmr-lab-page">
   <section class="asmr-lab-shell" id="asmr-lab-app">
     <header class="asmr-lab-header">
-      <p class="asmr-kicker">Retro-futurist creative control room</p>
-      <h1 class="asmr-title">ASMR Lab</h1>
-      <p class="asmr-intro">Route-first Gastown prototype. Compose, explore, and record a first-person Water Street walk from the Waterfront threshold to the Steam Clock corridor and split-building node.</p>
+      <p class="asmr-kicker">Retro-futurist rebuild chamber // archive specimen</p>
+      <h1 class="asmr-title">ASMR Lab: Rebuild in Progress</h1>
+      <p class="asmr-intro">Experimental predecessor to the Gastown simulator. Currently in major reconstruction with unstable modules and dramatic lighting.</p>
     </header>
 
+    <section class="asmr-rebuild-chamber" aria-labelledby="asmr-rebuild-title">
+      <p class="asmr-alert">⚠ Prototype unstable // rebuild chamber online</p>
+      <h2 id="asmr-rebuild-title">ASMR Lab: Under Major Development</h2>
+      <p>This started as a weird audio/visual experiment, survived too many iterations, and eventually got strange enough to help inspire the Gastown simulator.</p>
+      <p>The code survived. The interface is in the shop. Rebuild in progress.</p>
+      <div class="asmr-status-grid" role="list" aria-label="Rebuild status">
+        <p role="listitem"><strong>Status:</strong> major rebuild</p>
+        <p role="listitem"><strong>Stability:</strong> intentionally chaotic</p>
+        <p role="listitem"><strong>Mutation level:</strong> acceptable</p>
+      </div>
+      <div class="asmr-lab-voice-panel">
+        <button type="button" id="asmr-lab-voice-trigger" class="pixel-button">Activate lab narrator</button>
+        <p id="asmr-lab-voice-status" class="asmr-lab-voice-status" aria-live="polite">Silent mode engaged. Narrator stays quiet until requested.</p>
+      </div>
+      <div class="asmr-cta-row">
+        <a class="pixel-button" href="<?php echo esc_url( home_url('/gastown-sim/') ); ?>">Enter Gastown prototype</a>
+        <a class="pixel-button secondary" href="https://github.com/suzyeaston/suzyeastonca" target="_blank" rel="noopener noreferrer">View code on GitHub</a>
+      </div>
+    </section>
+
+    <details class="asmr-legacy-console">
+      <summary>Open legacy ASMR Lab console (experimental predecessor)</summary>
     <section class="asmr-lab-primer" aria-labelledby="asmr-lab-primer-title">
       <h2 id="asmr-lab-primer-title">What this prototype now performs</h2>
       <ul>
@@ -268,6 +290,8 @@ get_header();
       <section class="asmr-results-panel" data-results-panel="json" role="tabpanel" hidden>
         <article class="asmr-card asmr-card-json"><h3>Timeline Package JSON</h3><pre id="asmr-sound-json"></pre></article>
       </section>
+    </details>
+
     </section>
   </section>
 </main>


### PR DESCRIPTION
### Motivation
- Make the ASMR Lab page read as an intentional “under major development” rebuild rather than a broken/abandoned tool while preserving the legacy interface in-repo. 
- Provide an optional, user-triggered voice message using the same Web Speech API / playback pattern already used by the Albini Q&A page, but with a new original narrator character that does not impersonate Steve.

### Description
- Updated `page-asmr-lab.php` to change the header copy, add a new `asmr-rebuild-chamber` section with status messaging, a CTA row linking to the Gastown prototype and the public GitHub repo, and a user-triggered `Activate lab narrator` button, and wrapped the existing tool UI in a collapsible `details` block so legacy functionality remains accessible. 
- Added a lightweight narrator implementation in `js/asmr-lab.js` (`initLabNarrator`) that follows the established voice-selection + `voiceschanged` fallback + `speechSynthesis` playback pattern used by `page-albini-qa.php`, but emits original snarky lines and explicitly avoids impersonation. 
- Added rebuild-chamber styling to `assets/css/asmr-lab.css` (warning/status panels, voice panel, CTA row, legacy-console disclosure) to give the page a retro/dark rebuild-lab aesthetic. 
- Kept existing ASMR Lab generation and engine code untouched; this change only reframes the page and wires the optional narrator control into the same client-side pattern the site already uses.

### Testing
- Ran PHP syntax check with `php -l page-asmr-lab.php`, which reported no syntax errors. 
- Checked the modified JS with `node --check js/asmr-lab.js`, which passed without errors. 
- Launched a lightweight local PHP server and captured a Playwright screenshot of `page-asmr-lab.php` to validate layout rendering, but the environment did not provide a full WordPress route so the artifact may not reflect the production template mounted in WP (artifact was produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b62046df80832ea4da9acf953d5fdd)