### PR TITLE
Fix Gastown simulator hidden dialog state

### DIFF
--- a/__tests__/gastown-dialog.test.js
+++ b/__tests__/gastown-dialog.test.js
@@ -63,3 +63,55 @@ test('openDialogForNpc source exits pointer lock before scheduling the modal UI'
   assert.ok(branch.includes('window.setTimeout(showDialog, 0);'));
   assert.ok(branch.indexOf('document.exitPointerLock();') < branch.indexOf('window.setTimeout(showDialog, 0);'));
 });
+
+
+test('Gastown simulator markup starts with dialog and interact prompt hidden', () => {
+  const pagePath = path.join(__dirname, '..', 'page-gastown-sim.php');
+  const markup = fs.readFileSync(pagePath, 'utf8');
+
+  assert.match(markup, /class="gastown-interact-prompt"[^>]*hidden/);
+  assert.match(markup, /class="gastown-dialog-modal"[^>]*aria-hidden="true"[^>]*hidden/);
+});
+
+test('Gastown simulator CSS preserves hidden attribute semantics for modal and prompt', () => {
+  const cssPath = path.join(__dirname, '..', 'assets', 'css', 'gastown-sim.css');
+  const css = fs.readFileSync(cssPath, 'utf8');
+
+  assert.match(css, /\.gastown-interact-prompt\[hidden\]\s*\{[^}]*display:\s*none\s*!important;/s);
+  assert.match(css, /\.gastown-dialog-modal\[hidden\]\s*\{[^}]*display:\s*none\s*!important;/s);
+});
+
+test('closeDialog source restores hidden state and resumable scene focus cues', () => {
+  const simPath = path.join(__dirname, '..', 'js', 'gastown-sim.js');
+  const src = fs.readFileSync(simPath, 'utf8');
+  const start = src.indexOf('function closeDialog() {');
+  const end = src.indexOf('function openDialogForNpc', start);
+  const block = src.slice(start, end);
+
+  assert.notEqual(start, -1, 'expected closeDialog function');
+  assert.match(block, /dialogModalEl\.setAttribute\('hidden', 'hidden'\);/);
+  assert.match(block, /dialogModalEl\.setAttribute\('aria-hidden', 'true'\);/);
+  assert.match(block, /setInteractPrompt\(''\);/);
+  assert.match(block, /setStatus\('Dialog closed\. Click scene to resume\.'\);/);
+  assert.match(block, /renderer\.domElement \|\| canvasWrap/);
+});
+
+test('init path does not auto-open a guide dialog during simulator boot', () => {
+  const simPath = path.join(__dirname, '..', 'js', 'gastown-sim.js');
+  const src = fs.readFileSync(simPath, 'utf8');
+  const start = src.indexOf('async function init() {');
+  const end = src.indexOf('init();', start);
+  const block = src.slice(start, end);
+
+  assert.notEqual(start, -1, 'expected init function');
+  assert.equal(block.includes('openDialogForNpc('), false);
+});
+
+test('Gastown audio setup fails softly when assets are unavailable', () => {
+  const simPath = path.join(__dirname, '..', 'js', 'gastown-sim.js');
+  const src = fs.readFileSync(simPath, 'utf8');
+
+  assert.match(src, /function createSafeHowl\(options\)/);
+  assert.match(src, /warnAudioUnavailable\('Gastown audio assets missing or failed to load; simulator continuing without some audio\.'/);
+  assert.match(src, /warnAudioUnavailable\('Howler audio unavailable; simulator continuing without ambient audio\.'/);
+});

--- a/assets/css/gastown-sim.css
+++ b/assets/css/gastown-sim.css
@@ -247,6 +247,10 @@
   margin: 0.1rem 0;
 }
 
+.gastown-interact-prompt[hidden] {
+  display: none !important;
+}
+
 .gastown-interact-prompt {
   display: inline-block;
   margin: 0.45rem 0;
@@ -256,6 +260,10 @@
   background: rgba(7, 13, 22, 0.72);
   color: #eff7ff;
   box-shadow: 0 0 0 1px rgba(51, 86, 126, 0.28) inset;
+}
+
+.gastown-dialog-modal[hidden] {
+  display: none !important;
 }
 
 .gastown-dialog-modal {

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -32,10 +32,7 @@
     failStartupDependency('Missing building normalizer. Simulator could not start.');
     return;
   }
-  if (!window.Howl || !window.Howler) {
-    failStartupDependency('Missing Howler audio globals. Simulator could not start.');
-    return;
-  }
+  const hasHowler = !!(window.Howl && window.Howler);
 
   const canvasWrap = app.querySelector('[data-sim-canvas]');
   const pointerStatusEl = app.querySelector('[data-sim-pointer-status]');
@@ -108,6 +105,7 @@
     barkTimer: null,
     clockTimer: null,
     boundaryNoticeTimer: null,
+    audioWarningIssued: false,
   };
 
   const scene = new THREE.Scene();
@@ -379,6 +377,75 @@
     }
   }
 
+  function warnAudioUnavailable(message, error) {
+    if (state.audioWarningIssued) {
+      return;
+    }
+    state.audioWarningIssued = true;
+    if (window.console && typeof window.console.warn === 'function') {
+      if (error) {
+        window.console.warn('[Gastown Sim] ' + message, error);
+      } else {
+        window.console.warn('[Gastown Sim] ' + message);
+      }
+    }
+  }
+
+  function createSafeHowl(options) {
+    if (!hasHowler) {
+      warnAudioUnavailable('Howler audio unavailable; simulator continuing without ambient audio.');
+      return null;
+    }
+
+    const srcList = Array.isArray(options && options.src) ? options.src.filter(Boolean) : [];
+
+    try {
+      const howl = new Howl(Object.assign({}, options, {
+        onloaderror(id, error) {
+          warnAudioUnavailable('Gastown audio assets missing or failed to load; simulator continuing without some audio.', error);
+          if (typeof options.onloaderror === 'function') {
+            options.onloaderror.call(this, id, error);
+          }
+        },
+        onplayerror(id, error) {
+          warnAudioUnavailable('Gastown audio playback failed; simulator continuing without some audio.', error);
+          if (typeof options.onplayerror === 'function') {
+            options.onplayerror.call(this, id, error);
+          }
+        }
+      }));
+      howl.__seSources = srcList;
+      return howl;
+    } catch (error) {
+      warnAudioUnavailable('Gastown audio setup failed; simulator continuing without ambient audio.', error);
+      return null;
+    }
+  }
+
+  function playHowl(howl) {
+    if (!howl || typeof howl.play !== 'function') {
+      return;
+    }
+    try {
+      if (!howl.playing()) {
+        howl.play();
+      }
+    } catch (error) {
+      warnAudioUnavailable('Gastown audio playback failed; simulator continuing without some audio.', error);
+    }
+  }
+
+  function fadeHowl(howl, toVolume, duration) {
+    if (!howl || typeof howl.fade !== 'function' || typeof howl.volume !== 'function') {
+      return;
+    }
+    try {
+      howl.fade(howl.volume(), toVolume, duration);
+    } catch (error) {
+      warnAudioUnavailable('Gastown audio fade failed; simulator continuing without some audio.', error);
+    }
+  }
+
   function clearMovementInput() {
     state.move.forward = false;
     state.move.backward = false;
@@ -482,9 +549,11 @@
       dialogModalEl.setAttribute('hidden', 'hidden');
       dialogModalEl.setAttribute('aria-hidden', 'true');
     }
+    clearMovementInput();
+    setInteractPrompt('');
     setStatus('Dialog closed. Click scene to resume.');
     setPointerStatus('Pointer unlocked. Click scene to enter look mode.');
-    const focusTarget = canvasWrap || renderer.domElement;
+    const focusTarget = renderer.domElement || canvasWrap;
     if (focusTarget && typeof focusTarget.focus === 'function') {
       window.setTimeout(() => focusTarget.focus(), 0);
     }
@@ -1833,14 +1902,14 @@
     const src = (name) => [base + '/' + name + '.mp3', base + '/' + name + '.ogg'];
 
     ['quiet_night', 'eerie_drones', 'nightlife_hum', 'commuter_mix'].forEach((id) => {
-      state.sounds.beds[id] = new Howl({ src: src('beds/' + id), loop: true, volume: 0, html5: false });
+      state.sounds.beds[id] = createSafeHowl({ src: src('beds/' + id), loop: true, volume: 0, html5: false });
     });
 
-    state.sounds.rainLoop = new Howl({ src: src('weather/rain_pavement'), loop: true, volume: 0 });
-    state.sounds.clockBurst = new Howl({ src: src('events/steam_clock_burst'), volume: 0.45 });
+    state.sounds.rainLoop = createSafeHowl({ src: src('weather/rain_pavement'), loop: true, volume: 0 });
+    state.sounds.clockBurst = createSafeHowl({ src: src('events/steam_clock_burst'), volume: 0.45 });
 
-    world.audioZones.forEach((zone) => {
-      state.sounds.zoneBeds[zone.id] = new Howl({ src: src('zones/' + zone.bed), loop: true, volume: 0 });
+    (world.audioZones || []).forEach((zone) => {
+      state.sounds.zoneBeds[zone.id] = createSafeHowl({ src: src('zones/' + zone.bed), loop: true, volume: 0 });
     });
   }
 
@@ -1902,10 +1971,8 @@
 
     rebuildRain((weather.rainIntensity || 0) * (timeOfDay.rainVisibility || 1));
 
-    if (!state.sounds.rainLoop.playing()) {
-      state.sounds.rainLoop.play();
-    }
-    state.sounds.rainLoop.fade(state.sounds.rainLoop.volume(), (weather.rainIntensity || 0) * 0.45, 380);
+    playHowl(state.sounds.rainLoop);
+    fadeHowl(state.sounds.rainLoop, (weather.rainIntensity || 0) * 0.45, 380);
   }
 
   function applyMood(moodId) {
@@ -1916,10 +1983,8 @@
 
     Object.keys(state.sounds.beds).forEach((id) => {
       const howl = state.sounds.beds[id];
-      if (!howl.playing()) {
-        howl.play();
-      }
-      howl.fade(howl.volume(), id === preset.ambientBed ? 0.45 * preset.audioDensity : 0, 420);
+      playHowl(howl);
+      fadeHowl(howl, id === preset.ambientBed ? 0.45 * preset.audioDensity : 0, 420);
     });
 
     if (state.barkTimer) {
@@ -1930,14 +1995,14 @@
       if (!state.isRunning || Math.random() > preset.voiceFreq) {
         return;
       }
-      const bark = new Howl({
+      const bark = createSafeHowl({
         src: [
           (config.audioBaseUrl || '').replace(/\/$/, '') + '/barks/hey_you.mp3',
           (config.audioBaseUrl || '').replace(/\/$/, '') + '/barks/hey_you.ogg'
         ],
         volume: 0.38 + (Math.random() * 0.2)
       });
-      bark.play();
+      playHowl(bark);
     }, barkInterval);
   }
 
@@ -1959,10 +2024,10 @@
       const normalized = Math.max(0, 1 - (dist / zone.radius));
       const howl = state.sounds.zoneBeds[zone.id];
       if (!howl) return;
-      if (!howl.playing()) {
-        howl.play();
+      playHowl(howl);
+      if (howl && typeof howl.volume === 'function') {
+        howl.volume(normalized * 0.4);
       }
-      howl.volume(normalized * 0.4);
     });
   }
 
@@ -2181,7 +2246,7 @@
       if (!steamClock) return;
       const distance = Math.hypot(player.position.x - steamClock.x, player.position.z - steamClock.z);
       if (distance < 20 && Math.random() > 0.48) {
-        state.sounds.clockBurst.play();
+        playHowl(state.sounds.clockBurst);
       }
     }, 6000);
   }


### PR DESCRIPTION
### Motivation
- Prevent the dialog modal and interact prompt from being made visible on page load due to class-level `display` rules overriding the browser `hidden` attribute. 
- Keep simulator boot behavior unchanged: do not auto-open any guide dialog and ensure closing a dialog returns the user to a resumable scene state. 
- Make audio initialization tolerant of missing Howler or missing audio assets so the simulator still boots when audio files are absent.

### Description
- Add explicit `[hidden]` CSS overrides so hidden elements remain hidden even when their classes set `display` values, specifically `.gastown-dialog-modal[hidden] { display: none !important; }` and `.gastown-interact-prompt[hidden] { display: none !important; }` in `assets/css/gastown-sim.css`.
- Keep `openDialogForNpc()` semantics unchanged (it uses `removeAttribute('hidden')` and `aria-hidden="false"`) and strengthen `closeDialog()` to re-apply the hidden/aria-hidden state, clear movement input, clear the interact prompt, and return focus to the renderer canvas for a clean resume (`js/gastown-sim.js`).
- Replace the hard startup failure when Howler is missing with guarded audio helpers: `createSafeHowl`, `playHowl`, `fadeHowl`, and `warnAudioUnavailable`, and use these wrappers when creating/playing audio so audio 404s or missing Howler do not block simulator init (`js/gastown-sim.js`).
- Add regression tests to assert the modal & prompt start hidden, CSS preserves `[hidden]` semantics, `closeDialog()` restores hidden/resumable cues, no `openDialogForNpc()` is called during `init()`, and audio setup fails softly (`__tests__/gastown-dialog.test.js`).

### Testing
- Ran the project tests with `npm test` which executes `node --test "./__tests__/**/*.test.js"`.
- All tests passed: `35` tests ran with `0` failures.
- New/updated unit tests added in `__tests__/gastown-dialog.test.js` passed and verify hidden-by-default markup, CSS selectors for `[hidden]`, `closeDialog()` behavior, lack of init-time auto-open, and soft audio failure handling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfb26def28832e964e3660c245435c)