### PR TITLE
Fix ASMR Lab Gastown prototype CTA URL

### DIFF
--- a/page-asmr-lab.php
+++ b/page-asmr-lab.php
@@ -4,6 +4,9 @@ Template Name: ASMR Lab
 */
 
 get_header();
+
+$gastown_page     = get_page_by_path( 'page-gastown-sim' );
+$gastown_page_url = $gastown_page ? get_permalink( $gastown_page ) : home_url( '/page-gastown-sim/' );
 ?>
 <main id="primary" class="content-area asmr-lab-page">
   <section class="asmr-lab-shell" id="asmr-lab-app">
@@ -28,7 +31,7 @@ get_header();
         <p id="asmr-lab-voice-status" class="asmr-lab-voice-status" aria-live="polite">Silent mode engaged. Narrator stays quiet until requested.</p>
       </div>
       <div class="asmr-cta-row">
-        <a class="pixel-button" href="<?php echo esc_url( home_url('/gastown-sim/') ); ?>">Enter Gastown prototype</a>
+        <a class="pixel-button" href="<?php echo esc_url( $gastown_page_url ); ?>">Enter Gastown prototype</a>
         <a class="pixel-button secondary" href="https://github.com/suzyeaston/suzyeastonca" target="_blank" rel="noopener noreferrer">View code on GitHub</a>
       </div>
     </section>


### PR DESCRIPTION
### Motivation
- The ASMR Lab page CTA was pointing to the incorrect hardcoded `/gastown-sim/` path instead of the live simulator page and should use a WordPress-safe permalink lookup to avoid brittle paths.

### Description
- Replaced the hardcoded CTA href in `page-asmr-lab.php` with a WordPress-safe lookup that uses `get_page_by_path('page-gastown-sim')` and `get_permalink()` with a fallback to `home_url('/page-gastown-sim/')`.
- Updated the CTA anchor to use the resolved `$gastown_page_url` variable so the link now opens the correct `/page-gastown-sim/` page.

### Testing
- Searched the repo with `rg -n "gastown-sim|Enter Gastown prototype|Gastown prototype|page-gastown-sim" .` and confirmed the incorrect hardcoded CTA was updated.
- Ran `php -l page-asmr-lab.php` to validate PHP syntax and received no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b678765ec4832e892b8e10c5152ec8)