### PR TITLE
Fix Gastown 3D building rendering by normalizing building schema

### DIFF
--- a/__tests__/gastown-building-normalizer.test.js
+++ b/__tests__/gastown-building-normalizer.test.js
@@ -1,0 +1,45 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { normalizeBuildingForRender } = require('../js/gastown-building-normalizer.js');
+
+test('normalizer makes absolute-footprint buildings renderable', () => {
+  const normalized = normalizeBuildingForRender({
+    id: 'legacy-1',
+    footprint: [
+      { x: 10, z: 20 },
+      { x: 18, z: 20 },
+      { x: 18, z: 28 },
+      { x: 10, z: 28 },
+      { x: 10, z: 20 },
+    ],
+    height: 14,
+  });
+
+  assert.equal(Number.isFinite(normalized.x), true);
+  assert.equal(Number.isFinite(normalized.z), true);
+  assert.equal(Array.isArray(normalized.footprint_local), true);
+  assert.ok(normalized.footprint_local.length >= 3);
+  assert.equal(Number.isFinite(normalized.width), true);
+  assert.equal(Number.isFinite(normalized.depth), true);
+  assert.equal(Number.isFinite(normalized.yaw), true);
+});
+
+test('normalizer never returns NaN positions or empty footprint', () => {
+  const normalized = normalizeBuildingForRender({
+    id: 'malformed',
+    footprint: [{ x: NaN, z: 1 }, { x: Infinity, z: 2 }],
+    x: NaN,
+    z: undefined,
+    width: 0,
+    depth: null,
+  });
+
+  assert.equal(Number.isFinite(normalized.x), true);
+  assert.equal(Number.isFinite(normalized.z), true);
+  assert.equal(Number.isFinite(normalized.width), true);
+  assert.equal(Number.isFinite(normalized.depth), true);
+  assert.equal(Number.isFinite(normalized.yaw), true);
+  assert.ok(Array.isArray(normalized.footprint_local));
+  assert.ok(normalized.footprint_local.length >= 3);
+});

--- a/__tests__/gastown-world-generator.test.js
+++ b/__tests__/gastown-world-generator.test.js
@@ -31,6 +31,17 @@ test('generator keeps world polygons valid with existing or generated output', (
   data.zones.street.forEach((zone) => assertFinitePoints(zone.polygon));
   data.zones.sidewalk.forEach((zone) => assertFinitePoints(zone.polygon));
 
+  if (result.generated) {
+    const sampleBuilding = (data.buildings || [])[0];
+    assert.ok(sampleBuilding, 'generated world should contain at least one building');
+    ['x', 'z', 'width', 'depth', 'yaw'].forEach((field) => {
+      assert.equal(Number.isFinite(sampleBuilding[field]), true, 'generated building.' + field + ' should be finite');
+    });
+    assert.ok(Array.isArray(sampleBuilding.footprint_local));
+    assert.ok(sampleBuilding.footprint_local.length >= 3);
+    assertFinitePoints(sampleBuilding.footprint_local);
+  }
+
   if (fs.existsSync(tmpPath)) {
     fs.unlinkSync(tmpPath);
   }

--- a/functions.php
+++ b/functions.php
@@ -221,12 +221,23 @@ function se_enqueue_gastown_sim_assets() {
         );
     }
 
+    $normalizer_path = '/js/gastown-building-normalizer.js';
+    if ( file_exists( $dir . $normalizer_path ) ) {
+        wp_enqueue_script(
+            'se-gastown-building-normalizer',
+            $uri . $normalizer_path,
+            array(),
+            filemtime( $dir . $normalizer_path ),
+            true
+        );
+    }
+
     $app_path = '/js/gastown-sim.js';
     if ( file_exists( $dir . $app_path ) ) {
         wp_enqueue_script(
             'se-gastown-sim',
             $uri . $app_path,
-            array( 'three-js', 'howler-js', 'se-gastown-world-loader' ),
+            array( 'three-js', 'howler-js', 'se-gastown-world-loader', 'se-gastown-building-normalizer' ),
             filemtime( $dir . $app_path ),
             true
         );

--- a/js/gastown-building-normalizer.js
+++ b/js/gastown-building-normalizer.js
@@ -1,0 +1,147 @@
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+    return;
+  }
+
+  root.GastownBuildingNormalizer = factory();
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  'use strict';
+
+  function isFiniteNumber(value) {
+    return typeof value === 'number' && Number.isFinite(value);
+  }
+
+  function sanitizePoints(points) {
+    if (!Array.isArray(points)) return [];
+    return points
+      .filter((point) => point && isFiniteNumber(point.x) && isFiniteNumber(point.z))
+      .map((point) => ({ x: point.x, z: point.z }));
+  }
+
+  function uniquePointCount(points) {
+    return new Set(points.map((point) => point.x.toFixed(4) + '|' + point.z.toFixed(4))).size;
+  }
+
+  function ensureRenderableFootprint(localFootprint, width, depth) {
+    const usable = sanitizePoints(localFootprint);
+    if (usable.length >= 3 && uniquePointCount(usable) >= 3) {
+      return usable;
+    }
+
+    const safeWidth = Math.max(3, isFiniteNumber(width) ? Math.abs(width) : 8);
+    const safeDepth = Math.max(3, isFiniteNumber(depth) ? Math.abs(depth) : 8);
+    return [
+      { x: -safeWidth / 2, z: -safeDepth / 2 },
+      { x: safeWidth / 2, z: -safeDepth / 2 },
+      { x: safeWidth / 2, z: safeDepth / 2 },
+      { x: -safeWidth / 2, z: safeDepth / 2 },
+    ];
+  }
+
+  function getCentroid(points) {
+    const usable = sanitizePoints(points);
+    if (!usable.length) return { x: 0, z: 0 };
+
+    const sum = usable.reduce((acc, point) => ({ x: acc.x + point.x, z: acc.z + point.z }), { x: 0, z: 0 });
+    return { x: sum.x / usable.length, z: sum.z / usable.length };
+  }
+
+  function getBounds(points) {
+    const usable = sanitizePoints(points);
+    if (!usable.length) {
+      return { minX: -4, maxX: 4, minZ: -4, maxZ: 4, width: 8, depth: 8 };
+    }
+
+    let minX = Infinity;
+    let maxX = -Infinity;
+    let minZ = Infinity;
+    let maxZ = -Infinity;
+
+    usable.forEach((point) => {
+      minX = Math.min(minX, point.x);
+      maxX = Math.max(maxX, point.x);
+      minZ = Math.min(minZ, point.z);
+      maxZ = Math.max(maxZ, point.z);
+    });
+
+    return {
+      minX,
+      maxX,
+      minZ,
+      maxZ,
+      width: Math.max(3, maxX - minX),
+      depth: Math.max(3, maxZ - minZ),
+    };
+  }
+
+  function deriveYawFromFootprint(points, fallbackYaw) {
+    if (isFiniteNumber(fallbackYaw)) {
+      return fallbackYaw;
+    }
+
+    const usable = sanitizePoints(points);
+    let longest = { dx: 0, dz: 0, len: 0 };
+    for (let i = 0; i < usable.length; i += 1) {
+      const current = usable[i];
+      const next = usable[(i + 1) % usable.length];
+      const dx = next.x - current.x;
+      const dz = next.z - current.z;
+      const len = Math.hypot(dx, dz);
+      if (len > longest.len) {
+        longest = { dx, dz, len };
+      }
+    }
+
+    if (longest.len < 0.01) return 0;
+    return Math.atan2(longest.dz, longest.dx);
+  }
+
+  function normalizeBuildingForRender(building) {
+    const source = building || {};
+    const absoluteFootprint = sanitizePoints(source.footprint);
+    const localFromSource = sanitizePoints(source.footprint_local);
+    const sourceCentroid = getCentroid(absoluteFootprint);
+
+    const x = isFiniteNumber(source.x) ? source.x : sourceCentroid.x;
+    const z = isFiniteNumber(source.z) ? source.z : sourceCentroid.z;
+
+    const localFootprint = localFromSource.length >= 3
+      ? localFromSource
+      : absoluteFootprint.map((point) => ({ x: point.x - x, z: point.z - z }));
+
+    const safeLocalFootprint = ensureRenderableFootprint(localFootprint, source.width, source.depth);
+    const localBounds = getBounds(safeLocalFootprint);
+
+    const width = isFiniteNumber(source.width) ? Math.max(3, Math.abs(source.width)) : localBounds.width;
+    const depth = isFiniteNumber(source.depth) ? Math.max(3, Math.abs(source.depth)) : localBounds.depth;
+    const yaw = deriveYawFromFootprint(safeLocalFootprint, source.yaw);
+
+    const absolute = absoluteFootprint.length >= 3
+      ? absoluteFootprint
+      : safeLocalFootprint.map((point) => ({ x: x + point.x, z: z + point.z }));
+
+    return {
+      ...source,
+      x: isFiniteNumber(x) ? x : 0,
+      z: isFiniteNumber(z) ? z : 0,
+      width,
+      depth,
+      yaw: isFiniteNumber(yaw) ? yaw : 0,
+      height: isFiniteNumber(source.height) ? Math.max(4, source.height) : 12,
+      footprint: absolute,
+      footprint_local: safeLocalFootprint,
+      roofline_type: source.roofline_type || 'flat_cornice',
+      window_bay_count: isFiniteNumber(source.window_bay_count) ? source.window_bay_count : 4,
+      recessed_entry_count: isFiniteNumber(source.recessed_entry_count) ? source.recessed_entry_count : 1,
+      storefront_rhythm: source.storefront_rhythm || { base_band: 0.18, upper_rows: 3 },
+      material_palette: source.material_palette || { primary: 'brickDark', trim: 'stoneMuted', accent: 'stoneMuted' },
+      cornice_emphasis: isFiniteNumber(source.cornice_emphasis) ? source.cornice_emphasis : 0.24,
+      mass_inset: isFiniteNumber(source.mass_inset) ? source.mass_inset : 0.96,
+    };
+  }
+
+  return {
+    normalizeBuildingForRender,
+  };
+});

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -3,7 +3,7 @@
 
   const config = window.seGastownSim || {};
   const app = document.getElementById('gastown-sim-app');
-  if (!app || !window.THREE || !window.GastownWorldLoader || !window.Howl || !window.Howler) {
+  if (!app || !window.THREE || !window.GastownWorldLoader || !window.GastownBuildingNormalizer || !window.Howl || !window.Howler) {
     return;
   }
 
@@ -388,21 +388,48 @@
     });
   }
 
+  function localPointToWorld(building, localX, localZ) {
+    const yaw = building.yaw || 0;
+    const cos = Math.cos(yaw);
+    const sin = Math.sin(yaw);
+    return {
+      x: building.x + (localX * cos) - (localZ * sin),
+      z: building.z + (localX * sin) + (localZ * cos),
+    };
+  }
+
+  function toRenderableShapePoints(building) {
+    if (!Array.isArray(building.footprint_local) || building.footprint_local.length < 3) {
+      return [];
+    }
+    const points = building.footprint_local
+      .filter((point) => Number.isFinite(point.x) && Number.isFinite(point.z))
+      .map((point) => ({ x: point.x, z: point.z }));
+
+    if (points.length < 3) {
+      return [];
+    }
+
+    const first = points[0];
+    const last = points[points.length - 1];
+    if (Math.abs(first.x - last.x) < 0.0001 && Math.abs(first.z - last.z) < 0.0001) {
+      points.pop();
+    }
+
+    return points.length >= 3 ? points : [];
+  }
+
   function addBuildings(world) {
+    world.buildings = (world.buildings || []).map((building) => window.GastownBuildingNormalizer.normalizeBuildingForRender(building));
+
     world.buildings.forEach((b) => {
+      if (!Number.isFinite(b.x) || !Number.isFinite(b.z)) return;
+      const shapePoints = toRenderableShapePoints(b);
+      if (shapePoints.length < 3) return;
+
       const profilePreset = facadeProfilePresets[b.facade_profile] || facadeProfilePresets.gastown_heritage_masonry;
       const colors = paletteToColors(b);
       const massingInset = b.mass_inset || profilePreset.baseInset;
-      const shapePoints = Array.isArray(b.footprint_local) && b.footprint_local.length >= 3
-        ? b.footprint_local
-        : (Array.isArray(b.footprint) && b.footprint.length >= 3
-          ? b.footprint.map((point) => ({ x: point.x - (b.x || 0), z: point.z - (b.z || 0) }))
-          : [
-            { x: -b.width / 2, z: -b.depth / 2 },
-            { x: b.width / 2, z: -b.depth / 2 },
-            { x: b.width / 2, z: b.depth / 2 },
-            { x: -b.width / 2, z: b.depth / 2 },
-          ]);
       const geom = new THREE.ExtrudeGeometry(new THREE.Shape(shapePoints.map((point) => new THREE.Vector2(point.x, point.z))), {
         depth: b.height,
         bevelEnabled: false,
@@ -444,7 +471,8 @@
         new THREE.BoxGeometry((b.width || 8) * 0.92, storefrontBandHeight, Math.max(2, (b.depth || 8) * 0.15)),
         new THREE.MeshStandardMaterial({ color: colors.accent, roughness: 0.72, metalness: 0.1 })
       );
-      storefront.position.set(b.x, storefrontBandHeight / 2 + 0.2, b.z + ((b.depth || 8) * 0.34));
+      const storefrontPos = localPointToWorld(b, 0, (b.depth || 8) * 0.34);
+      storefront.position.set(storefrontPos.x, storefrontBandHeight / 2 + 0.2, storefrontPos.z);
       storefront.rotation.y = b.yaw || 0;
       worldGroup.add(storefront);
 
@@ -457,7 +485,8 @@
           const xOffset = (((bay + 1) / (bayCount + 1)) - 0.5) * ((b.width || 8) * 0.78);
           const yOffset = storefrontBandHeight + 1.4 + row * ((b.height - storefrontBandHeight - 2) / windowRows);
           const depthOffset = (b.depth || 8) * 0.52;
-          win.position.set(b.x + xOffset * Math.cos(b.yaw || 0), yOffset, b.z + depthOffset * Math.cos((b.yaw || 0) - Math.PI / 2) + xOffset * Math.sin(b.yaw || 0));
+          const winPos = localPointToWorld(b, xOffset, depthOffset);
+          win.position.set(winPos.x, yOffset, winPos.z);
           win.rotation.y = b.yaw || 0;
           worldGroup.add(win);
         }
@@ -468,7 +497,8 @@
           new THREE.BoxGeometry((b.width || 8) * 0.86, 0.3, Math.max(0.8, profilePreset.awningDepth)),
           new THREE.MeshStandardMaterial({ color: colors.trim, roughness: 0.64, metalness: 0.08 })
         );
-        awning.position.set(b.x, storefrontBandHeight + 0.6, b.z + ((b.depth || 8) * 0.45));
+        const awningPos = localPointToWorld(b, 0, (b.depth || 8) * 0.45);
+        awning.position.set(awningPos.x, storefrontBandHeight + 0.6, awningPos.z);
         awning.rotation.y = b.yaw || 0;
         worldGroup.add(awning);
       }
@@ -483,11 +513,8 @@
             new THREE.CylinderGeometry(0.24, 0.28, colHeight, 10),
             new THREE.MeshStandardMaterial({ color: 0xd6d3ca, roughness: 0.5, metalness: 0.08 })
           );
-          col.position.set(
-            b.x + localX * Math.cos(b.yaw || 0),
-            colHeight / 2,
-            b.z + ((b.depth || 10) * 0.5) * Math.cos((b.yaw || 0) - Math.PI / 2) + localX * Math.sin(b.yaw || 0)
-          );
+          const colPos = localPointToWorld(b, localX, (b.depth || 10) * 0.5);
+          col.position.set(colPos.x, colHeight / 2, colPos.z);
           worldGroup.add(col);
 
           if (b.id === 'waterfront-station-civic') {
@@ -510,11 +537,8 @@
             new THREE.BoxGeometry(0.9, 2.4, 0.5),
             new THREE.MeshStandardMaterial({ color: 0x1d222b, roughness: 0.45, metalness: 0.22 })
           );
-          entry.position.set(
-            b.x + t * Math.cos(b.yaw || 0),
-            1.25,
-            b.z + ((b.depth || 8) * 0.48) * Math.cos((b.yaw || 0) - Math.PI / 2) + t * Math.sin(b.yaw || 0)
-          );
+          const entryPos = localPointToWorld(b, t, (b.depth || 8) * 0.48);
+          entry.position.set(entryPos.x, 1.25, entryPos.z);
           worldGroup.add(entry);
 
           if (b.id === 'waterfront-station-civic') {
@@ -522,7 +546,8 @@
               new THREE.PlaneGeometry(1.3, 3),
               new THREE.MeshStandardMaterial({ color: 0x161d27, emissive: 0x2f3d4f, emissiveIntensity: 0.2, roughness: 0.34, metalness: 0.25 })
             );
-            door.position.set(entry.position.x, 1.6, entry.position.z + 0.23);
+            const doorPos = localPointToWorld(b, t, (b.depth || 8) * 0.48 + 0.23);
+            door.position.set(doorPos.x, 1.6, doorPos.z);
             door.rotation.y = b.yaw || 0;
             worldGroup.add(door);
 
@@ -530,7 +555,8 @@
               new THREE.PlaneGeometry(1.35, 0.55),
               new THREE.MeshStandardMaterial({ color: 0x45576c, emissive: 0x29394b, emissiveIntensity: 0.16, roughness: 0.42, metalness: 0.2 })
             );
-            transom.position.set(entry.position.x, 3.2, entry.position.z + 0.24);
+            const transomPos = localPointToWorld(b, t, (b.depth || 8) * 0.48 + 0.24);
+            transom.position.set(transomPos.x, 3.2, transomPos.z);
             transom.rotation.y = b.yaw || 0;
             worldGroup.add(transom);
           }
@@ -542,7 +568,8 @@
           new THREE.BoxGeometry((b.width || 40) * 0.78, 0.42, 1.8),
           new THREE.MeshStandardMaterial({ color: 0x8a8f96, roughness: 0.62, metalness: 0.2 })
         );
-        canopy.position.set(b.x, storefrontBandHeight + 1.8, b.z + ((b.depth || 10) * 0.52));
+        const canopyPos = localPointToWorld(b, 0, (b.depth || 10) * 0.52);
+        canopy.position.set(canopyPos.x, storefrontBandHeight + 1.8, canopyPos.z);
         canopy.rotation.y = b.yaw || 0;
         worldGroup.add(canopy);
 
@@ -550,7 +577,8 @@
           new THREE.BoxGeometry((b.width || 40) * 0.7, Math.max(3.2, storefrontBandHeight * 0.82), 1.1),
           new THREE.MeshStandardMaterial({ color: 0x18202a, roughness: 0.76, metalness: 0.08 })
         );
-        recess.position.set(b.x, Math.max(1.9, storefrontBandHeight * 0.4) + 0.3, b.z + ((b.depth || 10) * 0.49));
+        const recessPos = localPointToWorld(b, 0, (b.depth || 10) * 0.49);
+        recess.position.set(recessPos.x, Math.max(1.9, storefrontBandHeight * 0.4) + 0.3, recessPos.z);
         recess.rotation.y = b.yaw || 0;
         worldGroup.add(recess);
       }

--- a/js/gastown-world-loader.js
+++ b/js/gastown-world-loader.js
@@ -16,6 +16,18 @@
     return data;
   }
 
+
+  function isFiniteNumber(value) {
+    return typeof value === 'number' && Number.isFinite(value);
+  }
+
+  function assertFiniteNumberIfPresent(value, label) {
+    if (value === undefined || value === null) return;
+    if (!isFiniteNumber(value)) {
+      throw new Error('Gastown world data is malformed: ' + label + ' must be a finite number when present.');
+    }
+  }
+
   function assertPolygon(points, label) {
     if (!Array.isArray(points) || points.length < 3) {
       throw new Error('Gastown world data is malformed: ' + label + ' requires at least 3 points.');
@@ -67,11 +79,32 @@
     }
 
     data.buildings.forEach((building, index) => {
-      if (building.footprint) {
+      const hasAbsoluteFootprint = Array.isArray(building.footprint);
+      const hasLocalFootprint = Array.isArray(building.footprint_local);
+      if (hasAbsoluteFootprint) {
         assertPolygon(building.footprint, 'buildings[' + index + '].footprint');
       }
-      if (building.window_bay_count && typeof building.window_bay_count !== 'number') {
+      if (hasLocalFootprint) {
+        assertPolygon(building.footprint_local, 'buildings[' + index + '].footprint_local');
+      }
+      if (!hasAbsoluteFootprint && !hasLocalFootprint) {
+        throw new Error('Gastown world data is malformed: buildings[' + index + '] requires footprint or footprint_local.');
+      }
+
+      if (building.window_bay_count !== undefined && typeof building.window_bay_count !== 'number') {
         throw new Error('Gastown world data is malformed: buildings[' + index + '].window_bay_count must be numeric.');
+      }
+
+      ['x', 'z', 'width', 'depth', 'yaw', 'height', 'cornice_emphasis', 'mass_inset', 'recessed_entry_count'].forEach((field) => {
+        assertFiniteNumberIfPresent(building[field], 'buildings[' + index + '].' + field);
+      });
+
+      if (building.storefront_rhythm && typeof building.storefront_rhythm !== 'object') {
+        throw new Error('Gastown world data is malformed: buildings[' + index + '].storefront_rhythm must be an object when present.');
+      }
+      if (building.storefront_rhythm) {
+        assertFiniteNumberIfPresent(building.storefront_rhythm.base_band, 'buildings[' + index + '].storefront_rhythm.base_band');
+        assertFiniteNumberIfPresent(building.storefront_rhythm.upper_rows, 'buildings[' + index + '].storefront_rhythm.upper_rows');
       }
     });
   }


### PR DESCRIPTION
### Motivation
- The 3D renderer expected renderer-oriented fields (`x`, `z`, `width`, `depth`, `yaw`, `footprint_local`) while some world data only supplied legacy absolute `footprint`, causing meshes to be misplaced or invisible.
- The minimap continued to work because it can draw from absolute `footprint`, but the renderer extruded geometry in the wrong space or double-offset it when expected local coordinates were missing.

### Description
- Add a standalone normalizer `js/gastown-building-normalizer.js` that converts either schema into safe renderer-ready data including finite `x/z`, derived `width/depth/yaw`, guaranteed non-empty `footprint_local`, preserved absolute `footprint`, and sensible defaults for facade/render fields.
- Refactor `js/gastown-sim.js` to call `normalizeBuildingForRender` for every building, extrude geometry from `footprint_local`, then place meshes at the building `x/z`, and update facade element placement to use a `localPointToWorld` transform so all pieces align correctly.
- Update `js/gastown-world-loader.js` validation to accept both absolute `footprint` and `footprint_local`, and add finite-number checks for optional numeric fields when present (without rejecting older valid worlds).
- Wire the new script into the WordPress asset pipeline by enqueueing `js/gastown-building-normalizer.js` in `functions.php` before `gastown-sim.js` and add/adjust tests: `__tests__/gastown-building-normalizer.test.js` (new) and an extension to `__tests__/gastown-world-generator.test.js` to assert generated renderer fields when generation runs.

### Testing
- Ran the normalizer unit tests with `node --test __tests__/gastown-building-normalizer.test.js` and the modified generator unit (`__tests__/gastown-world-generator.test.js`) and the targeted suite passed locally (no failures in those tests).
- Executed JS syntax checks `node -c` on `js/gastown-sim.js`, `js/gastown-world-loader.js`, `js/gastown-building-normalizer.js` and `scripts/generate-gastown-world.js`, which returned clean results.
- Attempted to run `node scripts/generate-gastown-world.js` but it requires offline civic data (`route-anchors.json`, `public-streets.geojson`, `building-footprints.geojson`) so generation cannot complete in this environment (this is expected); the generator already emits renderer fields when inputs are present.
- Ran the full test suite via `npm test` and observed unrelated pre-existing front-end integration tests failing (outside the Gastown changes); the new/modified gastown-focused tests are passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b764dc4180832e9108047554b0a9ee)