### PR TITLE
Fix Gastown local-space normalization and curb rendering; add debug overlays

### DIFF
--- a/__tests__/gastown-building-normalizer.test.js
+++ b/__tests__/gastown-building-normalizer.test.js
@@ -43,3 +43,56 @@ test('normalizer never returns NaN positions or empty footprint', () => {
   assert.ok(Array.isArray(normalized.footprint_local));
   assert.ok(normalized.footprint_local.length >= 3);
 });
+
+
+test('normalizer converts legacy absolute footprint into yaw-neutral local footprint', () => {
+  const abs = [
+    { x: 0, z: 0 },
+    { x: 10, z: 10 },
+    { x: 6, z: 14 },
+    { x: -4, z: 4 },
+    { x: 0, z: 0 },
+  ];
+
+  const normalized = normalizeBuildingForRender({ id: 'legacy-rotated', footprint: abs });
+  const localYawFromEdges = (() => {
+    let longest = { len: 0, dx: 0, dz: 0 };
+    for (let i = 0; i < normalized.footprint_local.length; i += 1) {
+      const a = normalized.footprint_local[i];
+      const b = normalized.footprint_local[(i + 1) % normalized.footprint_local.length];
+      const dx = b.x - a.x;
+      const dz = b.z - a.z;
+      const len = Math.hypot(dx, dz);
+      if (len > longest.len) longest = { len, dx, dz };
+    }
+    return Math.atan2(longest.dz, longest.dx);
+  })();
+
+  assert.ok(Math.abs(localYawFromEdges) < 1e-6, 'local footprint should be yaw neutral');
+  assert.equal(normalized.yaw > 0.1, true, 'world yaw should be preserved');
+});
+
+test('normalizer preserves trusted local geometry and yaw', () => {
+  const normalized = normalizeBuildingForRender({
+    id: 'trusted-local',
+    x: 12,
+    z: -8,
+    yaw: 0.3,
+    footprint_local: [
+      { x: -5, z: -2 },
+      { x: 5, z: -2 },
+      { x: 5, z: 2 },
+      { x: -5, z: 2 },
+    ],
+  });
+
+  assert.equal(normalized.x, 12);
+  assert.equal(normalized.z, -8);
+  assert.equal(normalized.yaw, 0.3);
+  assert.deepEqual(normalized.footprint_local, [
+    { x: -5, z: -2 },
+    { x: 5, z: -2 },
+    { x: 5, z: 2 },
+    { x: -5, z: 2 },
+  ]);
+});

--- a/__tests__/gastown-sim-ground.test.js
+++ b/__tests__/gastown-sim-ground.test.js
@@ -1,0 +1,12 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+test('ground rendering no longer uses scaled street polygon curb hack', () => {
+  const simPath = path.join(__dirname, '..', 'js', 'gastown-sim.js');
+  const src = fs.readFileSync(simPath, 'utf8');
+
+  assert.equal(src.includes('curb.scale.set(1.008, 1.008, 1.008)'), false);
+  assert.equal(src.includes('new THREE.Line(new THREE.BufferGeometry().setFromPoints(borderPoints), visualState.curbMaterial)'), true);
+});

--- a/js/gastown-building-normalizer.js
+++ b/js/gastown-building-normalizer.js
@@ -97,25 +97,50 @@
     return Math.atan2(longest.dz, longest.dx);
   }
 
+  function rotatePoint(point, angle) {
+    const cos = Math.cos(angle);
+    const sin = Math.sin(angle);
+    return {
+      x: (point.x * cos) - (point.z * sin),
+      z: (point.x * sin) + (point.z * cos),
+    };
+  }
+
+  function hasTrustedLocalFootprint(source, localFootprint) {
+    return localFootprint.length >= 3
+      && uniquePointCount(localFootprint) >= 3
+      && isFiniteNumber(source.x)
+      && isFiniteNumber(source.z)
+      && isFiniteNumber(source.yaw);
+  }
+
   function normalizeBuildingForRender(building) {
     const source = building || {};
     const absoluteFootprint = sanitizePoints(source.footprint);
     const localFromSource = sanitizePoints(source.footprint_local);
     const sourceCentroid = getCentroid(absoluteFootprint);
 
+    const trustedLocal = hasTrustedLocalFootprint(source, localFromSource);
     const x = isFiniteNumber(source.x) ? source.x : sourceCentroid.x;
     const z = isFiniteNumber(source.z) ? source.z : sourceCentroid.z;
 
-    const localFootprint = localFromSource.length >= 3
-      ? localFromSource
-      : absoluteFootprint.map((point) => ({ x: point.x - x, z: point.z - z }));
+    let yaw = deriveYawFromFootprint(absoluteFootprint.length >= 3 ? absoluteFootprint : localFromSource, source.yaw);
+    let localFootprint = localFromSource;
+
+    if (!trustedLocal) {
+      const centered = absoluteFootprint.map((point) => ({
+        x: point.x - x,
+        z: point.z - z,
+      }));
+      localFootprint = centered.map((point) => rotatePoint(point, -yaw));
+    }
 
     const safeLocalFootprint = ensureRenderableFootprint(localFootprint, source.width, source.depth);
     const localBounds = getBounds(safeLocalFootprint);
 
     const width = isFiniteNumber(source.width) ? Math.max(3, Math.abs(source.width)) : localBounds.width;
     const depth = isFiniteNumber(source.depth) ? Math.max(3, Math.abs(source.depth)) : localBounds.depth;
-    const yaw = deriveYawFromFootprint(safeLocalFootprint, source.yaw);
+    yaw = trustedLocal ? deriveYawFromFootprint(safeLocalFootprint, source.yaw) : yaw;
 
     const absolute = absoluteFootprint.length >= 3
       ? absoluteFootprint

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -270,17 +270,21 @@
   }
 
   function addGround(world) {
-    visualState.roadMaterial = new THREE.MeshStandardMaterial({ color: 0x1e232b, roughness: 0.93, metalness: 0.16 });
-    visualState.sidewalkMaterial = new THREE.MeshStandardMaterial({ color: 0x6a3f37, roughness: 0.89, metalness: 0.06 });
-    visualState.curbMaterial = new THREE.MeshStandardMaterial({ color: 0xc4ccd3, roughness: 0.83, metalness: 0.1 });
+    visualState.roadMaterial = new THREE.MeshStandardMaterial({ color: 0x1b1f25, roughness: 0.94, metalness: 0.14 });
+    visualState.sidewalkMaterial = new THREE.MeshStandardMaterial({ color: 0x755247, roughness: 0.88, metalness: 0.05 });
+    visualState.curbMaterial = new THREE.LineBasicMaterial({ color: 0xb8c2cb, transparent: true, opacity: 0.7 });
     visualState.laneMaterial = new THREE.LineBasicMaterial({ color: 0xa5bdcf, transparent: true, opacity: 0.56 });
 
     world.zones.street.forEach((zone) => createZoneMesh(zone.polygon, visualState.roadMaterial, 0));
     world.zones.sidewalk.forEach((zone) => createZoneMesh(zone.polygon, visualState.sidewalkMaterial, 0.12));
 
     world.zones.street.forEach((zone) => {
-      const curb = createZoneMesh(zone.polygon, visualState.curbMaterial, 0.05);
-      curb.scale.set(1.008, 1.008, 1.008);
+      if (!Array.isArray(zone.polygon) || zone.polygon.length < 3) return;
+      const borderPoints = zone.polygon.map((point) => new THREE.Vector3(point.x, 0.16, point.z));
+      const first = zone.polygon[0];
+      borderPoints.push(new THREE.Vector3(first.x, 0.16, first.z));
+      const curbLine = new THREE.Line(new THREE.BufferGeometry().setFromPoints(borderPoints), visualState.curbMaterial);
+      worldGroup.add(curbLine);
     });
 
     const routePoints = world.route.centerline.map((point) => new THREE.Vector3(point.x, 0.14, point.z));
@@ -696,10 +700,44 @@
     );
     debugGroup.add(walkBoundLine);
 
+    function addPolygonOutline(polygon, y, color) {
+      if (!Array.isArray(polygon) || polygon.length < 3) return;
+      const points = polygon.map((point) => new THREE.Vector3(point.x, y, point.z));
+      const first = polygon[0];
+      points.push(new THREE.Vector3(first.x, y, first.z));
+      debugGroup.add(new THREE.Line(
+        new THREE.BufferGeometry().setFromPoints(points),
+        new THREE.LineBasicMaterial({ color })
+      ));
+    }
+
+    (world.zones.street || []).forEach((zone) => addPolygonOutline(zone.polygon, 0.3, 0x49c4ff));
+    (world.zones.sidewalk || []).forEach((zone) => addPolygonOutline(zone.polygon, 0.34, 0xff9c57));
+
     world.nodes.forEach((node) => {
       const marker = new THREE.Mesh(new THREE.SphereGeometry(0.45, 12, 12), new THREE.MeshBasicMaterial({ color: 0xd5f3ff }));
       marker.position.set(node.x, 0.5, node.z);
       debugGroup.add(marker);
+    });
+
+    (world.buildings || []).forEach((building) => {
+      if (!Number.isFinite(building.x) || !Number.isFinite(building.z)) return;
+      const marker = new THREE.Mesh(new THREE.SphereGeometry(0.24, 8, 8), new THREE.MeshBasicMaterial({ color: 0x98ff9b }));
+      marker.position.set(building.x, 0.62, building.z);
+      debugGroup.add(marker);
+
+      if (Number.isFinite(building.yaw)) {
+        const arrowLen = Math.max(3, Math.min(6, (building.depth || 6) * 0.6));
+        const tip = localPointToWorld(building, 0, arrowLen);
+        const arrow = new THREE.Line(
+          new THREE.BufferGeometry().setFromPoints([
+            new THREE.Vector3(building.x, 0.66, building.z),
+            new THREE.Vector3(tip.x, 0.66, tip.z),
+          ]),
+          new THREE.LineBasicMaterial({ color: 0xa3f9a7 })
+        );
+        debugGroup.add(arrow);
+      }
     });
 
     if (routeDebugOverlay) {
@@ -708,6 +746,7 @@
       routeDebugOverlay.hidden = !state.debugEnabled;
     }
   }
+
 
   function rebuildRain(intensity) {
     while (rainGroup.children.length) {
@@ -1230,7 +1269,7 @@
       visualState.sidewalkMaterial.color.set(timeOfDay.sidewalkColor || '#3a444f');
     }
     if (visualState.curbMaterial) {
-      visualState.curbMaterial.color.set(timeOfDay.sidewalkColor || '#3a444f').multiplyScalar(0.74);
+      visualState.curbMaterial.color.set(timeOfDay.sidewalkColor || '#8f99a3').multiplyScalar(0.74);
     }
     if (visualState.laneMaterial) {
       visualState.laneMaterial.color.set(timeOfDay.laneColor || '#5d6a76');

--- a/scripts/generate-gastown-world.js
+++ b/scripts/generate-gastown-world.js
@@ -337,6 +337,15 @@ function sanitizeNumber(value, fallback) {
   return Number.isFinite(value) ? value : fallback;
 }
 
+
+function rotatePoint(point, angle) {
+  const cos = Math.cos(angle);
+  const sin = Math.sin(angle);
+  return {
+    x: (point.x * cos) - (point.z * sin),
+    z: (point.x * sin) + (point.z * cos),
+  };
+}
 function deterministicValue(seed, min, max) {
   let hash = 2166136261;
   const text = String(seed || 'default');
@@ -398,8 +407,22 @@ function deriveFootprintMetrics(footprint) {
   }
 
   const yaw = longestEdge.length > 0.01 ? Math.atan2(longestEdge.dz, longestEdge.dx) : 0;
-  const width = Math.max(3, maxX - minX);
-  const depth = Math.max(3, maxZ - minZ);
+  const centered = footprint.map((point) => ({ x: point.x - centroid.x, z: point.z - centroid.z }));
+  const localFootprint = closePolygon(centered.map((point) => rotatePoint(point, -yaw)));
+
+  let localMinX = Infinity;
+  let localMaxX = -Infinity;
+  let localMinZ = Infinity;
+  let localMaxZ = -Infinity;
+  localFootprint.forEach((point) => {
+    localMinX = Math.min(localMinX, point.x);
+    localMaxX = Math.max(localMaxX, point.x);
+    localMinZ = Math.min(localMinZ, point.z);
+    localMaxZ = Math.max(localMaxZ, point.z);
+  });
+
+  const width = Math.max(3, localMaxX - localMinX);
+  const depth = Math.max(3, localMaxZ - localMinZ);
 
   return {
     x: centroid.x,
@@ -407,7 +430,7 @@ function deriveFootprintMetrics(footprint) {
     width,
     depth,
     yaw,
-    localFootprint: closePolygon(footprint.map((point) => ({ x: point.x - centroid.x, z: point.z - centroid.z }))),
+    localFootprint,
   };
 }
 


### PR DESCRIPTION
### Motivation
- Legacy buildings shipped only absolute `footprint` data and were being double-rotated at render time, while the curb implementation used a scaled street polygon that drifted around the origin and could visually cover the roadway.

### Description
- Update `js/gastown-building-normalizer.js` to properly normalize legacy buildings by deriving centroid `x/z`, deriving `yaw` from the dominant edge when missing, centering absolute footprint points, rotating them by `-yaw` to produce a true yaw-neutral `footprint_local`, preserving already-trusted `footprint_local + x + z + yaw`, and keeping finite-safe fallbacks and default fields.
- Update `js/gastown-sim.js` to continue extruding from `footprint_local` and place/rotate meshes only once at `b.x`, `b.z` with `b.yaw`, replace the scaled full-polygon curb hack with lightweight street-edge `THREE.Line` curb rendering, and add debug overlays (toggle via `?gastownDebug=1`) that draw route centerline, street/sidewalk outlines, building centroids, and forward-direction arrows.
- Update `scripts/generate-gastown-world.js` to emit yaw-neutral `localFootprint` and compute `width`/`depth` from rotated local bounds so generated world assets are renderer-friendly.
- Add/extend tests: enhanced `__tests__/gastown-building-normalizer.test.js` with legacy->local and trusted-local cases, and added `__tests__/gastown-sim-ground.test.js` to assert the curb scaling hack is removed.

### Testing
- Ran targeted tests: `node --test __tests__/gastown-building-normalizer.test.js __tests__/gastown-world-generator.test.js __tests__/gastown-sim-ground.test.js` and they all passed.
- Ran full suite with `npm test`; the suite failed due to unrelated existing `lousy-outages` integration/refresh tests (a DOM-mocking error `anchor.parentNode.insertBefore is not a function`), which are not caused by these Gastown changes.
- Attempted to regenerate the shipped world asset with `node scripts/generate-gastown-world.js`, but regeneration could not run because required offline inputs (`route-anchors.json`, `public-streets.geojson`, `building-footprints.geojson`) are missing in this environment; therefore `assets/world/gastown-water-street.json` was not regenerated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b769606ff4832eaa0367f20ff5f5fc)