### PR TITLE
Add Contact Suzy modal with assets, front-end script, and AJAX handler

### DIFF
--- a/assets/css/header-contact-modal.css
+++ b/assets/css/header-contact-modal.css
@@ -1,0 +1,147 @@
+.main-header .header-contact-trigger {
+  font-size: 0.62rem;
+  padding: 0.5rem 0.65rem;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.se-contact-modal[hidden] {
+  display: none;
+}
+
+.se-contact-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 10050;
+}
+
+.se-contact-modal__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.78);
+  backdrop-filter: blur(2px);
+}
+
+.se-contact-modal__dialog {
+  position: relative;
+  width: min(92vw, 540px);
+  margin: min(12vh, 5rem) auto;
+  background: linear-gradient(180deg, rgba(6, 8, 20, 0.95), rgba(3, 3, 10, 0.98));
+  border: 2px solid var(--accent-color);
+  box-shadow: 0 0 22px rgba(57, 255, 20, 0.22);
+  color: #d8ffe0;
+  padding: 1rem 1rem 1.1rem;
+}
+
+.se-contact-modal__close {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.55rem;
+  border: 1px solid #7efcaa;
+  background: #0e1324;
+  color: #b7ffd8;
+  font: inherit;
+  cursor: pointer;
+  width: 1.8rem;
+  height: 1.8rem;
+}
+
+.se-contact-modal__copy {
+  margin: 0.4rem 0 0.8rem;
+  color: #b7ffd8;
+}
+
+.se-contact-modal__audio {
+  border: 1px solid rgba(126, 252, 170, 0.45);
+  background: rgba(5, 20, 22, 0.55);
+  padding: 0.6rem;
+  margin-bottom: 0.8rem;
+}
+
+.se-contact-modal__audio-btn {
+  font-size: 0.58rem;
+  padding: 0.42rem 0.5rem;
+}
+
+.se-contact-modal__audio-status {
+  margin: 0.55rem 0 0;
+  font-size: 0.74rem;
+  color: #8ceab6;
+}
+
+.se-contact-form {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.se-contact-form label {
+  font-size: 0.73rem;
+  color: #aaf8ca;
+}
+
+.se-contact-form input,
+.se-contact-form textarea {
+  width: 100%;
+  border: 1px solid #3bdc70;
+  background: #030607;
+  color: #d8ffe0;
+  padding: 0.5rem 0.56rem;
+  font: inherit;
+  font-size: 0.84rem;
+}
+
+.se-contact-form input:focus,
+.se-contact-form textarea:focus,
+.se-contact-modal__close:focus,
+.se-contact-modal__audio-btn:focus {
+  outline: 2px solid #8eff8e;
+  outline-offset: 2px;
+}
+
+.se-contact-form__status {
+  min-height: 1.15rem;
+  margin: 0.2rem 0;
+  color: #8de0ff;
+  font-size: 0.8rem;
+}
+
+.se-contact-form__status.is-error {
+  color: #ff8f8f;
+}
+
+.se-contact-form__actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.se-contact-success {
+  margin-top: 0.9rem;
+  border-top: 1px solid rgba(126, 252, 170, 0.45);
+  padding-top: 0.8rem;
+  font-size: 0.9rem;
+}
+
+.se-contact-success__headline {
+  margin: 0 0 0.4rem;
+  color: #a7ffbc;
+}
+
+.se-contact-success a {
+  color: #8de0ff;
+}
+
+@media (max-width: 768px) {
+  .main-header .header-contact-trigger {
+    font-size: 0.52rem;
+    padding: 0.4rem 0.5rem;
+  }
+
+  .se-contact-modal__dialog {
+    width: min(94vw, 520px);
+    margin: 9vh auto;
+    padding: 0.88rem;
+  }
+}
+
+body.se-modal-open { overflow: hidden; }
+

--- a/assets/js/header-contact-modal.js
+++ b/assets/js/header-contact-modal.js
@@ -1,0 +1,131 @@
+(function () {
+  var trigger = document.querySelector('[data-contact-trigger]');
+  var modal = document.querySelector('[data-contact-modal]');
+  if (!trigger || !modal) return;
+
+  var dialog = modal.querySelector('.se-contact-modal__dialog');
+  var closeEls = modal.querySelectorAll('[data-contact-close]');
+  var form = modal.querySelector('[data-contact-form]');
+  var statusEl = modal.querySelector('[data-contact-status]');
+  var successEl = modal.querySelector('[data-contact-success]');
+  var playIntroBtn = modal.querySelector('[data-contact-play-intro]');
+  var audioStatus = modal.querySelector('[data-contact-audio-status]');
+  var firstInput = modal.querySelector('#se-contact-name');
+  var lastFocused = null;
+
+  function setStatus(message, isError) {
+    if (!statusEl) return;
+    statusEl.textContent = message || '';
+    statusEl.classList.toggle('is-error', !!isError);
+  }
+
+  function openModal() {
+    lastFocused = document.activeElement;
+    modal.hidden = false;
+    document.body.classList.add('se-modal-open');
+    window.setTimeout(function () {
+      if (firstInput) firstInput.focus();
+    }, 10);
+    document.addEventListener('keydown', onKeydown);
+  }
+
+  function closeModal() {
+    modal.hidden = true;
+    document.body.classList.remove('se-modal-open');
+    document.removeEventListener('keydown', onKeydown);
+    if (lastFocused && typeof lastFocused.focus === 'function') {
+      lastFocused.focus();
+    } else {
+      trigger.focus();
+    }
+  }
+
+  function trapFocus(e) {
+    if (e.key !== 'Tab') return;
+    var focusables = dialog.querySelectorAll('button, [href], input, textarea, select, [tabindex]:not([tabindex="-1"])');
+    if (!focusables.length) return;
+    var first = focusables[0];
+    var last = focusables[focusables.length - 1];
+
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+
+  function onKeydown(e) {
+    if (e.key === 'Escape') {
+      closeModal();
+      return;
+    }
+    trapFocus(e);
+  }
+
+  async function submitForm(event) {
+    event.preventDefault();
+    setStatus('Sending message...', false);
+
+    var endpoint = form.getAttribute('data-endpoint') || '/wp-admin/admin-ajax.php';
+    var formData = new FormData(form);
+
+    try {
+      var response = await fetch(endpoint, {
+        method: 'POST',
+        credentials: 'same-origin',
+        body: formData
+      });
+
+      var data = await response.json();
+      if (!response.ok || !data || !data.success) {
+        var errorMessage = (data && data.data && data.data.message) ? data.data.message : 'Could not send message right now.';
+        throw new Error(errorMessage);
+      }
+
+      setStatus(data.data && data.data.message ? data.data.message : 'Message sent.', false);
+      form.hidden = true;
+      if (successEl) successEl.hidden = false;
+    } catch (error) {
+      setStatus(error.message || 'Could not send message right now.', true);
+    }
+  }
+
+  function playIntro() {
+    if (!('speechSynthesis' in window)) {
+      if (audioStatus) {
+        audioStatus.textContent = 'Voice intro not supported in this browser, but the form still works great.';
+      }
+      return;
+    }
+
+    window.speechSynthesis.cancel();
+    var utterance = new SpeechSynthesisUtterance('Yo, what\'s up? Write a message and Suzy will get back to you.');
+    utterance.rate = 1;
+    utterance.pitch = 1;
+    utterance.onstart = function () {
+      if (audioStatus) audioStatus.textContent = 'Playing intro voice...';
+    };
+    utterance.onend = function () {
+      if (audioStatus) audioStatus.textContent = 'Intro complete. Drop your message below.';
+    };
+    utterance.onerror = function () {
+      if (audioStatus) audioStatus.textContent = 'Could not play intro voice on this device.';
+    };
+    window.speechSynthesis.speak(utterance);
+  }
+
+  trigger.addEventListener('click', openModal);
+  closeEls.forEach(function (el) {
+    el.addEventListener('click', closeModal);
+  });
+
+  if (form) {
+    form.addEventListener('submit', submitForm);
+  }
+
+  if (playIntroBtn) {
+    playIntroBtn.addEventListener('click', playIntro);
+  }
+})();

--- a/functions.php
+++ b/functions.php
@@ -281,6 +281,95 @@ if ( ! has_action('wp_enqueue_scripts', 'se_enqueue_header_tweak_css') ) {
     add_action('wp_enqueue_scripts', 'se_enqueue_header_tweak_css');
 }
 
+if ( ! function_exists( 'se_enqueue_header_contact_assets' ) ) {
+    function se_enqueue_header_contact_assets() {
+        if ( is_admin() ) {
+            return;
+        }
+
+        $dir = get_stylesheet_directory();
+        $uri = get_stylesheet_directory_uri();
+
+        $css_path = '/assets/css/header-contact-modal.css';
+        if ( file_exists( $dir . $css_path ) ) {
+            wp_enqueue_style(
+                'se-header-contact-modal',
+                $uri . $css_path,
+                array(),
+                filemtime( $dir . $css_path )
+            );
+        }
+
+        $js_path = '/assets/js/header-contact-modal.js';
+        if ( file_exists( $dir . $js_path ) ) {
+            wp_enqueue_script(
+                'se-header-contact-modal',
+                $uri . $js_path,
+                array(),
+                filemtime( $dir . $js_path ),
+                true
+            );
+        }
+    }
+}
+add_action( 'wp_enqueue_scripts', 'se_enqueue_header_contact_assets' );
+
+if ( ! function_exists( 'se_handle_contact_suzy_submission' ) ) {
+    function se_handle_contact_suzy_submission() {
+        if ( ! wp_doing_ajax() ) {
+            wp_send_json_error( array( 'message' => 'Invalid request.' ), 400 );
+        }
+
+        $nonce = isset( $_POST['nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['nonce'] ) ) : '';
+        if ( ! wp_verify_nonce( $nonce, 'se_contact_suzy' ) ) {
+            wp_send_json_error( array( 'message' => 'Security check failed. Please refresh and try again.' ), 403 );
+        }
+
+        $name = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
+        $email = isset( $_POST['email'] ) ? sanitize_email( wp_unslash( $_POST['email'] ) ) : '';
+        $message = isset( $_POST['message'] ) ? sanitize_textarea_field( wp_unslash( $_POST['message'] ) ) : '';
+        $chaos_check = isset( $_POST['chaos_check'] ) ? sanitize_text_field( wp_unslash( $_POST['chaos_check'] ) ) : '';
+
+        if ( '' === $name || '' === $email || '' === $message || '' === $chaos_check ) {
+            wp_send_json_error( array( 'message' => 'Please fill out every field before sending.' ), 422 );
+        }
+
+        if ( ! is_email( $email ) ) {
+            wp_send_json_error( array( 'message' => 'Please enter a valid email address.' ), 422 );
+        }
+
+        if ( 'yowhatsup' !== strtolower( $chaos_check ) ) {
+            wp_send_json_error( array( 'message' => 'Chaos bot check failed. Type yowhatsup and try again.' ), 422 );
+        }
+
+        $to = 'suzyeaston@icloud.com';
+        $subject = sprintf( 'New site message from %s', $name );
+        $body = "New Contact Suzy submission:
+
+";
+        $body .= "Name: {$name}
+";
+        $body .= "Email: {$email}
+
+";
+        $body .= "Message:
+{$message}
+";
+
+        $headers = array( 'Reply-To: ' . $name . ' <' . $email . '>' );
+
+        $sent = wp_mail( $to, $subject, $body, $headers );
+
+        if ( ! $sent ) {
+            wp_send_json_error( array( 'message' => 'Message failed to send. Please try again in a bit.' ), 500 );
+        }
+
+        wp_send_json_success( array( 'message' => 'Message received. Suzy will get back to you soon.' ) );
+    }
+}
+add_action( 'wp_ajax_se_contact_suzy', 'se_handle_contact_suzy_submission' );
+add_action( 'wp_ajax_nopriv_se_contact_suzy', 'se_handle_contact_suzy_submission' );
+
 // Load bundled Lousy Outages plugin so shortcode and REST endpoint work
 $lousy_outages = get_template_directory() . '/lousy-outages/lousy-outages.php';
 if ( file_exists( $lousy_outages ) ) {

--- a/header.php
+++ b/header.php
@@ -141,15 +141,58 @@
     </a>
   </div>
   <div class="header-actions">
-    <a class="pixel-button header-support-link"
-       href="https://buymeacoffee.com/wi0amge"
-       target="_blank"
-       rel="noopener noreferrer"
-       aria-label="Support Suzy">
-       Support
-    </a>
+    <button class="pixel-button header-contact-trigger"
+            type="button"
+            data-contact-trigger
+            aria-haspopup="dialog"
+            aria-controls="contact-suzy-modal"
+            aria-label="Contact Suzy">
+      CONTACT SUZY
+    </button>
   </div>
 </header>
+
+<div class="se-contact-modal" id="contact-suzy-modal" data-contact-modal hidden>
+  <div class="se-contact-modal__overlay" data-contact-close tabindex="-1"></div>
+  <div class="se-contact-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="se-contact-title" aria-describedby="se-contact-copy">
+    <button type="button" class="se-contact-modal__close" data-contact-close aria-label="Close contact form">✕</button>
+    <h2 id="se-contact-title" class="pixel-font">Contact Suzy</h2>
+    <p id="se-contact-copy" class="se-contact-modal__copy">Yo, what’s up? Drop a note and Suzy will get back to you.</p>
+
+    <div class="se-contact-modal__audio">
+      <button type="button" class="pixel-button se-contact-modal__audio-btn" data-contact-play-intro>Play intro</button>
+      <p class="se-contact-modal__audio-status" data-contact-audio-status aria-live="polite">Optional voice intro. Click play if you want the full vibe.</p>
+    </div>
+
+    <form class="se-contact-form" data-contact-form data-endpoint="<?php echo esc_url( admin_url( "admin-ajax.php" ) ); ?>" novalidate>
+      <input type="hidden" name="action" value="se_contact_suzy">
+      <input type="hidden" name="nonce" value="<?php echo esc_attr( wp_create_nonce( 'se_contact_suzy' ) ); ?>">
+
+      <label for="se-contact-name">Name</label>
+      <input id="se-contact-name" name="name" type="text" autocomplete="name" required>
+
+      <label for="se-contact-email">Email</label>
+      <input id="se-contact-email" name="email" type="email" autocomplete="email" required>
+
+      <label for="se-contact-message">Message</label>
+      <textarea id="se-contact-message" name="message" rows="5" required></textarea>
+
+      <label for="se-contact-chaos">Type “yowhatsup” so I know you’re not a chaos bot.</label>
+      <input id="se-contact-chaos" name="chaos_check" type="text" autocapitalize="off" autocomplete="off" spellcheck="false" required>
+
+      <p class="se-contact-form__status" data-contact-status aria-live="polite"></p>
+
+      <div class="se-contact-form__actions">
+        <button type="submit" class="pixel-button">Send message</button>
+      </div>
+    </form>
+
+    <div class="se-contact-success" data-contact-success hidden>
+      <p class="se-contact-success__headline">Message received. Suzy will get back to you soon.</p>
+      <p>Want to fuel the weird little upgrades? <a href="https://buymeacoffee.com/wi0amge" target="_blank" rel="noopener noreferrer">Buy Suzy a coffee</a> or <a href="<?php echo esc_url( home_url( '/' ) ); ?>">share the site</a>.</p>
+    </div>
+  </div>
+</div>
 
 <!-- Hero banner lives in page templates (e.g., homepage hero); this header stays compact above it -->
 <!-- Full‑screen moving starfield background -->

--- a/style.css
+++ b/style.css
@@ -1703,6 +1703,7 @@ body {
     letter-spacing: 0.08em;
     flex-wrap: wrap;
   }
+
 }
 
 .pixel-font {


### PR DESCRIPTION
### Motivation
- Provide a lightweight contact modal in the header so visitors can message Suzy without leaving the page.
- Include an optional speech-synthesis intro and accessible focus management for a better UX.
- Wire the front-end form to a server-side AJAX handler that validates input and sends mail to Suzy.

### Description
- Added `assets/css/header-contact-modal.css` to style the modal and related UI states and responsive rules.
- Added `assets/js/header-contact-modal.js` which handles opening/closing the dialog, focus trapping, speech-synthesis intro, and AJAX form submission with status updates.
- Updated `header.php` to replace the previous support link with a `CONTACT SUZY` trigger button and injected the modal markup (form, audio intro, success message) with proper ARIA attributes and a nonce field.
- Extended `functions.php` with `se_enqueue_header_contact_assets` to enqueue the new CSS/JS on the front end, and added `se_handle_contact_suzy_submission` as the AJAX handler that verifies the nonce, validates fields (including the "yowhatsup" chaos check), sends email via `wp_mail`, and returns JSON success/error; also registered `wp_ajax` and `wp_ajax_nopriv` hooks.
- Minor whitespace/format tweak in `style.css` to keep formatting consistent.

### Testing
- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b629b47d88832eb7d92a2056e7479d)