### PR TITLE
Refresh v4.0 theme identity and flagship messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,58 @@
-# Suzy's Retro Arcade – v3.0
-A custom WordPress theme powering [suzyeaston.ca](https://suzyeaston.ca), complete with games, music tools and a dash of civic spirit.
+# Suzy's Retro Arcade – v4.0
+A custom WordPress theme powering [suzyeaston.ca](https://suzyeaston.ca) — part retro arcade, part creative-tech lab, part Vancouver build-in-public experiment.
+
+Current highlights:
+- **Gastown First-Person Simulator**, a live Vancouver prototype evolving in public
+- **Track Analyzer** for MP3 vibe checks
+- **Lousy Outages**, an arcade-style status board
+- **Albini Q&A** / "What Would Steve Do" style experiments
+- **ASMR Lab**, the earlier audio/visual prototype that helped inspire the Gastown simulator and is now under major redevelopment
+
+The repo is open source, the process is visible, and the goal is to keep building playful, useful, and strange little things that invite people in. We rise together.
 
 ## What's Included
-- Retro pixel-art inspired design with neon CRT vibes
-- **Canucks Puck Bash** – an 80s style hockey game built with HTML5 canvas
-- **Riff Generator 8000** for instant rock, punk, metal or jazz riffs
-- **Track Analyzer** for quick MP3 vibe checks using OpenAI
-- Album reviews of classic jazz and rock discovered during Suzy's HMV days
-- **Albini Q&A** widget that channels legendary producer Steve Albini via OpenAI
-- Music releases, livestream schedules and a "Now Listening" section featuring a static YouTube embed
-- Downtown Eastside advocacy section and notes on Suzy's possible 2026 city council run
-- Custom REST endpoints for Canucks news and betting odds
-- **Lousy Outages** arcade‑style status board with homepage teaser
-- A single Support link (header + homepage About group) for supporting Suzy's work
-- Mobile friendly with drag & tap controls
+- Custom WordPress theme with neon CRT/pixel styling and arcade energy
+- Homepage + project templates for live creative-tech experiments
+- Gastown simulator page and supporting systems for rapid iteration
+- Track Analyzer workflow for AI-assisted feedback on uploaded MP3s
+- Lousy Outages dashboard and teaser components
+- Experimental voice/tool pages, including Albini Q&A style workflows
+- Legacy + rebuilding ASMR Lab experience (kept online while redevelopment continues)
 
-## Lousy Outages refresh
-The neon dashboard now streams live provider data from `/api/outages` on load and every five minutes (override with the `OUTAGES_POLL_MS` env var or the `lousy_outages_interval` option in wp-admin). Each request fan-outs to the official status APIs with 10s timeouts, caches the merged JSON in a transient for ~90 seconds and then renders per-incident drawers with start time, latest update/ETA and impact badges. Albini-style snark is generated client-side with speech synth support when enabled, and the homepage teaser reuses the same copy: “Check if your favourite services are up. Insert coin to refresh.”
+## Current flagship / live experiments
+### Gastown First-Person Simulator
+The current flagship prototype. A first-person Vancouver corridor build focused on Waterfront Station → Water Street → Steam Clock, with ongoing updates to atmosphere, navigation, and scene detail. It changes often because it is built in public.
 
-The legacy REST endpoint at `/wp-json/lousy-outages/v1/status` still works and returns the expanded payload, while the new `/api/outages` edge route emits uncached JSON with `Cache-Control: no-store`. WordPress cron keeps polling in the background—run `wp cron event run lousy_outages_poll` if you need to warm the datastore manually.
+### Albini Q&A and related experiments
+"What Would Steve Do" style tools are still part of the ecosystem: quote-grounded prompts, commentary workflows, and playful interfaces that test how voice, archives, and creative tooling can coexist.
 
-The status arcade now opens with an "at-a-glance" headline that calls out any degraded providers, links straight to the custom RSS feed at `/outages/feed/` and highlights the alerts inbox (`suzanneeaston@gmail.com`) so you can wire it into whatever mail filters you prefer. Unknown telemetry also surfaces in the banner, making it obvious when a provider's API stops responding.
+## Lousy Outages
+**Lousy Outages** remains active as the arcade-style status board.
 
-## Get alerts on your phone
-- **RSS**: Subscribe to https://<your-site>/outages/feed in any mobile RSS app (NetNewsWire, Reeder, Feedly). You’ll get a push/badge when incidents publish.
-- **SMS (optional)**: Enter your Twilio SID/Auth/From and your phone under Settings → Lousy Outages. Use “Send Test SMS” to verify.
+- `/api/outages` provides live provider pulls with `Cache-Control: no-store`
+- `/wp-json/lousy-outages/v1/status` remains available for legacy consumers
+- Polling cadence can be tuned with `OUTAGES_POLL_MS` or the `lousy_outages_interval` option
+- Background refresh can be warmed manually with `wp cron event run lousy_outages_poll`
+
+It is intentionally practical but still fun: command-line vibes, alert hooks, and very online reliability energy.
 
 ## Track Analyzer
-Uploads are sent to OpenAI's Whisper and GPT‑4 APIs for a quick analysis of your
-MP3. Results appear with a fun retro overlay and clear loading indicators. For
-production use, consider exposing this feature through a custom REST endpoint
-and caching results in case OpenAI is unavailable.
+**Track Analyzer** is still in rotation for MP3 uploads and quick AI-assisted mix feedback. It is designed as a fast creative checkpoint for musicians who want signal, not fluff.
+
+## ASMR Lab status
+**ASMR Lab** is an earlier audio/visual experiment that got weird enough to help inspire the Gastown simulator.
+
+It still matters, it is still in the repo, and parts are still playable — but it is currently under major redevelopment.
+
+## Open source / build in public
+This repo is open source: <https://github.com/suzyeaston/suzyeastonca>
+
+Expect frequent updates, rough edges, and visible iteration. If something looks off right after a deploy, hard refresh, clear cache, or pop into incognito and try again.
+
+Community, collaboration, and shared momentum are core to the project. If you want to contribute ideas, report bugs, or remix experiments, you are welcome here.
 
 ## About Suzy Easton
-Suzy is a Vancouver-based musician, technologist and all-around creative builder. She toured Canada playing bass, recorded with Steve Albini and once appeared on MuchMusic. These days she writes album reviews of jazz and rock classics found during her time at HMV (2007–2012). Inspired by the single "A Little Louder" airing on CiTR, she's crafting new hard rock demos. Suzy loves hockey, punk rock, 8-bit aesthetics and fixing things that break in production, and she's considering a run for Vancouver City Council in 2026.
+Suzy Easton is a Vancouver-based musician and creative technologist working at the intersection of music, software, civic curiosity, and internet-era storytelling. Touring, recording, and production culture still inform the build style: direct, experimental, and always in motion.
 
 ## License
-MIT License. Play nice.
+MIT License. Build kindly.

--- a/header.php
+++ b/header.php
@@ -26,9 +26,9 @@
       $meta_keywords = 'Suzy Easton, Suzanne Easton, Vancouver musician, creative technologist, Lousy Outages, indie music, retro arcade website, outage analysis';
       $meta_img   = $default_img;
     } elseif ( is_page_template( 'page-asmr-lab.php' ) ) {
-      $meta_title = 'ASMR Lab – AI sensory ad concepts and 8-bit foley recipes';
-      $meta_desc  = 'ASMR Lab generates AI sensory ad concepts, tactile beat sheets, retro-foley sound recipes, and model-ready video prompts in one creative package.';
-      $meta_keywords = 'ASMR lab, AI ad concept generator, foley recipe tool, sensory marketing prompts, Suzy Easton';
+      $meta_title = 'ASMR Lab – experimental predecessor now under major redevelopment';
+      $meta_desc  = 'ASMR Lab is Suzy\'s earlier audio/visual prototype that inspired the Gastown simulator and is now being rebuilt in public.';
+      $meta_keywords = 'ASMR Lab, Gastown simulator predecessor, creative tech prototype, Suzy Easton';
       $meta_img   = $default_img;
     } elseif ( is_page_template( 'page-lousy-outages.php' ) ) {
       $meta_title = 'Lousy Outages – Retro outage dashboard for modern chaos';

--- a/page-home.php
+++ b/page-home.php
@@ -60,8 +60,8 @@ get_header();
             <p class="hero-subhead">Born in Vancouver, BC and a generalist by nature, I build things, play guitars, and live by one motto: always be creating. My background spans classical music training, plus five years behind the counter at HMV talking records and discovering new sounds.</p>
             <p class="hero-microproof">I’ve toured across Canada as a bassist, appeared on MuchMusic, and recorded in Chicago with Steve Albini. These days, I’m building apps, exploring AI models, experimenting with short AI films through BC + AI Film Club, and writing whatever songs show up next.</p>
             <div class="hero-cta-group">
-                <a href="/suzys-track-analyzer/" class="pixel-button hero-primary-cta">Start with: Track Analyzer</a>
-                <a href="/asmr-lab/" class="pixel-button hero-secondary-cta">Try: ASMR Lab</a>
+                <a href="/page-gastown-sim/" class="pixel-button hero-primary-cta">Start with: Gastown Simulator</a>
+                <a href="/suzys-track-analyzer/" class="pixel-button hero-secondary-cta">Try: Track Analyzer</a>
                 <a href="/lousy-outages/" class="pixel-button hero-secondary-cta">Or explore: Lousy Outages</a>
                 <a href="/bio/" class="pixel-button hero-bio-button">Read full bio</a>
             </div>
@@ -70,9 +70,9 @@ get_header();
         <p class="arcade-subtext">Insert coin to explore</p>
 
         <section class="gastown-sim-teaser crt-block" aria-labelledby="gastown-sim-teaser-title">
-            <p class="gastown-sim-teaser__eyebrow pixel-font"><span class="gastown-sim-teaser__badge">New</span> In progress. Shipping weird little upgrades constantly.</p>
-            <h2 id="gastown-sim-teaser-title" class="pixel-font">New: Gastown First-Person Simulator</h2>
-            <p class="gastown-sim-teaser__description">A first-person Vancouver experiment inspired by the ASMR Lab and now mutating into a playable Gastown walk. Start near Waterfront Station and head toward Water Street and the Steam Clock.</p>
+            <p class="gastown-sim-teaser__eyebrow pixel-font"><span class="gastown-sim-teaser__badge">Flagship</span> Live build in public. Shipping weird little upgrades constantly.</p>
+            <h2 id="gastown-sim-teaser-title" class="pixel-font">Gastown First-Person Simulator</h2>
+            <p class="gastown-sim-teaser__description">A first-person Vancouver prototype evolving in public. Drop in near Waterfront Station, walk Water Street, and chase the Steam Clock through sound, weather, and constant iteration.</p>
             <p class="gastown-sim-teaser__microcopy">Getting tuned up often, sometimes daily. If the world looks haunted, hard refresh or hop into a private window and dive back in.</p>
             <a href="<?php echo esc_url(home_url('/page-gastown-sim/')); ?>" class="pixel-button gastown-sim-teaser__cta">Enter Gastown</a>
         </section>
@@ -161,9 +161,9 @@ get_header();
     </section>
 
     <section class="asmr-lab-teaser crt-block" aria-labelledby="asmr-lab-teaser-title">
-        <p class="asmr-lab-teaser__eyebrow pixel-font">Experimental Machine Online</p>
-        <h2 id="asmr-lab-teaser-title" class="pixel-font">ASMR Lab</h2>
-        <p class="asmr-lab-teaser__description">Step into the noise chamber: AI-generated sensory ad concepts, 8-bit foley recipes, and model-ready video prompts wired for curious makers.</p>
+        <p class="asmr-lab-teaser__eyebrow pixel-font">Earlier Prototype • Rebuild Mode</p>
+        <h2 id="asmr-lab-teaser-title" class="pixel-font">ASMR Lab (Under Major Redevelopment)</h2>
+        <p class="asmr-lab-teaser__description">The earlier audio/visual experiment that got weird enough to inspire Gastown. The legacy console is still playable while the next-gen rebuild happens in public.</p>
         <a href="<?php echo esc_url(home_url('/asmr-lab/')); ?>" class="pixel-button asmr-lab-teaser__cta">Enter ASMR Lab</a>
     </section>
 
@@ -177,13 +177,15 @@ get_header();
     <section class="creative-tool-links crt-block" aria-labelledby="creative-tool-links-title">
         <h2 id="creative-tool-links-title" class="pixel-font">Creative Tool Deck</h2>
         <p>Prefer crawl-first browsing? Jump straight to the public tool pages:</p>
+        <p>Everything here is open source, built in public, and updated often — if a new deploy looks cursed, hard refresh, clear cache, or jump into incognito and roll again.</p>
         <ul>
             <li><a href="<?php echo esc_url(home_url('/page-gastown-sim/')); ?>">Gastown First-Person Simulator</a> — first-person Vancouver prototype, currently in active daily-ish mutation mode.</li>
-            <li><a href="<?php echo esc_url(home_url('/asmr-lab/')); ?>">ASMR Lab</a> — AI sensory ad concepts, tactile beat sheets, and retro-foley prompt kits.</li>
+            <li><a href="<?php echo esc_url(home_url('/asmr-lab/')); ?>">ASMR Lab</a> — earlier audio/visual prototype, now under major redevelopment after inspiring the Gastown sim.</li>
             <li><a href="<?php echo esc_url(home_url('/suzys-track-analyzer/')); ?>">Track Analyzer</a> — upload a mix and get fast AI feedback.</li>
             <li><a href="<?php echo esc_url(home_url('/riff-generator/')); ?>">Riff Generator</a> — generate guitar ideas in a retro experiment shell.</li>
             <li><a href="<?php echo esc_url(home_url('/lousy-outages/')); ?>">Lousy Outages</a> — outage tracker with a throwback command-line vibe.</li>
         </ul>
+        <p>Build logs + code live at <a href="https://github.com/suzyeaston/suzyeastonca" target="_blank" rel="noopener noreferrer">github.com/suzyeaston/suzyeastonca</a>. Pull requests, bug reports, and kind chaos are welcome.</p>
     </section>
 
     <section class="party-announcement crt-block">

--- a/page-lousy-outages.php
+++ b/page-lousy-outages.php
@@ -152,7 +152,7 @@ if ($unsub_success) {
             <p class="lo-status-board__eyebrow">System Status Console</p>
             <h2 class="lo-status-board__title">Current Outages</h2>
           </div>
-          <div class="lo-status-board__badge" aria-hidden="true">v3.0 arcade build</div>
+          <div class="lo-status-board__badge" aria-hidden="true">v4.0 arcade build</div>
         </header>
         <div class="lo-status-board__body">
           <div class="lo-scanline" aria-hidden="true"></div>

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: Suzys Music Theme Lets Go Vancouver BC
 Author: Suzy Easton
 Description: An '80s video game inspired music WordPress theme, thanks much.
-Version: 3.0
+Version: 4.0
 */
 
 /* ====================== */


### PR DESCRIPTION
### Motivation
- Update the theme metadata and public-facing copy to reflect a clear v4.0 identity and project direction. 
- Promote the Gastown First-Person Simulator as the current flagship, while reframing ASMR Lab as an earlier prototype now under major redevelopment. 
- Make README and homepage messaging honest about frequent public iteration, open-source status, and community-minded tone. 

### Description
- Bumped the WordPress theme header `Version` to `4.0` in `style.css`. 
- Rewrote and restructured `README.md` to a v4.0 narrative that highlights the Gastown simulator, Track Analyzer, Lousy Outages, Albini Q&A, and the ASMR Lab rebuild, and added the GitHub repo link. 
- Updated homepage (`page-home.php`) to prioritize the Gastown Simulator (primary CTA and teaser copy), reframe ASMR Lab as “Under Major Redevelopment,” and add a short build-in-public / cache-refresh note and link to the repo. 
- Updated `header.php` meta copy for the ASMR Lab page template to reflect the predecessor/rebuild framing. 
- Replaced the public-facing Lousy Outages badge from `v3.0 arcade build` to `v4.0 arcade build` in `page-lousy-outages.php`. 

### Testing
- Ran PHP lint checks with `php -l` for `header.php`, `page-home.php`, `page-lousy-outages.php`, and `functions.php`, and there were no syntax errors. 
- Verified the updated `style.css`, `README.md`, `page-home.php`, `header.php`, and `page-lousy-outages.php` content via repository search and diff. 
- Attempted a Playwright screenshot of `http://localhost` but it failed with `ERR_EMPTY_RESPONSE` because no local web server responded in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6253ddad8832e969ee91cd435e75a)