### PR TITLE
Tighten Gastown corridor matching with strict hblock parsing

### DIFF
--- a/__tests__/gastown-hblock-matcher.test.js
+++ b/__tests__/gastown-hblock-matcher.test.js
@@ -1,0 +1,60 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { parseHblockStreet, isTargetCorridorBlock, getArterialBias } = require('../scripts/generate-gastown-world');
+
+function feature(hblock, streetuse = 'ARTERIAL') {
+  return {
+    properties: {
+      hblock,
+      streetuse,
+    },
+  };
+}
+
+test('parseHblockStreet parses direction/street/suffix from hblock', () => {
+  const parsed = parseHblockStreet(feature('800-900 W CORDOVA ST'));
+  assert.equal(parsed.street, 'w cordova st');
+  assert.equal(parsed.block, '800-900');
+});
+
+test('target corridor matcher includes confirmed true positives', () => {
+  const positives = [
+    '0 W CORDOVA ST',
+    '100 W CORDOVA ST',
+    '300 W CORDOVA ST',
+    '400 W CORDOVA ST',
+    '500 W CORDOVA ST',
+    '600 W CORDOVA ST',
+    '700 W CORDOVA ST',
+    '800-900 W CORDOVA ST',
+    '0 WATER ST',
+    '100 WATER ST',
+    '200-300 WATER ST',
+  ];
+
+  positives.forEach((hblock) => {
+    const parsed = parseHblockStreet(feature(hblock));
+    assert.equal(isTargetCorridorBlock(parsed), true, hblock);
+  });
+});
+
+test('target corridor matcher excludes confirmed false positives', () => {
+  const negatives = [
+    '0 E CORDOVA ST',
+    '100 CORDOVA DIVERSION',
+    '200 WATERLOO ST',
+    '300 BAYSWATER ST',
+    '0 WATERFRONT ROAD',
+  ];
+
+  negatives.forEach((hblock) => {
+    const parsed = parseHblockStreet(feature(hblock));
+    assert.equal(isTargetCorridorBlock(parsed), false, hblock);
+  });
+});
+
+test('arterial bias prefers arterial segments', () => {
+  assert.equal(getArterialBias(feature('100 W CORDOVA ST', 'ARTERIAL')), 75);
+  assert.equal(getArterialBias(feature('100 W CORDOVA ST', 'LOCAL')), 0);
+});

--- a/scripts/generate-gastown-world.js
+++ b/scripts/generate-gastown-world.js
@@ -56,6 +56,38 @@ function getStreetName(feature) {
   );
 }
 
+function parseHblockStreet(feature) {
+  const props = getProps(feature);
+  const hblock = String(props.hblock || '').trim().toUpperCase();
+  if (!hblock) return null;
+
+  const match = hblock.match(/^(\d+(?:\s*-\s*\d+)?)\s+((?:N|S|E|W)\s+)?([A-Z0-9'\- ]+?)\s+(ST|AVE|RD|DR|BLVD|PL|WAY|LANE|LN|CT|CRES|TER|TRL|PKWY)$/);
+  if (!match) return null;
+
+  const block = match[1].replace(/\s+/g, '');
+  const directional = (match[2] || '').trim();
+  const base = normalizeStreet(match[3]);
+  const suffix = normalizeStreet(match[4]);
+  return {
+    hblock,
+    block,
+    street: normalizeStreet(`${directional} ${base} ${suffix}`),
+  };
+}
+
+function isTargetCorridorBlock(parsed) {
+  if (!parsed) return false;
+
+  const validByStreet = {
+    'w cordova st': new Set(['0', '100', '300', '400', '500', '600', '700', '800-900']),
+    'water st': new Set(['0', '100', '200-300']),
+  };
+
+  const blocks = validByStreet[parsed.street];
+  if (!blocks) return false;
+  return blocks.has(parsed.block);
+}
+
 function normalizeStreet(name) {
   return String(name || '').toLowerCase().replace(/\./g, '').replace(/\s+/g, ' ').trim();
 }
@@ -281,6 +313,26 @@ function mergeCorridorSegments(segments, origin, dest) {
   return route;
 }
 
+function segmentAnchorScore(segment, anchors) {
+  if (!segment.length || !anchors.length) return Infinity;
+  return anchors.reduce((acc, anchor) => {
+    const best = segment.reduce((min, point) => Math.min(min, distance(point, anchor)), Infinity);
+    return acc + best;
+  }, 0);
+}
+
+function sortSegmentsByAnchorProximity(segments, anchors) {
+  return segments
+    .map((segment) => ({ segment: segment.coords, score: segmentAnchorScore(segment.coords, anchors) - segment.arterialBias }))
+    .sort((a, b) => a.score - b.score)
+    .map((entry) => entry.segment);
+}
+
+function getArterialBias(feature) {
+  const streetUse = String(getProps(feature).streetuse || '').toLowerCase();
+  return streetUse.includes('arterial') ? 75 : 0;
+}
+
 function sanitizeNumber(value, fallback) {
   return Number.isFinite(value) ? value : fallback;
 }
@@ -323,11 +375,25 @@ function buildWorld(options = {}) {
   const originProjected = projectLonLat(origin.lon, origin.lat, origin);
   const destProjected = projectLonLat(dest.lon, dest.lat, origin);
 
-  const wantedStreetNames = new Set(['water st', 'w cordova st', 'water street', 'west cordova street', 'cordova st w']);
-  const corridorSegments = (streets.features || [])
-    .filter((feature) => wantedStreetNames.has(normalizeStreet(getStreetName(feature))))
-    .flatMap((feature) => extractLineStrings(feature))
-    .map((line) => line.map((coord) => projectLonLat(coord[0], coord[1], origin)));
+  const corridorAnchorPath = [
+    originProjected,
+    {
+      x: originProjected.x + (destProjected.x - originProjected.x) * 0.4,
+      z: originProjected.z + (destProjected.z - originProjected.z) * 0.4,
+    },
+    {
+      x: originProjected.x + (destProjected.x - originProjected.x) * 0.72,
+      z: originProjected.z + (destProjected.z - originProjected.z) * 0.72,
+    },
+    destProjected,
+  ];
+
+  const corridorSegments = sortSegmentsByAnchorProximity((streets.features || [])
+    .filter((feature) => isTargetCorridorBlock(parseHblockStreet(feature)))
+    .flatMap((feature) => extractLineStrings(feature).map((line) => ({
+      coords: line.map((coord) => projectLonLat(coord[0], coord[1], origin)),
+      arterialBias: getArterialBias(feature),
+    }))), corridorAnchorPath);
 
   if (!corridorSegments.length) {
     return {
@@ -520,4 +586,4 @@ if (require.main === module) {
   process.stdout.write(`Generated ${path.relative(process.cwd(), result.outputPath)} (route ${result.routeLength.toFixed(1)}m)\n`);
 }
 
-module.exports = { buildWorld };
+module.exports = { buildWorld, parseHblockStreet, isTargetCorridorBlock, getArterialBias };


### PR DESCRIPTION
### Motivation
- The City of Vancouver `public-streets.geojson` lacks conventional `street_name` fields so street identity must be derived from `properties.hblock`, and loose name matching produced false positives (e.g. `E CORDOVA ST`, `CORDOVA DIVERSION`, `WATERLOO ST`).
- The generator should prefer arterial corridor geometry aligned Waterfront → W Cordova → Water → Steam Clock to produce a stable Gastown route.

### Description
- Replaced loose street-name filtering with strict `hblock` parsing by adding `parseHblockStreet(feature)` which extracts block number, optional direction, base name and suffix from `properties.hblock` in `scripts/generate-gastown-world.js`.
- Added `isTargetCorridorBlock(parsed)` with explicit allowlists for confirmed true-positive blocks on `W CORDOVA ST` and `WATER ST` so only those hblocks are matched.
- Introduced anchor-aware ranking and arterial preference by adding `segmentAnchorScore`, `sortSegmentsByAnchorProximity`, and `getArterialBias` so candidate segments are ranked toward the Waterfront→Cordova→Water corridor before merging.
- Switched corridor selection to use parsed `hblock` matches and per-feature `streetuse` bias, and exported helper functions for testing via `module.exports`.
- Added focused tests in `__tests__/gastown-hblock-matcher.test.js` covering `parseHblockStreet`, `isTargetCorridorBlock`, and `getArterialBias` and updated generator behavior in `scripts/generate-gastown-world.js`.

### Testing
- Ran the generator + matcher unit tests: `node --test __tests__/gastown-hblock-matcher.test.js __tests__/gastown-world-generator.test.js` — all included generator/matcher tests passed. ✅
- Ran the full test suite: `npm test` — the new matcher tests passed but unrelated UI integration/refresh tests failed (existing failures in outage UI tests surfaced as `anchor.parentNode.insertBefore is not a function`). ❌
- The matcher helpers (`parseHblockStreet`, `isTargetCorridorBlock`, `getArterialBias`) were exercised by automated tests and behaved as expected. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b748f77c88832eaa8986087ef76c0a)