### PR TITLE
Restore Gastown sim boot by reverting to global Three.js and classic script loading

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -195,6 +195,14 @@ function se_enqueue_gastown_sim_assets() {
     }
 
     wp_enqueue_script(
+        'three-js',
+        'https://unpkg.com/three@0.160.1/build/three.min.js',
+        array(),
+        '0.160.1',
+        true
+    );
+
+    wp_enqueue_script(
         'howler-js',
         'https://unpkg.com/howler@2.2.4/dist/howler.min.js',
         array(),
@@ -229,11 +237,11 @@ function se_enqueue_gastown_sim_assets() {
         wp_enqueue_script(
             'se-gastown-sim',
             $uri . $app_path,
-            array( 'howler-js', 'se-gastown-world-loader', 'se-gastown-building-normalizer' ),
+            array( 'three-js', 'howler-js', 'se-gastown-world-loader', 'se-gastown-building-normalizer' ),
             filemtime( $dir . $app_path ),
             true
         );
-        wp_script_add_data( 'se-gastown-sim', 'type', 'module' );
+        // TODO: three.min.js global build works for now; perform a full ESM migration later with verified module-safe rendered tags and a dependency strategy for loader/normalizer/app scripts in real WordPress output.
 
         wp_localize_script(
             'se-gastown-sim',

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -1,16 +1,43 @@
-import * as THREE from 'https://unpkg.com/three@0.160.1/build/three.module.js';
 
 (function (window, document) {
   'use strict';
 
   const config = window.seGastownSim || {};
   const app = document.getElementById('gastown-sim-app');
-  if (!app || !window.GastownWorldLoader || !window.GastownBuildingNormalizer || !window.Howl || !window.Howler) {
+  const statusEl = app ? app.querySelector('[data-sim-status]') : null;
+
+  function failStartupDependency(message) {
+    if (statusEl) {
+      statusEl.textContent = message;
+    }
+    if (window.console && typeof window.console.error === 'function') {
+      window.console.error('[Gastown Sim] ' + message);
+    }
+  }
+
+  if (!app) {
+    return;
+  }
+
+  const THREE = window.THREE;
+  if (!THREE) {
+    failStartupDependency('Missing THREE global. Simulator could not start.');
+    return;
+  }
+  if (!window.GastownWorldLoader) {
+    failStartupDependency('Missing world loader. Simulator could not start.');
+    return;
+  }
+  if (!window.GastownBuildingNormalizer) {
+    failStartupDependency('Missing building normalizer. Simulator could not start.');
+    return;
+  }
+  if (!window.Howl || !window.Howler) {
+    failStartupDependency('Missing Howler audio globals. Simulator could not start.');
     return;
   }
 
   const canvasWrap = app.querySelector('[data-sim-canvas]');
-  const statusEl = app.querySelector('[data-sim-status]');
   const pointerStatusEl = app.querySelector('[data-sim-pointer-status]');
   const landmarkEl = app.querySelector('[data-sim-landmark]');
   const pauseBtn = app.querySelector('[data-action="pause"]');


### PR DESCRIPTION
### Motivation
- The simulator was crashing in browsers with `Uncaught SyntaxError: Cannot use import statement outside a module` because the app script contained a top-level ESM `import` while the page rendered a classic script tag.  
- Priority is to restore a working runtime quickly by reverting to the stable global Three.js build rather than leaving a half-complete module migration.  
- Preserve recent gameplay/render improvements and only change the minimal startup/dependency wiring required to get the simulator back online.  

### Description
- Re-enqueue the global Three.js build by adding a `three-js` handle that loads `https://unpkg.com/three@0.160.1/build/three.min.js` and make `se-gastown-sim` depend on `three-js`, `howler-js`, `se-gastown-world-loader`, and `se-gastown-building-normalizer`.  
- Remove the partial module-tag behavior for `se-gastown-sim` (removed `wp_script_add_data(..., 'type', 'module')`) and leave a concise `TODO` comment describing a proper future ESM migration plan.  
- Revert `js/gastown-sim.js` to classic-script compatibility by removing the top-level `import`, using `const THREE = window.THREE`, and restoring a startup guard that reports missing dependencies.  
- Add a small startup diagnostic helper that writes an explanatory message into the sim status element and logs an error to the console when critical globals (`THREE`, `GastownWorldLoader`, `GastownBuildingNormalizer`, `Howl`/`Howler`) are missing, while leaving the simulator logic otherwise unchanged.  

### Testing
- Ran `php -l functions.php` and it returned no syntax errors (success).  
- Ran `node --check js/gastown-sim.js` for basic JS syntax validation and it returned no syntax errors (success).  
- Ran ripgrep checks for remaining `import * as THREE`, `type='module'` attempt, and related markers and confirmed the ESM `import` and module tag attempt are no longer present (success).  
- Attempted a Playwright page load/screenshot against `http://localhost:8080/page-gastown-sim.php` but it failed with `ERR_EMPTY_RESPONSE` because no local WordPress server was available in this environment (test failed / environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b78d62d66c832e91fa1a933e5a03aa)