### PR TITLE
Harden Gastown classic sim startup with world normalization defaults

### DIFF
--- a/__tests__/gastown-world-loader-normalize.test.js
+++ b/__tests__/gastown-world-loader-normalize.test.js
@@ -1,0 +1,111 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadNormalizeWorldData() {
+  const loaderPath = path.join(__dirname, '..', 'js', 'gastown-world-loader.js');
+  const src = fs.readFileSync(loaderPath, 'utf8');
+  const sandbox = {
+    window: {},
+    fetch: async () => ({ ok: true, json: async () => ({}) }),
+  };
+  vm.runInNewContext(src, sandbox);
+  return sandbox.window.GastownWorldLoader.normalizeWorldData;
+}
+
+function minimalValidWorld(overrides = {}) {
+  return {
+    route: {
+      centerline: [{ x: 0, z: 0 }, { x: 5, z: 0 }],
+      walkBounds: [{ x: 0, z: 0 }, { x: 5, z: 0 }, { x: 5, z: 5 }],
+    },
+    nodes: [{ id: 'n1', x: 0, z: 0 }],
+    buildings: [
+      {
+        id: 'b1',
+        footprint: [{ x: 0, z: 0 }, { x: 3, z: 0 }, { x: 3, z: 3 }],
+      },
+    ],
+    zones: {
+      street: [{ polygon: [{ x: 0, z: 0 }, { x: 6, z: 0 }, { x: 6, z: 6 }] }],
+      sidewalk: [{ polygon: [{ x: -1, z: -1 }, { x: 7, z: -1 }, { x: 7, z: 7 }] }],
+    },
+    ...overrides,
+  };
+}
+
+test('normalizeWorldData adds safe defaults for missing optional sections', () => {
+  const normalizeWorldData = loadNormalizeWorldData();
+  const normalized = normalizeWorldData(minimalValidWorld());
+
+  assert.equal(Array.isArray(normalized.landmarks), true);
+  assert.equal(Array.isArray(normalized.audioZones), true);
+  assert.equal(Array.isArray(normalized.hero_landmarks), true);
+  assert.equal(typeof normalized.facade_profiles, 'object');
+  assert.equal(Array.isArray(normalized.navigator.focusCorridor), true);
+  assert.equal(Array.isArray(normalized.streetscape.lamps), true);
+  assert.equal(Array.isArray(normalized.streetscape.trees), true);
+  assert.equal(Array.isArray(normalized.streetscape.bollards), true);
+  assert.equal(Array.isArray(normalized.streetscape.surfaceBands), true);
+});
+
+test('starter-like world with no landmarks or audioZones normalizes without crashing', () => {
+  const normalizeWorldData = loadNormalizeWorldData();
+  const starter = minimalValidWorld({ streetscape: {} });
+  delete starter.landmarks;
+  delete starter.audioZones;
+
+  const normalized = normalizeWorldData(starter);
+
+  assert.equal(Array.isArray(normalized.landmarks), true);
+  assert.equal(Array.isArray(normalized.audioZones), true);
+  assert.equal(normalized.landmarks.length, 0);
+  assert.equal(normalized.audioZones.length, 0);
+});
+
+test('normalizeWorldData guarantees required mood/weather/time presets and fields', () => {
+  const normalizeWorldData = loadNormalizeWorldData();
+  const normalized = normalizeWorldData(minimalValidWorld());
+
+  const requiredMoodKeys = ['ambientBed', 'audioDensity', 'voiceFreq', 'lightIntensity'];
+  const requiredWeatherKeys = ['rainIntensity', 'fogDensity'];
+  const requiredTimeKeys = [
+    'sky', 'ambientColor', 'ambientIntensity', 'keyColor', 'keyIntensity', 'fillColor',
+    'fillIntensity', 'buildingContrast', 'buildingEdgeColor', 'roadColor', 'sidewalkColor',
+    'laneColor', 'landmarkGlow', 'rainVisibility', 'pathBrightness', 'fogBoost'
+  ];
+
+  ['eerie', 'calm', 'lively'].forEach((id) => {
+    const preset = normalized.moodPresets[id];
+    assert.ok(preset, `missing mood preset ${id}`);
+    requiredMoodKeys.forEach((key) => assert.notEqual(preset[key], undefined));
+  });
+
+  ['clear', 'rain', 'fog'].forEach((id) => {
+    const preset = normalized.weatherPresets[id];
+    assert.ok(preset, `missing weather preset ${id}`);
+    requiredWeatherKeys.forEach((key) => assert.notEqual(preset[key], undefined));
+  });
+
+  ['morning', 'dusk', 'night'].forEach((id) => {
+    const preset = normalized.timeOfDayPresets[id];
+    assert.ok(preset, `missing time preset ${id}`);
+    requiredTimeKeys.forEach((key) => assert.notEqual(preset[key], undefined));
+  });
+});
+
+test('classic sim startup paths are guarded against missing optional arrays', () => {
+  const simPath = path.join(__dirname, '..', 'js', 'gastown-sim-classic.js');
+  const src = fs.readFileSync(simPath, 'utf8');
+
+  assert.equal(src.includes('world.landmarks.forEach('), false);
+  assert.equal(src.includes('world.audioZones.forEach('), false);
+  assert.equal(src.includes('state.world.landmarks.find('), false);
+  assert.equal(src.includes('state.world.audioZones.forEach('), false);
+  assert.equal(src.includes('(world.landmarks || []).forEach('), true);
+  assert.equal(src.includes('(world.audioZones || []).forEach('), true);
+  assert.equal(src.includes('(state.world.landmarks || []).find('), true);
+  assert.equal(src.includes('(state.world.audioZones || []).forEach('), true);
+});

--- a/js/gastown-sim-classic.js
+++ b/js/gastown-sim-classic.js
@@ -712,7 +712,7 @@ console.log('[Gastown Sim] classic runtime build 2026-03-15 recovery 2');
   }
 
   function addLandmarks(world) {
-    world.landmarks.forEach((landmark) => {
+    (world.landmarks || []).forEach((landmark) => {
       const col = landmark.type === 'clock' ? 0xc8a460 : landmark.type === 'split' ? 0x7ea2c7 : 0x8793a1;
       const markerMaterial = new THREE.MeshStandardMaterial({ color: col, emissive: col, emissiveIntensity: 0.2 });
       const markerHeight = landmark.type === 'clock' ? 7.2 : 4.5;
@@ -1315,7 +1315,7 @@ console.log('[Gastown Sim] classic runtime build 2026-03-15 recovery 2');
     state.sounds.rainLoop = new Howl({ src: src('weather/rain_pavement'), loop: true, volume: 0 });
     state.sounds.clockBurst = new Howl({ src: src('events/steam_clock_burst'), volume: 0.45 });
 
-    world.audioZones.forEach((zone) => {
+    (world.audioZones || []).forEach((zone) => {
       state.sounds.zoneBeds[zone.id] = new Howl({ src: src('zones/' + zone.bed), loop: true, volume: 0 });
     });
   }
@@ -1325,9 +1325,12 @@ console.log('[Gastown Sim] classic runtime build 2026-03-15 recovery 2');
       return;
     }
 
-    const mood = state.world.moodPresets[state.activeMood] || state.world.moodPresets.eerie;
-    const weather = state.world.weatherPresets[state.activeWeather] || state.world.weatherPresets.rain;
-    const timeOfDay = state.world.timeOfDayPresets[state.activeTimeOfDay] || state.world.timeOfDayPresets.night;
+    const moodPresets = state.world.moodPresets || {};
+    const mood = moodPresets[state.activeMood] || moodPresets.eerie || { ambientBed: 'eerie_drones', audioDensity: 0.65, voiceFreq: 0.2, lightIntensity: 0.78 };
+    const weatherPresets = state.world.weatherPresets || {};
+    const weather = weatherPresets[state.activeWeather] || weatherPresets.rain || { rainIntensity: 0, fogDensity: 0.012 };
+    const timePresets = state.world.timeOfDayPresets || {};
+    const timeOfDay = timePresets[state.activeTimeOfDay] || timePresets.night || { sky: '#101822', ambientColor: '#8aa0b8', ambientIntensity: 0.8, keyColor: '#9eb9d4', keyIntensity: 0.68, fillColor: '#5b6f87', fillIntensity: 0.25, buildingContrast: 1, buildingEdgeColor: '#223142', roadColor: '#2b3138', sidewalkColor: '#8f8780', laneColor: '#aab1b8', landmarkGlow: 0.3, rainVisibility: 1, pathBrightness: 0.22, fogBoost: 0 };
 
     const weatherFogBoost = state.activeWeather === 'fog' ? 0.008 : state.activeWeather === 'rain' ? 0.003 : -0.001;
     const fogDensity = Math.max(0.004, (weather.fogDensity || 0.01) + (timeOfDay.fogBoost || 0) + weatherFogBoost);
@@ -1380,7 +1383,8 @@ console.log('[Gastown Sim] classic runtime build 2026-03-15 recovery 2');
 
   function applyMood(moodId) {
     state.activeMood = moodId;
-    const preset = state.world.moodPresets[moodId] || state.world.moodPresets.eerie;
+    const moodPresets = state.world.moodPresets || {};
+    const preset = moodPresets[moodId] || moodPresets.eerie || { ambientBed: 'eerie_drones', audioDensity: 0.65, voiceFreq: 0.2, lightIntensity: 0.78 };
 
     applyVisualState();
 
@@ -1422,9 +1426,9 @@ console.log('[Gastown Sim] classic runtime build 2026-03-15 recovery 2');
   }
 
   function updateAudioZones() {
-    if (!state.world || !state.world.audioZones) return;
+    if (!state.world) return;
 
-    state.world.audioZones.forEach((zone) => {
+    (state.world.audioZones || []).forEach((zone) => {
       const dist = Math.hypot(zone.x - player.position.x, zone.z - player.position.z);
       const normalized = Math.max(0, 1 - (dist / zone.radius));
       const howl = state.sounds.zoneBeds[zone.id];
@@ -1631,7 +1635,7 @@ console.log('[Gastown Sim] classic runtime build 2026-03-15 recovery 2');
 
     state.clockTimer = setInterval(() => {
       if (!state.isRunning) return;
-      const steamClock = state.world.landmarks.find((landmark) => landmark.id === 'steam-clock');
+      const steamClock = (state.world.landmarks || []).find((landmark) => landmark.id === 'steam-clock');
       if (!steamClock) return;
       const distance = Math.hypot(player.position.x - steamClock.x, player.position.z - steamClock.z);
       if (distance < 20 && Math.random() > 0.48) {
@@ -1644,19 +1648,31 @@ console.log('[Gastown Sim] classic runtime build 2026-03-15 recovery 2');
     try {
       state.world = await window.GastownWorldLoader.load(config.worldDataUrl, config.starterWorldDataUrl);
       updateAttribution(state.world);
-      addGround(state.world);
-      addBuildings(state.world);
-      addStreetscape(state.world);
-      addHeroLandmarks(state.world);
-      addLandmarks(state.world);
-      addDebugRoute(state.world);
-      setupAudio(state.world);
+      try {
+        addGround(state.world);
+        addBuildings(state.world);
+        addStreetscape(state.world);
+        addHeroLandmarks(state.world);
+        addLandmarks(state.world);
+        addDebugRoute(state.world);
+      } catch (phaseError) {
+        throw new Error('failed while adding landmarks/world geometry: ' + phaseError.message);
+      }
+      try {
+        setupAudio(state.world);
+      } catch (phaseError) {
+        throw new Error('failed while setting up audio: ' + phaseError.message);
+      }
       minimapState.worldMetrics = getWorldMetrics();
       restoreMinimapZoom();
       updateSize();
-      applyTimeOfDay(state.activeTimeOfDay);
-      applyMood(state.activeMood);
-      applyWeather(state.activeWeather);
+      try {
+        applyTimeOfDay(state.activeTimeOfDay);
+        applyMood(state.activeMood);
+        applyWeather(state.activeWeather);
+      } catch (phaseError) {
+        throw new Error('failed while applying visual presets: ' + phaseError.message);
+      }
       resetToStart();
       attachEvents();
       setDebugState(state.debugEnabled);

--- a/js/gastown-world-loader.js
+++ b/js/gastown-world-loader.js
@@ -8,7 +8,7 @@
     }
     const data = await response.json();
     validateWorldData(data);
-    return data;
+    return normalizeWorldData(data);
   }
 
   async function loadGastownWorldData(url, fallbackUrl) {
@@ -122,7 +122,78 @@
     });
   }
 
+  function mergePreset(base, override) {
+    return Object.assign({}, base, override || {});
+  }
+
+  function normalizeWorldData(data) {
+    const normalized = data || {};
+
+    normalized.landmarks = Array.isArray(normalized.landmarks) ? normalized.landmarks : [];
+    normalized.audioZones = Array.isArray(normalized.audioZones) ? normalized.audioZones : [];
+    normalized.hero_landmarks = Array.isArray(normalized.hero_landmarks) ? normalized.hero_landmarks : [];
+    normalized.facade_profiles = normalized.facade_profiles && typeof normalized.facade_profiles === 'object' ? normalized.facade_profiles : {};
+
+    normalized.navigator = normalized.navigator && typeof normalized.navigator === 'object' ? normalized.navigator : {};
+    normalized.navigator.focusCorridor = Array.isArray(normalized.navigator.focusCorridor) ? normalized.navigator.focusCorridor : [];
+
+    normalized.streetscape = normalized.streetscape && typeof normalized.streetscape === 'object' ? normalized.streetscape : {};
+    normalized.streetscape.lamps = Array.isArray(normalized.streetscape.lamps) ? normalized.streetscape.lamps : [];
+    normalized.streetscape.trees = Array.isArray(normalized.streetscape.trees) ? normalized.streetscape.trees : [];
+    normalized.streetscape.bollards = Array.isArray(normalized.streetscape.bollards) ? normalized.streetscape.bollards : [];
+    normalized.streetscape.surfaceBands = Array.isArray(normalized.streetscape.surfaceBands) ? normalized.streetscape.surfaceBands : [];
+
+    const defaultMoodPreset = {
+      ambientBed: 'eerie_drones',
+      audioDensity: 0.65,
+      voiceFreq: 0.2,
+      lightIntensity: 0.78,
+    };
+
+    const defaultWeatherPreset = {
+      rainIntensity: 0,
+      fogDensity: 0.012,
+    };
+
+    const defaultTimeOfDayPreset = {
+      sky: '#101822',
+      ambientColor: '#8aa0b8',
+      ambientIntensity: 0.8,
+      keyColor: '#9eb9d4',
+      keyIntensity: 0.68,
+      fillColor: '#5b6f87',
+      fillIntensity: 0.25,
+      buildingContrast: 1,
+      buildingEdgeColor: '#223142',
+      roadColor: '#2b3138',
+      sidewalkColor: '#8f8780',
+      laneColor: '#aab1b8',
+      landmarkGlow: 0.3,
+      rainVisibility: 1,
+      pathBrightness: 0.22,
+      fogBoost: 0,
+    };
+
+    normalized.moodPresets = normalized.moodPresets && typeof normalized.moodPresets === 'object' ? normalized.moodPresets : {};
+    normalized.moodPresets.eerie = mergePreset(defaultMoodPreset, normalized.moodPresets.eerie);
+    normalized.moodPresets.calm = mergePreset(defaultMoodPreset, Object.assign({ ambientBed: 'quiet_night', audioDensity: 0.45, voiceFreq: 0.1, lightIntensity: 0.86 }, normalized.moodPresets.calm));
+    normalized.moodPresets.lively = mergePreset(defaultMoodPreset, Object.assign({ ambientBed: 'nightlife_hum', audioDensity: 0.84, voiceFreq: 0.35, lightIntensity: 0.96 }, normalized.moodPresets.lively));
+
+    normalized.weatherPresets = normalized.weatherPresets && typeof normalized.weatherPresets === 'object' ? normalized.weatherPresets : {};
+    normalized.weatherPresets.clear = mergePreset(defaultWeatherPreset, Object.assign({ rainIntensity: 0, fogDensity: 0.008 }, normalized.weatherPresets.clear));
+    normalized.weatherPresets.rain = mergePreset(defaultWeatherPreset, Object.assign({ rainIntensity: 0.85, fogDensity: 0.016 }, normalized.weatherPresets.rain));
+    normalized.weatherPresets.fog = mergePreset(defaultWeatherPreset, Object.assign({ rainIntensity: 0.08, fogDensity: 0.024 }, normalized.weatherPresets.fog));
+
+    normalized.timeOfDayPresets = normalized.timeOfDayPresets && typeof normalized.timeOfDayPresets === 'object' ? normalized.timeOfDayPresets : {};
+    normalized.timeOfDayPresets.morning = mergePreset(defaultTimeOfDayPreset, Object.assign({ sky: '#8aa8bf', ambientColor: '#cfdeee', ambientIntensity: 1.02, keyColor: '#fff2d1', keyIntensity: 0.84, fillColor: '#8ba2ba', fillIntensity: 0.32, buildingContrast: 0.95, buildingEdgeColor: '#2d3948', roadColor: '#4f5862', sidewalkColor: '#9e968e', laneColor: '#d4d8dc', landmarkGlow: 0.22, rainVisibility: 0.74, pathBrightness: 0.34, fogBoost: -0.002 }, normalized.timeOfDayPresets.morning));
+    normalized.timeOfDayPresets.dusk = mergePreset(defaultTimeOfDayPreset, Object.assign({ sky: '#3f4b67', ambientColor: '#9eb0c6', ambientIntensity: 0.84, keyColor: '#f4c18f', keyIntensity: 0.65, fillColor: '#6e7a97', fillIntensity: 0.28, buildingContrast: 1.08, buildingEdgeColor: '#1f2c3c', roadColor: '#343a45', sidewalkColor: '#8f8780', laneColor: '#c4c7cc', landmarkGlow: 0.38, rainVisibility: 0.92, pathBrightness: 0.24, fogBoost: 0.003 }, normalized.timeOfDayPresets.dusk));
+    normalized.timeOfDayPresets.night = mergePreset(defaultTimeOfDayPreset, Object.assign({ sky: '#101822', ambientColor: '#7e93ab', ambientIntensity: 0.72, keyColor: '#9eb9d4', keyIntensity: 0.6, fillColor: '#526782', fillIntensity: 0.22, buildingContrast: 1.2, buildingEdgeColor: '#1a2230', roadColor: '#2b3138', sidewalkColor: '#827a74', laneColor: '#adb3ba', landmarkGlow: 0.44, rainVisibility: 1, pathBrightness: 0.2, fogBoost: 0.006 }, normalized.timeOfDayPresets.night));
+
+    return normalized;
+  }
+
   window.GastownWorldLoader = {
     load: loadGastownWorldData,
+    normalizeWorldData: normalizeWorldData,
   };
 })(window);


### PR DESCRIPTION
### Motivation
- The classic simulator was crashing at startup when optional world sections were absent (errors like "Cannot read properties of undefined (reading 'forEach')").
- The goal is to make the runtime robust when either the main world or the starter fallback is used by hydrating missing optional sections and guarding runtime access.
- Preserve the current classic delivery path and runtime fingerprint while improving fault visibility for remaining failures.

### Description
- Add `normalizeWorldData(data)` in `js/gastown-world-loader.js` and make `fetchWorld()` return the normalized object so the loader is the primary source-of-truth for safe defaults. (`GastownWorldLoader.normalizeWorldData` is exported for tests.)
- Ensure these runtime-safe defaults are always present: `landmarks: []`, `audioZones: []`, `hero_landmarks: []`, `facade_profiles: {}`, `navigator.focusCorridor: []`, and `streetscape` arrays (`lamps`, `trees`, `bollards`, `surfaceBands`).
- Hydrate complete starter-safe presets for `moodPresets` (`eerie`, `calm`, `lively`), `weatherPresets` (`clear`, `rain`, `fog`), and `timeOfDayPresets` (`morning`, `dusk`, `night`) including fields consumed by the runtime (`ambientBed`, `audioDensity`, `voiceFreq`, `lightIntensity`, `rainIntensity`, `fogDensity`, `sky`, `ambientColor`, `ambientIntensity`, `keyColor`, `keyIntensity`, `fillColor`, `fillIntensity`, `buildingContrast`, `buildingEdgeColor`, `roadColor`, `sidewalkColor`, `laneColor`, `landmarkGlow`, `rainVisibility`, `pathBrightness`, `fogBoost`).
- Add defensive guards and safer preset lookups in `js/gastown-sim-classic.js` (use `(world.landmarks || []).forEach`, `(world.audioZones || []).forEach`, `(state.world.landmarks || []).find`, guarded preset lookup chains) and add try/catch around init phases to surface which phase failed (geometry, audio, visual presets).
- Added unit tests at `__tests__/gastown-world-loader-normalize.test.js` to validate normalization, starter fallback normalization, presence of presets and static guard checks; left classic runtime fingerprint and delivery path unchanged.

### Testing
- Ran the new unit test: `node --test __tests__/gastown-world-loader-normalize.test.js`, and it passed (all new normalization and guard assertions succeeded). ✅
- Ran the repository test suite via `npm test`; the run failed but failures are unrelated to these changes (integration and refresh-loop tests fail due to DOM/mocking errors in `lousy-outages` assets: `anchor.parentNode.insertBefore is not a function`). ❌
- The changes are intentionally defensive: loader normalization is the primary protection and sim-side guards are a secondary safety net; targeted unit tests confirm the normalization behavior. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7953d79d8832e9cc0f6c5987736b2)