### PR TITLE
Refactor homepage positioning to improve project & hiring conversion

### DIFF
--- a/header.php
+++ b/header.php
@@ -21,9 +21,9 @@
     $meta_keywords = 'Suzy Easton, musician, creative technologist';
 
     if ( is_front_page() ) {
-      $meta_title = 'Suzy Easton – Vancouver Musician & Creative Technologist';
-      $meta_desc  = 'Suzanne (Suzy) Easton shares indie music spotlights, outage stories, retro-inspired tools, and Vancouver-based creative tech experiments.';
-      $meta_keywords = 'Suzy Easton, Suzanne Easton, Vancouver musician, creative technologist, Lousy Outages, indie music, retro arcade website, outage analysis';
+      $meta_title = 'Suzy Easton | Vancouver Creative Technologist, Musician, QA & AI Prototyping Support';
+      $meta_desc  = 'Suzy Easton is a Vancouver musician and creative technologist building AI experiments, music tools, and public prototypes. Available for select technical consulting, QA automation, debugging, and WordPress support.';
+      $meta_keywords = 'Suzy Easton, Vancouver creative technologist, Vancouver technical consultant, QA automation, AI prototyping, WordPress developer, debugging support';
       $meta_img   = $default_img;
     } elseif ( is_page_template( 'page-asmr-lab.php' ) ) {
       $meta_title = 'ASMR Lab – experimental predecessor now under major redevelopment';
@@ -61,6 +61,32 @@
     } else {
       $meta_url = home_url( add_query_arg( [], $wp->request ) );
     }
+    $home_profile_graph = [];
+    if ( is_front_page() ) {
+      $home_profile_graph[] = [
+        '@type' => 'ProfilePage',
+        'name' => 'Suzy Easton',
+        'url' => home_url( '/' ),
+        'description' => $meta_desc,
+        'mainEntity' => [
+          '@type' => 'Person',
+          'name' => 'Suzy Easton',
+          'jobTitle' => 'Musician, Creative Technologist, and Technical Consultant',
+          'address' => [
+            '@type' => 'PostalAddress',
+            'addressLocality' => 'Vancouver',
+            'addressCountry' => 'CA',
+          ],
+          'sameAs' => [
+            'https://suzyeaston.bandcamp.com',
+            'https://soundcloud.com/suzyeaston',
+            'https://instagram.com/suzyeaston',
+            'https://youtube.com/@suzyeaston',
+          ],
+        ],
+      ];
+    }
+
     $structured_data = [
       '@context' => 'https://schema.org',
       '@graph'   => [
@@ -95,6 +121,10 @@
         ],
       ],
     ];
+
+    if ( ! empty( $home_profile_graph ) ) {
+      $structured_data['@graph'] = array_merge( $structured_data['@graph'], $home_profile_graph );
+    }
   ?>
   <title><?php echo esc_html( $meta_title ); ?></title>
   <meta name="description" content="<?php echo esc_attr( $meta_desc ); ?>">

--- a/page-home.php
+++ b/page-home.php
@@ -7,7 +7,7 @@ get_header();
     <div class="hero hero-section">
         <div class="hero-grid">
             <?php
-            $hero_eyebrow = apply_filters('se_home_hero_eyebrow', '');
+            $hero_eyebrow = apply_filters('se_home_hero_eyebrow', 'Vancouver, BC • Built in public');
             $hero_logo_label = apply_filters('se_home_hero_title', 'Suzanne (Suzy) Easton');
             $hero_logo_top = apply_filters('se_home_hero_logo_top', 'Suzanne');
             $hero_logo_mid = apply_filters('se_home_hero_logo_mid', '(Suzy)');
@@ -15,7 +15,7 @@ get_header();
             $hero_logo_top_text = function_exists('mb_strtoupper') ? mb_strtoupper($hero_logo_top, 'UTF-8') : strtoupper($hero_logo_top);
             $hero_logo_mid_text = function_exists('mb_strtoupper') ? mb_strtoupper($hero_logo_mid, 'UTF-8') : strtoupper($hero_logo_mid);
             $hero_logo_bottom_text = function_exists('mb_strtoupper') ? mb_strtoupper($hero_logo_bottom, 'UTF-8') : strtoupper($hero_logo_bottom);
-            $hero_copy    = apply_filters('se_home_hero_copy', 'Music and tech experiments from Vancouver, BC.');
+            $hero_copy = apply_filters('se_home_hero_copy', 'Musician, creative technologist, and builder of strange useful things.');
             ?>
             <div class="hero-main">
                 <?php if (!empty($hero_eyebrow)) : ?>
@@ -54,183 +54,95 @@ get_header();
                 </p>
             </div>
         </div>
-        <h2 class="retro-title glow-lite">Musician &amp; Creative Technologist</h2>
-        <section class="pixel-intro hero-intro">
-            <p class="hero-headline pixel-font">Hi, I’m Suzy Easton — musician and creative technologist.</p>
-            <p class="hero-subhead">Born in Vancouver, BC and a generalist by nature, I build things, play guitars, and live by one motto: always be creating. My background spans classical music training, plus five years behind the counter at HMV talking records and discovering new sounds.</p>
-            <p class="hero-microproof">I’ve toured across Canada as a bassist, appeared on MuchMusic, and recorded in Chicago with Steve Albini. These days, I’m building apps, exploring AI models, experimenting with short AI films through BC + AI Film Club, and writing whatever songs show up next.</p>
+
+        <section class="pixel-intro hero-intro" aria-labelledby="home-positioning-title">
+            <h2 id="home-positioning-title" class="retro-title glow-lite">Musician, creative technologist, and practical AI builder</h2>
+            <p class="hero-headline pixel-font">I make AI experiments, public prototypes, music tools, and messy systems behave.</p>
+            <p class="hero-subhead">I am a Vancouver-born generalist: bassist, songwriter, debugger, QA-minded fixer, and person you call when your workflow is chaos and you still need to ship.</p>
             <div class="hero-cta-group">
-                <a href="/page-gastown-sim/" class="pixel-button hero-primary-cta">Start with: Gastown Simulator</a>
-                <a href="/suzys-track-analyzer/" class="pixel-button hero-secondary-cta">Try: Track Analyzer</a>
-                <a href="/lousy-outages/" class="pixel-button hero-secondary-cta">Or explore: Lousy Outages</a>
-                <a href="/bio/" class="pixel-button hero-bio-button">Read full bio</a>
+                <a href="<?php echo esc_url(home_url('/page-gastown-sim/')); ?>" class="pixel-button hero-primary-cta">Start with Gastown Simulator</a>
+                <a href="<?php echo esc_url(home_url('/work-with-suzy/')); ?>" class="pixel-button hero-secondary-cta">Work With Suzy</a>
+                <a href="<?php echo esc_url(home_url('/bio/')); ?>" class="pixel-button hero-bio-button">Read full bio</a>
             </div>
         </section>
 
         <p class="arcade-subtext">Insert coin to explore</p>
-
-        <section class="gastown-sim-teaser crt-block" aria-labelledby="gastown-sim-teaser-title">
-            <p class="gastown-sim-teaser__eyebrow pixel-font"><span class="gastown-sim-teaser__badge">Flagship</span> Live build in public. Shipping weird little upgrades constantly.</p>
-            <h2 id="gastown-sim-teaser-title" class="pixel-font">Gastown First-Person Simulator</h2>
-            <p class="gastown-sim-teaser__description">A first-person Vancouver prototype evolving in public. Drop in near Waterfront Station, walk Water Street, and chase the Steam Clock through sound, weather, and constant iteration.</p>
-            <p class="gastown-sim-teaser__microcopy">Getting tuned up often, sometimes daily. If the world looks haunted, hard refresh or hop into a private window and dive back in.</p>
-            <a href="<?php echo esc_url(home_url('/page-gastown-sim/')); ?>" class="pixel-button gastown-sim-teaser__cta">Enter Gastown</a>
-        </section>
-        <div class="puck-icon" role="img" aria-label="retro hockey puck icon">🏒</div>
-        <?php
-        $visitor_data = include get_template_directory() . '/visitor-tracker.php';
-        ?>
-        <div class="visitor-counter">
-          <?php
-            $total = isset($visitor_data['count']) ? (int) $visitor_data['count'] : 0;
-            $total = max(0, $total);
-            $globalPhrases = [
-                '👁️ %d drop-in(s) so far.',
-                '⚡ %d pixel ping(s) logged.',
-                '🎸 %d riff request(s) processed.',
-                '🚀 %d prompt(s) launched.',
-                '🔥 %d spark(s) on the dashboard.'
-            ];
-            $phrase = $globalPhrases[array_rand($globalPhrases)];
-          ?>
-          <p><?php printf(esc_html($phrase), $total); ?></p>
-        </div>
-
-
-
-        <div class="button-cluster">
-            <!-- Put the human stuff first. -->
-            <div class="button-group">
-                <h3 class="group-title">📚 About &amp; Info</h3>
-                <div class="group-buttons">
-                    <a href="/bio" class="pixel-button">About Suzy</a>
-                    <a href="/work-with-suzy/" class="pixel-button">Work With Suzy</a>
-                    <a href="https://buymeacoffee.com/wi0amge" class="pixel-button" target="_blank" rel="noopener noreferrer">Support</a>
-                </div>
-            </div>
-
-            <div class="button-group">
-                <h3 class="group-title">🎵 Music &amp; Podcasts</h3>
-                <div class="group-buttons">
-                    <a href="https://suzyeaston.bandcamp.com" class="pixel-button" target="_blank">Bandcamp</a>
-                    <a href="/podcast" class="pixel-button">Podcast: Easy Living</a>
-                </div>
-            </div>
-
-            <div class="button-group">
-                <h3 class="group-title">🎮 Games &amp; Tools</h3>
-                <div class="group-buttons">
-                    <a href="/asmr-lab/" class="pixel-button">ASMR Lab</a>
-                    <a href="/suzys-track-analyzer/" class="pixel-button">Track Analyzer</a>
-                    <a href="/riff-generator" class="pixel-button">Riff Generator</a>
-                    <a href="/arcade" class="pixel-button">Canucks Game</a>
-                    <a href="/canucks-stats" class="pixel-button">Canucks Stats</a>
-                    <a href="/albini-qa" class="pixel-button">Albini Q&amp;A</a>
-                </div>
-            </div>
-
-        </div>
-
     </div>
 
-    <section class="ai-film-feature crt-block">
-        <div class="ai-film-feature__video">
-            <div class="ai-film-feature__embed-wrap">
-                <iframe
-                    src="<?php echo esc_url('https://www.youtube-nocookie.com/embed/FrjuKGj91Pw'); ?>"
-                    title="<?php echo esc_attr('AI Film Club: Rain City Roll Reserve'); ?>"
-                    loading="lazy"
-                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                    referrerpolicy="strict-origin-when-cross-origin"
-                    allowfullscreen>
-                </iframe>
-            </div>
+    <section class="selected-work crt-block" aria-labelledby="selected-work-title">
+        <h2 id="selected-work-title" class="pixel-font">What I build / selected work</h2>
+        <p class="selected-work__intro">A few projects that show how I blend creative internet energy with useful technical execution.</p>
+        <div class="selected-work__grid">
+            <article class="selected-work__card">
+                <h3 class="pixel-font">Gastown Simulator</h3>
+                <p>Flagship first-person Vancouver prototype: live worldbuilding, rapid iteration, and weird atmospheric details.</p>
+                <a class="pixel-button" href="<?php echo esc_url(home_url('/page-gastown-sim/')); ?>">Enter Gastown</a>
+            </article>
+            <article class="selected-work__card">
+                <h3 class="pixel-font">Track Analyzer</h3>
+                <p>Upload an MP3 and get practical AI mix feedback fast. Built for musicians who want signal, not fluff.</p>
+                <a class="pixel-button" href="<?php echo esc_url(home_url('/suzys-track-analyzer/')); ?>">Analyze a Track</a>
+            </article>
+            <article class="selected-work__card">
+                <h3 class="pixel-font">Lousy Outages</h3>
+                <p>Retro terminal-style outage tracking with alerting, incident clarity, and public utility for modern service chaos.</p>
+                <a class="pixel-button" href="<?php echo esc_url(home_url('/lousy-outages/')); ?>">View Outages</a>
+            </article>
+            <article class="selected-work__card">
+                <h3 class="pixel-font">AI Film Club shorts</h3>
+                <p>Short-form AI films made for BC + AI Film Club prompt challenges: weird, cinematic, and production-minded.</p>
+                <a class="pixel-button" href="https://www.youtube.com/watch?v=FrjuKGj91Pw" target="_blank" rel="noopener noreferrer">Watch the short</a>
+            </article>
         </div>
-        <div class="ai-film-feature__copy">
-            <h2 class="pixel-font">AI Film Club: Rain City Roll Reserve</h2>
-            <p class="pixel-font ai-film-feature__kicker">BC + AI Film Club Prompt Challenge. Tiny Ghost Studios</p>
-            <p>My first AI short got screened in a room full of filmmakers. It is a 19 second retro future Vancouver toilet paper ad. More experiments incoming.</p>
-            <p class="ai-film-feature__credit">
-                Built for
-                <a href="<?php echo esc_url('https://vancouver.bc-ai.net/ai-film-club-launch'); ?>" target="_blank" rel="noopener noreferrer">BC + AI Film Club Prompt Challenge. Tiny Ghost Studios</a>
-            </p>
-            <div class="ai-film-feature__actions">
-                <a href="<?php echo esc_url('https://www.youtube.com/watch?v=FrjuKGj91Pw'); ?>" target="_blank" rel="noopener noreferrer" class="pixel-button">Watch on YouTube</a>
-                <a href="<?php echo esc_url(home_url('/suzys-track-analyzer/')); ?>" class="pixel-button">More AI Builds</a>
-            </div>
-        </div>
     </section>
 
-    <section class="asmr-lab-teaser crt-block" aria-labelledby="asmr-lab-teaser-title">
-        <p class="asmr-lab-teaser__eyebrow pixel-font">Earlier Prototype • Rebuild Mode</p>
-        <h2 id="asmr-lab-teaser-title" class="pixel-font">ASMR Lab (Under Major Redevelopment)</h2>
-        <p class="asmr-lab-teaser__description">The earlier audio/visual experiment that got weird enough to inspire Gastown. The legacy console is still playable while the next-gen rebuild happens in public.</p>
-        <a href="<?php echo esc_url(home_url('/asmr-lab/')); ?>" class="pixel-button asmr-lab-teaser__cta">Enter ASMR Lab</a>
-    </section>
-
-
-    <section class="track-analyzer-feature">
-        <h2 class="pixel-font">Track Analyzer</h2>
-        <p class="pixel-font">Upload an MP3 and get instant feedback on your mix.</p>
-        <a href="/suzys-track-analyzer/" class="pixel-button analyzer-cta">Analyze Your Track</a>
-    </section>
-
-    <section class="creative-tool-links crt-block" aria-labelledby="creative-tool-links-title">
-        <h2 id="creative-tool-links-title" class="pixel-font">Creative Tool Deck</h2>
-        <p>Prefer crawl-first browsing? Jump straight to the public tool pages:</p>
-        <p>Everything here is open source, built in public, and updated often — if a new deploy looks cursed, hard refresh, clear cache, or jump into incognito and roll again.</p>
-        <ul>
-            <li><a href="<?php echo esc_url(home_url('/page-gastown-sim/')); ?>">Gastown First-Person Simulator</a> — first-person Vancouver prototype, currently in active daily-ish mutation mode.</li>
-            <li><a href="<?php echo esc_url(home_url('/asmr-lab/')); ?>">ASMR Lab</a> — earlier audio/visual prototype, now under major redevelopment after inspiring the Gastown sim.</li>
-            <li><a href="<?php echo esc_url(home_url('/suzys-track-analyzer/')); ?>">Track Analyzer</a> — upload a mix and get fast AI feedback.</li>
-            <li><a href="<?php echo esc_url(home_url('/riff-generator/')); ?>">Riff Generator</a> — generate guitar ideas in a retro experiment shell.</li>
-            <li><a href="<?php echo esc_url(home_url('/lousy-outages/')); ?>">Lousy Outages</a> — outage tracker with a throwback command-line vibe.</li>
+    <section class="work-with-suzy-home crt-block" aria-labelledby="work-with-suzy-title">
+        <p class="work-with-suzy-home__eyebrow pixel-font">Available for select freelance, contract, and advisory work</p>
+        <h2 id="work-with-suzy-title" class="pixel-font">Work With Suzy</h2>
+        <p>If you need a technical consultant in Vancouver who can bridge creative ideas and shipping code, I am open to the right kind of project.</p>
+        <ul class="work-with-suzy-home__list">
+            <li>Debugging stubborn bugs and untangling messy systems</li>
+            <li>QA strategy, test automation, and release confidence checks</li>
+            <li>Workflow cleanup and automation for small teams</li>
+            <li>AI-assisted prototypes and experiments that are actually usable</li>
+            <li>WordPress and custom site improvements without killing your vibe</li>
+            <li>Technical translation between non-technical stakeholders and builders</li>
         </ul>
-        <p>Build logs + code live at <a href="https://github.com/suzyeaston/suzyeastonca" target="_blank" rel="noopener noreferrer">github.com/suzyeaston/suzyeastonca</a>. Pull requests, bug reports, and kind chaos are welcome.</p>
+        <div class="work-with-suzy-home__actions">
+            <a href="<?php echo esc_url(home_url('/work-with-suzy/')); ?>" class="pixel-button">See project fit + process</a>
+            <a href="mailto:suzyeaston@icloud.com?subject=Work%20With%20Suzy%20%E2%80%94%20%5Bproject%5D" class="pixel-button">Email Suzy</a>
+        </div>
     </section>
 
-    <section class="party-announcement crt-block">
-        <h2>Grunge &amp; Rock Video Party (Instagram)</h2>
-        <p>We’re cueing up a feed of loud guitars, grainy VHS vibes, and deep cuts.
-           Follow <a href="https://instagram.com/officialsuzyeaston" target="_blank">@officialsuzyeaston</a>
-           for the kickoff date &amp; set list. Requests welcome. Bring flannel.</p>
+    <section class="music-world crt-block" aria-labelledby="music-world-title">
+        <h2 id="music-world-title" class="pixel-font">Music / media / world</h2>
+        <p>This is the creative universe behind the builds: songs, podcast chats, film experiments, and social dispatches.</p>
+        <div class="music-world__links">
+            <a href="https://suzyeaston.bandcamp.com" class="pixel-button" target="_blank" rel="noopener noreferrer">Bandcamp</a>
+            <a href="<?php echo esc_url(home_url('/podcast/')); ?>" class="pixel-button">Easy Living podcast</a>
+            <a href="https://instagram.com/officialsuzyeaston" class="pixel-button" target="_blank" rel="noopener noreferrer">Instagram</a>
+            <a href="https://www.youtube.com/@suzyeaston" class="pixel-button" target="_blank" rel="noopener noreferrer">YouTube</a>
+        </div>
     </section>
 
-
-    
+    <?php
+    $visitor_data = include get_template_directory() . '/visitor-tracker.php';
+    $total = isset($visitor_data['count']) ? (int) $visitor_data['count'] : 0;
+    $total = max(0, $total);
+    ?>
+    <section class="utility-nav-home crt-block" aria-labelledby="utility-nav-title">
+        <h2 id="utility-nav-title" class="pixel-font">Quick links</h2>
+        <p class="utility-nav-home__counter"><?php echo esc_html(sprintf('👁️ %d drop-in(s) logged so far.', $total)); ?></p>
+        <div class="utility-nav-home__links">
+            <a href="<?php echo esc_url(home_url('/bio/')); ?>">Bio</a>
+            <a href="<?php echo esc_url(home_url('/work-with-suzy/')); ?>">Work With Suzy</a>
+            <a href="<?php echo esc_url(home_url('/asmr-lab/')); ?>">ASMR Lab</a>
+            <a href="<?php echo esc_url(home_url('/riff-generator/')); ?>">Riff Generator</a>
+            <a href="<?php echo esc_url(home_url('/coffee-for-builders/')); ?>">Coffee for Builders</a>
+            <a href="https://github.com/suzyeaston/suzyeastonca" target="_blank" rel="noopener noreferrer">Build logs on GitHub</a>
+            <a href="https://buymeacoffee.com/wi0amge" target="_blank" rel="noopener noreferrer">Buy me a coffee</a>
+        </div>
+    </section>
 </main>
-
-    <script>
-      (function () {
-        var ticker = document.querySelector('[data-influence-rotator]');
-        if (!ticker) {
-          return;
-        }
-        var influences;
-        try {
-          influences = JSON.parse(ticker.getAttribute('data-influences') || '[]');
-        } catch (err) {
-          influences = [];
-        }
-        if (!Array.isArray(influences) || influences.length === 0) {
-          return;
-        }
-        var index = 0;
-        var mq = typeof window.matchMedia === 'function' ? window.matchMedia('(prefers-reduced-motion: reduce)') : null;
-        var update = function () {
-          ticker.classList.remove('influence-swap');
-          void ticker.offsetWidth;
-          ticker.textContent = influences[index];
-          ticker.classList.add('influence-swap');
-          index = (index + 1) % influences.length;
-        };
-        if (!mq || !mq.matches) {
-          update();
-          window.setInterval(update, 7000);
-        } else {
-          ticker.textContent = influences[0];
-        }
-      }());
-    </script>
 
 <?php get_footer(); ?>

--- a/style.css
+++ b/style.css
@@ -3705,3 +3705,134 @@ body.page-template-page-bio-php .bio-content {
         text-align: center;
     }
 }
+
+/* Homepage repositioning blocks */
+.selected-work,
+.work-with-suzy-home,
+.music-world,
+.utility-nav-home {
+  margin: 34px auto;
+  max-width: 960px;
+  padding: 24px 28px;
+  border-radius: 12px;
+}
+
+.selected-work h2,
+.work-with-suzy-home h2,
+.music-world h2,
+.utility-nav-home h2 {
+  margin: 0 0 0.85rem;
+  color: #b6ffd7;
+}
+
+.selected-work__intro,
+.work-with-suzy-home p,
+.music-world p,
+.utility-nav-home p {
+  margin-top: 0;
+  color: #e8ffee;
+  line-height: 1.65;
+}
+
+.selected-work__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 14px;
+  margin-top: 1rem;
+}
+
+.selected-work__card {
+  border: 1px solid rgba(0, 255, 170, 0.28);
+  border-radius: 10px;
+  padding: 14px;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.selected-work__card h3 {
+  margin: 0;
+  color: #9bffc6;
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.selected-work__card p {
+  margin: 0;
+  color: #def9eb;
+  line-height: 1.55;
+  flex: 1;
+}
+
+.work-with-suzy-home {
+  border: 2px solid rgba(0, 255, 170, 0.4);
+  box-shadow: 0 0 20px rgba(0, 255, 170, 0.18);
+}
+
+.work-with-suzy-home__eyebrow {
+  margin: 0 0 0.6rem;
+  color: var(--secondary-color);
+  font-size: 0.7rem;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.work-with-suzy-home__list {
+  margin: 1rem 0;
+  padding-left: 1.2rem;
+  color: #e8ffee;
+}
+
+.work-with-suzy-home__list li {
+  margin-bottom: 0.5rem;
+  line-height: 1.5;
+}
+
+.work-with-suzy-home__actions,
+.music-world__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 1rem;
+}
+
+.utility-nav-home__counter {
+  color: #9bffc6;
+  margin-bottom: 0.8rem;
+}
+
+.utility-nav-home__links {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 8px 12px;
+}
+
+.utility-nav-home__links a {
+  color: var(--secondary-color);
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.utility-nav-home__links a:hover,
+.utility-nav-home__links a:focus {
+  text-decoration: underline;
+}
+
+@media (max-width: 760px) {
+  .selected-work,
+  .work-with-suzy-home,
+  .music-world,
+  .utility-nav-home {
+    margin: 24px auto;
+    padding: 18px;
+  }
+
+  .selected-work__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-section .hero-cta-group {
+    gap: 0.6rem;
+  }
+}


### PR DESCRIPTION
### Motivation
- Make the homepage a clearer front door that quickly communicates who Suzy is and drives visitors to flagship projects and hiring intents. 
- Reduce duplicated project listings and long hero copy so CTAs (flagship project + “Work With Suzy”) are immediately visible. 
- Keep the site’s retro, public-build personality while making the page useful for hiring/consulting discovery and SEO.

### Description
- Reworked `page-home.php` to a clearer hierarchy: tightened hero copy and CTAs, a curated “What I build / selected work” card grid (Gastown Simulator, Track Analyzer, Lousy Outages, AI Film Club), a prominent “Work With Suzy” conversion block with concrete service bullets and CTAs, a separate music/media section, and a compact utility link area. 
- Added scoped homepage styles to `style.css` for the new blocks, cards, responsive grid behavior, and mobile spacing. 
- Updated `header.php` SEO treatment for the front page: stronger `title`, `meta description`, refined `keywords`, and added a `ProfilePage` entry merged into the existing structured data graph to better describe Suzy as a person/creator/technologist. 
- Preserved existing visual language and accessibility cues (ARIA/semantic headings) and avoided adding new dependencies or heavy JS.

### Testing
- Ran syntax checks: `php -l page-home.php` succeeded and `php -l header.php` succeeded. 
- Verified local file changes and CSS additions load without PHP syntax errors. 
- Attempted to spin up a local server and capture a screenshot via Playwright, but navigation to the local server returned `net::ERR_EMPTY_RESPONSE` in this environment so no screenshot artifact was produced. 
- No other automated tests were changed; existing unit tests in the repo were not modified by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8361556fc832ea2bc9feeab26f30a)