### PR TITLE
Add on-brand “Work With Suzy” page template and homepage CTA

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -104,6 +104,7 @@ get_header();
                 <h3 class="group-title">📚 About &amp; Info</h3>
                 <div class="group-buttons">
                     <a href="/bio" class="pixel-button">About Suzy</a>
+                    <a href="/work-with-suzy/" class="pixel-button">Work With Suzy</a>
                     <a href="https://buymeacoffee.com/wi0amge" class="pixel-button" target="_blank" rel="noopener noreferrer">Support</a>
                 </div>
             </div>

--- a/page-work-with-suzy.php
+++ b/page-work-with-suzy.php
@@ -1,0 +1,93 @@
+<?php
+/*
+Template Name: Work With Suzy
+*/
+get_header();
+?>
+
+<main id="main-content" class="work-with-suzy-page">
+    <article class="page-content work-with-suzy-content">
+        <section class="crt-block wws-hero" aria-labelledby="work-with-suzy-title">
+            <p class="wws-kicker pixel-font">Need a systems fixer with musician instincts?</p>
+            <h1 id="work-with-suzy-title" class="retro-title glow-lite">Work With Suzy</h1>
+            <p class="wws-lead">Technical help for weird bugs, messy workflows, AI experiments, and getting unstuck. I’m a Vancouver-based technical operator and creative technologist who helps small teams, founders, and makers make their systems behave.</p>
+            <a class="pixel-button wws-hero-cta" href="mailto:suzyeaston@icloud.com?subject=Work%20With%20Suzy%20%E2%80%94%20%5Bproject%5D">Email Suzy</a>
+        </section>
+
+        <section class="crt-block wws-section" aria-labelledby="what-i-help-with">
+            <h2 id="what-i-help-with" class="pixel-font">What I can help with</h2>
+            <div class="wws-grid">
+                <article class="wws-card">
+                    <h3>Technical troubleshooting &amp; escalations</h3>
+                    <p>When everyone says “it should work” and it still does not, I trace the issue across logs, APIs, integrations, and handoffs until we find the real problem.</p>
+                </article>
+                <article class="wws-card">
+                    <h3>QA, test automation, and bug reproduction</h3>
+                    <p>I can tighten up test coverage, isolate flaky behavior, and help your team move from “random bug reports” to reproducible defects with clear next actions.</p>
+                </article>
+                <article class="wws-card">
+                    <h3>Workflow automation &amp; systems cleanup</h3>
+                    <p>If your team is held together by copy-paste rituals and duct tape, I can help streamline the flow and automate the repetitive pain.</p>
+                </article>
+                <article class="wws-card">
+                    <h3>AI-assisted prototypes and practical builds</h3>
+                    <p>I use AI as leverage, not hype: rapid prototyping, internal helpers, and focused experiments that make real work easier.</p>
+                </article>
+                <article class="wws-card">
+                    <h3>WordPress and custom site improvements</h3>
+                    <p>Need your site to do something specific without becoming a plugin circus? I can implement upgrades, custom tweaks, and integrations that stay maintainable.</p>
+                </article>
+                <article class="wws-card">
+                    <h3>Cross-team technical advisory</h3>
+                    <p>Part support lead, part QA brain, part builder: I help teams stuck between product, support, and engineering align on what is actually broken and what to do next.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="crt-block wws-section" aria-labelledby="proof-of-life">
+            <h2 id="proof-of-life" class="pixel-font">Proof of life</h2>
+            <ul class="wws-proof-list">
+                <li><strong>11+ years</strong> across support, operations, QA, infrastructure, and automation.</li>
+                <li>Hands-on with <strong>SQL, logs, escalations, API/integration debugging, and discrepancy hunts</strong>.</li>
+                <li>Deep diagnostics in <strong>SSO/SAML, OAuth, SCIM, access and provisioning flows</strong>.</li>
+                <li>Built QA automation with <strong>Cypress, JavaScript, and CI/CD pipelines</strong>.</li>
+                <li>Built custom tools including <strong>an OpenAI-powered audio analyzer and an outage monitoring dashboard</strong>.</li>
+                <li>Comfortable translating between non-technical stakeholders and technical teams without the usual chaos.</li>
+            </ul>
+        </section>
+
+        <section class="crt-block wws-section" aria-labelledby="good-fit">
+            <h2 id="good-fit" class="pixel-font">Good fit if...</h2>
+            <ul class="wws-fit-list">
+                <li>You have a weird system issue, a deadline, and no time for blame ping-pong.</li>
+                <li>Your small team needs one person who can debug across product, support, QA, and infrastructure.</li>
+                <li>You are a founder, creative, or operator who wants practical AI help without the hype circus.</li>
+                <li>You need a reliable second brain for messy technical work that keeps stalling out.</li>
+            </ul>
+        </section>
+
+        <section class="crt-block wws-section" aria-labelledby="ways-to-work">
+            <h2 id="ways-to-work" class="pixel-font">Ways we can work together</h2>
+            <div class="wws-work-modes">
+                <div class="wws-mode"><strong>One-off troubleshooting session</strong><span>Fast triage and a plan you can execute immediately.</span></div>
+                <div class="wws-mode"><strong>Short technical audit</strong><span>Targeted review of a system, workflow, or recurring issue cluster.</span></div>
+                <div class="wws-mode"><strong>Implementation sprint</strong><span>Focused build/fix window to ship improvements quickly.</span></div>
+                <div class="wws-mode"><strong>Fractional technical support</strong><span>Ongoing help for teams that need steady hands, not full-time overhead.</span></div>
+                <div class="wws-mode"><strong>Build / fix / unblock advisory</strong><span>Practical guidance while your team executes.</span></div>
+            </div>
+        </section>
+
+        <section class="crt-block wws-final-cta" aria-labelledby="work-with-suzy-contact">
+            <h2 id="work-with-suzy-contact" class="pixel-font">Let&apos;s make the broken thing behave.</h2>
+            <p>Email me at <a href="mailto:suzyeaston@icloud.com?subject=Work%20With%20Suzy%20%E2%80%94%20%5Bproject%5D">suzyeaston@icloud.com</a> and include a short summary of what you are trying to solve.</p>
+            <p class="wws-subjects"><strong>Suggested subject lines:</strong> Work With Suzy — [project] • Need Help With a Weird Bug • AI / Automation Help</p>
+            <a class="pixel-button wws-final-button" href="mailto:suzyeaston@icloud.com?subject=Need%20Help%20With%20a%20Weird%20Bug">Send the email</a>
+        </section>
+
+        <section class="wws-boundaries" aria-label="Small print">
+            <p><strong>Small print:</strong> I&apos;m into thoughtful projects, honest teams, and practical outcomes. I am not available for crypto-casino nonsense, vague exposure deals, or shady growth spam.</p>
+        </section>
+    </article>
+</main>
+
+<?php get_footer(); ?>

--- a/style.css
+++ b/style.css
@@ -3568,3 +3568,140 @@ body.page-template-page-bio-php .bio-content {
 .asmr-lab-page .asmr-lab-form {
   gap: 1rem;
 }
+
+/* Work With Suzy page */
+.page-template-page-work-with-suzy .work-with-suzy-content {
+    max-width: 980px;
+    display: grid;
+    gap: 24px;
+}
+
+.page-template-page-work-with-suzy .wws-kicker {
+    margin: 0 0 10px;
+    color: rgba(57, 255, 20, 0.88);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-size: 0.78rem;
+}
+
+.page-template-page-work-with-suzy .wws-hero,
+.page-template-page-work-with-suzy .wws-section,
+.page-template-page-work-with-suzy .wws-final-cta {
+    position: relative;
+    border: 2px solid rgba(57, 255, 20, 0.52);
+    border-radius: 16px;
+    background: linear-gradient(155deg, rgba(6, 10, 6, 0.95), rgba(4, 18, 13, 0.9));
+    box-shadow: inset 0 0 28px rgba(57, 255, 20, 0.08), 0 0 24px rgba(57, 255, 20, 0.2);
+    padding: clamp(20px, 3.8vw, 34px);
+}
+
+.page-template-page-work-with-suzy .wws-hero .retro-title {
+    margin-bottom: 14px;
+    font-size: clamp(2rem, 6vw, 3.25rem);
+}
+
+.page-template-page-work-with-suzy .wws-lead,
+.page-template-page-work-with-suzy .wws-section p,
+.page-template-page-work-with-suzy .wws-section li,
+.page-template-page-work-with-suzy .wws-final-cta p,
+.page-template-page-work-with-suzy .wws-boundaries p {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    line-height: 1.75;
+    color: var(--primary-color);
+}
+
+.page-template-page-work-with-suzy .wws-hero-cta,
+.page-template-page-work-with-suzy .wws-final-button {
+    margin-top: 18px;
+    display: inline-block;
+}
+
+.page-template-page-work-with-suzy .wws-grid {
+    margin-top: 14px;
+    display: grid;
+    gap: 14px;
+    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+}
+
+.page-template-page-work-with-suzy .wws-card {
+    border: 1px solid rgba(57, 255, 20, 0.4);
+    border-radius: 12px;
+    background: rgba(5, 14, 9, 0.72);
+    padding: 16px;
+}
+
+.page-template-page-work-with-suzy .wws-card h3 {
+    margin: 0 0 10px;
+    font-size: 1.02rem;
+    color: #b9ff8a;
+}
+
+.page-template-page-work-with-suzy .wws-card p {
+    margin: 0;
+}
+
+.page-template-page-work-with-suzy .wws-proof-list,
+.page-template-page-work-with-suzy .wws-fit-list {
+    margin: 14px 0 0;
+    padding-left: 20px;
+    display: grid;
+    gap: 10px;
+}
+
+.page-template-page-work-with-suzy .wws-work-modes {
+    margin-top: 14px;
+    display: grid;
+    gap: 10px;
+}
+
+.page-template-page-work-with-suzy .wws-mode {
+    border-left: 3px solid rgba(57, 255, 20, 0.62);
+    padding: 10px 12px;
+    background: rgba(8, 16, 9, 0.6);
+}
+
+.page-template-page-work-with-suzy .wws-mode strong {
+    display: block;
+    margin-bottom: 4px;
+    color: #d5ffb6;
+}
+
+.page-template-page-work-with-suzy .wws-mode span {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    color: rgba(223, 255, 211, 0.88);
+    font-size: 0.98rem;
+}
+
+.page-template-page-work-with-suzy .wws-final-cta {
+    border-color: rgba(255, 80, 214, 0.52);
+    box-shadow: inset 0 0 30px rgba(255, 80, 214, 0.1), 0 0 24px rgba(255, 80, 214, 0.2);
+}
+
+.page-template-page-work-with-suzy .wws-subjects {
+    margin-top: 10px;
+    color: #ffd7f6;
+}
+
+.page-template-page-work-with-suzy .wws-boundaries {
+    border: 1px dashed rgba(57, 255, 20, 0.45);
+    border-radius: 12px;
+    padding: 14px 16px;
+    background: rgba(2, 8, 3, 0.65);
+}
+
+@media (max-width: 700px) {
+    .page-template-page-work-with-suzy .work-with-suzy-content {
+        gap: 18px;
+    }
+
+    .page-template-page-work-with-suzy .wws-proof-list,
+    .page-template-page-work-with-suzy .wws-fit-list {
+        padding-left: 18px;
+    }
+
+    .page-template-page-work-with-suzy .wws-hero-cta,
+    .page-template-page-work-with-suzy .wws-final-button {
+        width: 100%;
+        text-align: center;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a polished, on-brand “Work with me” page that attracts side-income inquiries without feeling like a resume or corporate consulting pitch. 
- Make it clear what Suzy can help with (technical troubleshooting, QA, automation, AI-assisted builds, WordPress tweaks, advisory) while preserving the site’s retro-arcade / CRT / neon-pixel aesthetic.

### Description
- Added a new WordPress page template `page-work-with-suzy.php` (contains `Template Name: Work With Suzy`) with structured sections: hero, “What I can help with” service cards, compact proof-of-life, “Good fit if…”, engagement formats, strong email CTA with prefilled subjects, and short boundaries text. 
- Added scoped CSS rules in `style.css` under the `.page-template-page-work-with-suzy` selector to implement CRT/neon card styling, responsive grids, pixel buttons, and mobile-friendly CTA behavior without affecting other pages. 
- Added a tasteful homepage CTA link to `/work-with-suzy/` in the existing “About & Info” button cluster in `page-home.php`. 
- Changes were kept limited to the new template, the scoped styles, and the single homepage link and reuse existing classes/patterns like `.crt-block`, `.pixel-button`, `.retro-title`, and `.page-content`.

### Testing
- Ran `php -l page-work-with-suzy.php` and `php -l page-home.php`, and both returned "No syntax errors detected" (success). 
- Attempted an automated page render / screenshot (Playwright / `curl`) but it failed due to no local web server at `127.0.0.1:8080` in this environment, so visual verification was not possible here (environment-limited failure). 
- Verified the generated diff and inspected the new scoped CSS selectors and `mailto:` links to ensure they match the requested structure and constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b831a0b670832ea8d095c18d7e0c9d)