### PR TITLE
Load Gastown sim using Three.js ES module

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -195,14 +195,6 @@ function se_enqueue_gastown_sim_assets() {
     }
 
     wp_enqueue_script(
-        'three-js',
-        'https://unpkg.com/three@0.160.1/build/three.min.js',
-        array(),
-        '0.160.1',
-        true
-    );
-
-    wp_enqueue_script(
         'howler-js',
         'https://unpkg.com/howler@2.2.4/dist/howler.min.js',
         array(),
@@ -237,10 +229,11 @@ function se_enqueue_gastown_sim_assets() {
         wp_enqueue_script(
             'se-gastown-sim',
             $uri . $app_path,
-            array( 'three-js', 'howler-js', 'se-gastown-world-loader', 'se-gastown-building-normalizer' ),
+            array( 'howler-js', 'se-gastown-world-loader', 'se-gastown-building-normalizer' ),
             filemtime( $dir . $app_path ),
             true
         );
+        wp_script_add_data( 'se-gastown-sim', 'type', 'module' );
 
         wp_localize_script(
             'se-gastown-sim',

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -1,9 +1,11 @@
+import * as THREE from 'https://unpkg.com/three@0.160.1/build/three.module.js';
+
 (function (window, document) {
   'use strict';
 
   const config = window.seGastownSim || {};
   const app = document.getElementById('gastown-sim-app');
-  if (!app || !window.THREE || !window.GastownWorldLoader || !window.GastownBuildingNormalizer || !window.Howl || !window.Howler) {
+  if (!app || !window.GastownWorldLoader || !window.GastownBuildingNormalizer || !window.Howl || !window.Howler) {
     return;
   }
 


### PR DESCRIPTION
### Motivation
- Three.js global builds (`build/three.js` / `build/three.min.js`) are deprecated; the Gastown sim should use the ES module build and stop depending on a global `window.THREE` to avoid future breakage.

### Description
- Removed enqueue of the deprecated `three.min.js` script and removed the `three-js` dependency from the `se-gastown-sim` script registration in `functions.php`.
- Marked the `se-gastown-sim` script as an ES module by adding `wp_script_add_data( 'se-gastown-sim', 'type', 'module' )` so browsers will allow `import` statements.
- Updated `js/gastown-sim.js` to `import * as THREE from 'https://unpkg.com/three@0.160.1/build/three.module.js';` and removed the runtime bootstrap check that required `window.THREE` so the module can provide `THREE` directly.

### Testing
- Ran `php -l functions.php`, which reported no syntax errors and succeeded. 
- Ran `npm test`, which executed the JS test suite producing 19 tests with 14 passing and 5 failures; the failures are in existing `lousy-outages` integration/refresh tests (`anchor.parentNode.insertBefore is not a function`) and appear unrelated to the Three.js loader changes. 
- Attempted Node module checks for `js/gastown-sim.js` using `node --check`/module import methods which failed with `Cannot use import statement outside a module` when run in the current Node/CommonJS test environment, which is expected because the script is intended to be loaded as a browser ES module (the WordPress `type=module` flag is used to enable that in browsers).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7872b8ca0832e8892d8f91a92cfd2)