### PR TITLE
Fix Gastown dialog modal interactions and add dialog action support

### DIFF
--- a/__tests__/gastown-dialog.test.js
+++ b/__tests__/gastown-dialog.test.js
@@ -1,0 +1,65 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const { normalizeDialogEntry } = require('../js/gastown-dialog.js');
+
+test('dialog entries without actions still normalize to readable fallback content', () => {
+  const entry = normalizeDialogEntry({
+    title: 'Street busker',
+    lines: ['Local looped audio lives here.'],
+  }, {
+    fallbackTitle: 'Gastown guide',
+    defaultCloseLabel: 'Back to walk',
+  });
+
+  assert.equal(entry.title, 'Street busker');
+  assert.deepEqual(entry.lines, ['Local looped audio lives here.']);
+  assert.equal(entry.actions.length, 0);
+  assert.equal(entry.hasCustomActions, false);
+});
+
+test('dialog actions are normalized and only safe same-origin relative links survive', () => {
+  const entry = normalizeDialogEntry({
+    title: 'Gastown guide',
+    lines: ['Choose your next stop.'],
+    actions: [
+      { type: 'close', label: 'Back to walk' },
+      { type: 'link', label: 'Visit Waterfront', href: '/gastown-simulator/' },
+      { type: 'link', label: 'External', href: 'https://example.com/outside' },
+      { type: 'link', label: 'Proto-relative', href: '//evil.example.com' },
+    ],
+  }, {});
+
+  assert.deepEqual(entry.actions, [
+    { type: 'close', label: 'Back to walk' },
+    { type: 'link', label: 'Visit Waterfront', href: '/gastown-simulator/' },
+  ]);
+  assert.equal(entry.hasCustomActions, true);
+});
+
+test('invalid external hrefs are rejected and missing entries get a visible fallback line', () => {
+  const entry = normalizeDialogEntry(null, {
+    fallbackTitle: 'Pedestrian',
+    unavailableLine: 'Dialog data unavailable.',
+  });
+
+  assert.equal(entry.title, 'Pedestrian');
+  assert.deepEqual(entry.lines, ['Dialog data unavailable.']);
+  assert.deepEqual(entry.actions, []);
+});
+
+test('openDialogForNpc source exits pointer lock before scheduling the modal UI', () => {
+  const simPath = path.join(__dirname, '..', 'js', 'gastown-sim.js');
+  const src = fs.readFileSync(simPath, 'utf8');
+  const branchNeedle = "if (document.pointerLockElement === renderer.domElement) {";
+  const branchStart = src.indexOf(branchNeedle);
+  const branchEnd = src.indexOf('return;', branchStart);
+  const branch = src.slice(branchStart, branchEnd);
+
+  assert.notEqual(branchStart, -1, 'expected pointer lock branch');
+  assert.ok(branch.includes('document.exitPointerLock();'));
+  assert.ok(branch.includes('window.setTimeout(showDialog, 0);'));
+  assert.ok(branch.indexOf('document.exitPointerLock();') < branch.indexOf('window.setTimeout(showDialog, 0);'));
+});

--- a/assets/css/gastown-sim.css
+++ b/assets/css/gastown-sim.css
@@ -307,3 +307,20 @@
   margin-top: 1rem;
   justify-content: flex-end;
 }
+
+
+.gastown-dialog-actions-dynamic {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.gastown-dialog-actions .pixel-button {
+  text-decoration: none;
+}
+
+.gastown-dialog-actions .pixel-button:focus-visible,
+.gastown-sim-canvas:focus-visible {
+  outline: 2px solid rgba(155, 212, 255, 0.92);
+  outline-offset: 2px;
+}

--- a/assets/dialog/gastown.json
+++ b/assets/dialog/gastown.json
@@ -4,6 +4,9 @@
     "lines": [
       "Welcome to the starter Gastown corridor build. This guide marks where interaction, dialog, and future quest hooks plug into the walk.",
       "World authors can assign a dialogId on any guide, pedestrian, or busker entry and the simulator will open the matching local dialog record."
+    ],
+    "actions": [
+      { "type": "close", "label": "Back to walk" }
     ]
   },
   "busker_intro": {

--- a/functions.php
+++ b/functions.php
@@ -232,12 +232,23 @@ function se_enqueue_gastown_sim_assets() {
         );
     }
 
+    $dialog_path = '/js/gastown-dialog.js';
+    if ( file_exists( $dir . $dialog_path ) ) {
+        wp_enqueue_script(
+            'se-gastown-dialog',
+            $uri . $dialog_path,
+            array(),
+            filemtime( $dir . $dialog_path ),
+            true
+        );
+    }
+
     $app_path = '/js/gastown-sim.js';
     if ( file_exists( $dir . $app_path ) ) {
         wp_enqueue_script(
             'se-gastown-sim',
             $uri . $app_path,
-            array( 'three-js', 'howler-js', 'se-gastown-world-loader', 'se-gastown-building-normalizer' ),
+            array( 'three-js', 'howler-js', 'se-gastown-world-loader', 'se-gastown-building-normalizer', 'se-gastown-dialog' ),
             filemtime( $dir . $app_path ) . '-pbr-props-npcs',
             true
         );

--- a/js/gastown-dialog.js
+++ b/js/gastown-dialog.js
@@ -1,0 +1,94 @@
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+    return;
+  }
+
+  root.GastownDialog = factory();
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  'use strict';
+
+  const DEFAULT_FALLBACK_LINE = 'Dialog data unavailable.';
+  const DEFAULT_MISSING_DIALOG_LINE = 'This guide does not have dialog copy yet.';
+
+  function sanitizeText(value, fallback) {
+    const trimmed = typeof value === 'string' ? value.trim() : '';
+    return trimmed || fallback;
+  }
+
+  function sanitizeRelativeHref(href) {
+    if (typeof href !== 'string') {
+      return '';
+    }
+
+    const trimmed = href.trim();
+    if (!trimmed || /^[a-z][a-z\d+.-]*:/i.test(trimmed) || trimmed.startsWith('//')) {
+      return '';
+    }
+
+    if (!trimmed.startsWith('/') && !trimmed.startsWith('./') && !trimmed.startsWith('../') && !trimmed.startsWith('#') && !trimmed.startsWith('?')) {
+      return '';
+    }
+
+    return trimmed;
+  }
+
+  function normalizeDialogEntry(entry, options) {
+    const settings = options && typeof options === 'object' ? options : {};
+    const fallbackTitle = sanitizeText(settings.fallbackTitle, 'Gastown guide');
+    const unavailableLine = sanitizeText(settings.unavailableLine, DEFAULT_FALLBACK_LINE);
+    const missingLine = sanitizeText(settings.missingLine, DEFAULT_MISSING_DIALOG_LINE);
+    const defaultCloseLabel = sanitizeText(settings.defaultCloseLabel, 'Back to walk');
+    const hasSourceEntry = entry && typeof entry === 'object' && !Array.isArray(entry);
+
+    const title = hasSourceEntry ? sanitizeText(entry.title, fallbackTitle) : fallbackTitle;
+    const sourceLines = hasSourceEntry && Array.isArray(entry.lines) ? entry.lines : [];
+    const lines = sourceLines
+      .map((line) => sanitizeText(line, ''))
+      .filter(Boolean);
+
+    const normalizedLines = lines.length
+      ? lines
+      : [hasSourceEntry ? missingLine : unavailableLine];
+
+    const sourceActions = hasSourceEntry && Array.isArray(entry.actions) ? entry.actions : [];
+    const actions = sourceActions.reduce((list, action) => {
+      if (!action || typeof action !== 'object') {
+        return list;
+      }
+
+      const type = sanitizeText(action.type, '').toLowerCase();
+      const label = sanitizeText(action.label, type === 'close' ? defaultCloseLabel : 'Open link');
+
+      if (type === 'close') {
+        list.push({ type: 'close', label });
+        return list;
+      }
+
+      if (type === 'link') {
+        const href = sanitizeRelativeHref(action.href);
+        if (!href) {
+          return list;
+        }
+
+        list.push({ type: 'link', label, href });
+      }
+
+      return list;
+    }, []);
+
+    return {
+      title,
+      lines: normalizedLines,
+      actions,
+      hasCustomActions: actions.length > 0,
+    };
+  }
+
+  return {
+    DEFAULT_FALLBACK_LINE,
+    DEFAULT_MISSING_DIALOG_LINE,
+    normalizeDialogEntry,
+    sanitizeRelativeHref,
+  };
+});

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -58,7 +58,26 @@
   const dialogModalEl = app.querySelector('[data-dialog-modal]');
   const dialogTitleEl = app.querySelector('[data-dialog-title]');
   const dialogBodyEl = app.querySelector('[data-dialog-body]');
+  const dialogActionsDynamicEl = app.querySelector('[data-dialog-actions-dynamic]');
   const dialogCloseEls = app.querySelectorAll('[data-dialog-close]');
+  const dialogFallbackCloseEl = app.querySelector('[data-dialog-close-fallback]');
+  const dialogUtils = window.GastownDialog || {};
+  const normalizeDialogEntry = typeof dialogUtils.normalizeDialogEntry === 'function'
+    ? dialogUtils.normalizeDialogEntry
+    : function fallbackNormalizeDialogEntry(entry, options) {
+      const fallbackTitle = (options && options.fallbackTitle) || 'Gastown guide';
+      const missingLine = (options && options.missingLine) || 'This guide does not have dialog copy yet.';
+      const unavailableLine = (options && options.unavailableLine) || 'Dialog data unavailable.';
+      const defaultCloseLabel = (options && options.defaultCloseLabel) || 'Back to walk';
+      const hasEntry = entry && typeof entry === 'object' && !Array.isArray(entry);
+      const lines = hasEntry && Array.isArray(entry.lines) && entry.lines.length ? entry.lines : [hasEntry ? missingLine : unavailableLine];
+      return {
+        title: (hasEntry && entry.title) || fallbackTitle,
+        lines,
+        actions: hasEntry && Array.isArray(entry.actions) ? entry.actions : [{ type: 'close', label: defaultCloseLabel }],
+        hasCustomActions: !!(hasEntry && Array.isArray(entry.actions) && entry.actions.length),
+      };
+    };
 
   const state = {
     world: null,
@@ -82,6 +101,8 @@
     },
     dialogData: {},
     activeDialogNpcId: '',
+    activeDialogEntry: null,
+    dialogLastFocusEl: null,
     hoveredNpcId: '',
     audioContext: null,
     barkTimer: null,
@@ -358,23 +379,159 @@
     }
   }
 
+  function clearMovementInput() {
+    state.move.forward = false;
+    state.move.backward = false;
+    state.move.left = false;
+    state.move.right = false;
+    state.turn.left = false;
+    state.turn.right = false;
+    state.velocity.set(0, 0, 0);
+  }
+
+  function getDialogFallbackTitle(npcState) {
+    if (npcState && npcState.role === 'guide') {
+      return 'Gastown guide';
+    }
+    return (npcState && npcState.id) || 'Gastown guide';
+  }
+
+  function createDialogLineElement(line) {
+    const paragraph = document.createElement('p');
+    paragraph.textContent = line;
+    return paragraph;
+  }
+
+  function renderDialogBody(lines) {
+    if (!dialogBodyEl) return;
+    dialogBodyEl.innerHTML = '';
+    (Array.isArray(lines) && lines.length ? lines : ['Dialog data unavailable.']).forEach((line) => {
+      dialogBodyEl.appendChild(createDialogLineElement(line));
+    });
+  }
+
+  function renderDialogActions(entry) {
+    if (!dialogActionsDynamicEl || !dialogFallbackCloseEl) {
+      return [];
+    }
+
+    dialogActionsDynamicEl.innerHTML = '';
+    const actions = entry && Array.isArray(entry.actions) ? entry.actions : [];
+    const controls = [];
+
+    actions.forEach((action) => {
+      if (!action || typeof action !== 'object' || !action.type) {
+        return;
+      }
+
+      if (action.type === 'close') {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'pixel-button secondary';
+        button.textContent = action.label || 'Back to walk';
+        button.addEventListener('click', closeDialog);
+        dialogActionsDynamicEl.appendChild(button);
+        controls.push(button);
+        return;
+      }
+
+      if (action.type === 'link' && action.href) {
+        const link = document.createElement('a');
+        link.className = 'pixel-button secondary';
+        link.href = action.href;
+        link.textContent = action.label || 'Open';
+        dialogActionsDynamicEl.appendChild(link);
+        controls.push(link);
+      }
+    });
+
+    if (controls.length > 0) {
+      dialogFallbackCloseEl.setAttribute('hidden', 'hidden');
+    } else {
+      dialogFallbackCloseEl.removeAttribute('hidden');
+      controls.push(dialogFallbackCloseEl);
+    }
+
+    return controls;
+  }
+
+  function focusFirstDialogControl() {
+    const controls = [];
+    if (dialogActionsDynamicEl) {
+      dialogActionsDynamicEl.querySelectorAll('button, a').forEach((el) => controls.push(el));
+    }
+    dialogCloseEls.forEach((el) => {
+      if (!el.hasAttribute('hidden')) controls.push(el);
+    });
+    const target = controls.find((el) => el && typeof el.focus === 'function');
+    if (target) {
+      window.setTimeout(() => target.focus(), 0);
+    }
+  }
+
   function closeDialog() {
     state.activeDialogNpcId = '';
+    state.activeDialogEntry = null;
+    if (dialogActionsDynamicEl) {
+      dialogActionsDynamicEl.innerHTML = '';
+    }
+    if (dialogFallbackCloseEl) {
+      dialogFallbackCloseEl.removeAttribute('hidden');
+    }
     if (dialogModalEl) {
       dialogModalEl.setAttribute('hidden', 'hidden');
       dialogModalEl.setAttribute('aria-hidden', 'true');
+    }
+    setStatus('Dialog closed. Click scene to resume.');
+    setPointerStatus('Pointer unlocked. Click scene to enter look mode.');
+    const focusTarget = canvasWrap || renderer.domElement;
+    if (focusTarget && typeof focusTarget.focus === 'function') {
+      window.setTimeout(() => focusTarget.focus(), 0);
     }
   }
 
   function openDialogForNpc(npcState) {
     if (!npcState || !dialogModalEl || !dialogTitleEl || !dialogBodyEl) return;
-    const dialog = state.dialogData[npcState.dialogId] || {};
-    dialogTitleEl.textContent = dialog.title || (npcState.role === 'guide' ? 'Gastown guide' : npcState.id);
-    const lines = Array.isArray(dialog.lines) ? dialog.lines : [dialog.body || 'No dialog loaded yet.'];
-    dialogBodyEl.innerHTML = lines.map((line) => '<p>' + line + '</p>').join('');
-    dialogModalEl.removeAttribute('hidden');
-    dialogModalEl.setAttribute('aria-hidden', 'false');
-    state.activeDialogNpcId = npcState.id;
+    clearMovementInput();
+    state.isRunning = false;
+    state.dialogLastFocusEl = document.activeElement;
+
+    const entry = Object.prototype.hasOwnProperty.call(state.dialogData, npcState.dialogId)
+      ? state.dialogData[npcState.dialogId]
+      : null;
+
+    if (!entry && window.console && typeof window.console.warn === 'function') {
+      window.console.warn('[Gastown Sim] Missing dialog entry for', npcState.dialogId);
+    }
+
+    const normalized = normalizeDialogEntry(entry, {
+      fallbackTitle: getDialogFallbackTitle(npcState),
+      unavailableLine: 'Dialog data unavailable.',
+      missingLine: 'This guide does not have dialog copy yet.',
+      defaultCloseLabel: 'Back to walk',
+    });
+
+    dialogTitleEl.textContent = normalized.title;
+    renderDialogBody(normalized.lines);
+    renderDialogActions(normalized);
+
+    const showDialog = () => {
+      dialogModalEl.removeAttribute('hidden');
+      dialogModalEl.setAttribute('aria-hidden', 'false');
+      state.activeDialogNpcId = npcState.id;
+      state.activeDialogEntry = normalized;
+      setStatus('Dialog open. Review the guide options below.');
+      setPointerStatus('Pointer unlocked. Dialog controls are active.');
+      focusFirstDialogControl();
+    };
+
+    if (document.pointerLockElement === renderer.domElement) {
+      document.exitPointerLock();
+      window.setTimeout(showDialog, 0);
+      return;
+    }
+
+    showDialog();
   }
 
   function makeNpcVisual(role) {
@@ -1918,12 +2075,7 @@
 
   function pauseSim() {
     state.isRunning = false;
-    state.move.forward = false;
-    state.move.backward = false;
-    state.move.left = false;
-    state.move.right = false;
-    state.turn.left = false;
-    state.turn.right = false;
+    clearMovementInput();
     if (document.pointerLockElement) {
       document.exitPointerLock();
     }
@@ -1934,6 +2086,9 @@
   function attachEvents() {
     window.addEventListener('resize', updateSize);
     renderer.domElement.addEventListener('click', () => {
+      if (state.activeDialogNpcId) {
+        return;
+      }
       ensureAudioContext();
       enterPlayMode();
     });
@@ -1941,12 +2096,16 @@
     renderer.domElement.addEventListener('wheel', onWheelLook, { passive: false });
 
     document.addEventListener('keydown', (event) => {
-      if (event.code === 'KeyE' && interactWithHoveredNpc()) {
+      if (event.code === 'Escape' && state.activeDialogNpcId) {
         event.preventDefault();
+        closeDialog();
         return;
       }
-      if (event.code === 'Escape' && state.activeDialogNpcId) {
-        closeDialog();
+      if (state.activeDialogNpcId) {
+        return;
+      }
+      if (event.code === 'KeyE' && interactWithHoveredNpc()) {
+        event.preventDefault();
         return;
       }
       const consumedPitch = handlePitchKeyControl(event);
@@ -1982,12 +2141,7 @@
       if (document.pointerLockElement === renderer.domElement) {
         setPointerStatus('Pointer locked. Mouse look active. Press Esc to release pointer.');
       } else if (state.isRunning) {
-        state.move.forward = false;
-        state.move.backward = false;
-        state.move.left = false;
-        state.move.right = false;
-        state.turn.left = false;
-        state.turn.right = false;
+        clearMovementInput();
         state.isRunning = false;
         setStatus('Paused. Pointer released. Click scene to resume look mode and movement.');
         setPointerStatus('Pointer released. Click scene to re-enter look mode.');
@@ -2035,9 +2189,9 @@
   async function init() {
     try {
       const loadedWorld = await window.GastownWorldLoader.load(config.worldDataUrl, config.starterWorldDataUrl);
-      const dialogData = await loadDialogData().catch(() => ({}));
+      const dialogData = await loadDialogData().catch(() => null);
       state.world = loadedWorld;
-      state.dialogData = dialogData;
+      state.dialogData = dialogData && typeof dialogData === 'object' ? dialogData : {};
       updateAttribution(state.world);
       addGround(state.world);
       addProps(state.world);

--- a/page-gastown-sim.php
+++ b/page-gastown-sim.php
@@ -64,7 +64,7 @@ get_header();
     <p class="gastown-route-segment" data-sim-route-segment aria-live="polite">Route segment: Waterfront Station Threshold</p>
     <p class="gastown-interact-prompt" data-sim-interact-prompt aria-live="polite" hidden></p>
 
-    <div class="gastown-sim-canvas" data-sim-canvas>
+    <div class="gastown-sim-canvas" data-sim-canvas tabindex="-1">
       <aside class="gastown-minimap" aria-label="Route navigator minimap">
         <div class="gastown-minimap-toolbar" role="group" aria-label="Minimap zoom controls">
           <button type="button" class="gastown-minimap-zoom" data-action="minimap-zoom-in" aria-label="Zoom in minimap">+</button>
@@ -116,7 +116,8 @@ get_header();
         </div>
         <div class="gastown-dialog-body" data-dialog-body></div>
         <div class="gastown-dialog-actions">
-          <button type="button" class="pixel-button secondary" data-dialog-close>Back to walk</button>
+          <div class="gastown-dialog-actions-dynamic" data-dialog-actions-dynamic aria-live="polite"></div>
+          <button type="button" class="pixel-button secondary" data-dialog-close data-dialog-close-fallback>Back to walk</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- The NPC dialog modal was unusable because the simulator opened overlays while pointer lock remained active and the dialog system only supported close-only content.
- Guides need an extensible, safe action system so authors can optionally present navigation/link buttons later without breaking backward compatibility.

### Description
- Release pointer lock and clear movement state before showing the dialog, pause the sim, focus the first interactive control, and avoid auto-relocking on close by updating `openDialogForNpc`, `closeDialog`, and event handling in `js/gastown-sim.js`.
- Add a dialog normalizer module `js/gastown-dialog.js` that safely normalizes entries, supports optional `actions` (`type: "close"` and `type: "link"`) and rejects external/protocol-relative hrefs (only same-origin relative hrefs allowed).
- Update markup in `page-gastown-sim.php` to add a dynamic actions container (`data-dialog-actions-dynamic`) and make the canvas focusable, and add focused-visible styles in `assets/css/gastown-sim.css` to preserve visual style for dynamic controls.
- Enqueue the dialog helper from `functions.php` and update `assets/dialog/gastown.json` to include an example `actions` entry while preserving backward compatibility for dialogs that lack `actions`.

### Testing
- Ran the repository test suite with `npm test`, including the new `__tests__/gastown-dialog.test.js`, and all tests passed (30 tests, 0 failures).
- Unit tests added assert that dialogs without `actions` normalize correctly, that action arrays are normalized and only safe same-origin links survive, that missing dialog entries produce visible fallback copy, and that the `openDialogForNpc` pointer-lock exit is scheduled before showing the modal.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfae63cca8832ea34d39f6a2607632)