### PR TITLE
Improve Gastown simulator with deterministic starter corridor fallback and pitch controls

### DIFF
--- a/assets/world/gastown-water-street-starter.json
+++ b/assets/world/gastown-water-street-starter.json
@@ -10,7 +10,7 @@
       "Starter corridor fallback is active because required offline civic source files are missing.",
       "This world is intentionally human-scaled and deterministic for readability; it is not GIS-accurate Gastown reconstruction."
     ],
-    "lastBuild": "2026-03-16T03:48:56.774Z"
+    "lastBuild": "2026-03-16T03:46:45.370Z"
   },
   "route": {
     "name": "Gastown starter block corridor",
@@ -433,7 +433,7 @@
           "z": -3.6
         }
       ],
-      "facade_profile": "cordova_commercial_transition",
+      "facade_profile": "cordoba_commercial_transition",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 3,
@@ -573,7 +573,7 @@
           "z": 4.8
         }
       ],
-      "facade_profile": "cordova_commercial_transition",
+      "facade_profile": "cordoba_commercial_transition",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 4,
@@ -713,7 +713,7 @@
           "z": -3.2
         }
       ],
-      "facade_profile": "cordova_commercial_transition",
+      "facade_profile": "cordoba_commercial_transition",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 3,
@@ -853,7 +853,7 @@
           "z": 6
         }
       ],
-      "facade_profile": "cordova_commercial_transition",
+      "facade_profile": "cordoba_commercial_transition",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 5,
@@ -993,7 +993,7 @@
           "z": 4
         }
       ],
-      "facade_profile": "cordova_commercial_transition",
+      "facade_profile": "cordoba_commercial_transition",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 4,
@@ -1133,7 +1133,7 @@
           "z": -5.2
         }
       ],
-      "facade_profile": "cordova_commercial_transition",
+      "facade_profile": "cordoba_commercial_transition",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 5,
@@ -1273,7 +1273,7 @@
           "z": -4.4
         }
       ],
-      "facade_profile": "cordova_commercial_transition",
+      "facade_profile": "cordoba_commercial_transition",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 4,
@@ -1413,7 +1413,7 @@
           "z": 3.6
         }
       ],
-      "facade_profile": "cordova_commercial_transition",
+      "facade_profile": "cordoba_commercial_transition",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 3,
@@ -1553,7 +1553,7 @@
           "z": 5.6
         }
       ],
-      "facade_profile": "cordova_commercial_transition",
+      "facade_profile": "cordoba_commercial_transition",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 5,
@@ -1693,7 +1693,7 @@
           "z": -4
         }
       ],
-      "facade_profile": "cordova_commercial_transition",
+      "facade_profile": "cordoba_commercial_transition",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 4,
@@ -1833,7 +1833,7 @@
           "z": -3.6
         }
       ],
-      "facade_profile": "cordova_commercial_transition",
+      "facade_profile": "cordoba_commercial_transition",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 3,
@@ -1973,7 +1973,7 @@
           "z": -4.8
         }
       ],
-      "facade_profile": "cordova_commercial_transition",
+      "facade_profile": "cordoba_commercial_transition",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 4,
@@ -2113,7 +2113,7 @@
           "z": -3.2
         }
       ],
-      "facade_profile": "cordova_commercial_transition",
+      "facade_profile": "cordoba_commercial_transition",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 3,

--- a/functions.php
+++ b/functions.php
@@ -247,6 +247,7 @@ function se_enqueue_gastown_sim_assets() {
             'seGastownSim',
             array(
                 'worldDataUrl'   => esc_url_raw( $uri . '/assets/world/gastown-water-street.json' ),
+                'starterWorldDataUrl' => esc_url_raw( $uri . '/assets/world/gastown-water-street-starter.json' ),
                 'audioBaseUrl'   => esc_url_raw( $uri . '/assets/audio/gastown' ),
                 'defaultWeather' => 'rain',
                 'defaultMood'    => 'eerie',

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -51,7 +51,7 @@
   };
 
   const scene = new THREE.Scene();
-  const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 800);
+  const camera = new THREE.PerspectiveCamera(68, 1, 0.08, 700);
   camera.position.set(0, 1.7, 0);
   const renderer = new THREE.WebGLRenderer({ antialias: true });
   renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
@@ -90,6 +90,23 @@
     landmarkVisuals: [],
     groundMeshes: [],
   };
+
+  const LOOK_PITCH_LIMIT = Math.PI / 2.25;
+  const WHEEL_PITCH_SENSITIVITY = 0.00085;
+  const KEYBOARD_PITCH_STEP = 0.045;
+
+  function clampPitch(value) {
+    return Math.max(-LOOK_PITCH_LIMIT, Math.min(LOOK_PITCH_LIMIT, value));
+  }
+
+  function adjustPitch(delta) {
+    state.pitch = clampPitch(state.pitch + delta);
+    camera.rotation.x = state.pitch;
+  }
+
+  function canUseLookFallbackControls() {
+    return state.isRunning || document.pointerLockElement === renderer.domElement || document.activeElement === renderer.domElement;
+  }
 
   const minimapState = {
     ctx: minimapCanvas ? minimapCanvas.getContext('2d') : null,
@@ -134,6 +151,14 @@
 
   function setLandmark(text) {
     landmarkEl.textContent = text;
+  }
+
+  function setWorldModeStatus(world) {
+    if (!world || !world.meta) return;
+    const isStarter = world.meta.fallbackMode === 'starter-corridor' || world.meta.runtimeFallbackActive || world.meta.isRealCivicBuild === false;
+    if (!isStarter) return;
+    const buildNote = (world.meta.buildNotes && world.meta.buildNotes[0]) || 'Starter corridor fallback world active.';
+    setStatus('Starter fallback world active: ' + buildNote);
   }
 
   function updateAttribution(world) {
@@ -271,7 +296,7 @@
 
   function addGround(world) {
     visualState.roadMaterial = new THREE.MeshStandardMaterial({ color: 0x1b1f25, roughness: 0.94, metalness: 0.14 });
-    visualState.sidewalkMaterial = new THREE.MeshStandardMaterial({ color: 0x755247, roughness: 0.88, metalness: 0.05 });
+    visualState.sidewalkMaterial = new THREE.MeshStandardMaterial({ color: 0xa19486, roughness: 0.9, metalness: 0.02 });
     visualState.curbMaterial = new THREE.LineBasicMaterial({ color: 0xb8c2cb, transparent: true, opacity: 0.7 });
     visualState.laneMaterial = new THREE.LineBasicMaterial({ color: 0xa5bdcf, transparent: true, opacity: 0.56 });
 
@@ -299,8 +324,8 @@
       if (!next) return;
       const heading = Math.atan2(next.x - point.x, next.z - point.z);
       const stripe = new THREE.Mesh(
-        new THREE.PlaneGeometry(0.22, 2.4),
-        new THREE.MeshStandardMaterial({ color: 0xb9c7d5, roughness: 0.78, metalness: 0.22, transparent: true, opacity: 0.38 })
+        new THREE.PlaneGeometry(0.18, 1.9),
+        new THREE.MeshStandardMaterial({ color: 0xbfc8cf, roughness: 0.8, metalness: 0.1, transparent: true, opacity: 0.34 })
       );
       stripe.rotation.x = -Math.PI / 2;
       stripe.rotation.y = heading;
@@ -738,15 +763,47 @@
         );
         debugGroup.add(arrow);
       }
+
+      if (Array.isArray(building.footprint) && building.footprint.length >= 3) {
+        addPolygonOutline(building.footprint, 0.54, 0x72f194);
+      }
     });
 
+    if (world.spawn) {
+      const spawnMarker = new THREE.Mesh(new THREE.ConeGeometry(0.35, 1.2, 12), new THREE.MeshBasicMaterial({ color: 0xffdb6b }));
+      spawnMarker.position.set(world.spawn.x, 0.95, world.spawn.z);
+      spawnMarker.rotation.x = Math.PI;
+      debugGroup.add(spawnMarker);
+    }
+
+    const playerMarker = new THREE.Mesh(new THREE.SphereGeometry(0.32, 10, 10), new THREE.MeshBasicMaterial({ color: 0xfff9b2 }));
+    playerMarker.position.set(player.position.x, 0.72, player.position.z);
+    playerMarker.userData.role = 'player-marker';
+    debugGroup.add(playerMarker);
+
     if (routeDebugOverlay) {
-      const lines = world.route.centerline.map((point, index) => (index + 1) + '. ' + (point.label || point.id || ('node-' + index)) + ' [' + point.x + ', ' + point.z + ']');
-      routeDebugOverlay.textContent = lines.join('\n');
       routeDebugOverlay.hidden = !state.debugEnabled;
+      refreshDebugRuntimeReadout();
     }
   }
 
+
+
+  function refreshDebugRuntimeReadout() {
+    if (!state.debugEnabled || !routeDebugOverlay || !state.world || !state.world.route) return;
+    const lines = state.world.route.centerline.map((point, index) => (index + 1) + '. ' + (point.label || point.id || ('node-' + index)) + ' [' + point.x + ', ' + point.z + ']');
+    const modeLine = state.world.meta && state.world.meta.fallbackMode === 'starter-corridor'
+      ? 'Mode: starter fallback corridor (not GIS-accurate civic build)'
+      : 'Mode: civic-data-derived world';
+    lines.unshift(modeLine);
+    lines.push('Player: [' + player.position.x.toFixed(2) + ', ' + player.position.z.toFixed(2) + ']');
+    routeDebugOverlay.textContent = lines.join('\n');
+
+    const marker = debugGroup.children.find((child) => child.userData && child.userData.role === 'player-marker');
+    if (marker) {
+      marker.position.set(player.position.x, 0.72, player.position.z);
+    }
+  }
 
   function rebuildRain(intensity) {
     while (rainGroup.children.length) {
@@ -1266,14 +1323,14 @@
       visualState.roadMaterial.roughness = 0.92 - ((weather.rainIntensity || 0) * 0.26);
     }
     if (visualState.sidewalkMaterial) {
-      visualState.sidewalkMaterial.color.set(timeOfDay.sidewalkColor || '#3a444f');
+      visualState.sidewalkMaterial.color.set(timeOfDay.sidewalkColor || '#8f8780');
     }
     if (visualState.curbMaterial) {
       visualState.curbMaterial.color.set(timeOfDay.sidewalkColor || '#8f99a3').multiplyScalar(0.74);
     }
     if (visualState.laneMaterial) {
-      visualState.laneMaterial.color.set(timeOfDay.laneColor || '#5d6a76');
-      visualState.laneMaterial.opacity = 0.2 + ((timeOfDay.pathBrightness || 0.25) * 0.5);
+      visualState.laneMaterial.color.set(timeOfDay.laneColor || '#aab1b8');
+      visualState.laneMaterial.opacity = 0.24 + ((timeOfDay.pathBrightness || 0.2) * 0.4);
     }
 
     visualState.landmarkVisuals.forEach((landmarkVisual) => {
@@ -1388,11 +1445,15 @@
 
     const sensitivity = 0.0018;
     state.yaw -= event.movementX * sensitivity;
-    state.pitch -= event.movementY * sensitivity;
-    state.pitch = Math.max(-Math.PI / 2.25, Math.min(Math.PI / 2.25, state.pitch));
+    adjustPitch(-(event.movementY * sensitivity));
 
     player.rotation.y = state.yaw;
-    camera.rotation.x = state.pitch;
+  }
+
+  function onWheelLook(event) {
+    if (!canUseLookFallbackControls()) return;
+    event.preventDefault();
+    adjustPitch(event.deltaY * WHEEL_PITCH_SENSITIVITY);
   }
 
   function setMoveKey(code, pressed) {
@@ -1404,14 +1465,27 @@
     if (code === 'ArrowRight') state.turn.right = pressed;
   }
 
+  function handlePitchKeyControl(event) {
+    if (!event.ctrlKey || !canUseLookFallbackControls()) return false;
+    if (event.code === 'ArrowUp') {
+      adjustPitch(-KEYBOARD_PITCH_STEP);
+      return true;
+    }
+    if (event.code === 'ArrowDown') {
+      adjustPitch(KEYBOARD_PITCH_STEP);
+      return true;
+    }
+    return false;
+  }
+
   function resetToStart() {
     const spawn = resolveSafeSpawn();
     player.position.set(spawn.x, spawn.y, spawn.z);
     state.lastSafePosition.copy(player.position);
     state.yaw = spawn.yaw || 0;
-    state.pitch = 0;
+    state.pitch = Number.isFinite(spawn.pitch) ? clampPitch(spawn.pitch) : 0;
     player.rotation.y = state.yaw;
-    camera.rotation.x = 0;
+    camera.rotation.x = state.pitch;
     updateNearestNode();
   }
 
@@ -1458,10 +1532,12 @@
       enterPlayMode();
     });
     document.addEventListener('mousemove', onMouseMove);
+    renderer.domElement.addEventListener('wheel', onWheelLook, { passive: false });
 
     document.addEventListener('keydown', (event) => {
+      const consumedPitch = handlePitchKeyControl(event);
       setMoveKey(event.code, true);
-      if (event.code.startsWith('Arrow') && (state.isRunning || document.pointerLockElement === renderer.domElement)) {
+      if (consumedPitch || (event.code.startsWith('Arrow') && (state.isRunning || document.pointerLockElement === renderer.domElement))) {
         event.preventDefault();
       }
     }, { passive: false });
@@ -1535,7 +1611,7 @@
 
   async function init() {
     try {
-      state.world = await window.GastownWorldLoader.load(config.worldDataUrl);
+      state.world = await window.GastownWorldLoader.load(config.worldDataUrl, config.starterWorldDataUrl);
       updateAttribution(state.world);
       addGround(state.world);
       addBuildings(state.world);
@@ -1557,7 +1633,10 @@
         debugPanel.removeAttribute('hidden');
       }
       scheduleSteamClock();
-      setStatus('Prototype ready. Click scene to enter look mode and begin moving.');
+      setWorldModeStatus(state.world);
+      if (!(state.world.meta && state.world.meta.fallbackMode === 'starter-corridor')) {
+        setStatus('Prototype ready. Click scene to enter look mode and begin moving.');
+      }
       setPointerStatus('Pointer unlocked. Click scene to enter look mode.');
       renderer.setAnimationLoop((time) => {
         const delta = Math.min(0.03, (time - (init.prevTime || time)) / 1000);
@@ -1569,6 +1648,7 @@
 
         animateRain(delta);
         drawMinimap();
+        refreshDebugRuntimeReadout();
         renderer.render(scene, camera);
       });
     } catch (error) {

--- a/js/gastown-world-loader.js
+++ b/js/gastown-world-loader.js
@@ -1,19 +1,32 @@
 (function (window) {
   'use strict';
 
-  async function loadGastownWorldData(url) {
-    if (!url) {
-      throw new Error('Missing world data URL.');
-    }
-
+  async function fetchWorld(url) {
     const response = await fetch(url, { credentials: 'same-origin' });
     if (!response.ok) {
       throw new Error('Could not load Gastown world data.');
     }
-
     const data = await response.json();
     validateWorldData(data);
     return data;
+  }
+
+  async function loadGastownWorldData(url, fallbackUrl) {
+    if (!url) {
+      throw new Error('Missing world data URL.');
+    }
+
+    try {
+      return await fetchWorld(url);
+    } catch (primaryError) {
+      if (!fallbackUrl || fallbackUrl === url) {
+        throw primaryError;
+      }
+      const fallback = await fetchWorld(fallbackUrl);
+      fallback.meta = fallback.meta || {};
+      fallback.meta.runtimeFallbackActive = true;
+      return fallback;
+    }
   }
 
 

--- a/page-gastown-sim.php
+++ b/page-gastown-sim.php
@@ -52,6 +52,8 @@ get_header();
         <li><strong>Mouse</strong> = look around</li>
         <li><strong>W A S D</strong> = move / strafe</li>
         <li><strong>Arrow keys</strong> = move forward/back + turn left/right</li>
+        <li><strong>Mouse wheel</strong> = look up/down (while focused/in play mode)</li>
+        <li><strong>Ctrl + ↑ / Ctrl + ↓</strong> = precise look up/down steps</li>
         <li><strong>Esc</strong> = release pointer / pause</li>
       </ul>
     </section>
@@ -85,6 +87,7 @@ get_header();
         <li>W/S + Arrow Up/Down move forward/back; A/D strafe</li>
         <li>Arrow Left/Right turns the player heading</li>
         <li>Mouse look while pointer is locked</li>
+        <li>Wheel and Ctrl+ArrowUp/Down also adjust pitch while focused/in play mode</li>
         <li>Walk bounds clamp keeps the player in the playable corridor slice</li>
         <li>Route debug can also be enabled with <code>?gastownDebug=1</code></li>
         <li>Audio zones: station rumble, steam clock core, split-building nightlife edge</li>

--- a/scripts/build-gastown-world.js
+++ b/scripts/build-gastown-world.js
@@ -81,7 +81,11 @@ function runScaffold() {
 function run() {
   const generated = buildWorld({ root, outputPath: worldPath });
   if (generated.generated) {
-    process.stdout.write('Generated offline world data at ' + path.relative(root, worldPath) + '\n');
+    if (generated.usedStarterFallback) {
+      process.stdout.write('Generated deterministic starter fallback world at ' + path.relative(root, worldPath) + '\n');
+    } else {
+      process.stdout.write('Generated offline civic-data world at ' + path.relative(root, worldPath) + '\n');
+    }
     return;
   }
 

--- a/scripts/generate-gastown-world.js
+++ b/scripts/generate-gastown-world.js
@@ -471,6 +471,187 @@ function proceduralStreetscape(points, options) {
   return placements.slice(0, maxCount);
 }
 
+function makeRectFootprint(center, tangent, width, depth) {
+  const normal = perpendicularLeft(tangent);
+  const halfW = width / 2;
+  const halfD = depth / 2;
+  const corners = [
+    { x: (-halfW), z: (-halfD) },
+    { x: halfW, z: (-halfD) },
+    { x: halfW, z: halfD },
+    { x: (-halfW), z: halfD },
+  ];
+  const world = corners.map((corner) => ({
+    x: center.x + (normal.x * corner.x) + (tangent.x * corner.z),
+    z: center.z + (normal.z * corner.x) + (tangent.z * corner.z),
+  }));
+  return closePolygon(world.map((point) => ({ x: Number(point.x.toFixed(2)), z: Number(point.z.toFixed(2)) })));
+}
+
+function makeStarterWorld(outputPath) {
+  const routePoints = [
+    { x: 0, z: 0 },
+    { x: 4, z: -46 },
+    { x: 8, z: -95 },
+    { x: 12, z: -154 },
+    { x: 15, z: -188 },
+  ];
+  const routeLength = polylineLength(routePoints);
+  const beatCount = 10;
+  const centerline = [];
+  for (let i = 0; i <= beatCount; i += 1) {
+    const at = (routeLength * i) / beatCount;
+    const point = samplePointAtDistance(routePoints, at);
+    centerline.push({
+      id: 'starter-beat-' + i,
+      label: i === 0 ? 'Starter Corridor Start' : i === beatCount ? 'Starter Corridor End' : 'Starter Beat ' + i,
+      x: Number(point.x.toFixed(2)),
+      z: Number(point.z.toFixed(2)),
+    });
+  }
+
+  centerline[0].id = 'starter-corridor-start';
+  centerline[Math.floor(centerline.length / 2)].id = 'starter-mid-block';
+  centerline[centerline.length - 1].id = 'starter-corridor-end';
+
+  const streetWidth = 9.8;
+  const sidewalkWidth = 3.2;
+  const softBoundary = 3.2;
+  const streetHalf = streetWidth / 2;
+  const sidewalkOuter = streetHalf + sidewalkWidth;
+  const walkOuter = sidewalkOuter + softBoundary;
+
+  const streetPolygon = ribbonPolygon(routePoints, streetHalf);
+  const leftSidewalk = closePolygon(lineOffset(routePoints, sidewalkOuter).concat(lineOffset(routePoints, streetHalf).reverse()));
+  const rightSidewalk = closePolygon(lineOffset(routePoints, -streetHalf).concat(lineOffset(routePoints, -sidewalkOuter).reverse()));
+  const walkBounds = ribbonPolygon(routePoints, walkOuter);
+
+  const frontagePattern = [9, 12, 8, 15, 10, 13, 11, 9, 14, 10];
+  const depthPattern = [17, 20, 15, 23, 18, 22, 19, 16, 21, 18];
+  const heightPattern = [10, 14, 12, 18, 11, 20, 15, 9, 16, 13];
+  const buildings = [];
+  let cursor = 8;
+  let i = 0;
+  while (cursor < routeLength - 14 && i < 28) {
+    const frontage = frontagePattern[i % frontagePattern.length];
+    const depth = depthPattern[i % depthPattern.length];
+    const height = heightPattern[i % heightPattern.length];
+    const center = samplePointAtDistance(routePoints, cursor);
+    const ahead = samplePointAtDistance(routePoints, Math.min(routeLength, cursor + 2));
+    const behind = samplePointAtDistance(routePoints, Math.max(0, cursor - 2));
+    const tangent = normalize({ x: ahead.x - behind.x, z: ahead.z - behind.z });
+    const normal = perpendicularLeft(tangent);
+
+    [-1, 1].forEach((side) => {
+      const centerOffset = sidewalkOuter + (depth / 2) + 0.8;
+      const footprintCenter = {
+        x: center.x + (normal.x * centerOffset * side),
+        z: center.z + (normal.z * centerOffset * side),
+      };
+      const footprint = makeRectFootprint(footprintCenter, tangent, frontage, depth);
+      const metrics = deriveFootprintMetrics(footprint);
+      const id = `starter-bldg-${i}-${side < 0 ? 'left' : 'right'}`;
+      buildings.push({
+        id,
+        reference_name: side < 0 ? 'Starter west frontage' : 'Starter east frontage',
+        x: Number(metrics.x.toFixed(2)),
+        z: Number(metrics.z.toFixed(2)),
+        width: Number(metrics.width.toFixed(2)),
+        depth: Number(metrics.depth.toFixed(2)),
+        yaw: Number(metrics.yaw.toFixed(4)),
+        height,
+        footprint,
+        footprint_local: metrics.localFootprint.map((point) => ({ x: Number(point.x.toFixed(2)), z: Number(point.z.toFixed(2)) })),
+        facade_profile: side < 0 ? 'gastown_heritage_row' : 'cordova_commercial_transition',
+        tone: side < 0 ? 'brickWarm' : 'stoneMuted',
+        roofline_type: 'flat_cornice',
+        window_bay_count: Math.max(3, Math.round(frontage / 2.8)),
+        recessed_entry_count: 1,
+        storefront_rhythm: { base_band: 0.18, upper_rows: height >= 16 ? 4 : 3 },
+        material_palette: {
+          primary: side < 0 ? '#74493c' : '#7f868e',
+          trim: '#c7b8a5',
+          accent: '#4f5f6f',
+        },
+        cornice_emphasis: 0.26,
+        mass_inset: 0.97,
+      });
+    });
+
+    cursor += frontage + 2.5;
+    i += 1;
+  }
+
+  const start = centerline[0];
+  const next = centerline[1] || centerline[0];
+  const dir = normalize({ x: next.x - start.x, z: next.z - start.z });
+  const spawn = {
+    x: Number((start.x + (dir.x * 9)).toFixed(2)),
+    y: 1.7,
+    z: Number((start.z + (dir.z * 9)).toFixed(2)),
+    yaw: Number(Math.atan2(-dir.x, -dir.z).toFixed(4)),
+  };
+
+  const world = {
+    routeId: 'gastown_water_street_starter_corridor',
+    meta: {
+      title: 'Gastown Starter Corridor (deterministic fallback)',
+      units: 'meters',
+      source: 'deterministic starter fallback',
+      fallbackMode: 'starter-corridor',
+      isRealCivicBuild: false,
+      buildNotes: [
+        'Starter corridor fallback is active because required offline civic source files are missing.',
+        'This world is intentionally human-scaled and deterministic for readability; it is not GIS-accurate Gastown reconstruction.',
+      ],
+      lastBuild: new Date().toISOString(),
+    },
+    route: {
+      name: 'Gastown starter block corridor',
+      centerline,
+      walkBounds,
+      streetWidth,
+      sidewalkWidth,
+      softBoundary,
+      hardResetDistance: 12,
+    },
+    nodes: [
+      { ...centerline[0], label: 'Starter start' },
+      { ...centerline[Math.floor(centerline.length / 2)], label: 'Starter mid block' },
+      { ...centerline[centerline.length - 1], label: 'Starter end' },
+    ],
+    zones: {
+      street: [{ id: 'starter-roadway', surface: 'road', polygon: streetPolygon }],
+      sidewalk: [
+        { id: 'starter-sidewalk-left', side: 'left', polygon: leftSidewalk },
+        { id: 'starter-sidewalk-right', side: 'right', polygon: rightSidewalk },
+      ],
+    },
+    buildings,
+    streetscape: {
+      lamps: proceduralStreetscape(routePoints, {
+        idPrefix: 'starter-lamp', strideMeters: 24, laneOffset: sidewalkOuter - 0.5, maxCount: 24,
+        mapper: (point, id) => ({ id, x: Number(point.x.toFixed(2)), z: Number(point.z.toFixed(2)), height: 5.4 }),
+      }),
+      trees: proceduralStreetscape(routePoints, {
+        idPrefix: 'starter-tree', strideMeters: 30, laneOffset: sidewalkOuter + 2.2, maxCount: 16,
+        mapper: (point, id) => ({ id, x: Number(point.x.toFixed(2)), z: Number(point.z.toFixed(2)), radius: 1.4 }),
+      }),
+      bollards: [],
+      surfaceBands: [],
+    },
+    spawn,
+    bounds: {
+      floorY: 0,
+      edgeMessage: 'Stayed within the starter street corridor.',
+      resetMessage: 'Returned to the starter street corridor.',
+    },
+  };
+
+  fs.writeFileSync(outputPath, JSON.stringify(world, null, 2) + '\n', 'utf8');
+  return { generated: true, outputPath, routeLength, usedStarterFallback: true };
+}
+
 function buildWorld(options = {}) {
   const root = options.root || path.resolve(__dirname, '..');
   const outputPath = options.outputPath || path.join(root, 'assets', 'world', 'gastown-water-street.json');
@@ -481,10 +662,7 @@ function buildWorld(options = {}) {
   const treesPath = path.join(root, 'data', 'cov', 'public-trees.geojson');
 
   if (!fs.existsSync(routeAnchorsPath) || !fs.existsSync(streetsPath) || !fs.existsSync(buildingsPath)) {
-    return {
-      generated: false,
-      reason: 'Required offline inputs missing (need route-anchors.json + public-streets.geojson + building-footprints.geojson).',
-    };
+    return makeStarterWorld(outputPath);
   }
 
   const anchors = readJson(routeAnchorsPath);


### PR DESCRIPTION
### Motivation
- Provide a safe, readable fallback world when offline civic inputs are missing instead of rendering awkward legacy geometry. 
- Make the first-person corridor feel human-scaled and legible from spawn, with clear road/sidewalk contrast and stable building rhythm. 
- Add convenient vertical-look fallback controls (wheel + Ctrl+Arrow) while preserving pointer-lock mouse look. 
- Improve debug visibility so starter vs civic builds and spatial layout can be verified quickly. 

### Description
- Added a deterministic starter-world generator and fallback path in `scripts/generate-gastown-world.js` (`makeStarterWorld`) that emits a human-scaled corridor and returns `{ generated: true, usedStarterFallback: true }` when required local civic files are absent, and committed `assets/world/gastown-water-street-starter.json` as the starter asset. 
- Switched the build scaffold to call the generator fallback and updated `scripts/build-gastown-world.js` messaging to explicitly report starter-fallback generation. 
- Extended the runtime loader to accept a primary and fallback URL (`js/gastown-world-loader.js`) and mark `meta.runtimeFallbackActive` when the fallback is used. 
- Exposed `starterWorldDataUrl` via `wp_localize_script` in `functions.php` so the frontend can request the starter JSON as a fallback. 
- Improved simulator visuals, spawn, and camera ergonomics in `js/gastown-sim.js`: tuned camera FOV/near/far, clarified road vs sidewalk materials, subtle centerline stripes, safer spawn resolving along route, and adjusted world bounds/hard-reset distance for the starter corridor. 
- Implemented shared, clamped pitch state and added additive pitch controls in `js/gastown-sim.js`: mouse-wheel look (`wheel` on the renderer canvas) and `Ctrl+ArrowUp` / `Ctrl+ArrowDown` pitch steps, routed through the same clamp and preserving pointer-lock mouse movement. 
- Extended debug overlays and readouts in `js/gastown-sim.js`: route centerline, street/sidewalk outlines, building footprint outlines, spawn marker, live player marker + position readout, and a mode line showing `starter fallback` vs `civic-data` build. 
- Updated UI/help text in `page-gastown-sim.php` to document the new wheel and keyboard pitch controls. 

### Testing
- Ran `node --check js/gastown-sim.js` and `node --check scripts/generate-gastown-world.js` with no syntax errors (succeeded). 
- Executed `node scripts/build-gastown-world.js` which produced the starter fallback world and updated `assets/world/gastown-water-street.json` (succeeded, reported deterministic starter fallback generation). 
- Ran targeted unit tests `node --test __tests__/gastown-world-generator.test.js __tests__/gastown-sim-ground.test.js` and both passed (succeeded). 
- Ran the full test suite via `npm test`; unrelated pre-existing integration tests for `lousy-outages` failed (`anchor.parentNode.insertBefore is not a function`) and are not affected by these simulator changes (failures are known/unrelated). 
- Attempted a Playwright screenshot of the live page but no local web server responded (`ERR_EMPTY_RESPONSE`), so end-to-end visual validation was not executed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b77c8541b4832e917f6688b5903ed5)