### PR TITLE
Enhance Gastown starter fallback corridor

### DIFF
--- a/__tests__/gastown-world-generator.test.js
+++ b/__tests__/gastown-world-generator.test.js
@@ -40,6 +40,23 @@ test('generator keeps world polygons valid with existing or generated output', (
     assert.ok(Array.isArray(sampleBuilding.footprint_local));
     assert.ok(sampleBuilding.footprint_local.length >= 3);
     assertFinitePoints(sampleBuilding.footprint_local);
+
+    if (data.meta && data.meta.fallbackMode === 'starter-corridor') {
+      assert.ok(Array.isArray(data.streetscape.surfaceBands));
+      assert.ok(data.streetscape.surfaceBands.length > 0, 'starter fallback should include deterministic surface bands');
+      const surfaceTones = new Set(data.streetscape.surfaceBands.map((band) => band.tone));
+      ['curb_grime', 'intersection_pavers'].forEach((tone) => {
+        assert.equal(surfaceTones.has(tone), true, 'starter fallback surface bands should include ' + tone);
+      });
+
+      const propKinds = new Set((data.props || []).map((prop) => prop.kind));
+      ['trash_bag', 'newspaper_box', 'utility_box', 'bench', 'planter'].forEach((kind) => {
+        assert.equal(propKinds.has(kind), true, 'starter fallback props should include ' + kind);
+      });
+
+      assert.ok(Array.isArray(data.landmarks));
+      assert.equal(data.landmarks.length >= 3, true, 'starter fallback should expose route beats as landmarks');
+    }
   }
 
   if (fs.existsSync(tmpPath)) {

--- a/assets/world/gastown-water-street-starter.json
+++ b/assets/world/gastown-water-street-starter.json
@@ -10,7 +10,7 @@
       "Starter corridor fallback is active because required offline civic source files are missing.",
       "This world is intentionally human-scaled and deterministic for readability; it is not GIS-accurate Gastown reconstruction."
     ],
-    "lastBuild": "2026-03-16T03:46:45.370Z"
+    "lastBuild": "2026-03-22T09:40:47.244Z"
   },
   "route": {
     "name": "Gastown starter block corridor",
@@ -313,54 +313,56 @@
     {
       "id": "starter-bldg-0-left",
       "reference_name": "Starter west frontage",
-      "x": -17.68,
-      "z": -7.86,
-      "width": 17.01,
-      "depth": 9,
-      "yaw": 1.6574,
-      "height": 10,
+      "segment_style": "waterfront-threshold",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": -17.3,
+      "z": -5.92,
+      "width": 16,
+      "depth": 8,
+      "yaw": -1.4844,
+      "height": 12,
       "footprint": [
         {
-          "x": -21.86,
-          "z": -1.4
+          "x": -21.04,
+          "z": 0.18
         },
         {
-          "x": -12.89,
-          "z": -0.62
+          "x": -13.07,
+          "z": 0.87
         },
         {
-          "x": -11.42,
-          "z": -17.56
+          "x": -11.69,
+          "z": -15.07
         },
         {
-          "x": -20.39,
-          "z": -18.34
+          "x": -19.66,
+          "z": -15.76
         },
         {
-          "x": -21.86,
-          "z": -1.4
+          "x": -21.04,
+          "z": 0.18
         }
       ],
       "footprint_local": [
         {
-          "x": 6.8,
-          "z": 3.6
+          "x": -6.4,
+          "z": -3.2
         },
         {
-          "x": 6.8,
-          "z": -5.4
+          "x": -6.4,
+          "z": 4.8
         },
         {
-          "x": -10.2,
-          "z": -5.4
+          "x": 9.6,
+          "z": 4.8
         },
         {
-          "x": -10.2,
-          "z": 3.6
+          "x": 9.6,
+          "z": -3.2
         },
         {
-          "x": 6.8,
-          "z": 3.6
+          "x": -6.4,
+          "z": -3.2
         }
       ],
       "facade_profile": "gastown_heritage_row",
@@ -369,676 +371,706 @@
       "window_bay_count": 3,
       "recessed_entry_count": 1,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.16,
         "upper_rows": 3
       },
       "material_palette": {
         "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "trim": "#cfb8a2",
+        "accent": "#4f5f6f",
+        "tone": "brickWarm"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.95
     },
     {
       "id": "starter-bldg-0-right",
       "reference_name": "Starter east frontage",
-      "x": 16.98,
-      "z": -4.84,
-      "width": 17.01,
-      "depth": 9,
-      "yaw": -1.4837,
-      "height": 10,
+      "segment_style": "waterfront-threshold",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": 17.21,
+      "z": -2.77,
+      "width": 17.51,
+      "depth": 8,
+      "yaw": 1.6577,
+      "height": 11,
       "footprint": [
         {
-          "x": 12.81,
-          "z": 1.62
+          "x": 13.41,
+          "z": 3.93
         },
         {
-          "x": 21.77,
-          "z": 2.4
+          "x": 21.38,
+          "z": 4.62
         },
         {
-          "x": 23.25,
-          "z": -14.54
+          "x": 22.9,
+          "z": -12.81
         },
         {
-          "x": 14.28,
-          "z": -15.32
+          "x": 14.93,
+          "z": -13.51
         },
         {
-          "x": 12.81,
-          "z": 1.62
+          "x": 13.41,
+          "z": 3.93
         }
       ],
       "footprint_local": [
         {
-          "x": -6.8,
-          "z": -3.6
+          "x": 7,
+          "z": 3.2
         },
         {
-          "x": -6.8,
-          "z": 5.4
+          "x": 7,
+          "z": -4.8
         },
         {
-          "x": 10.2,
-          "z": 5.4
+          "x": -10.5,
+          "z": -4.8
         },
         {
-          "x": 10.2,
-          "z": -3.61
+          "x": -10.5,
+          "z": 3.2
         },
         {
-          "x": -6.8,
-          "z": -3.6
+          "x": 7,
+          "z": 3.2
         }
       ],
-      "facade_profile": "cordoba_commercial_transition",
+      "facade_profile": "cordova_commercial_transition",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 3,
-      "recessed_entry_count": 1,
+      "recessed_entry_count": 2,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.16,
         "upper_rows": 3
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#8a857d",
+        "trim": "#d8c9b6",
+        "accent": "#57656e",
+        "tone": "stoneMuted"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.95
     },
     {
       "id": "starter-bldg-1-left",
       "reference_name": "Starter west frontage",
-      "x": -18.51,
-      "z": -19.18,
-      "width": 20.01,
-      "depth": 12,
-      "yaw": -1.4842,
-      "height": 14,
+      "segment_style": "waterfront-threshold",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": -19.29,
+      "z": -15.43,
+      "width": 21,
+      "depth": 11,
+      "yaw": -1.484,
+      "height": 16,
       "footprint": [
         {
-          "x": -23.98,
-          "z": -11.62
+          "x": -24.4,
+          "z": -7.44
         },
         {
-          "x": -12.03,
-          "z": -10.58
+          "x": -13.44,
+          "z": -6.49
         },
         {
-          "x": -10.3,
-          "z": -30.51
+          "x": -11.62,
+          "z": -27.41
         },
         {
-          "x": -22.25,
-          "z": -31.55
+          "x": -22.58,
+          "z": -28.36
         },
         {
-          "x": -23.98,
-          "z": -11.62
+          "x": -24.4,
+          "z": -7.44
         }
       ],
       "footprint_local": [
         {
-          "x": -8,
-          "z": -4.8
+          "x": -8.4,
+          "z": -4.4
         },
         {
-          "x": -8,
-          "z": 7.2
+          "x": -8.4,
+          "z": 6.6
         },
         {
-          "x": 12,
-          "z": 7.2
+          "x": 12.6,
+          "z": 6.6
         },
         {
-          "x": 12,
-          "z": -4.8
+          "x": 12.6,
+          "z": -4.4
         },
         {
-          "x": -8,
-          "z": -4.8
+          "x": -8.4,
+          "z": -4.4
         }
       ],
-      "facade_profile": "gastown_heritage_row",
-      "tone": "brickWarm",
+      "facade_profile": "cordova_commercial_transition",
+      "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 4,
-      "recessed_entry_count": 1,
+      "recessed_entry_count": 2,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.16,
         "upper_rows": 3
       },
       "material_palette": {
-        "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#8a857d",
+        "trim": "#d8c9b6",
+        "accent": "#57656e",
+        "tone": "stoneMuted"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.95
     },
     {
       "id": "starter-bldg-1-right",
       "reference_name": "Starter east frontage",
-      "x": 19.15,
-      "z": -15.9,
-      "width": 20,
-      "depth": 12.01,
-      "yaw": 1.6579,
-      "height": 14,
+      "segment_style": "waterfront-threshold",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": 20.2,
+      "z": -11.84,
+      "width": 22.5,
+      "depth": 11,
+      "yaw": 1.6576,
+      "height": 15,
       "footprint": [
         {
-          "x": 13.67,
-          "z": -8.35
+          "x": 15.04,
+          "z": -3.26
         },
         {
-          "x": 25.63,
-          "z": -7.31
+          "x": 26,
+          "z": -2.31
         },
         {
-          "x": 27.36,
-          "z": -27.23
+          "x": 27.95,
+          "z": -24.72
         },
         {
-          "x": 15.41,
-          "z": -28.27
+          "x": 16.99,
+          "z": -25.67
         },
         {
-          "x": 13.67,
-          "z": -8.35
+          "x": 15.04,
+          "z": -3.26
         }
       ],
       "footprint_local": [
         {
-          "x": 8,
-          "z": 4.8
-        },
-        {
-          "x": 8,
-          "z": -7.21
-        },
-        {
-          "x": -12,
-          "z": -7.2
-        },
-        {
-          "x": -12,
-          "z": 4.8
-        },
-        {
-          "x": 8,
-          "z": 4.8
-        }
-      ],
-      "facade_profile": "cordoba_commercial_transition",
-      "tone": "stoneMuted",
-      "roofline_type": "flat_cornice",
-      "window_bay_count": 4,
-      "recessed_entry_count": 1,
-      "storefront_rhythm": {
-        "base_band": 0.18,
-        "upper_rows": 3
-      },
-      "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
-      },
-      "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
-    },
-    {
-      "id": "starter-bldg-2-left",
-      "reference_name": "Starter west frontage",
-      "x": -14.32,
-      "z": -33.87,
-      "width": 15.01,
-      "depth": 8,
-      "yaw": -1.4841,
-      "height": 12,
-      "footprint": [
-        {
-          "x": -18.03,
-          "z": -28.17
-        },
-        {
-          "x": -10.06,
-          "z": -27.47
-        },
-        {
-          "x": -8.76,
-          "z": -42.42
-        },
-        {
-          "x": -16.73,
-          "z": -43.11
-        },
-        {
-          "x": -18.03,
-          "z": -28.17
-        }
-      ],
-      "footprint_local": [
-        {
-          "x": -6,
-          "z": -3.2
-        },
-        {
-          "x": -6,
-          "z": 4.8
+          "x": 9,
+          "z": 4.4
         },
         {
           "x": 9,
-          "z": 4.8
+          "z": -6.6
+        },
+        {
+          "x": -13.5,
+          "z": -6.6
+        },
+        {
+          "x": -13.5,
+          "z": 4.4
         },
         {
           "x": 9,
-          "z": -3.2
-        },
-        {
-          "x": -6,
-          "z": -3.2
+          "z": 4.4
         }
       ],
       "facade_profile": "gastown_heritage_row",
       "tone": "brickWarm",
       "roofline_type": "flat_cornice",
-      "window_bay_count": 3,
+      "window_bay_count": 4,
       "recessed_entry_count": 1,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.16,
         "upper_rows": 3
       },
       "material_palette": {
-        "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#6e3f36",
+        "trim": "#caa98c",
+        "accent": "#445666",
+        "tone": "brickWarm"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.95
+    },
+    {
+      "id": "starter-bldg-2-left",
+      "reference_name": "Starter corner heritage anchor",
+      "segment_style": "waterfront-threshold",
+      "style_notes": "Corner building massing with stronger cornice to punctuate the route.",
+      "x": -17.26,
+      "z": -29.56,
+      "width": 17.51,
+      "depth": 10.01,
+      "yaw": -1.4844,
+      "height": 15,
+      "footprint": [
+        {
+          "x": -21.85,
+          "z": -22.93
+        },
+        {
+          "x": -11.88,
+          "z": -22.06
+        },
+        {
+          "x": -10.37,
+          "z": -39.5
+        },
+        {
+          "x": -20.33,
+          "z": -40.36
+        },
+        {
+          "x": -21.85,
+          "z": -22.93
+        }
+      ],
+      "footprint_local": [
+        {
+          "x": -7,
+          "z": -4.01
+        },
+        {
+          "x": -7,
+          "z": 6
+        },
+        {
+          "x": 10.5,
+          "z": 6
+        },
+        {
+          "x": 10.5,
+          "z": -3.99
+        },
+        {
+          "x": -7,
+          "z": -4.01
+        }
+      ],
+      "facade_profile": "gastown_heritage_row",
+      "tone": "brickWarm",
+      "roofline_type": "wrapped_cornice",
+      "window_bay_count": 3,
+      "recessed_entry_count": 1,
+      "storefront_rhythm": {
+        "base_band": 0.16,
+        "upper_rows": 3
+      },
+      "material_palette": {
+        "primary": "#6e3f36",
+        "trim": "#caa98c",
+        "accent": "#445666",
+        "tone": "brickWarm"
+      },
+      "cornice_emphasis": 0.42,
+      "mass_inset": 0.95
     },
     {
       "id": "starter-bldg-2-right",
       "reference_name": "Starter east frontage",
-      "x": 18.36,
-      "z": -31.03,
-      "width": 15.01,
-      "depth": 8,
-      "yaw": -1.4841,
+      "segment_style": "waterfront-threshold",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": 18.38,
+      "z": -26.66,
+      "width": 15.51,
+      "depth": 7.01,
+      "yaw": 1.6573,
       "height": 12,
       "footprint": [
         {
-          "x": 14.65,
-          "z": -25.33
+          "x": 15.05,
+          "z": -20.72
         },
         {
-          "x": 22.62,
-          "z": -24.63
+          "x": 22.03,
+          "z": -20.12
         },
         {
-          "x": 23.92,
-          "z": -39.58
+          "x": 23.37,
+          "z": -35.56
         },
         {
-          "x": 15.95,
-          "z": -40.27
+          "x": 16.39,
+          "z": -36.17
         },
         {
-          "x": 14.65,
-          "z": -25.33
+          "x": 15.05,
+          "z": -20.72
         }
       ],
       "footprint_local": [
         {
-          "x": -6,
-          "z": -3.2
+          "x": 6.2,
+          "z": 2.8
         },
         {
-          "x": -6,
-          "z": 4.8
+          "x": 6.2,
+          "z": -4.2
         },
         {
-          "x": 9,
-          "z": 4.8
+          "x": -9.3,
+          "z": -4.2
         },
         {
-          "x": 9,
-          "z": -3.2
+          "x": -9.3,
+          "z": 2.8
         },
         {
-          "x": -6,
-          "z": -3.2
+          "x": 6.2,
+          "z": 2.8
         }
       ],
-      "facade_profile": "cordoba_commercial_transition",
+      "facade_profile": "narrow_brick_shaft",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 3,
-      "recessed_entry_count": 1,
+      "recessed_entry_count": 3,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.16,
         "upper_rows": 3
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#6f747c",
+        "trim": "#d0c3b3",
+        "accent": "#3f5363",
+        "tone": "stoneMuted"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.95
     },
     {
       "id": "starter-bldg-3-left",
       "reference_name": "Starter west frontage",
-      "x": -18.16,
-      "z": -43.93,
-      "width": 23,
+      "segment_style": "waterfront-threshold",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": -19.14,
+      "z": -39,
+      "width": 24,
       "depth": 15,
-      "yaw": -1.4846,
-      "height": 18,
+      "yaw": -1.484,
+      "height": 20,
       "footprint": [
         {
-          "x": -24.93,
-          "z": -35.28
+          "x": -25.95,
+          "z": -29.96
         },
         {
-          "x": -9.99,
-          "z": -33.99
+          "x": -11.01,
+          "z": -28.66
         },
         {
-          "x": -8.01,
-          "z": -56.9
+          "x": -8.93,
+          "z": -52.57
         },
         {
-          "x": -22.95,
-          "z": -58.19
+          "x": -23.87,
+          "z": -53.87
         },
         {
-          "x": -24.93,
-          "z": -35.28
+          "x": -25.95,
+          "z": -29.96
         }
       ],
       "footprint_local": [
         {
-          "x": -9.2,
+          "x": -9.6,
           "z": -6
         },
         {
-          "x": -9.2,
+          "x": -9.6,
           "z": 9
         },
         {
-          "x": 13.8,
+          "x": 14.4,
           "z": 9
         },
         {
-          "x": 13.8,
+          "x": 14.4,
           "z": -6
         },
         {
-          "x": -9.2,
+          "x": -9.6,
           "z": -6
         }
       ],
-      "facade_profile": "gastown_heritage_row",
-      "tone": "brickWarm",
+      "facade_profile": "narrow_brick_shaft",
+      "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
-      "window_bay_count": 5,
-      "recessed_entry_count": 1,
+      "window_bay_count": 6,
+      "recessed_entry_count": 3,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.16,
         "upper_rows": 4
       },
       "material_palette": {
-        "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#6f747c",
+        "trim": "#d0c3b3",
+        "accent": "#3f5363",
+        "tone": "stoneMuted"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.95
     },
     {
       "id": "starter-bldg-3-right",
       "reference_name": "Starter east frontage",
-      "x": 22.49,
-      "z": -40.41,
-      "width": 23.01,
-      "depth": 15,
-      "yaw": 1.657,
-      "height": 18,
+      "segment_style": "waterfront-threshold",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": 23.33,
+      "z": -35.16,
+      "width": 25.5,
+      "depth": 15.01,
+      "yaw": 1.6576,
+      "height": 19,
       "footprint": [
         {
-          "x": 15.72,
-          "z": -31.76
+          "x": 16.47,
+          "z": -25.52
         },
         {
-          "x": 30.66,
-          "z": -30.47
+          "x": 31.42,
+          "z": -24.22
         },
         {
-          "x": 32.64,
-          "z": -53.38
+          "x": 33.63,
+          "z": -49.62
         },
         {
-          "x": 17.7,
-          "z": -54.68
+          "x": 18.68,
+          "z": -50.92
         },
         {
-          "x": 15.72,
-          "z": -31.76
+          "x": 16.47,
+          "z": -25.52
         }
       ],
       "footprint_local": [
         {
-          "x": 9.2,
+          "x": 10.2,
           "z": 6
         },
         {
-          "x": 9.2,
+          "x": 10.2,
           "z": -9
         },
         {
-          "x": -13.8,
+          "x": -15.3,
           "z": -9
         },
         {
-          "x": -13.8,
+          "x": -15.3,
           "z": 6
         },
         {
-          "x": 9.2,
+          "x": 10.2,
           "z": 6
         }
       ],
-      "facade_profile": "cordoba_commercial_transition",
-      "tone": "stoneMuted",
+      "facade_profile": "gastown_heritage_row",
+      "tone": "brickWarm",
       "roofline_type": "flat_cornice",
-      "window_bay_count": 5,
+      "window_bay_count": 6,
       "recessed_entry_count": 1,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.16,
         "upper_rows": 4
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#74493c",
+        "trim": "#cfb8a2",
+        "accent": "#4f5f6f",
+        "tone": "brickWarm"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.95
     },
     {
       "id": "starter-bldg-4-left",
       "reference_name": "Starter west frontage",
-      "x": -13.7,
-      "z": -61.52,
-      "width": 18,
-      "depth": 10,
-      "yaw": 1.6526,
-      "height": 11,
+      "segment_style": "mid-corridor-heritage-rhythm",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": -14.1,
+      "z": -55.93,
+      "width": 18.01,
+      "depth": 9,
+      "yaw": -1.489,
+      "height": 10,
       "footprint": [
         {
-          "x": -18.27,
-          "z": -54.67
+          "x": -18.28,
+          "z": -49.05
         },
         {
-          "x": -8.3,
-          "z": -53.85
+          "x": -9.31,
+          "z": -48.32
         },
         {
-          "x": -6.84,
-          "z": -71.79
+          "x": -7.84,
+          "z": -66.26
         },
         {
-          "x": -16.8,
-          "z": -72.61
+          "x": -16.81,
+          "z": -66.99
         },
         {
-          "x": -18.27,
-          "z": -54.67
+          "x": -18.28,
+          "z": -49.05
         }
       ],
       "footprint_local": [
         {
-          "x": 7.2,
-          "z": 4
+          "x": -7.2,
+          "z": -3.6
         },
         {
-          "x": 7.2,
-          "z": -6
+          "x": -7.2,
+          "z": 5.4
         },
         {
-          "x": -10.8,
-          "z": -5.99
+          "x": 10.8,
+          "z": 5.4
         },
         {
-          "x": -10.8,
-          "z": 4
+          "x": 10.8,
+          "z": -3.6
         },
         {
-          "x": 7.2,
-          "z": 4
+          "x": -7.2,
+          "z": -3.6
         }
       ],
       "facade_profile": "gastown_heritage_row",
       "tone": "brickWarm",
       "roofline_type": "flat_cornice",
-      "window_bay_count": 4,
+      "window_bay_count": 3,
       "recessed_entry_count": 1,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.19,
         "upper_rows": 3
       },
       "material_palette": {
         "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "trim": "#cfb8a2",
+        "accent": "#4f5f6f",
+        "tone": "brickWarm"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-4-right",
-      "reference_name": "Starter east frontage",
-      "x": 21.98,
-      "z": -58.6,
-      "width": 18.01,
-      "depth": 10,
-      "yaw": 1.6526,
-      "height": 11,
+      "reference_name": "Starter corner heritage anchor",
+      "segment_style": "mid-corridor-heritage-rhythm",
+      "style_notes": "Corner building massing with stronger cornice to punctuate the route.",
+      "x": 24.14,
+      "z": -52.46,
+      "width": 21.5,
+      "depth": 12,
+      "yaw": -1.4893,
+      "height": 12,
       "footprint": [
         {
-          "x": 17.41,
-          "z": -51.75
+          "x": 18.66,
+          "z": -44.28
         },
         {
-          "x": 27.38,
-          "z": -50.94
+          "x": 30.62,
+          "z": -43.3
         },
         {
-          "x": 28.84,
-          "z": -68.88
+          "x": 32.37,
+          "z": -64.73
         },
         {
-          "x": 18.88,
-          "z": -69.69
+          "x": 20.41,
+          "z": -65.71
         },
         {
-          "x": 17.41,
-          "z": -51.75
+          "x": 18.66,
+          "z": -44.28
         }
       ],
       "footprint_local": [
         {
-          "x": 7.2,
-          "z": 4
+          "x": -8.6,
+          "z": -4.8
         },
         {
-          "x": 7.2,
-          "z": -6
+          "x": -8.6,
+          "z": 7.2
         },
         {
-          "x": -10.8,
-          "z": -5.99
+          "x": 12.9,
+          "z": 7.2
         },
         {
-          "x": -10.8,
-          "z": 4
+          "x": 12.9,
+          "z": -4.8
         },
         {
-          "x": 7.2,
-          "z": 4
+          "x": -8.6,
+          "z": -4.8
         }
       ],
-      "facade_profile": "cordoba_commercial_transition",
+      "facade_profile": "cordova_commercial_transition",
       "tone": "stoneMuted",
-      "roofline_type": "flat_cornice",
+      "roofline_type": "wrapped_cornice",
       "window_bay_count": 4,
-      "recessed_entry_count": 1,
+      "recessed_entry_count": 2,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.19,
         "upper_rows": 3
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#8a857d",
+        "trim": "#d8c9b6",
+        "accent": "#57656e",
+        "tone": "stoneMuted"
       },
-      "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "cornice_emphasis": 0.42,
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-5-left",
       "reference_name": "Starter west frontage",
-      "x": -15,
-      "z": -73.77,
-      "width": 22,
-      "depth": 12.99,
+      "segment_style": "mid-corridor-heritage-rhythm",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": -15.56,
+      "z": -67.59,
+      "width": 22.01,
+      "depth": 13,
       "yaw": -1.4894,
-      "height": 20,
+      "height": 21,
       "footprint": [
         {
-          "x": -20.9,
-          "z": -65.42
+          "x": -21.46,
+          "z": -59.24
         },
         {
-          "x": -7.95,
-          "z": -64.36
+          "x": -8.5,
+          "z": -58.18
         },
         {
-          "x": -6.16,
-          "z": -86.29
+          "x": -6.71,
+          "z": -80.11
         },
         {
-          "x": -19.11,
-          "z": -87.34
+          "x": -19.67,
+          "z": -81.17
         },
         {
-          "x": -20.9,
-          "z": -65.42
+          "x": -21.46,
+          "z": -59.24
         }
       ],
       "footprint_local": [
@@ -1055,7 +1087,7 @@
           "z": 7.8
         },
         {
-          "x": 13.19,
+          "x": 13.2,
           "z": -5.2
         },
         {
@@ -1063,52 +1095,55 @@
           "z": -5.2
         }
       ],
-      "facade_profile": "gastown_heritage_row",
-      "tone": "brickWarm",
+      "facade_profile": "cordova_commercial_transition",
+      "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 5,
-      "recessed_entry_count": 1,
+      "recessed_entry_count": 2,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.19,
         "upper_rows": 4
       },
       "material_palette": {
-        "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#8a857d",
+        "trim": "#d8c9b6",
+        "accent": "#57656e",
+        "tone": "stoneMuted"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-5-right",
       "reference_name": "Starter east frontage",
-      "x": 24.67,
-      "z": -70.53,
-      "width": 22.01,
-      "depth": 12.99,
-      "yaw": -1.4894,
-      "height": 20,
+      "segment_style": "mid-corridor-heritage-rhythm",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": 24.21,
+      "z": -64.34,
+      "width": 21.99,
+      "depth": 13,
+      "yaw": -1.4893,
+      "height": 21,
       "footprint": [
         {
-          "x": 18.77,
-          "z": -62.18
+          "x": 18.31,
+          "z": -56
         },
         {
-          "x": 31.72,
-          "z": -61.12
+          "x": 31.27,
+          "z": -54.94
         },
         {
-          "x": 33.51,
-          "z": -83.05
+          "x": 33.06,
+          "z": -76.86
         },
         {
-          "x": 20.56,
-          "z": -84.11
+          "x": 20.1,
+          "z": -77.92
         },
         {
-          "x": 18.77,
-          "z": -62.18
+          "x": 18.31,
+          "z": -56
         }
       ],
       "footprint_local": [
@@ -1121,7 +1156,7 @@
           "z": 7.8
         },
         {
-          "x": 13.2,
+          "x": 13.19,
           "z": 7.8
         },
         {
@@ -1133,1002 +1168,1160 @@
           "z": -5.2
         }
       ],
-      "facade_profile": "cordoba_commercial_transition",
-      "tone": "stoneMuted",
+      "facade_profile": "gastown_heritage_row",
+      "tone": "brickWarm",
       "roofline_type": "flat_cornice",
       "window_bay_count": 5,
-      "recessed_entry_count": 1,
+      "recessed_entry_count": 2,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.19,
         "upper_rows": 4
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#6e3f36",
+        "trim": "#caa98c",
+        "accent": "#445666",
+        "tone": "brickWarm"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-6-left",
       "reference_name": "Starter west frontage",
-      "x": -12.02,
-      "z": -89.37,
+      "segment_style": "mid-corridor-heritage-rhythm",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": -12.45,
+      "z": -83.59,
       "width": 19,
-      "depth": 11.01,
-      "yaw": -1.4897,
-      "height": 15,
+      "depth": 10,
+      "yaw": 1.6519,
+      "height": 16,
       "footprint": [
         {
-          "x": -17.03,
-          "z": -82.16
+          "x": -17.05,
+          "z": -76.34
         },
         {
-          "x": -6.06,
-          "z": -81.26
+          "x": -7.08,
+          "z": -75.53
         },
         {
-          "x": -4.52,
-          "z": -100.2
+          "x": -5.54,
+          "z": -94.46
         },
         {
-          "x": -15.48,
-          "z": -101.09
+          "x": -15.51,
+          "z": -95.28
         },
         {
-          "x": -17.03,
-          "z": -82.16
+          "x": -17.05,
+          "z": -76.34
         }
       ],
       "footprint_local": [
         {
-          "x": -7.6,
-          "z": -4.4
+          "x": 7.6,
+          "z": 4
         },
         {
-          "x": -7.6,
-          "z": 6.6
+          "x": 7.6,
+          "z": -6
         },
         {
-          "x": 11.4,
-          "z": 6.6
+          "x": -11.39,
+          "z": -6
         },
         {
-          "x": 11.4,
-          "z": -4.39
+          "x": -11.4,
+          "z": 4
         },
         {
-          "x": -7.6,
-          "z": -4.4
+          "x": 7.6,
+          "z": 4
         }
       ],
       "facade_profile": "gastown_heritage_row",
       "tone": "brickWarm",
       "roofline_type": "flat_cornice",
       "window_bay_count": 4,
-      "recessed_entry_count": 1,
+      "recessed_entry_count": 2,
       "storefront_rhythm": {
-        "base_band": 0.18,
-        "upper_rows": 3
+        "base_band": 0.19,
+        "upper_rows": 4
       },
       "material_palette": {
-        "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#6e3f36",
+        "trim": "#caa98c",
+        "accent": "#445666",
+        "tone": "brickWarm"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-6-right",
       "reference_name": "Starter east frontage",
-      "x": 24.65,
-      "z": -86.38,
-      "width": 19.01,
-      "depth": 11,
+      "segment_style": "mid-corridor-heritage-rhythm",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": 24.33,
+      "z": -80.59,
+      "width": 19,
+      "depth": 10,
       "yaw": -1.4891,
-      "height": 15,
+      "height": 16,
       "footprint": [
         {
-          "x": 19.65,
-          "z": -79.16
+          "x": 19.73,
+          "z": -73.34
         },
         {
-          "x": 30.61,
-          "z": -78.27
+          "x": 29.69,
+          "z": -72.52
         },
         {
-          "x": 32.16,
-          "z": -97.21
+          "x": 31.24,
+          "z": -91.46
         },
         {
-          "x": 21.2,
-          "z": -98.1
+          "x": 21.27,
+          "z": -92.27
         },
         {
-          "x": 19.65,
-          "z": -79.16
+          "x": 19.73,
+          "z": -73.34
         }
       ],
       "footprint_local": [
         {
           "x": -7.6,
-          "z": -4.4
+          "z": -4
         },
         {
           "x": -7.6,
-          "z": 6.6
-        },
-        {
-          "x": 11.41,
-          "z": 6.6
+          "z": 6
         },
         {
           "x": 11.4,
-          "z": -4.4
+          "z": 6
+        },
+        {
+          "x": 11.4,
+          "z": -4
         },
         {
           "x": -7.6,
-          "z": -4.4
+          "z": -4
         }
       ],
-      "facade_profile": "cordoba_commercial_transition",
+      "facade_profile": "narrow_brick_shaft",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 4,
       "recessed_entry_count": 1,
       "storefront_rhythm": {
-        "base_band": 0.18,
-        "upper_rows": 3
+        "base_band": 0.19,
+        "upper_rows": 4
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#6f747c",
+        "trim": "#d0c3b3",
+        "accent": "#3f5363",
+        "tone": "stoneMuted"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-7-left",
       "reference_name": "Starter west frontage",
-      "x": -9.32,
-      "z": -102.75,
-      "width": 16.01,
-      "depth": 9,
-      "yaw": -1.5033,
-      "height": 9,
+      "segment_style": "steam-clock-approach",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": -13.24,
+      "z": -95.18,
+      "width": 20,
+      "depth": 18.01,
+      "yaw": 1.6424,
+      "height": 18,
       "footprint": [
         {
-          "x": -13.34,
-          "z": -96.61
+          "x": -21,
+          "z": -87.72
         },
         {
-          "x": -4.36,
-          "z": -96
+          "x": -3.04,
+          "z": -86.43
         },
         {
-          "x": -3.28,
-          "z": -111.97
+          "x": -1.61,
+          "z": -106.38
         },
         {
-          "x": -12.26,
-          "z": -112.57
+          "x": -19.57,
+          "z": -107.67
         },
         {
-          "x": -13.34,
-          "z": -96.61
+          "x": -21,
+          "z": -87.72
         }
       ],
       "footprint_local": [
         {
-          "x": -6.4,
-          "z": -3.6
+          "x": 8,
+          "z": 7.2
         },
         {
-          "x": -6.4,
-          "z": 5.4
+          "x": 8,
+          "z": -10.8
         },
         {
-          "x": 9.6,
-          "z": 5.4
+          "x": -12,
+          "z": -10.8
         },
         {
-          "x": 9.6,
-          "z": -3.6
+          "x": -12,
+          "z": 7.2
         },
         {
-          "x": -6.4,
-          "z": -3.6
+          "x": 8,
+          "z": 7.2
         }
       ],
-      "facade_profile": "gastown_heritage_row",
-      "tone": "brickWarm",
-      "roofline_type": "flat_cornice",
-      "window_bay_count": 3,
+      "facade_profile": "narrow_brick_shaft",
+      "tone": "stoneMuted",
+      "roofline_type": "ornate_cornice",
+      "window_bay_count": 7,
       "recessed_entry_count": 1,
       "storefront_rhythm": {
-        "base_band": 0.18,
-        "upper_rows": 3
+        "base_band": 0.22,
+        "upper_rows": 4
       },
       "material_palette": {
-        "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#6f747c",
+        "trim": "#d0c3b3",
+        "accent": "#3f5363",
+        "tone": "stoneMuted"
       },
-      "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "cornice_emphasis": 0.34,
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-7-right",
       "reference_name": "Starter east frontage",
-      "x": 24.4,
-      "z": -100.47,
-      "width": 16.01,
-      "depth": 9,
-      "yaw": 1.6383,
-      "height": 9,
+      "segment_style": "steam-clock-approach",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": 25.46,
+      "z": -92.41,
+      "width": 20.01,
+      "depth": 18.01,
+      "yaw": -1.4992,
+      "height": 18,
       "footprint": [
         {
-          "x": 20.38,
-          "z": -94.32
+          "x": 17.7,
+          "z": -84.94
         },
         {
-          "x": 29.36,
-          "z": -93.72
+          "x": 35.66,
+          "z": -83.66
         },
         {
-          "x": 30.44,
-          "z": -109.68
+          "x": 37.09,
+          "z": -103.61
         },
         {
-          "x": 21.46,
-          "z": -110.29
+          "x": 19.13,
+          "z": -104.89
         },
         {
-          "x": 20.38,
-          "z": -94.32
+          "x": 17.7,
+          "z": -84.94
         }
       ],
       "footprint_local": [
         {
-          "x": 6.4,
-          "z": 3.6
+          "x": -8,
+          "z": -7.2
         },
         {
-          "x": 6.4,
-          "z": -5.4
+          "x": -8,
+          "z": 10.8
         },
         {
-          "x": -9.6,
-          "z": -5.4
+          "x": 12.01,
+          "z": 10.8
         },
         {
-          "x": -9.6,
-          "z": 3.6
+          "x": 12,
+          "z": -7.2
         },
         {
-          "x": 6.4,
-          "z": 3.6
+          "x": -8,
+          "z": -7.2
         }
       ],
-      "facade_profile": "cordoba_commercial_transition",
-      "tone": "stoneMuted",
-      "roofline_type": "flat_cornice",
-      "window_bay_count": 3,
-      "recessed_entry_count": 1,
+      "facade_profile": "gastown_heritage_row",
+      "tone": "brickWarm",
+      "roofline_type": "ornate_cornice",
+      "window_bay_count": 7,
+      "recessed_entry_count": 3,
       "storefront_rhythm": {
-        "base_band": 0.18,
-        "upper_rows": 3
+        "base_band": 0.22,
+        "upper_rows": 4
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#74493c",
+        "trim": "#cfb8a2",
+        "accent": "#4f5f6f",
+        "tone": "brickWarm"
       },
-      "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "cornice_emphasis": 0.34,
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-8-left",
       "reference_name": "Starter west frontage",
-      "x": -11.56,
-      "z": -113.93,
-      "width": 21,
-      "depth": 14,
-      "yaw": -1.5031,
-      "height": 16,
+      "segment_style": "steam-clock-approach",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": -12.75,
+      "z": -115.72,
+      "width": 23.01,
+      "depth": 12,
+      "yaw": -1.5029,
+      "height": 14,
       "footprint": [
         {
-          "x": -17.72,
-          "z": -105.93
+          "x": -18.16,
+          "z": -106.86
         },
         {
-          "x": -3.75,
-          "z": -104.98
+          "x": -6.19,
+          "z": -106.05
         },
         {
-          "x": -2.33,
-          "z": -125.93
+          "x": -4.63,
+          "z": -129
         },
         {
-          "x": -16.3,
-          "z": -126.88
+          "x": -16.6,
+          "z": -129.81
         },
         {
-          "x": -17.72,
-          "z": -105.93
+          "x": -18.16,
+          "z": -106.86
         }
       ],
       "footprint_local": [
         {
-          "x": -8.4,
-          "z": -5.6
+          "x": -9.2,
+          "z": -4.8
         },
         {
-          "x": -8.4,
-          "z": 8.4
+          "x": -9.2,
+          "z": 7.2
         },
         {
-          "x": 12.6,
-          "z": 8.4
+          "x": 13.8,
+          "z": 7.2
         },
         {
-          "x": 12.6,
-          "z": -5.6
+          "x": 13.8,
+          "z": -4.8
         },
         {
-          "x": -8.4,
-          "z": -5.6
+          "x": -9.2,
+          "z": -4.8
         }
       ],
       "facade_profile": "gastown_heritage_row",
       "tone": "brickWarm",
-      "roofline_type": "flat_cornice",
+      "roofline_type": "ornate_cornice",
       "window_bay_count": 5,
-      "recessed_entry_count": 1,
+      "recessed_entry_count": 3,
       "storefront_rhythm": {
-        "base_band": 0.18,
-        "upper_rows": 4
+        "base_band": 0.22,
+        "upper_rows": 3
       },
       "material_palette": {
         "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "trim": "#cfb8a2",
+        "accent": "#4f5f6f",
+        "tone": "brickWarm"
       },
-      "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "cornice_emphasis": 0.34,
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-8-right",
       "reference_name": "Starter east frontage",
-      "x": 27.15,
-      "z": -111.31,
-      "width": 21.01,
-      "depth": 14,
-      "yaw": 1.6384,
-      "height": 16,
+      "segment_style": "steam-clock-approach",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": 28.96,
+      "z": -112.89,
+      "width": 23,
+      "depth": 12,
+      "yaw": 1.6382,
+      "height": 14,
       "footprint": [
         {
-          "x": 20.99,
-          "z": -103.3
+          "x": 23.55,
+          "z": -104.03
         },
         {
-          "x": 34.96,
-          "z": -102.36
+          "x": 35.52,
+          "z": -103.22
         },
         {
-          "x": 36.38,
-          "z": -123.31
+          "x": 37.07,
+          "z": -126.17
         },
         {
-          "x": 22.41,
-          "z": -124.26
+          "x": 25.1,
+          "z": -126.98
         },
         {
-          "x": 20.99,
-          "z": -103.3
+          "x": 23.55,
+          "z": -104.03
         }
       ],
       "footprint_local": [
         {
-          "x": 8.4,
-          "z": 5.6
+          "x": 9.2,
+          "z": 4.8
         },
         {
-          "x": 8.4,
-          "z": -8.4
+          "x": 9.2,
+          "z": -7.2
         },
         {
-          "x": -12.6,
-          "z": -8.4
+          "x": -13.8,
+          "z": -7.2
         },
         {
-          "x": -12.6,
-          "z": 5.6
+          "x": -13.8,
+          "z": 4.8
         },
         {
-          "x": 8.4,
-          "z": 5.6
+          "x": 9.2,
+          "z": 4.8
         }
       ],
-      "facade_profile": "cordoba_commercial_transition",
+      "facade_profile": "cordova_commercial_transition",
       "tone": "stoneMuted",
-      "roofline_type": "flat_cornice",
+      "roofline_type": "ornate_cornice",
       "window_bay_count": 5,
       "recessed_entry_count": 1,
       "storefront_rhythm": {
-        "base_band": 0.18,
-        "upper_rows": 4
+        "base_band": 0.22,
+        "upper_rows": 3
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#8a857d",
+        "trim": "#d8c9b6",
+        "accent": "#57656e",
+        "tone": "stoneMuted"
       },
-      "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "cornice_emphasis": 0.34,
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-9-left",
-      "reference_name": "Starter west frontage",
-      "x": -8.53,
-      "z": -130.56,
-      "width": 18,
-      "depth": 10,
-      "yaw": 1.6386,
-      "height": 13,
+      "reference_name": "Starter corner heritage anchor",
+      "segment_style": "steam-clock-approach",
+      "style_notes": "Corner building massing with stronger cornice to punctuate the route.",
+      "x": -10.97,
+      "z": -130.78,
+      "width": 20.5,
+      "depth": 11.01,
+      "yaw": 1.6387,
+      "height": 11,
       "footprint": [
         {
-          "x": -13.01,
-          "z": -123.65
+          "x": -15.92,
+          "z": -122.9
         },
         {
-          "x": -3.03,
-          "z": -122.97
+          "x": -4.94,
+          "z": -122.15
         },
         {
-          "x": -1.82,
-          "z": -140.93
+          "x": -3.56,
+          "z": -142.6
         },
         {
-          "x": -11.79,
-          "z": -141.61
+          "x": -14.53,
+          "z": -143.35
         },
         {
-          "x": -13.01,
-          "z": -123.65
+          "x": -15.92,
+          "z": -122.9
         }
       ],
       "footprint_local": [
         {
-          "x": 7.2,
-          "z": 4
+          "x": 8.2,
+          "z": 4.4
         },
         {
-          "x": 7.2,
-          "z": -6
+          "x": 8.2,
+          "z": -6.61
         },
         {
-          "x": -10.8,
-          "z": -5.99
+          "x": -12.3,
+          "z": -6.6
         },
         {
-          "x": -10.8,
-          "z": 4
+          "x": -12.3,
+          "z": 4.4
         },
         {
-          "x": 7.2,
-          "z": 4
+          "x": 8.2,
+          "z": 4.4
         }
       ],
-      "facade_profile": "gastown_heritage_row",
-      "tone": "brickWarm",
-      "roofline_type": "flat_cornice",
-      "window_bay_count": 4,
+      "facade_profile": "cordova_commercial_transition",
+      "tone": "stoneMuted",
+      "roofline_type": "wrapped_cornice",
+      "window_bay_count": 3,
       "recessed_entry_count": 1,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.22,
         "upper_rows": 3
       },
       "material_palette": {
-        "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#8a857d",
+        "trim": "#d8c9b6",
+        "accent": "#57656e",
+        "tone": "stoneMuted"
       },
-      "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "cornice_emphasis": 0.42,
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-9-right",
       "reference_name": "Starter east frontage",
-      "x": 27.19,
-      "z": -128.14,
-      "width": 18,
-      "depth": 9.99,
-      "yaw": -1.503,
-      "height": 13,
+      "segment_style": "steam-clock-approach",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": 27.41,
+      "z": -128.53,
+      "width": 17,
+      "depth": 8,
+      "yaw": -1.5031,
+      "height": 9,
       "footprint": [
         {
-          "x": 22.71,
-          "z": -121.23
+          "x": 23.76,
+          "z": -121.96
         },
         {
-          "x": 32.68,
-          "z": -120.55
+          "x": 31.74,
+          "z": -121.42
         },
         {
-          "x": 33.9,
-          "z": -138.51
+          "x": 32.89,
+          "z": -138.38
         },
         {
-          "x": 23.93,
-          "z": -139.19
+          "x": 24.91,
+          "z": -138.92
         },
         {
-          "x": 22.71,
-          "z": -121.23
+          "x": 23.76,
+          "z": -121.96
         }
       ],
       "footprint_local": [
         {
-          "x": -7.2,
-          "z": -4
+          "x": -6.8,
+          "z": -3.2
         },
         {
-          "x": -7.2,
-          "z": 6
+          "x": -6.8,
+          "z": 4.8
         },
         {
-          "x": 10.8,
-          "z": 6
+          "x": 10.2,
+          "z": 4.8
         },
         {
-          "x": 10.8,
-          "z": -4
+          "x": 10.2,
+          "z": -3.2
         },
         {
-          "x": -7.2,
-          "z": -4
+          "x": -6.8,
+          "z": -3.2
         }
       ],
-      "facade_profile": "cordoba_commercial_transition",
-      "tone": "stoneMuted",
-      "roofline_type": "flat_cornice",
-      "window_bay_count": 4,
-      "recessed_entry_count": 1,
+      "facade_profile": "gastown_heritage_row",
+      "tone": "brickWarm",
+      "roofline_type": "ornate_cornice",
+      "window_bay_count": 3,
+      "recessed_entry_count": 2,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.22,
         "upper_rows": 3
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#6e3f36",
+        "trim": "#caa98c",
+        "accent": "#445666",
+        "tone": "brickWarm"
       },
-      "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "cornice_emphasis": 0.34,
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-10-left",
       "reference_name": "Starter west frontage",
-      "x": -7.08,
-      "z": -143.09,
-      "width": 17.01,
-      "depth": 9,
+      "segment_style": "post-clock-continuation",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": -12.24,
+      "z": -140.24,
+      "width": 25,
+      "depth": 18,
       "yaw": -1.5031,
-      "height": 10,
+      "height": 20,
       "footprint": [
         {
-          "x": -11.13,
-          "z": -136.55
+          "x": -20.1,
+          "z": -130.75
         },
         {
-          "x": -2.15,
-          "z": -135.94
+          "x": -2.14,
+          "z": -129.53
         },
         {
-          "x": -1,
-          "z": -152.91
+          "x": -0.45,
+          "z": -154.47
         },
         {
-          "x": -9.98,
-          "z": -153.51
+          "x": -18.41,
+          "z": -155.69
         },
         {
-          "x": -11.13,
-          "z": -136.55
+          "x": -20.1,
+          "z": -130.75
         }
       ],
       "footprint_local": [
         {
-          "x": -6.8,
-          "z": -3.6
+          "x": -10,
+          "z": -7.2
         },
         {
-          "x": -6.8,
-          "z": 5.4
+          "x": -10,
+          "z": 10.8
         },
         {
-          "x": 10.21,
-          "z": 5.4
+          "x": 15,
+          "z": 10.8
         },
         {
-          "x": 10.2,
-          "z": -3.6
+          "x": 15,
+          "z": -7.2
         },
         {
-          "x": -6.8,
-          "z": -3.6
+          "x": -10,
+          "z": -7.2
         }
       ],
       "facade_profile": "gastown_heritage_row",
       "tone": "brickWarm",
       "roofline_type": "flat_cornice",
-      "window_bay_count": 3,
-      "recessed_entry_count": 1,
+      "window_bay_count": 7,
+      "recessed_entry_count": 2,
       "storefront_rhythm": {
-        "base_band": 0.18,
-        "upper_rows": 3
+        "base_band": 0.19,
+        "upper_rows": 4
       },
       "material_palette": {
-        "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#6e3f36",
+        "trim": "#caa98c",
+        "accent": "#445666",
+        "tone": "brickWarm"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.93
     },
     {
       "id": "starter-bldg-10-right",
       "reference_name": "Starter east frontage",
-      "x": 27.64,
-      "z": -140.74,
-      "width": 17,
-      "depth": 9,
-      "yaw": -1.5031,
-      "height": 10,
+      "segment_style": "post-clock-continuation",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": 30.76,
+      "z": -137.32,
+      "width": 25.01,
+      "depth": 16.01,
+      "yaw": -1.5032,
+      "height": 20,
       "footprint": [
         {
-          "x": 23.59,
-          "z": -134.2
+          "x": 23.7,
+          "z": -127.78
         },
         {
-          "x": 32.57,
-          "z": -133.59
+          "x": 39.67,
+          "z": -126.69
         },
         {
-          "x": 33.72,
-          "z": -150.55
+          "x": 41.36,
+          "z": -151.64
         },
         {
-          "x": 24.74,
-          "z": -151.16
+          "x": 25.39,
+          "z": -152.72
         },
         {
-          "x": 23.59,
-          "z": -134.2
+          "x": 23.7,
+          "z": -127.78
         }
       ],
       "footprint_local": [
         {
-          "x": -6.8,
-          "z": -3.6
+          "x": -10,
+          "z": -6.4
         },
         {
-          "x": -6.8,
-          "z": 5.4
+          "x": -10.01,
+          "z": 9.6
         },
         {
-          "x": 10.2,
-          "z": 5.4
+          "x": 15,
+          "z": 9.6
         },
         {
-          "x": 10.2,
-          "z": -3.6
+          "x": 15,
+          "z": -6.4
         },
         {
-          "x": -6.8,
-          "z": -3.6
+          "x": -10,
+          "z": -6.4
         }
       ],
-      "facade_profile": "cordoba_commercial_transition",
+      "facade_profile": "narrow_brick_shaft",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
-      "window_bay_count": 3,
+      "window_bay_count": 6,
       "recessed_entry_count": 1,
       "storefront_rhythm": {
-        "base_band": 0.18,
-        "upper_rows": 3
+        "base_band": 0.19,
+        "upper_rows": 4
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#6f747c",
+        "trim": "#d0c3b3",
+        "accent": "#3f5363",
+        "tone": "stoneMuted"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.93
     },
     {
       "id": "starter-bldg-11-left",
       "reference_name": "Starter west frontage",
-      "x": -8.1,
-      "z": -154.7,
-      "width": 20.01,
-      "depth": 12,
-      "yaw": 1.6539,
-      "height": 14,
+      "segment_style": "post-clock-continuation",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": -6.6,
+      "z": -159.88,
+      "width": 18,
+      "depth": 11,
+      "yaw": -1.4829,
+      "height": 13,
       "footprint": [
         {
-          "x": -13.55,
-          "z": -147.12
+          "x": -11.62,
+          "z": -153.1
         },
         {
-          "x": -1.59,
-          "z": -146.13
+          "x": -0.66,
+          "z": -152.13
         },
         {
-          "x": 0.06,
-          "z": -166.06
+          "x": 0.92,
+          "z": -170.06
         },
         {
-          "x": -11.89,
-          "z": -167.06
+          "x": -10.04,
+          "z": -171.03
         },
         {
-          "x": -13.55,
-          "z": -147.12
+          "x": -11.62,
+          "z": -153.1
         }
       ],
       "footprint_local": [
         {
-          "x": 8,
-          "z": 4.8
+          "x": -7.2,
+          "z": -4.4
         },
         {
-          "x": 8,
-          "z": -7.2
+          "x": -7.2,
+          "z": 6.6
         },
         {
-          "x": -12,
-          "z": -7.19
+          "x": 10.8,
+          "z": 6.6
         },
         {
-          "x": -12.01,
-          "z": 4.8
+          "x": 10.8,
+          "z": -4.4
         },
         {
-          "x": 8,
-          "z": 4.8
+          "x": -7.2,
+          "z": -4.4
         }
       ],
-      "facade_profile": "gastown_heritage_row",
-      "tone": "brickWarm",
-      "roofline_type": "flat_cornice",
-      "window_bay_count": 4,
-      "recessed_entry_count": 1,
-      "storefront_rhythm": {
-        "base_band": 0.18,
-        "upper_rows": 3
-      },
-      "material_palette": {
-        "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
-      },
-      "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
-    },
-    {
-      "id": "starter-bldg-11-right",
-      "reference_name": "Starter east frontage",
-      "x": 29.56,
-      "z": -151.56,
-      "width": 20,
-      "depth": 11.99,
-      "yaw": -1.4877,
-      "height": 14,
-      "footprint": [
-        {
-          "x": 24.12,
-          "z": -143.99
-        },
-        {
-          "x": 36.07,
-          "z": -142.99
-        },
-        {
-          "x": 37.73,
-          "z": -162.92
-        },
-        {
-          "x": 25.78,
-          "z": -163.92
-        },
-        {
-          "x": 24.12,
-          "z": -143.99
-        }
-      ],
-      "footprint_local": [
-        {
-          "x": -8,
-          "z": -4.8
-        },
-        {
-          "x": -8,
-          "z": 7.2
-        },
-        {
-          "x": 12,
-          "z": 7.2
-        },
-        {
-          "x": 12,
-          "z": -4.8
-        },
-        {
-          "x": -8,
-          "z": -4.8
-        }
-      ],
-      "facade_profile": "cordoba_commercial_transition",
+      "facade_profile": "narrow_brick_shaft",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 4,
       "recessed_entry_count": 1,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.19,
         "upper_rows": 3
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#6f747c",
+        "trim": "#d0c3b3",
+        "accent": "#3f5363",
+        "tone": "stoneMuted"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.93
+    },
+    {
+      "id": "starter-bldg-11-right",
+      "reference_name": "Starter corner heritage anchor",
+      "segment_style": "post-clock-continuation",
+      "style_notes": "Corner building massing with stronger cornice to punctuate the route.",
+      "x": 31.82,
+      "z": -156.15,
+      "width": 21.5,
+      "depth": 12,
+      "yaw": 1.6588,
+      "height": 15,
+      "footprint": [
+        {
+          "x": 26.28,
+          "z": -148
+        },
+        {
+          "x": 38.23,
+          "z": -146.95
+        },
+        {
+          "x": 40.12,
+          "z": -168.36
+        },
+        {
+          "x": 28.17,
+          "z": -169.42
+        },
+        {
+          "x": 26.28,
+          "z": -148
+        }
+      ],
+      "footprint_local": [
+        {
+          "x": 8.6,
+          "z": 4.8
+        },
+        {
+          "x": 8.6,
+          "z": -7.2
+        },
+        {
+          "x": -12.9,
+          "z": -7.2
+        },
+        {
+          "x": -12.9,
+          "z": 4.8
+        },
+        {
+          "x": 8.6,
+          "z": 4.8
+        }
+      ],
+      "facade_profile": "gastown_heritage_row",
+      "tone": "brickWarm",
+      "roofline_type": "wrapped_cornice",
+      "window_bay_count": 4,
+      "recessed_entry_count": 1,
+      "storefront_rhythm": {
+        "base_band": 0.19,
+        "upper_rows": 3
+      },
+      "material_palette": {
+        "primary": "#74493c",
+        "trim": "#cfb8a2",
+        "accent": "#4f5f6f",
+        "tone": "brickWarm"
+      },
+      "cornice_emphasis": 0.42,
+      "mass_inset": 0.93
     },
     {
       "id": "starter-bldg-12-left",
       "reference_name": "Starter west frontage",
-      "x": -3.9,
-      "z": -169.49,
-      "width": 15,
-      "depth": 8,
-      "yaw": -1.4827,
-      "height": 12,
+      "segment_style": "post-clock-continuation",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": -4.44,
+      "z": -171.84,
+      "width": 16,
+      "depth": 10.01,
+      "yaw": -1.4826,
+      "height": 11,
       "footprint": [
         {
-          "x": -7.62,
-          "z": -163.79
+          "x": -8.99,
+          "z": -165.82
         },
         {
-          "x": 0.35,
-          "z": -163.09
+          "x": 0.97,
+          "z": -164.94
         },
         {
-          "x": 1.67,
-          "z": -178.03
+          "x": 2.38,
+          "z": -180.88
         },
         {
-          "x": -6.3,
-          "z": -178.73
+          "x": -7.59,
+          "z": -181.76
         },
         {
-          "x": -7.62,
-          "z": -163.79
+          "x": -8.99,
+          "z": -165.82
         }
       ],
       "footprint_local": [
         {
-          "x": -6,
-          "z": -3.2
+          "x": -6.4,
+          "z": -4
         },
         {
-          "x": -6,
-          "z": 4.8
+          "x": -6.4,
+          "z": 6
         },
         {
-          "x": 9,
-          "z": 4.8
+          "x": 9.6,
+          "z": 6
         },
         {
-          "x": 9,
-          "z": -3.2
+          "x": 9.6,
+          "z": -4.01
         },
         {
-          "x": -6,
-          "z": -3.2
+          "x": -6.4,
+          "z": -4
         }
       ],
       "facade_profile": "gastown_heritage_row",
       "tone": "brickWarm",
       "roofline_type": "flat_cornice",
-      "window_bay_count": 3,
+      "window_bay_count": 4,
       "recessed_entry_count": 1,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.19,
         "upper_rows": 3
       },
       "material_palette": {
         "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "trim": "#cfb8a2",
+        "accent": "#4f5f6f",
+        "tone": "brickWarm"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.93
     },
     {
       "id": "starter-bldg-12-right",
       "reference_name": "Starter east frontage",
-      "x": 28.78,
-      "z": -166.6,
-      "width": 15.01,
+      "segment_style": "post-clock-continuation",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": 29.52,
+      "z": -168.85,
+      "width": 16.01,
       "depth": 8,
-      "yaw": -1.4827,
-      "height": 12,
+      "yaw": -1.4826,
+      "height": 11,
       "footprint": [
         {
-          "x": 25.06,
-          "z": -160.91
+          "x": 25.77,
+          "z": -162.75
         },
         {
-          "x": 33.03,
-          "z": -160.2
+          "x": 33.74,
+          "z": -162.05
         },
         {
-          "x": 34.35,
-          "z": -175.15
+          "x": 35.15,
+          "z": -177.99
         },
         {
-          "x": 26.38,
-          "z": -175.85
+          "x": 27.18,
+          "z": -178.69
         },
         {
-          "x": 25.06,
-          "z": -160.91
+          "x": 25.77,
+          "z": -162.75
         }
       ],
       "footprint_local": [
         {
-          "x": -6,
+          "x": -6.4,
           "z": -3.2
         },
         {
-          "x": -6.01,
+          "x": -6.4,
           "z": 4.8
         },
         {
-          "x": 9,
+          "x": 9.6,
           "z": 4.8
         },
         {
-          "x": 9,
+          "x": 9.6,
           "z": -3.2
         },
         {
-          "x": -6,
+          "x": -6.4,
           "z": -3.2
         }
       ],
-      "facade_profile": "cordoba_commercial_transition",
+      "facade_profile": "cordova_commercial_transition",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 3,
-      "recessed_entry_count": 1,
+      "recessed_entry_count": 2,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.19,
         "upper_rows": 3
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#8a857d",
+        "trim": "#d8c9b6",
+        "accent": "#57656e",
+        "tone": "stoneMuted"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.93
+    }
+  ],
+  "landmarks": [
+    {
+      "id": "starter-landmark-threshold-anchor",
+      "label": "Waterfront threshold",
+      "kind": "cardboard_box",
+      "x": -9.62,
+      "y": 0,
+      "z": -12.88,
+      "scale": 1.35,
+      "cue": "Station canopies give way to brick-front Gastown blocks."
+    },
+    {
+      "id": "starter-landmark-clock-anchor",
+      "label": "Steam Clock approach",
+      "kind": "cardboard_box",
+      "x": 19.06,
+      "y": 0,
+      "z": -102.93,
+      "scale": 1.25,
+      "cue": "Denser storefront rhythm, pavers, and curb clutter build toward the clock node."
+    },
+    {
+      "id": "starter-landmark-postclock-anchor",
+      "label": "Post-clock continuation",
+      "kind": "cardboard_box",
+      "x": 2.75,
+      "y": 0,
+      "z": -166.39,
+      "scale": 1.18,
+      "cue": "The corridor loosens into longer facades and a quieter continuation east."
+    }
+  ],
+  "props": [
+    {
+      "id": "starter-prop-threshold-utility",
+      "kind": "utility_box",
+      "x": 10.8,
+      "y": 0,
+      "z": -23.15,
+      "yaw": 1.4841,
+      "scale": 1.1
+    },
+    {
+      "id": "starter-prop-corner-bags",
+      "kind": "trash_bag",
+      "x": 12.36,
+      "y": 0,
+      "z": -45.12,
+      "yaw": 1.4864,
+      "scale": 1.1
+    },
+    {
+      "id": "starter-prop-planter-west",
+      "kind": "planter",
+      "x": -3.63,
+      "y": 0,
+      "z": -62.5,
+      "yaw": 1.4893,
+      "scale": 1.15
+    },
+    {
+      "id": "starter-prop-planter-east",
+      "kind": "planter",
+      "x": 16.05,
+      "y": 0,
+      "z": -82.97,
+      "yaw": 1.4893,
+      "scale": 1.08
+    },
+    {
+      "id": "starter-prop-bench-clock",
+      "kind": "bench",
+      "x": -0.5,
+      "y": 0,
+      "z": -101.25,
+      "yaw": 3.0739,
+      "scale": 1.04
+    },
+    {
+      "id": "starter-prop-clock-box",
+      "kind": "newspaper_box",
+      "x": 17.44,
+      "y": 0,
+      "z": -107.05,
+      "yaw": 1.5031,
+      "scale": 0.98
+    },
+    {
+      "id": "starter-prop-postclock-utility",
+      "kind": "utility_box",
+      "x": 1.7,
+      "y": 0,
+      "z": -132.17,
+      "yaw": 1.5031,
+      "scale": 1.06
+    },
+    {
+      "id": "starter-prop-postclock-bags",
+      "kind": "trash_bag",
+      "x": 19.79,
+      "y": 0,
+      "z": -144.98,
+      "yaw": 1.5031,
+      "scale": 0.96
+    },
+    {
+      "id": "starter-prop-postclock-bench",
+      "kind": "bench",
+      "x": 21.76,
+      "y": 0,
+      "z": -162.7,
+      "yaw": 3.0536,
+      "scale": 1
     }
   ],
   "streetscape": {
@@ -2317,7 +2510,591 @@
       }
     ],
     "bollards": [],
-    "surfaceBands": []
+    "surfaceBands": [
+      {
+        "segment_id": "starter-corridor-start",
+        "width": 2.94,
+        "length": 14,
+        "yaw": 3.0551,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.24,
+        "elevation": 0.032
+      },
+      {
+        "segment_id": "starter-corridor-start",
+        "width": 1.76,
+        "length": 8.96,
+        "yaw": 3.0551,
+        "offset_x": -0.3,
+        "offset_z": 0,
+        "tone": "patch",
+        "opacity": 0.33,
+        "elevation": 0.038
+      },
+      {
+        "segment_id": "starter-corridor-start",
+        "width": 0.78,
+        "length": 14.84,
+        "yaw": 3.0551,
+        "offset_x": 3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-corridor-start",
+        "width": 0.78,
+        "length": 14.56,
+        "yaw": 3.0551,
+        "offset_x": -3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-corridor-start",
+        "width": 5.49,
+        "length": 3.08,
+        "yaw": 4.6259,
+        "offset_x": -2.16,
+        "offset_z": 0,
+        "tone": "paver_break",
+        "opacity": 0.34,
+        "elevation": 0.041
+      },
+      {
+        "segment_id": "starter-beat-1",
+        "width": 2.94,
+        "length": 14,
+        "yaw": 3.0545,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.24,
+        "elevation": 0.032
+      },
+      {
+        "segment_id": "starter-beat-1",
+        "width": 1.76,
+        "length": 8.96,
+        "yaw": 3.0545,
+        "offset_x": -0.1,
+        "offset_z": 0,
+        "tone": "patch",
+        "opacity": 0.33,
+        "elevation": 0.038
+      },
+      {
+        "segment_id": "starter-beat-1",
+        "width": 0.78,
+        "length": 14.84,
+        "yaw": 3.0545,
+        "offset_x": 3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-1",
+        "width": 0.78,
+        "length": 14.56,
+        "yaw": 3.0545,
+        "offset_x": -3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-1",
+        "width": 8.04,
+        "length": 4.2,
+        "yaw": 4.6253,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "intersection_pavers",
+        "opacity": 0.42,
+        "elevation": 0.045
+      },
+      {
+        "segment_id": "starter-beat-2",
+        "width": 2.94,
+        "length": 14,
+        "yaw": 3.0577,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.24,
+        "elevation": 0.032
+      },
+      {
+        "segment_id": "starter-beat-2",
+        "width": 1.76,
+        "length": 8.96,
+        "yaw": 3.0577,
+        "offset_x": 0.1,
+        "offset_z": 0,
+        "tone": "patch",
+        "opacity": 0.33,
+        "elevation": 0.038
+      },
+      {
+        "segment_id": "starter-beat-2",
+        "width": 0.78,
+        "length": 14.84,
+        "yaw": 3.0577,
+        "offset_x": 3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-2",
+        "width": 0.78,
+        "length": 14.56,
+        "yaw": 3.0577,
+        "offset_x": -3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-2",
+        "width": 5.49,
+        "length": 3.08,
+        "yaw": 4.6285,
+        "offset_x": 2.16,
+        "offset_z": 0,
+        "tone": "paver_break",
+        "opacity": 0.34,
+        "elevation": 0.041
+      },
+      {
+        "segment_id": "starter-beat-3",
+        "width": 2.94,
+        "length": 14,
+        "yaw": 3.0604,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.24,
+        "elevation": 0.032
+      },
+      {
+        "segment_id": "starter-beat-3",
+        "width": 1.76,
+        "length": 11.76,
+        "yaw": 3.0604,
+        "offset_x": 0.3,
+        "offset_z": 0,
+        "tone": "patch",
+        "opacity": 0.33,
+        "elevation": 0.038
+      },
+      {
+        "segment_id": "starter-beat-3",
+        "width": 0.78,
+        "length": 14.84,
+        "yaw": 3.0604,
+        "offset_x": 3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-3",
+        "width": 0.78,
+        "length": 14.56,
+        "yaw": 3.0604,
+        "offset_x": -3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-4",
+        "width": 2.94,
+        "length": 14,
+        "yaw": 3.0599,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.24,
+        "elevation": 0.032
+      },
+      {
+        "segment_id": "starter-beat-4",
+        "width": 1.76,
+        "length": 11.76,
+        "yaw": 3.0599,
+        "offset_x": -0.3,
+        "offset_z": 0,
+        "tone": "patch",
+        "opacity": 0.33,
+        "elevation": 0.038
+      },
+      {
+        "segment_id": "starter-beat-4",
+        "width": 0.78,
+        "length": 14.84,
+        "yaw": 3.0599,
+        "offset_x": 3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-4",
+        "width": 0.78,
+        "length": 14.56,
+        "yaw": 3.0599,
+        "offset_x": -3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-4",
+        "width": 5.49,
+        "length": 3.08,
+        "yaw": 4.6307,
+        "offset_x": -2.16,
+        "offset_z": 0,
+        "tone": "paver_break",
+        "opacity": 0.34,
+        "elevation": 0.041
+      },
+      {
+        "segment_id": "starter-mid-block",
+        "width": 2.94,
+        "length": 14,
+        "yaw": 3.0732,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.24,
+        "elevation": 0.032
+      },
+      {
+        "segment_id": "starter-mid-block",
+        "width": 1.76,
+        "length": 11.76,
+        "yaw": 3.0732,
+        "offset_x": -0.1,
+        "offset_z": 0,
+        "tone": "patch",
+        "opacity": 0.33,
+        "elevation": 0.038
+      },
+      {
+        "segment_id": "starter-mid-block",
+        "width": 0.78,
+        "length": 14.84,
+        "yaw": 3.0732,
+        "offset_x": 3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-mid-block",
+        "width": 0.78,
+        "length": 14.56,
+        "yaw": 3.0732,
+        "offset_x": -3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-mid-block",
+        "width": 8.04,
+        "length": 4.2,
+        "yaw": 4.644,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "intersection_pavers",
+        "opacity": 0.42,
+        "elevation": 0.045
+      },
+      {
+        "segment_id": "starter-beat-6",
+        "width": 2.94,
+        "length": 14,
+        "yaw": 3.0742,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.24,
+        "elevation": 0.032
+      },
+      {
+        "segment_id": "starter-beat-6",
+        "width": 1.76,
+        "length": 11.76,
+        "yaw": 3.0742,
+        "offset_x": 0.1,
+        "offset_z": 0,
+        "tone": "patch",
+        "opacity": 0.33,
+        "elevation": 0.038
+      },
+      {
+        "segment_id": "starter-beat-6",
+        "width": 0.78,
+        "length": 14.84,
+        "yaw": 3.0742,
+        "offset_x": 3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-6",
+        "width": 0.78,
+        "length": 14.56,
+        "yaw": 3.0742,
+        "offset_x": -3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-6",
+        "width": 7.06,
+        "length": 3.08,
+        "yaw": 4.645,
+        "offset_x": 2.16,
+        "offset_z": 0,
+        "tone": "cobble_break",
+        "opacity": 0.34,
+        "elevation": 0.041
+      },
+      {
+        "segment_id": "starter-beat-7",
+        "width": 2.94,
+        "length": 14,
+        "yaw": 3.0737,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.24,
+        "elevation": 0.032
+      },
+      {
+        "segment_id": "starter-beat-7",
+        "width": 1.76,
+        "length": 11.76,
+        "yaw": 3.0737,
+        "offset_x": 0.3,
+        "offset_z": 0,
+        "tone": "repair_patch_dark",
+        "opacity": 0.38,
+        "elevation": 0.038
+      },
+      {
+        "segment_id": "starter-beat-7",
+        "width": 0.78,
+        "length": 14.84,
+        "yaw": 3.0737,
+        "offset_x": 3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-7",
+        "width": 0.78,
+        "length": 14.56,
+        "yaw": 3.0737,
+        "offset_x": -3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-8",
+        "width": 2.94,
+        "length": 14,
+        "yaw": 3.0577,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.24,
+        "elevation": 0.032
+      },
+      {
+        "segment_id": "starter-beat-8",
+        "width": 1.76,
+        "length": 11.76,
+        "yaw": 3.0577,
+        "offset_x": -0.3,
+        "offset_z": 0,
+        "tone": "repair_patch_dark",
+        "opacity": 0.38,
+        "elevation": 0.038
+      },
+      {
+        "segment_id": "starter-beat-8",
+        "width": 0.78,
+        "length": 14.84,
+        "yaw": 3.0577,
+        "offset_x": 3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-8",
+        "width": 0.78,
+        "length": 14.56,
+        "yaw": 3.0577,
+        "offset_x": -3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-8",
+        "width": 5.49,
+        "length": 3.08,
+        "yaw": 4.6285,
+        "offset_x": -2.16,
+        "offset_z": 0,
+        "tone": "paver_break",
+        "opacity": 0.34,
+        "elevation": 0.041
+      },
+      {
+        "segment_id": "starter-beat-9",
+        "width": 2.94,
+        "length": 14,
+        "yaw": 3.0535,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.24,
+        "elevation": 0.032
+      },
+      {
+        "segment_id": "starter-beat-9",
+        "width": 1.76,
+        "length": 11.76,
+        "yaw": 3.0535,
+        "offset_x": -0.1,
+        "offset_z": 0,
+        "tone": "repair_patch_dark",
+        "opacity": 0.38,
+        "elevation": 0.038
+      },
+      {
+        "segment_id": "starter-beat-9",
+        "width": 0.78,
+        "length": 14.84,
+        "yaw": 3.0535,
+        "offset_x": 3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-9",
+        "width": 0.78,
+        "length": 14.56,
+        "yaw": 3.0535,
+        "offset_x": -3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-9",
+        "width": 8.04,
+        "length": 4.2,
+        "yaw": 4.6243,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "intersection_pavers",
+        "opacity": 0.42,
+        "elevation": 0.045
+      },
+      {
+        "segment_id": "starter-corridor-end",
+        "width": 2.94,
+        "length": 14,
+        "yaw": -0.0881,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.24,
+        "elevation": 0.032
+      },
+      {
+        "segment_id": "starter-corridor-end",
+        "width": 1.76,
+        "length": 11.76,
+        "yaw": -0.0881,
+        "offset_x": 0.1,
+        "offset_z": 0,
+        "tone": "repair_patch_dark",
+        "opacity": 0.38,
+        "elevation": 0.038
+      },
+      {
+        "segment_id": "starter-corridor-end",
+        "width": 0.78,
+        "length": 14.84,
+        "yaw": -0.0881,
+        "offset_x": 3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-corridor-end",
+        "width": 0.78,
+        "length": 14.56,
+        "yaw": -0.0881,
+        "offset_x": -3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-corridor-end",
+        "width": 5.49,
+        "length": 3.08,
+        "yaw": 1.4827,
+        "offset_x": 2.16,
+        "offset_z": 0,
+        "tone": "paver_break",
+        "opacity": 0.34,
+        "elevation": 0.041
+      }
+    ]
   },
   "spawn": {
     "x": 0.78,

--- a/assets/world/gastown-water-street.json
+++ b/assets/world/gastown-water-street.json
@@ -10,7 +10,7 @@
       "Starter corridor fallback is active because required offline civic source files are missing.",
       "This world is intentionally human-scaled and deterministic for readability; it is not GIS-accurate Gastown reconstruction."
     ],
-    "lastBuild": "2026-03-16T03:48:56.774Z"
+    "lastBuild": "2026-03-22T09:40:47.254Z"
   },
   "route": {
     "name": "Gastown starter block corridor",
@@ -313,54 +313,56 @@
     {
       "id": "starter-bldg-0-left",
       "reference_name": "Starter west frontage",
-      "x": -17.68,
-      "z": -7.86,
-      "width": 17.01,
-      "depth": 9,
-      "yaw": 1.6574,
-      "height": 10,
+      "segment_style": "waterfront-threshold",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": -17.3,
+      "z": -5.92,
+      "width": 16,
+      "depth": 8,
+      "yaw": -1.4844,
+      "height": 12,
       "footprint": [
         {
-          "x": -21.86,
-          "z": -1.4
+          "x": -21.04,
+          "z": 0.18
         },
         {
-          "x": -12.89,
-          "z": -0.62
+          "x": -13.07,
+          "z": 0.87
         },
         {
-          "x": -11.42,
-          "z": -17.56
+          "x": -11.69,
+          "z": -15.07
         },
         {
-          "x": -20.39,
-          "z": -18.34
+          "x": -19.66,
+          "z": -15.76
         },
         {
-          "x": -21.86,
-          "z": -1.4
+          "x": -21.04,
+          "z": 0.18
         }
       ],
       "footprint_local": [
         {
-          "x": 6.8,
-          "z": 3.6
+          "x": -6.4,
+          "z": -3.2
         },
         {
-          "x": 6.8,
-          "z": -5.4
+          "x": -6.4,
+          "z": 4.8
         },
         {
-          "x": -10.2,
-          "z": -5.4
+          "x": 9.6,
+          "z": 4.8
         },
         {
-          "x": -10.2,
-          "z": 3.6
+          "x": 9.6,
+          "z": -3.2
         },
         {
-          "x": 6.8,
-          "z": 3.6
+          "x": -6.4,
+          "z": -3.2
         }
       ],
       "facade_profile": "gastown_heritage_row",
@@ -369,676 +371,706 @@
       "window_bay_count": 3,
       "recessed_entry_count": 1,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.16,
         "upper_rows": 3
       },
       "material_palette": {
         "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "trim": "#cfb8a2",
+        "accent": "#4f5f6f",
+        "tone": "brickWarm"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.95
     },
     {
       "id": "starter-bldg-0-right",
       "reference_name": "Starter east frontage",
-      "x": 16.98,
-      "z": -4.84,
-      "width": 17.01,
-      "depth": 9,
-      "yaw": -1.4837,
-      "height": 10,
+      "segment_style": "waterfront-threshold",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": 17.21,
+      "z": -2.77,
+      "width": 17.51,
+      "depth": 8,
+      "yaw": 1.6577,
+      "height": 11,
       "footprint": [
         {
-          "x": 12.81,
-          "z": 1.62
+          "x": 13.41,
+          "z": 3.93
         },
         {
-          "x": 21.77,
-          "z": 2.4
+          "x": 21.38,
+          "z": 4.62
         },
         {
-          "x": 23.25,
-          "z": -14.54
+          "x": 22.9,
+          "z": -12.81
         },
         {
-          "x": 14.28,
-          "z": -15.32
+          "x": 14.93,
+          "z": -13.51
         },
         {
-          "x": 12.81,
-          "z": 1.62
+          "x": 13.41,
+          "z": 3.93
         }
       ],
       "footprint_local": [
         {
-          "x": -6.8,
-          "z": -3.6
+          "x": 7,
+          "z": 3.2
         },
         {
-          "x": -6.8,
-          "z": 5.4
+          "x": 7,
+          "z": -4.8
         },
         {
-          "x": 10.2,
-          "z": 5.4
+          "x": -10.5,
+          "z": -4.8
         },
         {
-          "x": 10.2,
-          "z": -3.61
+          "x": -10.5,
+          "z": 3.2
         },
         {
-          "x": -6.8,
-          "z": -3.6
+          "x": 7,
+          "z": 3.2
         }
       ],
       "facade_profile": "cordova_commercial_transition",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 3,
-      "recessed_entry_count": 1,
+      "recessed_entry_count": 2,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.16,
         "upper_rows": 3
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#8a857d",
+        "trim": "#d8c9b6",
+        "accent": "#57656e",
+        "tone": "stoneMuted"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.95
     },
     {
       "id": "starter-bldg-1-left",
       "reference_name": "Starter west frontage",
-      "x": -18.51,
-      "z": -19.18,
-      "width": 20.01,
-      "depth": 12,
-      "yaw": -1.4842,
-      "height": 14,
+      "segment_style": "waterfront-threshold",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": -19.29,
+      "z": -15.43,
+      "width": 21,
+      "depth": 11,
+      "yaw": -1.484,
+      "height": 16,
       "footprint": [
         {
-          "x": -23.98,
-          "z": -11.62
+          "x": -24.4,
+          "z": -7.44
         },
         {
-          "x": -12.03,
-          "z": -10.58
+          "x": -13.44,
+          "z": -6.49
         },
         {
-          "x": -10.3,
-          "z": -30.51
+          "x": -11.62,
+          "z": -27.41
         },
         {
-          "x": -22.25,
-          "z": -31.55
+          "x": -22.58,
+          "z": -28.36
         },
         {
-          "x": -23.98,
-          "z": -11.62
+          "x": -24.4,
+          "z": -7.44
         }
       ],
       "footprint_local": [
         {
-          "x": -8,
-          "z": -4.8
+          "x": -8.4,
+          "z": -4.4
         },
         {
-          "x": -8,
-          "z": 7.2
+          "x": -8.4,
+          "z": 6.6
         },
         {
-          "x": 12,
-          "z": 7.2
+          "x": 12.6,
+          "z": 6.6
         },
         {
-          "x": 12,
-          "z": -4.8
+          "x": 12.6,
+          "z": -4.4
         },
         {
-          "x": -8,
-          "z": -4.8
+          "x": -8.4,
+          "z": -4.4
         }
       ],
-      "facade_profile": "gastown_heritage_row",
-      "tone": "brickWarm",
+      "facade_profile": "cordova_commercial_transition",
+      "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 4,
-      "recessed_entry_count": 1,
+      "recessed_entry_count": 2,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.16,
         "upper_rows": 3
       },
       "material_palette": {
-        "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#8a857d",
+        "trim": "#d8c9b6",
+        "accent": "#57656e",
+        "tone": "stoneMuted"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.95
     },
     {
       "id": "starter-bldg-1-right",
       "reference_name": "Starter east frontage",
-      "x": 19.15,
-      "z": -15.9,
-      "width": 20,
-      "depth": 12.01,
-      "yaw": 1.6579,
-      "height": 14,
+      "segment_style": "waterfront-threshold",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": 20.2,
+      "z": -11.84,
+      "width": 22.5,
+      "depth": 11,
+      "yaw": 1.6576,
+      "height": 15,
       "footprint": [
         {
-          "x": 13.67,
-          "z": -8.35
+          "x": 15.04,
+          "z": -3.26
         },
         {
-          "x": 25.63,
-          "z": -7.31
+          "x": 26,
+          "z": -2.31
         },
         {
-          "x": 27.36,
-          "z": -27.23
+          "x": 27.95,
+          "z": -24.72
         },
         {
-          "x": 15.41,
-          "z": -28.27
+          "x": 16.99,
+          "z": -25.67
         },
         {
-          "x": 13.67,
-          "z": -8.35
+          "x": 15.04,
+          "z": -3.26
         }
       ],
       "footprint_local": [
         {
-          "x": 8,
-          "z": 4.8
-        },
-        {
-          "x": 8,
-          "z": -7.21
-        },
-        {
-          "x": -12,
-          "z": -7.2
-        },
-        {
-          "x": -12,
-          "z": 4.8
-        },
-        {
-          "x": 8,
-          "z": 4.8
-        }
-      ],
-      "facade_profile": "cordova_commercial_transition",
-      "tone": "stoneMuted",
-      "roofline_type": "flat_cornice",
-      "window_bay_count": 4,
-      "recessed_entry_count": 1,
-      "storefront_rhythm": {
-        "base_band": 0.18,
-        "upper_rows": 3
-      },
-      "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
-      },
-      "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
-    },
-    {
-      "id": "starter-bldg-2-left",
-      "reference_name": "Starter west frontage",
-      "x": -14.32,
-      "z": -33.87,
-      "width": 15.01,
-      "depth": 8,
-      "yaw": -1.4841,
-      "height": 12,
-      "footprint": [
-        {
-          "x": -18.03,
-          "z": -28.17
-        },
-        {
-          "x": -10.06,
-          "z": -27.47
-        },
-        {
-          "x": -8.76,
-          "z": -42.42
-        },
-        {
-          "x": -16.73,
-          "z": -43.11
-        },
-        {
-          "x": -18.03,
-          "z": -28.17
-        }
-      ],
-      "footprint_local": [
-        {
-          "x": -6,
-          "z": -3.2
-        },
-        {
-          "x": -6,
-          "z": 4.8
+          "x": 9,
+          "z": 4.4
         },
         {
           "x": 9,
-          "z": 4.8
+          "z": -6.6
+        },
+        {
+          "x": -13.5,
+          "z": -6.6
+        },
+        {
+          "x": -13.5,
+          "z": 4.4
         },
         {
           "x": 9,
-          "z": -3.2
-        },
-        {
-          "x": -6,
-          "z": -3.2
+          "z": 4.4
         }
       ],
       "facade_profile": "gastown_heritage_row",
       "tone": "brickWarm",
       "roofline_type": "flat_cornice",
-      "window_bay_count": 3,
+      "window_bay_count": 4,
       "recessed_entry_count": 1,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.16,
         "upper_rows": 3
       },
       "material_palette": {
-        "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#6e3f36",
+        "trim": "#caa98c",
+        "accent": "#445666",
+        "tone": "brickWarm"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.95
+    },
+    {
+      "id": "starter-bldg-2-left",
+      "reference_name": "Starter corner heritage anchor",
+      "segment_style": "waterfront-threshold",
+      "style_notes": "Corner building massing with stronger cornice to punctuate the route.",
+      "x": -17.26,
+      "z": -29.56,
+      "width": 17.51,
+      "depth": 10.01,
+      "yaw": -1.4844,
+      "height": 15,
+      "footprint": [
+        {
+          "x": -21.85,
+          "z": -22.93
+        },
+        {
+          "x": -11.88,
+          "z": -22.06
+        },
+        {
+          "x": -10.37,
+          "z": -39.5
+        },
+        {
+          "x": -20.33,
+          "z": -40.36
+        },
+        {
+          "x": -21.85,
+          "z": -22.93
+        }
+      ],
+      "footprint_local": [
+        {
+          "x": -7,
+          "z": -4.01
+        },
+        {
+          "x": -7,
+          "z": 6
+        },
+        {
+          "x": 10.5,
+          "z": 6
+        },
+        {
+          "x": 10.5,
+          "z": -3.99
+        },
+        {
+          "x": -7,
+          "z": -4.01
+        }
+      ],
+      "facade_profile": "gastown_heritage_row",
+      "tone": "brickWarm",
+      "roofline_type": "wrapped_cornice",
+      "window_bay_count": 3,
+      "recessed_entry_count": 1,
+      "storefront_rhythm": {
+        "base_band": 0.16,
+        "upper_rows": 3
+      },
+      "material_palette": {
+        "primary": "#6e3f36",
+        "trim": "#caa98c",
+        "accent": "#445666",
+        "tone": "brickWarm"
+      },
+      "cornice_emphasis": 0.42,
+      "mass_inset": 0.95
     },
     {
       "id": "starter-bldg-2-right",
       "reference_name": "Starter east frontage",
-      "x": 18.36,
-      "z": -31.03,
-      "width": 15.01,
-      "depth": 8,
-      "yaw": -1.4841,
+      "segment_style": "waterfront-threshold",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": 18.38,
+      "z": -26.66,
+      "width": 15.51,
+      "depth": 7.01,
+      "yaw": 1.6573,
       "height": 12,
       "footprint": [
         {
-          "x": 14.65,
-          "z": -25.33
+          "x": 15.05,
+          "z": -20.72
         },
         {
-          "x": 22.62,
-          "z": -24.63
+          "x": 22.03,
+          "z": -20.12
         },
         {
-          "x": 23.92,
-          "z": -39.58
+          "x": 23.37,
+          "z": -35.56
         },
         {
-          "x": 15.95,
-          "z": -40.27
+          "x": 16.39,
+          "z": -36.17
         },
         {
-          "x": 14.65,
-          "z": -25.33
+          "x": 15.05,
+          "z": -20.72
         }
       ],
       "footprint_local": [
         {
-          "x": -6,
-          "z": -3.2
+          "x": 6.2,
+          "z": 2.8
         },
         {
-          "x": -6,
-          "z": 4.8
+          "x": 6.2,
+          "z": -4.2
         },
         {
-          "x": 9,
-          "z": 4.8
+          "x": -9.3,
+          "z": -4.2
         },
         {
-          "x": 9,
-          "z": -3.2
+          "x": -9.3,
+          "z": 2.8
         },
         {
-          "x": -6,
-          "z": -3.2
+          "x": 6.2,
+          "z": 2.8
         }
       ],
-      "facade_profile": "cordova_commercial_transition",
+      "facade_profile": "narrow_brick_shaft",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 3,
-      "recessed_entry_count": 1,
+      "recessed_entry_count": 3,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.16,
         "upper_rows": 3
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#6f747c",
+        "trim": "#d0c3b3",
+        "accent": "#3f5363",
+        "tone": "stoneMuted"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.95
     },
     {
       "id": "starter-bldg-3-left",
       "reference_name": "Starter west frontage",
-      "x": -18.16,
-      "z": -43.93,
-      "width": 23,
+      "segment_style": "waterfront-threshold",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": -19.14,
+      "z": -39,
+      "width": 24,
       "depth": 15,
-      "yaw": -1.4846,
-      "height": 18,
+      "yaw": -1.484,
+      "height": 20,
       "footprint": [
         {
-          "x": -24.93,
-          "z": -35.28
+          "x": -25.95,
+          "z": -29.96
         },
         {
-          "x": -9.99,
-          "z": -33.99
+          "x": -11.01,
+          "z": -28.66
         },
         {
-          "x": -8.01,
-          "z": -56.9
+          "x": -8.93,
+          "z": -52.57
         },
         {
-          "x": -22.95,
-          "z": -58.19
+          "x": -23.87,
+          "z": -53.87
         },
         {
-          "x": -24.93,
-          "z": -35.28
+          "x": -25.95,
+          "z": -29.96
         }
       ],
       "footprint_local": [
         {
-          "x": -9.2,
+          "x": -9.6,
           "z": -6
         },
         {
-          "x": -9.2,
+          "x": -9.6,
           "z": 9
         },
         {
-          "x": 13.8,
+          "x": 14.4,
           "z": 9
         },
         {
-          "x": 13.8,
+          "x": 14.4,
           "z": -6
         },
         {
-          "x": -9.2,
+          "x": -9.6,
           "z": -6
         }
       ],
-      "facade_profile": "gastown_heritage_row",
-      "tone": "brickWarm",
+      "facade_profile": "narrow_brick_shaft",
+      "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
-      "window_bay_count": 5,
-      "recessed_entry_count": 1,
+      "window_bay_count": 6,
+      "recessed_entry_count": 3,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.16,
         "upper_rows": 4
       },
       "material_palette": {
-        "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#6f747c",
+        "trim": "#d0c3b3",
+        "accent": "#3f5363",
+        "tone": "stoneMuted"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.95
     },
     {
       "id": "starter-bldg-3-right",
       "reference_name": "Starter east frontage",
-      "x": 22.49,
-      "z": -40.41,
-      "width": 23.01,
-      "depth": 15,
-      "yaw": 1.657,
-      "height": 18,
+      "segment_style": "waterfront-threshold",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": 23.33,
+      "z": -35.16,
+      "width": 25.5,
+      "depth": 15.01,
+      "yaw": 1.6576,
+      "height": 19,
       "footprint": [
         {
-          "x": 15.72,
-          "z": -31.76
+          "x": 16.47,
+          "z": -25.52
         },
         {
-          "x": 30.66,
-          "z": -30.47
+          "x": 31.42,
+          "z": -24.22
         },
         {
-          "x": 32.64,
-          "z": -53.38
+          "x": 33.63,
+          "z": -49.62
         },
         {
-          "x": 17.7,
-          "z": -54.68
+          "x": 18.68,
+          "z": -50.92
         },
         {
-          "x": 15.72,
-          "z": -31.76
+          "x": 16.47,
+          "z": -25.52
         }
       ],
       "footprint_local": [
         {
-          "x": 9.2,
+          "x": 10.2,
           "z": 6
         },
         {
-          "x": 9.2,
+          "x": 10.2,
           "z": -9
         },
         {
-          "x": -13.8,
+          "x": -15.3,
           "z": -9
         },
         {
-          "x": -13.8,
+          "x": -15.3,
           "z": 6
         },
         {
-          "x": 9.2,
+          "x": 10.2,
           "z": 6
         }
       ],
-      "facade_profile": "cordova_commercial_transition",
-      "tone": "stoneMuted",
+      "facade_profile": "gastown_heritage_row",
+      "tone": "brickWarm",
       "roofline_type": "flat_cornice",
-      "window_bay_count": 5,
+      "window_bay_count": 6,
       "recessed_entry_count": 1,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.16,
         "upper_rows": 4
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#74493c",
+        "trim": "#cfb8a2",
+        "accent": "#4f5f6f",
+        "tone": "brickWarm"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.95
     },
     {
       "id": "starter-bldg-4-left",
       "reference_name": "Starter west frontage",
-      "x": -13.7,
-      "z": -61.52,
-      "width": 18,
-      "depth": 10,
-      "yaw": 1.6526,
-      "height": 11,
+      "segment_style": "mid-corridor-heritage-rhythm",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": -14.1,
+      "z": -55.93,
+      "width": 18.01,
+      "depth": 9,
+      "yaw": -1.489,
+      "height": 10,
       "footprint": [
         {
-          "x": -18.27,
-          "z": -54.67
+          "x": -18.28,
+          "z": -49.05
         },
         {
-          "x": -8.3,
-          "z": -53.85
+          "x": -9.31,
+          "z": -48.32
         },
         {
-          "x": -6.84,
-          "z": -71.79
+          "x": -7.84,
+          "z": -66.26
         },
         {
-          "x": -16.8,
-          "z": -72.61
+          "x": -16.81,
+          "z": -66.99
         },
         {
-          "x": -18.27,
-          "z": -54.67
+          "x": -18.28,
+          "z": -49.05
         }
       ],
       "footprint_local": [
         {
-          "x": 7.2,
-          "z": 4
+          "x": -7.2,
+          "z": -3.6
         },
         {
-          "x": 7.2,
-          "z": -6
+          "x": -7.2,
+          "z": 5.4
         },
         {
-          "x": -10.8,
-          "z": -5.99
+          "x": 10.8,
+          "z": 5.4
         },
         {
-          "x": -10.8,
-          "z": 4
+          "x": 10.8,
+          "z": -3.6
         },
         {
-          "x": 7.2,
-          "z": 4
+          "x": -7.2,
+          "z": -3.6
         }
       ],
       "facade_profile": "gastown_heritage_row",
       "tone": "brickWarm",
       "roofline_type": "flat_cornice",
-      "window_bay_count": 4,
+      "window_bay_count": 3,
       "recessed_entry_count": 1,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.19,
         "upper_rows": 3
       },
       "material_palette": {
         "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "trim": "#cfb8a2",
+        "accent": "#4f5f6f",
+        "tone": "brickWarm"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-4-right",
-      "reference_name": "Starter east frontage",
-      "x": 21.98,
-      "z": -58.6,
-      "width": 18.01,
-      "depth": 10,
-      "yaw": 1.6526,
-      "height": 11,
+      "reference_name": "Starter corner heritage anchor",
+      "segment_style": "mid-corridor-heritage-rhythm",
+      "style_notes": "Corner building massing with stronger cornice to punctuate the route.",
+      "x": 24.14,
+      "z": -52.46,
+      "width": 21.5,
+      "depth": 12,
+      "yaw": -1.4893,
+      "height": 12,
       "footprint": [
         {
-          "x": 17.41,
-          "z": -51.75
+          "x": 18.66,
+          "z": -44.28
         },
         {
-          "x": 27.38,
-          "z": -50.94
+          "x": 30.62,
+          "z": -43.3
         },
         {
-          "x": 28.84,
-          "z": -68.88
+          "x": 32.37,
+          "z": -64.73
         },
         {
-          "x": 18.88,
-          "z": -69.69
+          "x": 20.41,
+          "z": -65.71
         },
         {
-          "x": 17.41,
-          "z": -51.75
+          "x": 18.66,
+          "z": -44.28
         }
       ],
       "footprint_local": [
         {
-          "x": 7.2,
-          "z": 4
+          "x": -8.6,
+          "z": -4.8
         },
         {
-          "x": 7.2,
-          "z": -6
+          "x": -8.6,
+          "z": 7.2
         },
         {
-          "x": -10.8,
-          "z": -5.99
+          "x": 12.9,
+          "z": 7.2
         },
         {
-          "x": -10.8,
-          "z": 4
+          "x": 12.9,
+          "z": -4.8
         },
         {
-          "x": 7.2,
-          "z": 4
+          "x": -8.6,
+          "z": -4.8
         }
       ],
       "facade_profile": "cordova_commercial_transition",
       "tone": "stoneMuted",
-      "roofline_type": "flat_cornice",
+      "roofline_type": "wrapped_cornice",
       "window_bay_count": 4,
-      "recessed_entry_count": 1,
+      "recessed_entry_count": 2,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.19,
         "upper_rows": 3
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#8a857d",
+        "trim": "#d8c9b6",
+        "accent": "#57656e",
+        "tone": "stoneMuted"
       },
-      "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "cornice_emphasis": 0.42,
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-5-left",
       "reference_name": "Starter west frontage",
-      "x": -15,
-      "z": -73.77,
-      "width": 22,
-      "depth": 12.99,
+      "segment_style": "mid-corridor-heritage-rhythm",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": -15.56,
+      "z": -67.59,
+      "width": 22.01,
+      "depth": 13,
       "yaw": -1.4894,
-      "height": 20,
+      "height": 21,
       "footprint": [
         {
-          "x": -20.9,
-          "z": -65.42
+          "x": -21.46,
+          "z": -59.24
         },
         {
-          "x": -7.95,
-          "z": -64.36
+          "x": -8.5,
+          "z": -58.18
         },
         {
-          "x": -6.16,
-          "z": -86.29
+          "x": -6.71,
+          "z": -80.11
         },
         {
-          "x": -19.11,
-          "z": -87.34
+          "x": -19.67,
+          "z": -81.17
         },
         {
-          "x": -20.9,
-          "z": -65.42
+          "x": -21.46,
+          "z": -59.24
         }
       ],
       "footprint_local": [
@@ -1055,7 +1087,7 @@
           "z": 7.8
         },
         {
-          "x": 13.19,
+          "x": 13.2,
           "z": -5.2
         },
         {
@@ -1063,52 +1095,55 @@
           "z": -5.2
         }
       ],
-      "facade_profile": "gastown_heritage_row",
-      "tone": "brickWarm",
+      "facade_profile": "cordova_commercial_transition",
+      "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 5,
-      "recessed_entry_count": 1,
+      "recessed_entry_count": 2,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.19,
         "upper_rows": 4
       },
       "material_palette": {
-        "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#8a857d",
+        "trim": "#d8c9b6",
+        "accent": "#57656e",
+        "tone": "stoneMuted"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-5-right",
       "reference_name": "Starter east frontage",
-      "x": 24.67,
-      "z": -70.53,
-      "width": 22.01,
-      "depth": 12.99,
-      "yaw": -1.4894,
-      "height": 20,
+      "segment_style": "mid-corridor-heritage-rhythm",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": 24.21,
+      "z": -64.34,
+      "width": 21.99,
+      "depth": 13,
+      "yaw": -1.4893,
+      "height": 21,
       "footprint": [
         {
-          "x": 18.77,
-          "z": -62.18
+          "x": 18.31,
+          "z": -56
         },
         {
-          "x": 31.72,
-          "z": -61.12
+          "x": 31.27,
+          "z": -54.94
         },
         {
-          "x": 33.51,
-          "z": -83.05
+          "x": 33.06,
+          "z": -76.86
         },
         {
-          "x": 20.56,
-          "z": -84.11
+          "x": 20.1,
+          "z": -77.92
         },
         {
-          "x": 18.77,
-          "z": -62.18
+          "x": 18.31,
+          "z": -56
         }
       ],
       "footprint_local": [
@@ -1121,7 +1156,7 @@
           "z": 7.8
         },
         {
-          "x": 13.2,
+          "x": 13.19,
           "z": 7.8
         },
         {
@@ -1133,983 +1168,1025 @@
           "z": -5.2
         }
       ],
-      "facade_profile": "cordova_commercial_transition",
-      "tone": "stoneMuted",
+      "facade_profile": "gastown_heritage_row",
+      "tone": "brickWarm",
       "roofline_type": "flat_cornice",
       "window_bay_count": 5,
-      "recessed_entry_count": 1,
+      "recessed_entry_count": 2,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.19,
         "upper_rows": 4
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#6e3f36",
+        "trim": "#caa98c",
+        "accent": "#445666",
+        "tone": "brickWarm"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-6-left",
       "reference_name": "Starter west frontage",
-      "x": -12.02,
-      "z": -89.37,
+      "segment_style": "mid-corridor-heritage-rhythm",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": -12.45,
+      "z": -83.59,
       "width": 19,
-      "depth": 11.01,
-      "yaw": -1.4897,
-      "height": 15,
+      "depth": 10,
+      "yaw": 1.6519,
+      "height": 16,
       "footprint": [
         {
-          "x": -17.03,
-          "z": -82.16
+          "x": -17.05,
+          "z": -76.34
         },
         {
-          "x": -6.06,
-          "z": -81.26
+          "x": -7.08,
+          "z": -75.53
         },
         {
-          "x": -4.52,
-          "z": -100.2
+          "x": -5.54,
+          "z": -94.46
         },
         {
-          "x": -15.48,
-          "z": -101.09
+          "x": -15.51,
+          "z": -95.28
         },
         {
-          "x": -17.03,
-          "z": -82.16
+          "x": -17.05,
+          "z": -76.34
         }
       ],
       "footprint_local": [
         {
-          "x": -7.6,
-          "z": -4.4
+          "x": 7.6,
+          "z": 4
         },
         {
-          "x": -7.6,
-          "z": 6.6
+          "x": 7.6,
+          "z": -6
         },
         {
-          "x": 11.4,
-          "z": 6.6
+          "x": -11.39,
+          "z": -6
         },
         {
-          "x": 11.4,
-          "z": -4.39
+          "x": -11.4,
+          "z": 4
         },
         {
-          "x": -7.6,
-          "z": -4.4
+          "x": 7.6,
+          "z": 4
         }
       ],
       "facade_profile": "gastown_heritage_row",
       "tone": "brickWarm",
       "roofline_type": "flat_cornice",
       "window_bay_count": 4,
-      "recessed_entry_count": 1,
+      "recessed_entry_count": 2,
       "storefront_rhythm": {
-        "base_band": 0.18,
-        "upper_rows": 3
+        "base_band": 0.19,
+        "upper_rows": 4
       },
       "material_palette": {
-        "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#6e3f36",
+        "trim": "#caa98c",
+        "accent": "#445666",
+        "tone": "brickWarm"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-6-right",
       "reference_name": "Starter east frontage",
-      "x": 24.65,
-      "z": -86.38,
-      "width": 19.01,
-      "depth": 11,
+      "segment_style": "mid-corridor-heritage-rhythm",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": 24.33,
+      "z": -80.59,
+      "width": 19,
+      "depth": 10,
       "yaw": -1.4891,
-      "height": 15,
+      "height": 16,
       "footprint": [
         {
-          "x": 19.65,
-          "z": -79.16
+          "x": 19.73,
+          "z": -73.34
         },
         {
-          "x": 30.61,
-          "z": -78.27
+          "x": 29.69,
+          "z": -72.52
         },
         {
-          "x": 32.16,
-          "z": -97.21
+          "x": 31.24,
+          "z": -91.46
         },
         {
-          "x": 21.2,
-          "z": -98.1
+          "x": 21.27,
+          "z": -92.27
         },
         {
-          "x": 19.65,
-          "z": -79.16
+          "x": 19.73,
+          "z": -73.34
         }
       ],
       "footprint_local": [
         {
           "x": -7.6,
-          "z": -4.4
+          "z": -4
         },
         {
           "x": -7.6,
-          "z": 6.6
-        },
-        {
-          "x": 11.41,
-          "z": 6.6
+          "z": 6
         },
         {
           "x": 11.4,
-          "z": -4.4
+          "z": 6
+        },
+        {
+          "x": 11.4,
+          "z": -4
         },
         {
           "x": -7.6,
-          "z": -4.4
+          "z": -4
         }
       ],
-      "facade_profile": "cordova_commercial_transition",
+      "facade_profile": "narrow_brick_shaft",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 4,
       "recessed_entry_count": 1,
       "storefront_rhythm": {
-        "base_band": 0.18,
-        "upper_rows": 3
+        "base_band": 0.19,
+        "upper_rows": 4
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#6f747c",
+        "trim": "#d0c3b3",
+        "accent": "#3f5363",
+        "tone": "stoneMuted"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-7-left",
       "reference_name": "Starter west frontage",
-      "x": -9.32,
-      "z": -102.75,
-      "width": 16.01,
-      "depth": 9,
-      "yaw": -1.5033,
-      "height": 9,
+      "segment_style": "steam-clock-approach",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": -13.24,
+      "z": -95.18,
+      "width": 20,
+      "depth": 18.01,
+      "yaw": 1.6424,
+      "height": 18,
       "footprint": [
         {
-          "x": -13.34,
-          "z": -96.61
+          "x": -21,
+          "z": -87.72
         },
         {
-          "x": -4.36,
-          "z": -96
+          "x": -3.04,
+          "z": -86.43
         },
         {
-          "x": -3.28,
-          "z": -111.97
+          "x": -1.61,
+          "z": -106.38
         },
         {
-          "x": -12.26,
-          "z": -112.57
+          "x": -19.57,
+          "z": -107.67
         },
         {
-          "x": -13.34,
-          "z": -96.61
+          "x": -21,
+          "z": -87.72
         }
       ],
       "footprint_local": [
         {
-          "x": -6.4,
-          "z": -3.6
+          "x": 8,
+          "z": 7.2
         },
         {
-          "x": -6.4,
-          "z": 5.4
+          "x": 8,
+          "z": -10.8
         },
         {
-          "x": 9.6,
-          "z": 5.4
+          "x": -12,
+          "z": -10.8
         },
         {
-          "x": 9.6,
-          "z": -3.6
+          "x": -12,
+          "z": 7.2
         },
         {
-          "x": -6.4,
-          "z": -3.6
+          "x": 8,
+          "z": 7.2
         }
       ],
-      "facade_profile": "gastown_heritage_row",
-      "tone": "brickWarm",
-      "roofline_type": "flat_cornice",
-      "window_bay_count": 3,
+      "facade_profile": "narrow_brick_shaft",
+      "tone": "stoneMuted",
+      "roofline_type": "ornate_cornice",
+      "window_bay_count": 7,
       "recessed_entry_count": 1,
       "storefront_rhythm": {
-        "base_band": 0.18,
-        "upper_rows": 3
+        "base_band": 0.22,
+        "upper_rows": 4
       },
       "material_palette": {
-        "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#6f747c",
+        "trim": "#d0c3b3",
+        "accent": "#3f5363",
+        "tone": "stoneMuted"
       },
-      "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "cornice_emphasis": 0.34,
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-7-right",
       "reference_name": "Starter east frontage",
-      "x": 24.4,
-      "z": -100.47,
-      "width": 16.01,
-      "depth": 9,
-      "yaw": 1.6383,
-      "height": 9,
+      "segment_style": "steam-clock-approach",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": 25.46,
+      "z": -92.41,
+      "width": 20.01,
+      "depth": 18.01,
+      "yaw": -1.4992,
+      "height": 18,
       "footprint": [
         {
-          "x": 20.38,
-          "z": -94.32
+          "x": 17.7,
+          "z": -84.94
         },
         {
-          "x": 29.36,
-          "z": -93.72
+          "x": 35.66,
+          "z": -83.66
         },
         {
-          "x": 30.44,
-          "z": -109.68
+          "x": 37.09,
+          "z": -103.61
         },
         {
-          "x": 21.46,
-          "z": -110.29
+          "x": 19.13,
+          "z": -104.89
         },
         {
-          "x": 20.38,
-          "z": -94.32
+          "x": 17.7,
+          "z": -84.94
         }
       ],
       "footprint_local": [
         {
-          "x": 6.4,
-          "z": 3.6
+          "x": -8,
+          "z": -7.2
         },
         {
-          "x": 6.4,
-          "z": -5.4
+          "x": -8,
+          "z": 10.8
         },
         {
-          "x": -9.6,
-          "z": -5.4
+          "x": 12.01,
+          "z": 10.8
         },
         {
-          "x": -9.6,
-          "z": 3.6
+          "x": 12,
+          "z": -7.2
         },
         {
-          "x": 6.4,
-          "z": 3.6
+          "x": -8,
+          "z": -7.2
         }
       ],
-      "facade_profile": "cordova_commercial_transition",
-      "tone": "stoneMuted",
-      "roofline_type": "flat_cornice",
-      "window_bay_count": 3,
-      "recessed_entry_count": 1,
+      "facade_profile": "gastown_heritage_row",
+      "tone": "brickWarm",
+      "roofline_type": "ornate_cornice",
+      "window_bay_count": 7,
+      "recessed_entry_count": 3,
       "storefront_rhythm": {
-        "base_band": 0.18,
-        "upper_rows": 3
+        "base_band": 0.22,
+        "upper_rows": 4
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#74493c",
+        "trim": "#cfb8a2",
+        "accent": "#4f5f6f",
+        "tone": "brickWarm"
       },
-      "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "cornice_emphasis": 0.34,
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-8-left",
       "reference_name": "Starter west frontage",
-      "x": -11.56,
-      "z": -113.93,
-      "width": 21,
-      "depth": 14,
-      "yaw": -1.5031,
-      "height": 16,
+      "segment_style": "steam-clock-approach",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": -12.75,
+      "z": -115.72,
+      "width": 23.01,
+      "depth": 12,
+      "yaw": -1.5029,
+      "height": 14,
       "footprint": [
         {
-          "x": -17.72,
-          "z": -105.93
+          "x": -18.16,
+          "z": -106.86
         },
         {
-          "x": -3.75,
-          "z": -104.98
+          "x": -6.19,
+          "z": -106.05
         },
         {
-          "x": -2.33,
-          "z": -125.93
+          "x": -4.63,
+          "z": -129
         },
         {
-          "x": -16.3,
-          "z": -126.88
+          "x": -16.6,
+          "z": -129.81
         },
         {
-          "x": -17.72,
-          "z": -105.93
+          "x": -18.16,
+          "z": -106.86
         }
       ],
       "footprint_local": [
         {
-          "x": -8.4,
-          "z": -5.6
+          "x": -9.2,
+          "z": -4.8
         },
         {
-          "x": -8.4,
-          "z": 8.4
+          "x": -9.2,
+          "z": 7.2
         },
         {
-          "x": 12.6,
-          "z": 8.4
+          "x": 13.8,
+          "z": 7.2
         },
         {
-          "x": 12.6,
-          "z": -5.6
+          "x": 13.8,
+          "z": -4.8
         },
         {
-          "x": -8.4,
-          "z": -5.6
+          "x": -9.2,
+          "z": -4.8
         }
       ],
       "facade_profile": "gastown_heritage_row",
       "tone": "brickWarm",
-      "roofline_type": "flat_cornice",
+      "roofline_type": "ornate_cornice",
       "window_bay_count": 5,
-      "recessed_entry_count": 1,
+      "recessed_entry_count": 3,
       "storefront_rhythm": {
-        "base_band": 0.18,
-        "upper_rows": 4
+        "base_band": 0.22,
+        "upper_rows": 3
       },
       "material_palette": {
         "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "trim": "#cfb8a2",
+        "accent": "#4f5f6f",
+        "tone": "brickWarm"
       },
-      "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "cornice_emphasis": 0.34,
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-8-right",
       "reference_name": "Starter east frontage",
-      "x": 27.15,
-      "z": -111.31,
-      "width": 21.01,
-      "depth": 14,
-      "yaw": 1.6384,
-      "height": 16,
+      "segment_style": "steam-clock-approach",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": 28.96,
+      "z": -112.89,
+      "width": 23,
+      "depth": 12,
+      "yaw": 1.6382,
+      "height": 14,
       "footprint": [
         {
-          "x": 20.99,
-          "z": -103.3
+          "x": 23.55,
+          "z": -104.03
         },
         {
-          "x": 34.96,
-          "z": -102.36
+          "x": 35.52,
+          "z": -103.22
         },
         {
-          "x": 36.38,
-          "z": -123.31
+          "x": 37.07,
+          "z": -126.17
         },
         {
-          "x": 22.41,
-          "z": -124.26
+          "x": 25.1,
+          "z": -126.98
         },
         {
-          "x": 20.99,
-          "z": -103.3
+          "x": 23.55,
+          "z": -104.03
         }
       ],
       "footprint_local": [
         {
-          "x": 8.4,
-          "z": 5.6
+          "x": 9.2,
+          "z": 4.8
         },
         {
-          "x": 8.4,
-          "z": -8.4
+          "x": 9.2,
+          "z": -7.2
         },
         {
-          "x": -12.6,
-          "z": -8.4
+          "x": -13.8,
+          "z": -7.2
         },
         {
-          "x": -12.6,
-          "z": 5.6
+          "x": -13.8,
+          "z": 4.8
         },
         {
-          "x": 8.4,
-          "z": 5.6
+          "x": 9.2,
+          "z": 4.8
         }
       ],
       "facade_profile": "cordova_commercial_transition",
       "tone": "stoneMuted",
-      "roofline_type": "flat_cornice",
+      "roofline_type": "ornate_cornice",
       "window_bay_count": 5,
       "recessed_entry_count": 1,
       "storefront_rhythm": {
-        "base_band": 0.18,
-        "upper_rows": 4
+        "base_band": 0.22,
+        "upper_rows": 3
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#8a857d",
+        "trim": "#d8c9b6",
+        "accent": "#57656e",
+        "tone": "stoneMuted"
       },
-      "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "cornice_emphasis": 0.34,
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-9-left",
-      "reference_name": "Starter west frontage",
-      "x": -8.53,
-      "z": -130.56,
-      "width": 18,
-      "depth": 10,
-      "yaw": 1.6386,
-      "height": 13,
+      "reference_name": "Starter corner heritage anchor",
+      "segment_style": "steam-clock-approach",
+      "style_notes": "Corner building massing with stronger cornice to punctuate the route.",
+      "x": -10.97,
+      "z": -130.78,
+      "width": 20.5,
+      "depth": 11.01,
+      "yaw": 1.6387,
+      "height": 11,
       "footprint": [
         {
-          "x": -13.01,
-          "z": -123.65
+          "x": -15.92,
+          "z": -122.9
         },
         {
-          "x": -3.03,
-          "z": -122.97
+          "x": -4.94,
+          "z": -122.15
         },
         {
-          "x": -1.82,
-          "z": -140.93
+          "x": -3.56,
+          "z": -142.6
         },
         {
-          "x": -11.79,
-          "z": -141.61
+          "x": -14.53,
+          "z": -143.35
         },
         {
-          "x": -13.01,
-          "z": -123.65
+          "x": -15.92,
+          "z": -122.9
         }
       ],
       "footprint_local": [
         {
-          "x": 7.2,
-          "z": 4
+          "x": 8.2,
+          "z": 4.4
         },
         {
-          "x": 7.2,
-          "z": -6
+          "x": 8.2,
+          "z": -6.61
         },
         {
-          "x": -10.8,
-          "z": -5.99
+          "x": -12.3,
+          "z": -6.6
         },
         {
-          "x": -10.8,
-          "z": 4
+          "x": -12.3,
+          "z": 4.4
         },
         {
-          "x": 7.2,
-          "z": 4
+          "x": 8.2,
+          "z": 4.4
         }
       ],
-      "facade_profile": "gastown_heritage_row",
-      "tone": "brickWarm",
-      "roofline_type": "flat_cornice",
-      "window_bay_count": 4,
+      "facade_profile": "cordova_commercial_transition",
+      "tone": "stoneMuted",
+      "roofline_type": "wrapped_cornice",
+      "window_bay_count": 3,
       "recessed_entry_count": 1,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.22,
         "upper_rows": 3
       },
       "material_palette": {
-        "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#8a857d",
+        "trim": "#d8c9b6",
+        "accent": "#57656e",
+        "tone": "stoneMuted"
       },
-      "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "cornice_emphasis": 0.42,
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-9-right",
       "reference_name": "Starter east frontage",
-      "x": 27.19,
-      "z": -128.14,
-      "width": 18,
-      "depth": 9.99,
-      "yaw": -1.503,
-      "height": 13,
+      "segment_style": "steam-clock-approach",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": 27.41,
+      "z": -128.53,
+      "width": 17,
+      "depth": 8,
+      "yaw": -1.5031,
+      "height": 9,
       "footprint": [
         {
-          "x": 22.71,
-          "z": -121.23
+          "x": 23.76,
+          "z": -121.96
         },
         {
-          "x": 32.68,
-          "z": -120.55
+          "x": 31.74,
+          "z": -121.42
         },
         {
-          "x": 33.9,
-          "z": -138.51
+          "x": 32.89,
+          "z": -138.38
         },
         {
-          "x": 23.93,
-          "z": -139.19
+          "x": 24.91,
+          "z": -138.92
         },
         {
-          "x": 22.71,
-          "z": -121.23
+          "x": 23.76,
+          "z": -121.96
         }
       ],
       "footprint_local": [
         {
-          "x": -7.2,
-          "z": -4
+          "x": -6.8,
+          "z": -3.2
         },
         {
-          "x": -7.2,
-          "z": 6
+          "x": -6.8,
+          "z": 4.8
         },
         {
-          "x": 10.8,
-          "z": 6
+          "x": 10.2,
+          "z": 4.8
         },
         {
-          "x": 10.8,
-          "z": -4
+          "x": 10.2,
+          "z": -3.2
         },
         {
-          "x": -7.2,
-          "z": -4
+          "x": -6.8,
+          "z": -3.2
         }
       ],
-      "facade_profile": "cordova_commercial_transition",
-      "tone": "stoneMuted",
-      "roofline_type": "flat_cornice",
-      "window_bay_count": 4,
-      "recessed_entry_count": 1,
+      "facade_profile": "gastown_heritage_row",
+      "tone": "brickWarm",
+      "roofline_type": "ornate_cornice",
+      "window_bay_count": 3,
+      "recessed_entry_count": 2,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.22,
         "upper_rows": 3
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#6e3f36",
+        "trim": "#caa98c",
+        "accent": "#445666",
+        "tone": "brickWarm"
       },
-      "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "cornice_emphasis": 0.34,
+      "mass_inset": 0.96
     },
     {
       "id": "starter-bldg-10-left",
       "reference_name": "Starter west frontage",
-      "x": -7.08,
-      "z": -143.09,
-      "width": 17.01,
-      "depth": 9,
+      "segment_style": "post-clock-continuation",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": -12.24,
+      "z": -140.24,
+      "width": 25,
+      "depth": 18,
       "yaw": -1.5031,
-      "height": 10,
+      "height": 20,
       "footprint": [
         {
-          "x": -11.13,
-          "z": -136.55
+          "x": -20.1,
+          "z": -130.75
         },
         {
-          "x": -2.15,
-          "z": -135.94
+          "x": -2.14,
+          "z": -129.53
         },
         {
-          "x": -1,
-          "z": -152.91
+          "x": -0.45,
+          "z": -154.47
         },
         {
-          "x": -9.98,
-          "z": -153.51
+          "x": -18.41,
+          "z": -155.69
         },
         {
-          "x": -11.13,
-          "z": -136.55
+          "x": -20.1,
+          "z": -130.75
         }
       ],
       "footprint_local": [
         {
-          "x": -6.8,
-          "z": -3.6
+          "x": -10,
+          "z": -7.2
         },
         {
-          "x": -6.8,
-          "z": 5.4
+          "x": -10,
+          "z": 10.8
         },
         {
-          "x": 10.21,
-          "z": 5.4
+          "x": 15,
+          "z": 10.8
         },
         {
-          "x": 10.2,
-          "z": -3.6
+          "x": 15,
+          "z": -7.2
         },
         {
-          "x": -6.8,
-          "z": -3.6
+          "x": -10,
+          "z": -7.2
         }
       ],
       "facade_profile": "gastown_heritage_row",
       "tone": "brickWarm",
       "roofline_type": "flat_cornice",
-      "window_bay_count": 3,
-      "recessed_entry_count": 1,
+      "window_bay_count": 7,
+      "recessed_entry_count": 2,
       "storefront_rhythm": {
-        "base_band": 0.18,
-        "upper_rows": 3
+        "base_band": 0.19,
+        "upper_rows": 4
       },
       "material_palette": {
-        "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#6e3f36",
+        "trim": "#caa98c",
+        "accent": "#445666",
+        "tone": "brickWarm"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.93
     },
     {
       "id": "starter-bldg-10-right",
       "reference_name": "Starter east frontage",
-      "x": 27.64,
-      "z": -140.74,
-      "width": 17,
-      "depth": 9,
-      "yaw": -1.5031,
-      "height": 10,
+      "segment_style": "post-clock-continuation",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": 30.76,
+      "z": -137.32,
+      "width": 25.01,
+      "depth": 16.01,
+      "yaw": -1.5032,
+      "height": 20,
       "footprint": [
         {
-          "x": 23.59,
-          "z": -134.2
+          "x": 23.7,
+          "z": -127.78
         },
         {
-          "x": 32.57,
-          "z": -133.59
+          "x": 39.67,
+          "z": -126.69
         },
         {
-          "x": 33.72,
-          "z": -150.55
+          "x": 41.36,
+          "z": -151.64
         },
         {
-          "x": 24.74,
-          "z": -151.16
+          "x": 25.39,
+          "z": -152.72
         },
         {
-          "x": 23.59,
-          "z": -134.2
+          "x": 23.7,
+          "z": -127.78
         }
       ],
       "footprint_local": [
         {
-          "x": -6.8,
-          "z": -3.6
+          "x": -10,
+          "z": -6.4
         },
         {
-          "x": -6.8,
-          "z": 5.4
+          "x": -10.01,
+          "z": 9.6
         },
         {
-          "x": 10.2,
-          "z": 5.4
+          "x": 15,
+          "z": 9.6
         },
         {
-          "x": 10.2,
-          "z": -3.6
+          "x": 15,
+          "z": -6.4
         },
         {
-          "x": -6.8,
-          "z": -3.6
+          "x": -10,
+          "z": -6.4
         }
       ],
-      "facade_profile": "cordova_commercial_transition",
+      "facade_profile": "narrow_brick_shaft",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
-      "window_bay_count": 3,
+      "window_bay_count": 6,
       "recessed_entry_count": 1,
       "storefront_rhythm": {
-        "base_band": 0.18,
-        "upper_rows": 3
+        "base_band": 0.19,
+        "upper_rows": 4
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#6f747c",
+        "trim": "#d0c3b3",
+        "accent": "#3f5363",
+        "tone": "stoneMuted"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.93
     },
     {
       "id": "starter-bldg-11-left",
       "reference_name": "Starter west frontage",
-      "x": -8.1,
-      "z": -154.7,
-      "width": 20.01,
-      "depth": 12,
-      "yaw": 1.6539,
-      "height": 14,
+      "segment_style": "post-clock-continuation",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": -6.6,
+      "z": -159.88,
+      "width": 18,
+      "depth": 11,
+      "yaw": -1.4829,
+      "height": 13,
       "footprint": [
         {
-          "x": -13.55,
-          "z": -147.12
+          "x": -11.62,
+          "z": -153.1
         },
         {
-          "x": -1.59,
-          "z": -146.13
+          "x": -0.66,
+          "z": -152.13
         },
         {
-          "x": 0.06,
-          "z": -166.06
+          "x": 0.92,
+          "z": -170.06
         },
         {
-          "x": -11.89,
-          "z": -167.06
+          "x": -10.04,
+          "z": -171.03
         },
         {
-          "x": -13.55,
-          "z": -147.12
+          "x": -11.62,
+          "z": -153.1
         }
       ],
       "footprint_local": [
         {
-          "x": 8,
-          "z": 4.8
+          "x": -7.2,
+          "z": -4.4
         },
         {
-          "x": 8,
-          "z": -7.2
+          "x": -7.2,
+          "z": 6.6
         },
         {
-          "x": -12,
-          "z": -7.19
+          "x": 10.8,
+          "z": 6.6
         },
         {
-          "x": -12.01,
-          "z": 4.8
+          "x": 10.8,
+          "z": -4.4
         },
         {
-          "x": 8,
-          "z": 4.8
+          "x": -7.2,
+          "z": -4.4
         }
       ],
-      "facade_profile": "gastown_heritage_row",
-      "tone": "brickWarm",
-      "roofline_type": "flat_cornice",
-      "window_bay_count": 4,
-      "recessed_entry_count": 1,
-      "storefront_rhythm": {
-        "base_band": 0.18,
-        "upper_rows": 3
-      },
-      "material_palette": {
-        "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
-      },
-      "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
-    },
-    {
-      "id": "starter-bldg-11-right",
-      "reference_name": "Starter east frontage",
-      "x": 29.56,
-      "z": -151.56,
-      "width": 20,
-      "depth": 11.99,
-      "yaw": -1.4877,
-      "height": 14,
-      "footprint": [
-        {
-          "x": 24.12,
-          "z": -143.99
-        },
-        {
-          "x": 36.07,
-          "z": -142.99
-        },
-        {
-          "x": 37.73,
-          "z": -162.92
-        },
-        {
-          "x": 25.78,
-          "z": -163.92
-        },
-        {
-          "x": 24.12,
-          "z": -143.99
-        }
-      ],
-      "footprint_local": [
-        {
-          "x": -8,
-          "z": -4.8
-        },
-        {
-          "x": -8,
-          "z": 7.2
-        },
-        {
-          "x": 12,
-          "z": 7.2
-        },
-        {
-          "x": 12,
-          "z": -4.8
-        },
-        {
-          "x": -8,
-          "z": -4.8
-        }
-      ],
-      "facade_profile": "cordova_commercial_transition",
+      "facade_profile": "narrow_brick_shaft",
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 4,
       "recessed_entry_count": 1,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.19,
         "upper_rows": 3
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#6f747c",
+        "trim": "#d0c3b3",
+        "accent": "#3f5363",
+        "tone": "stoneMuted"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.93
+    },
+    {
+      "id": "starter-bldg-11-right",
+      "reference_name": "Starter corner heritage anchor",
+      "segment_style": "post-clock-continuation",
+      "style_notes": "Corner building massing with stronger cornice to punctuate the route.",
+      "x": 31.82,
+      "z": -156.15,
+      "width": 21.5,
+      "depth": 12,
+      "yaw": 1.6588,
+      "height": 15,
+      "footprint": [
+        {
+          "x": 26.28,
+          "z": -148
+        },
+        {
+          "x": 38.23,
+          "z": -146.95
+        },
+        {
+          "x": 40.12,
+          "z": -168.36
+        },
+        {
+          "x": 28.17,
+          "z": -169.42
+        },
+        {
+          "x": 26.28,
+          "z": -148
+        }
+      ],
+      "footprint_local": [
+        {
+          "x": 8.6,
+          "z": 4.8
+        },
+        {
+          "x": 8.6,
+          "z": -7.2
+        },
+        {
+          "x": -12.9,
+          "z": -7.2
+        },
+        {
+          "x": -12.9,
+          "z": 4.8
+        },
+        {
+          "x": 8.6,
+          "z": 4.8
+        }
+      ],
+      "facade_profile": "gastown_heritage_row",
+      "tone": "brickWarm",
+      "roofline_type": "wrapped_cornice",
+      "window_bay_count": 4,
+      "recessed_entry_count": 1,
+      "storefront_rhythm": {
+        "base_band": 0.19,
+        "upper_rows": 3
+      },
+      "material_palette": {
+        "primary": "#74493c",
+        "trim": "#cfb8a2",
+        "accent": "#4f5f6f",
+        "tone": "brickWarm"
+      },
+      "cornice_emphasis": 0.42,
+      "mass_inset": 0.93
     },
     {
       "id": "starter-bldg-12-left",
       "reference_name": "Starter west frontage",
-      "x": -3.9,
-      "z": -169.49,
-      "width": 15,
-      "depth": 8,
-      "yaw": -1.4827,
-      "height": 12,
+      "segment_style": "post-clock-continuation",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": -4.44,
+      "z": -171.84,
+      "width": 16,
+      "depth": 10.01,
+      "yaw": -1.4826,
+      "height": 11,
       "footprint": [
         {
-          "x": -7.62,
-          "z": -163.79
+          "x": -8.99,
+          "z": -165.82
         },
         {
-          "x": 0.35,
-          "z": -163.09
+          "x": 0.97,
+          "z": -164.94
         },
         {
-          "x": 1.67,
-          "z": -178.03
+          "x": 2.38,
+          "z": -180.88
         },
         {
-          "x": -6.3,
-          "z": -178.73
+          "x": -7.59,
+          "z": -181.76
         },
         {
-          "x": -7.62,
-          "z": -163.79
+          "x": -8.99,
+          "z": -165.82
         }
       ],
       "footprint_local": [
         {
-          "x": -6,
-          "z": -3.2
+          "x": -6.4,
+          "z": -4
         },
         {
-          "x": -6,
-          "z": 4.8
+          "x": -6.4,
+          "z": 6
         },
         {
-          "x": 9,
-          "z": 4.8
+          "x": 9.6,
+          "z": 6
         },
         {
-          "x": 9,
-          "z": -3.2
+          "x": 9.6,
+          "z": -4.01
         },
         {
-          "x": -6,
-          "z": -3.2
+          "x": -6.4,
+          "z": -4
         }
       ],
       "facade_profile": "gastown_heritage_row",
       "tone": "brickWarm",
       "roofline_type": "flat_cornice",
-      "window_bay_count": 3,
+      "window_bay_count": 4,
       "recessed_entry_count": 1,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.19,
         "upper_rows": 3
       },
       "material_palette": {
         "primary": "#74493c",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "trim": "#cfb8a2",
+        "accent": "#4f5f6f",
+        "tone": "brickWarm"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.93
     },
     {
       "id": "starter-bldg-12-right",
       "reference_name": "Starter east frontage",
-      "x": 28.78,
-      "z": -166.6,
-      "width": 15.01,
+      "segment_style": "post-clock-continuation",
+      "style_notes": "Stylized heritage storefront cadence tuned for fallback readability.",
+      "x": 29.52,
+      "z": -168.85,
+      "width": 16.01,
       "depth": 8,
-      "yaw": -1.4827,
-      "height": 12,
+      "yaw": -1.4826,
+      "height": 11,
       "footprint": [
         {
-          "x": 25.06,
-          "z": -160.91
+          "x": 25.77,
+          "z": -162.75
         },
         {
-          "x": 33.03,
-          "z": -160.2
+          "x": 33.74,
+          "z": -162.05
         },
         {
-          "x": 34.35,
-          "z": -175.15
+          "x": 35.15,
+          "z": -177.99
         },
         {
-          "x": 26.38,
-          "z": -175.85
+          "x": 27.18,
+          "z": -178.69
         },
         {
-          "x": 25.06,
-          "z": -160.91
+          "x": 25.77,
+          "z": -162.75
         }
       ],
       "footprint_local": [
         {
-          "x": -6,
+          "x": -6.4,
           "z": -3.2
         },
         {
-          "x": -6.01,
+          "x": -6.4,
           "z": 4.8
         },
         {
-          "x": 9,
+          "x": 9.6,
           "z": 4.8
         },
         {
-          "x": 9,
+          "x": 9.6,
           "z": -3.2
         },
         {
-          "x": -6,
+          "x": -6.4,
           "z": -3.2
         }
       ],
@@ -2117,18 +2194,134 @@
       "tone": "stoneMuted",
       "roofline_type": "flat_cornice",
       "window_bay_count": 3,
-      "recessed_entry_count": 1,
+      "recessed_entry_count": 2,
       "storefront_rhythm": {
-        "base_band": 0.18,
+        "base_band": 0.19,
         "upper_rows": 3
       },
       "material_palette": {
-        "primary": "#7f868e",
-        "trim": "#c7b8a5",
-        "accent": "#4f5f6f"
+        "primary": "#8a857d",
+        "trim": "#d8c9b6",
+        "accent": "#57656e",
+        "tone": "stoneMuted"
       },
       "cornice_emphasis": 0.26,
-      "mass_inset": 0.97
+      "mass_inset": 0.93
+    }
+  ],
+  "landmarks": [
+    {
+      "id": "starter-landmark-threshold-anchor",
+      "label": "Waterfront threshold",
+      "kind": "cardboard_box",
+      "x": -9.62,
+      "y": 0,
+      "z": -12.88,
+      "scale": 1.35,
+      "cue": "Station canopies give way to brick-front Gastown blocks."
+    },
+    {
+      "id": "starter-landmark-clock-anchor",
+      "label": "Steam Clock approach",
+      "kind": "cardboard_box",
+      "x": 19.06,
+      "y": 0,
+      "z": -102.93,
+      "scale": 1.25,
+      "cue": "Denser storefront rhythm, pavers, and curb clutter build toward the clock node."
+    },
+    {
+      "id": "starter-landmark-postclock-anchor",
+      "label": "Post-clock continuation",
+      "kind": "cardboard_box",
+      "x": 2.75,
+      "y": 0,
+      "z": -166.39,
+      "scale": 1.18,
+      "cue": "The corridor loosens into longer facades and a quieter continuation east."
+    }
+  ],
+  "props": [
+    {
+      "id": "starter-prop-threshold-utility",
+      "kind": "utility_box",
+      "x": 10.8,
+      "y": 0,
+      "z": -23.15,
+      "yaw": 1.4841,
+      "scale": 1.1
+    },
+    {
+      "id": "starter-prop-corner-bags",
+      "kind": "trash_bag",
+      "x": 12.36,
+      "y": 0,
+      "z": -45.12,
+      "yaw": 1.4864,
+      "scale": 1.1
+    },
+    {
+      "id": "starter-prop-planter-west",
+      "kind": "planter",
+      "x": -3.63,
+      "y": 0,
+      "z": -62.5,
+      "yaw": 1.4893,
+      "scale": 1.15
+    },
+    {
+      "id": "starter-prop-planter-east",
+      "kind": "planter",
+      "x": 16.05,
+      "y": 0,
+      "z": -82.97,
+      "yaw": 1.4893,
+      "scale": 1.08
+    },
+    {
+      "id": "starter-prop-bench-clock",
+      "kind": "bench",
+      "x": -0.5,
+      "y": 0,
+      "z": -101.25,
+      "yaw": 3.0739,
+      "scale": 1.04
+    },
+    {
+      "id": "starter-prop-clock-box",
+      "kind": "newspaper_box",
+      "x": 17.44,
+      "y": 0,
+      "z": -107.05,
+      "yaw": 1.5031,
+      "scale": 0.98
+    },
+    {
+      "id": "starter-prop-postclock-utility",
+      "kind": "utility_box",
+      "x": 1.7,
+      "y": 0,
+      "z": -132.17,
+      "yaw": 1.5031,
+      "scale": 1.06
+    },
+    {
+      "id": "starter-prop-postclock-bags",
+      "kind": "trash_bag",
+      "x": 19.79,
+      "y": 0,
+      "z": -144.98,
+      "yaw": 1.5031,
+      "scale": 0.96
+    },
+    {
+      "id": "starter-prop-postclock-bench",
+      "kind": "bench",
+      "x": 21.76,
+      "y": 0,
+      "z": -162.7,
+      "yaw": 3.0536,
+      "scale": 1
     }
   ],
   "streetscape": {
@@ -2317,7 +2510,591 @@
       }
     ],
     "bollards": [],
-    "surfaceBands": []
+    "surfaceBands": [
+      {
+        "segment_id": "starter-corridor-start",
+        "width": 2.94,
+        "length": 14,
+        "yaw": 3.0551,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.24,
+        "elevation": 0.032
+      },
+      {
+        "segment_id": "starter-corridor-start",
+        "width": 1.76,
+        "length": 8.96,
+        "yaw": 3.0551,
+        "offset_x": -0.3,
+        "offset_z": 0,
+        "tone": "patch",
+        "opacity": 0.33,
+        "elevation": 0.038
+      },
+      {
+        "segment_id": "starter-corridor-start",
+        "width": 0.78,
+        "length": 14.84,
+        "yaw": 3.0551,
+        "offset_x": 3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-corridor-start",
+        "width": 0.78,
+        "length": 14.56,
+        "yaw": 3.0551,
+        "offset_x": -3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-corridor-start",
+        "width": 5.49,
+        "length": 3.08,
+        "yaw": 4.6259,
+        "offset_x": -2.16,
+        "offset_z": 0,
+        "tone": "paver_break",
+        "opacity": 0.34,
+        "elevation": 0.041
+      },
+      {
+        "segment_id": "starter-beat-1",
+        "width": 2.94,
+        "length": 14,
+        "yaw": 3.0545,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.24,
+        "elevation": 0.032
+      },
+      {
+        "segment_id": "starter-beat-1",
+        "width": 1.76,
+        "length": 8.96,
+        "yaw": 3.0545,
+        "offset_x": -0.1,
+        "offset_z": 0,
+        "tone": "patch",
+        "opacity": 0.33,
+        "elevation": 0.038
+      },
+      {
+        "segment_id": "starter-beat-1",
+        "width": 0.78,
+        "length": 14.84,
+        "yaw": 3.0545,
+        "offset_x": 3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-1",
+        "width": 0.78,
+        "length": 14.56,
+        "yaw": 3.0545,
+        "offset_x": -3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-1",
+        "width": 8.04,
+        "length": 4.2,
+        "yaw": 4.6253,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "intersection_pavers",
+        "opacity": 0.42,
+        "elevation": 0.045
+      },
+      {
+        "segment_id": "starter-beat-2",
+        "width": 2.94,
+        "length": 14,
+        "yaw": 3.0577,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.24,
+        "elevation": 0.032
+      },
+      {
+        "segment_id": "starter-beat-2",
+        "width": 1.76,
+        "length": 8.96,
+        "yaw": 3.0577,
+        "offset_x": 0.1,
+        "offset_z": 0,
+        "tone": "patch",
+        "opacity": 0.33,
+        "elevation": 0.038
+      },
+      {
+        "segment_id": "starter-beat-2",
+        "width": 0.78,
+        "length": 14.84,
+        "yaw": 3.0577,
+        "offset_x": 3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-2",
+        "width": 0.78,
+        "length": 14.56,
+        "yaw": 3.0577,
+        "offset_x": -3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-2",
+        "width": 5.49,
+        "length": 3.08,
+        "yaw": 4.6285,
+        "offset_x": 2.16,
+        "offset_z": 0,
+        "tone": "paver_break",
+        "opacity": 0.34,
+        "elevation": 0.041
+      },
+      {
+        "segment_id": "starter-beat-3",
+        "width": 2.94,
+        "length": 14,
+        "yaw": 3.0604,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.24,
+        "elevation": 0.032
+      },
+      {
+        "segment_id": "starter-beat-3",
+        "width": 1.76,
+        "length": 11.76,
+        "yaw": 3.0604,
+        "offset_x": 0.3,
+        "offset_z": 0,
+        "tone": "patch",
+        "opacity": 0.33,
+        "elevation": 0.038
+      },
+      {
+        "segment_id": "starter-beat-3",
+        "width": 0.78,
+        "length": 14.84,
+        "yaw": 3.0604,
+        "offset_x": 3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-3",
+        "width": 0.78,
+        "length": 14.56,
+        "yaw": 3.0604,
+        "offset_x": -3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-4",
+        "width": 2.94,
+        "length": 14,
+        "yaw": 3.0599,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.24,
+        "elevation": 0.032
+      },
+      {
+        "segment_id": "starter-beat-4",
+        "width": 1.76,
+        "length": 11.76,
+        "yaw": 3.0599,
+        "offset_x": -0.3,
+        "offset_z": 0,
+        "tone": "patch",
+        "opacity": 0.33,
+        "elevation": 0.038
+      },
+      {
+        "segment_id": "starter-beat-4",
+        "width": 0.78,
+        "length": 14.84,
+        "yaw": 3.0599,
+        "offset_x": 3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-4",
+        "width": 0.78,
+        "length": 14.56,
+        "yaw": 3.0599,
+        "offset_x": -3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-4",
+        "width": 5.49,
+        "length": 3.08,
+        "yaw": 4.6307,
+        "offset_x": -2.16,
+        "offset_z": 0,
+        "tone": "paver_break",
+        "opacity": 0.34,
+        "elevation": 0.041
+      },
+      {
+        "segment_id": "starter-mid-block",
+        "width": 2.94,
+        "length": 14,
+        "yaw": 3.0732,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.24,
+        "elevation": 0.032
+      },
+      {
+        "segment_id": "starter-mid-block",
+        "width": 1.76,
+        "length": 11.76,
+        "yaw": 3.0732,
+        "offset_x": -0.1,
+        "offset_z": 0,
+        "tone": "patch",
+        "opacity": 0.33,
+        "elevation": 0.038
+      },
+      {
+        "segment_id": "starter-mid-block",
+        "width": 0.78,
+        "length": 14.84,
+        "yaw": 3.0732,
+        "offset_x": 3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-mid-block",
+        "width": 0.78,
+        "length": 14.56,
+        "yaw": 3.0732,
+        "offset_x": -3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-mid-block",
+        "width": 8.04,
+        "length": 4.2,
+        "yaw": 4.644,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "intersection_pavers",
+        "opacity": 0.42,
+        "elevation": 0.045
+      },
+      {
+        "segment_id": "starter-beat-6",
+        "width": 2.94,
+        "length": 14,
+        "yaw": 3.0742,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.24,
+        "elevation": 0.032
+      },
+      {
+        "segment_id": "starter-beat-6",
+        "width": 1.76,
+        "length": 11.76,
+        "yaw": 3.0742,
+        "offset_x": 0.1,
+        "offset_z": 0,
+        "tone": "patch",
+        "opacity": 0.33,
+        "elevation": 0.038
+      },
+      {
+        "segment_id": "starter-beat-6",
+        "width": 0.78,
+        "length": 14.84,
+        "yaw": 3.0742,
+        "offset_x": 3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-6",
+        "width": 0.78,
+        "length": 14.56,
+        "yaw": 3.0742,
+        "offset_x": -3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-6",
+        "width": 7.06,
+        "length": 3.08,
+        "yaw": 4.645,
+        "offset_x": 2.16,
+        "offset_z": 0,
+        "tone": "cobble_break",
+        "opacity": 0.34,
+        "elevation": 0.041
+      },
+      {
+        "segment_id": "starter-beat-7",
+        "width": 2.94,
+        "length": 14,
+        "yaw": 3.0737,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.24,
+        "elevation": 0.032
+      },
+      {
+        "segment_id": "starter-beat-7",
+        "width": 1.76,
+        "length": 11.76,
+        "yaw": 3.0737,
+        "offset_x": 0.3,
+        "offset_z": 0,
+        "tone": "repair_patch_dark",
+        "opacity": 0.38,
+        "elevation": 0.038
+      },
+      {
+        "segment_id": "starter-beat-7",
+        "width": 0.78,
+        "length": 14.84,
+        "yaw": 3.0737,
+        "offset_x": 3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-7",
+        "width": 0.78,
+        "length": 14.56,
+        "yaw": 3.0737,
+        "offset_x": -3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-8",
+        "width": 2.94,
+        "length": 14,
+        "yaw": 3.0577,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.24,
+        "elevation": 0.032
+      },
+      {
+        "segment_id": "starter-beat-8",
+        "width": 1.76,
+        "length": 11.76,
+        "yaw": 3.0577,
+        "offset_x": -0.3,
+        "offset_z": 0,
+        "tone": "repair_patch_dark",
+        "opacity": 0.38,
+        "elevation": 0.038
+      },
+      {
+        "segment_id": "starter-beat-8",
+        "width": 0.78,
+        "length": 14.84,
+        "yaw": 3.0577,
+        "offset_x": 3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-8",
+        "width": 0.78,
+        "length": 14.56,
+        "yaw": 3.0577,
+        "offset_x": -3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-8",
+        "width": 5.49,
+        "length": 3.08,
+        "yaw": 4.6285,
+        "offset_x": -2.16,
+        "offset_z": 0,
+        "tone": "paver_break",
+        "opacity": 0.34,
+        "elevation": 0.041
+      },
+      {
+        "segment_id": "starter-beat-9",
+        "width": 2.94,
+        "length": 14,
+        "yaw": 3.0535,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.24,
+        "elevation": 0.032
+      },
+      {
+        "segment_id": "starter-beat-9",
+        "width": 1.76,
+        "length": 11.76,
+        "yaw": 3.0535,
+        "offset_x": -0.1,
+        "offset_z": 0,
+        "tone": "repair_patch_dark",
+        "opacity": 0.38,
+        "elevation": 0.038
+      },
+      {
+        "segment_id": "starter-beat-9",
+        "width": 0.78,
+        "length": 14.84,
+        "yaw": 3.0535,
+        "offset_x": 3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-9",
+        "width": 0.78,
+        "length": 14.56,
+        "yaw": 3.0535,
+        "offset_x": -3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-beat-9",
+        "width": 8.04,
+        "length": 4.2,
+        "yaw": 4.6243,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "intersection_pavers",
+        "opacity": 0.42,
+        "elevation": 0.045
+      },
+      {
+        "segment_id": "starter-corridor-end",
+        "width": 2.94,
+        "length": 14,
+        "yaw": -0.0881,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.24,
+        "elevation": 0.032
+      },
+      {
+        "segment_id": "starter-corridor-end",
+        "width": 1.76,
+        "length": 11.76,
+        "yaw": -0.0881,
+        "offset_x": 0.1,
+        "offset_z": 0,
+        "tone": "repair_patch_dark",
+        "opacity": 0.38,
+        "elevation": 0.038
+      },
+      {
+        "segment_id": "starter-corridor-end",
+        "width": 0.78,
+        "length": 14.84,
+        "yaw": -0.0881,
+        "offset_x": 3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-corridor-end",
+        "width": 0.78,
+        "length": 14.56,
+        "yaw": -0.0881,
+        "offset_x": -3.43,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.28,
+        "elevation": 0.034
+      },
+      {
+        "segment_id": "starter-corridor-end",
+        "width": 5.49,
+        "length": 3.08,
+        "yaw": 1.4827,
+        "offset_x": 2.16,
+        "offset_z": 0,
+        "tone": "paver_break",
+        "opacity": 0.34,
+        "elevation": 0.041
+      }
+    ]
   },
   "spawn": {
     "x": 0.78,
@@ -2329,157 +3106,5 @@
     "floorY": 0,
     "edgeMessage": "Stayed within the starter street corridor.",
     "resetMessage": "Returned to the starter street corridor."
-  },
-  "props": [
-    {
-      "id": "prop-bag-1",
-      "kind": "trash_bag",
-      "x": 8.8,
-      "z": -24.5,
-      "yaw": 0.2,
-      "scale": 1.0
-    },
-    {
-      "id": "prop-box-1",
-      "kind": "cardboard_box",
-      "x": 10.9,
-      "z": -63.0,
-      "yaw": 0.45,
-      "scale": 1.1
-    },
-    {
-      "id": "prop-paper-1",
-      "kind": "newspaper_box",
-      "x": 16.1,
-      "z": -96.2,
-      "yaw": -0.2,
-      "scale": 1.0
-    },
-    {
-      "id": "prop-bag-2",
-      "kind": "trash_bag",
-      "x": -6.6,
-      "z": -42.0,
-      "yaw": -0.4,
-      "scale": 0.85
-    },
-    {
-      "id": "prop-box-2",
-      "kind": "cardboard_box",
-      "x": -7.2,
-      "z": -118.5,
-      "yaw": 0.1,
-      "scale": 0.9
-    },
-    {
-      "id": "prop-paper-2",
-      "kind": "newspaper_box",
-      "x": 19.4,
-      "z": -152.0,
-      "yaw": 0.0,
-      "scale": 0.95
-    }
-  ],
-  "npcs": [
-    {
-      "id": "npc-guide-station",
-      "role": "guide",
-      "idleSpot": {
-        "x": 6.9,
-        "z": -8.0
-      },
-      "interactRadius": 3.2,
-      "dialogId": "guide_intro"
-    },
-    {
-      "id": "npc-busker-mid",
-      "role": "busker",
-      "idleSpot": {
-        "x": 17.1,
-        "z": -86.0
-      },
-      "interactRadius": 4.4,
-      "dialogId": "busker_intro"
-    },
-    {
-      "id": "npc-ped-1",
-      "role": "pedestrian",
-      "patrol": [
-        {
-          "x": 7.2,
-          "z": -18.0
-        },
-        {
-          "x": 9.2,
-          "z": -35.0
-        },
-        {
-          "x": 7.8,
-          "z": -52.0
-        }
-      ],
-      "interactRadius": 2.8,
-      "dialogId": "pedestrian_intro"
-    },
-    {
-      "id": "npc-ped-2",
-      "role": "pedestrian",
-      "patrol": [
-        {
-          "x": -6.8,
-          "z": -26.0
-        },
-        {
-          "x": -5.9,
-          "z": -46.0
-        },
-        {
-          "x": -6.3,
-          "z": -66.0
-        }
-      ],
-      "interactRadius": 2.8,
-      "dialogId": "pedestrian_intro"
-    },
-    {
-      "id": "npc-ped-3",
-      "role": "pedestrian",
-      "patrol": [
-        {
-          "x": 17.3,
-          "z": -112.0
-        },
-        {
-          "x": 18.1,
-          "z": -132.0
-        },
-        {
-          "x": 18.9,
-          "z": -149.0
-        }
-      ],
-      "interactRadius": 2.8,
-      "dialogId": "pedestrian_intro"
-    },
-    {
-      "id": "npc-ped-4",
-      "role": "pedestrian",
-      "patrol": [
-        {
-          "x": -7.2,
-          "z": -126.0
-        },
-        {
-          "x": -6.4,
-          "z": -144.0
-        },
-        {
-          "x": -5.8,
-          "z": -166.0
-        }
-      ],
-      "interactRadius": 2.8,
-      "dialogId": "pedestrian_intro"
-    }
-  ]
+  }
 }

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -276,6 +276,21 @@
       material: new THREE.MeshStandardMaterial({ color: 0xb3452f, roughness: 0.72, metalness: 0.18 }),
       y: 0.59,
     },
+    utility_box: {
+      geometry: new THREE.BoxGeometry(1.18, 1.42, 0.68),
+      material: new THREE.MeshStandardMaterial({ color: 0x6f767d, roughness: 0.82, metalness: 0.24 }),
+      y: 0.71,
+    },
+    bench: {
+      geometry: new THREE.BoxGeometry(1.5, 0.42, 0.46),
+      material: new THREE.MeshStandardMaterial({ color: 0x6b4c33, roughness: 0.88, metalness: 0.08 }),
+      y: 0.34,
+    },
+    planter: {
+      geometry: new THREE.CylinderGeometry(0.48, 0.56, 0.72, 10),
+      material: new THREE.MeshStandardMaterial({ color: 0x7d684d, roughness: 0.9, metalness: 0.06 }),
+      y: 0.36,
+    },
   };
   const NPC_ROLE_STYLE = {
     pedestrian: { color: 0x9ab4c6, accent: 0x33414d, height: 1.72 },

--- a/scripts/generate-gastown-world.js
+++ b/scripts/generate-gastown-world.js
@@ -505,6 +505,92 @@ function makeRectFootprint(center, tangent, width, depth) {
   return closePolygon(world.map((point) => ({ x: Number(point.x.toFixed(2)), z: Number(point.z.toFixed(2)) })));
 }
 
+function starterRouteFrame(routePoints, distanceMeters) {
+  const routeLength = polylineLength(routePoints);
+  const center = samplePointAtDistance(routePoints, Math.max(0, Math.min(routeLength, distanceMeters)));
+  const ahead = samplePointAtDistance(routePoints, Math.min(routeLength, distanceMeters + 1.5));
+  const behind = samplePointAtDistance(routePoints, Math.max(0, distanceMeters - 1.5));
+  const tangent = normalize({ x: ahead.x - behind.x, z: ahead.z - behind.z });
+  const normal = perpendicularLeft(tangent);
+  return { center, tangent, normal, routeLength };
+}
+
+function placeStarterProp(routePoints, distanceMeters, lateralOffset, id, kind, extra = {}) {
+  const frame = starterRouteFrame(routePoints, distanceMeters);
+  return {
+    id,
+    kind,
+    x: Number((frame.center.x + (frame.normal.x * lateralOffset)).toFixed(2)),
+    y: Number((extra.y || 0).toFixed(2)),
+    z: Number((frame.center.z + (frame.normal.z * lateralOffset)).toFixed(2)),
+    yaw: Number(((extra.yawOffset || 0) + Math.atan2(frame.normal.x, frame.normal.z)).toFixed(4)),
+    scale: Number((extra.scale || 1).toFixed(2)),
+  };
+}
+
+function buildStarterProps(routePoints, sidewalkOuter, spawnDistance) {
+  const propSpecs = [
+    { id: 'starter-prop-threshold-box', kind: 'newspaper_box', d: 18, side: -1, offset: sidewalkOuter + 0.45, scale: 1.05 },
+    { id: 'starter-prop-threshold-utility', kind: 'utility_box', d: 24, side: 1, offset: sidewalkOuter + 0.65, scale: 1.1 },
+    { id: 'starter-prop-corner-bags', kind: 'trash_bag', d: 46, side: 1, offset: sidewalkOuter + 0.3, scale: 1.1 },
+    { id: 'starter-prop-planter-west', kind: 'planter', d: 62, side: -1, offset: sidewalkOuter + 0.85, scale: 1.15 },
+    { id: 'starter-prop-planter-east', kind: 'planter', d: 84, side: 1, offset: sidewalkOuter + 0.9, scale: 1.08 },
+    { id: 'starter-prop-bench-clock', kind: 'bench', d: 101, side: -1, offset: sidewalkOuter + 0.8, scale: 1.04 },
+    { id: 'starter-prop-clock-box', kind: 'newspaper_box', d: 108, side: 1, offset: sidewalkOuter + 0.5, scale: 0.98 },
+    { id: 'starter-prop-postclock-utility', kind: 'utility_box', d: 132, side: -1, offset: sidewalkOuter + 0.7, scale: 1.06 },
+    { id: 'starter-prop-postclock-bags', kind: 'trash_bag', d: 146, side: 1, offset: sidewalkOuter + 0.28, scale: 0.96 },
+    { id: 'starter-prop-postclock-bench', kind: 'bench', d: 164, side: 1, offset: sidewalkOuter + 0.86, scale: 1 },
+  ];
+
+  return propSpecs
+    .filter((spec) => Math.abs(spec.d - spawnDistance) > 10)
+    .map((spec) => placeStarterProp(routePoints, spec.d, spec.side * spec.offset, spec.id, spec.kind, {
+      scale: spec.scale,
+      yawOffset: spec.kind === 'bench' ? Math.PI / 2 : 0,
+    }));
+}
+
+function buildStarterLandmarks(routePoints, sidewalkOuter) {
+  return [
+    {
+      id: 'starter-waterfront-threshold',
+      label: 'Waterfront threshold',
+      kind: 'district_gate',
+      ...placeStarterProp(routePoints, 12, -1 * (sidewalkOuter + 2.6), 'starter-landmark-threshold-anchor', 'cardboard_box', { scale: 1 }),
+      y: 0,
+      scale: 1.35,
+      cue: 'Station canopies give way to brick-front Gastown blocks.',
+    },
+    {
+      id: 'starter-steam-clock-approach',
+      label: 'Steam Clock approach',
+      kind: 'clock-approach',
+      ...placeStarterProp(routePoints, 104, sidewalkOuter + 2.4, 'starter-landmark-clock-anchor', 'cardboard_box', { scale: 1 }),
+      y: 0,
+      scale: 1.25,
+      cue: 'Denser storefront rhythm, pavers, and curb clutter build toward the clock node.',
+    },
+    {
+      id: 'starter-post-clock-continuation',
+      label: 'Post-clock continuation',
+      kind: 'view-axis',
+      ...placeStarterProp(routePoints, 166, -1 * (sidewalkOuter + 2.2), 'starter-landmark-postclock-anchor', 'cardboard_box', { scale: 1 }),
+      y: 0,
+      scale: 1.18,
+      cue: 'The corridor loosens into longer facades and a quieter continuation east.',
+    },
+  ].map((landmark) => ({
+    id: landmark.id,
+    label: landmark.label,
+    kind: landmark.kind,
+    x: landmark.x,
+    y: landmark.y,
+    z: landmark.z,
+    scale: landmark.scale,
+    cue: landmark.cue,
+  }));
+}
+
 function makeStarterWorld(outputPath) {
   const routePoints = [
     { x: 0, z: 0 },
@@ -543,59 +629,74 @@ function makeStarterWorld(outputPath) {
   const rightSidewalk = closePolygon(lineOffset(routePoints, -streetHalf).concat(lineOffset(routePoints, -sidewalkOuter).reverse()));
   const walkBounds = ribbonPolygon(routePoints, walkOuter);
 
-  const frontagePattern = [9, 12, 8, 15, 10, 13, 11, 9, 14, 10];
-  const depthPattern = [17, 20, 15, 23, 18, 22, 19, 16, 21, 18];
-  const heightPattern = [10, 14, 12, 18, 11, 20, 15, 9, 16, 13];
+  const frontagePattern = [8, 11, 7, 15, 9, 13, 10, 18, 12, 8, 16, 9];
+  const depthPattern = [16, 21, 14, 24, 18, 22, 19, 20, 23, 17, 25, 18];
+  const heightPattern = [11, 15, 12, 19, 10, 21, 16, 18, 14, 9, 20, 13];
+  const recessPattern = [1, 2, 1, 3, 1, 2, 2, 1, 3, 1, 2, 1];
+  const palettePattern = [
+    { primary: '#74493c', trim: '#cfb8a2', accent: '#4f5f6f', tone: 'brickWarm' },
+    { primary: '#8a857d', trim: '#d8c9b6', accent: '#57656e', tone: 'stoneMuted' },
+    { primary: '#6e3f36', trim: '#caa98c', accent: '#445666', tone: 'brickWarm' },
+    { primary: '#6f747c', trim: '#d0c3b3', accent: '#3f5363', tone: 'stoneMuted' },
+  ];
+  const facadePattern = ['gastown_heritage_row', 'cordova_commercial_transition', 'gastown_heritage_row', 'narrow_brick_shaft'];
   const buildings = [];
-  let cursor = 8;
+  let cursor = 6;
   let i = 0;
-  while (cursor < routeLength - 14 && i < 28) {
+  while (cursor < routeLength - 12 && i < 30) {
     const frontage = frontagePattern[i % frontagePattern.length];
     const depth = depthPattern[i % depthPattern.length];
     const height = heightPattern[i % heightPattern.length];
-    const center = samplePointAtDistance(routePoints, cursor);
-    const ahead = samplePointAtDistance(routePoints, Math.min(routeLength, cursor + 2));
-    const behind = samplePointAtDistance(routePoints, Math.max(0, cursor - 2));
-    const tangent = normalize({ x: ahead.x - behind.x, z: ahead.z - behind.z });
-    const normal = perpendicularLeft(tangent);
+    const frame = starterRouteFrame(routePoints, cursor);
 
     [-1, 1].forEach((side) => {
-      const centerOffset = sidewalkOuter + (depth / 2) + 0.8;
+      const sideIndex = side < 0 ? 0 : 1;
+      const palette = palettePattern[(i + sideIndex) % palettePattern.length];
+      const blockPhase = cursor / routeLength;
+      const cornerMoment = i % 7 === (side < 0 ? 2 : 4);
+      const waterfrontThreshold = blockPhase < 0.22;
+      const steamClockApproach = blockPhase > 0.46 && blockPhase < 0.7;
+      const postClock = blockPhase >= 0.7;
+      const localDepth = depth + (cornerMoment ? 3.5 : 0) + (waterfrontThreshold && side > 0 ? 1.5 : 0);
+      const inset = cornerMoment ? 1.9 : (steamClockApproach ? 1.3 : 0.85);
+      const centerOffset = sidewalkOuter + (localDepth / 2) + inset;
       const footprintCenter = {
-        x: center.x + (normal.x * centerOffset * side),
-        z: center.z + (normal.z * centerOffset * side),
+        x: frame.center.x + (frame.normal.x * centerOffset * side),
+        z: frame.center.z + (frame.normal.z * centerOffset * side),
       };
-      const footprint = makeRectFootprint(footprintCenter, tangent, frontage, depth);
+      const localFrontage = frontage + (cornerMoment ? 3 : 0) + (postClock && side < 0 ? 2 : 0);
+      const footprint = makeRectFootprint(footprintCenter, frame.tangent, localFrontage, localDepth);
       const metrics = deriveFootprintMetrics(footprint);
       const id = `starter-bldg-${i}-${side < 0 ? 'left' : 'right'}`;
+      const recessedEntryCount = recessPattern[(i + sideIndex) % recessPattern.length];
+      const corniceEmphasis = cornerMoment ? 0.42 : (steamClockApproach ? 0.34 : 0.26);
+      const massInset = waterfrontThreshold ? 0.95 : (postClock ? 0.93 : 0.96);
       buildings.push({
         id,
-        reference_name: side < 0 ? 'Starter west frontage' : 'Starter east frontage',
+        reference_name: cornerMoment ? 'Starter corner heritage anchor' : side < 0 ? 'Starter west frontage' : 'Starter east frontage',
+        segment_style: waterfrontThreshold ? 'waterfront-threshold' : steamClockApproach ? 'steam-clock-approach' : postClock ? 'post-clock-continuation' : 'mid-corridor-heritage-rhythm',
+        style_notes: cornerMoment ? 'Corner building massing with stronger cornice to punctuate the route.' : 'Stylized heritage storefront cadence tuned for fallback readability.',
         x: Number(metrics.x.toFixed(2)),
         z: Number(metrics.z.toFixed(2)),
         width: Number(metrics.width.toFixed(2)),
         depth: Number(metrics.depth.toFixed(2)),
         yaw: Number(metrics.yaw.toFixed(4)),
-        height,
+        height: Number((height + (cornerMoment ? 2 : 0) + (waterfrontThreshold && side < 0 ? 1 : 0)).toFixed(1)),
         footprint,
         footprint_local: metrics.localFootprint.map((point) => ({ x: Number(point.x.toFixed(2)), z: Number(point.z.toFixed(2)) })),
-        facade_profile: side < 0 ? 'gastown_heritage_row' : 'cordova_commercial_transition',
-        tone: side < 0 ? 'brickWarm' : 'stoneMuted',
-        roofline_type: 'flat_cornice',
-        window_bay_count: Math.max(3, Math.round(frontage / 2.8)),
-        recessed_entry_count: 1,
-        storefront_rhythm: { base_band: 0.18, upper_rows: height >= 16 ? 4 : 3 },
-        material_palette: {
-          primary: side < 0 ? '#74493c' : '#7f868e',
-          trim: '#c7b8a5',
-          accent: '#4f5f6f',
-        },
-        cornice_emphasis: 0.26,
-        mass_inset: 0.97,
+        facade_profile: facadePattern[(i + sideIndex) % facadePattern.length],
+        tone: palette.tone,
+        roofline_type: cornerMoment ? 'wrapped_cornice' : steamClockApproach ? 'ornate_cornice' : 'flat_cornice',
+        window_bay_count: Math.max(3, Math.round(localFrontage / (cornerMoment ? 3.4 : 2.6))),
+        recessed_entry_count: recessedEntryCount,
+        storefront_rhythm: { base_band: Number((waterfrontThreshold ? 0.16 : steamClockApproach ? 0.22 : 0.19).toFixed(2)), upper_rows: height >= 16 ? 4 : 3 },
+        material_palette: palette,
+        cornice_emphasis: Number(corniceEmphasis.toFixed(2)),
+        mass_inset: Number(massInset.toFixed(2)),
       });
     });
 
-    cursor += frontage + 2.5;
+    cursor += frontage + (i % 3 === 0 ? 1.8 : 2.9);
     i += 1;
   }
 
@@ -608,6 +709,9 @@ function makeStarterWorld(outputPath) {
     z: Number((start.z + (dir.z * 9)).toFixed(2)),
     yaw: Number(Math.atan2(-dir.x, -dir.z).toFixed(4)),
   };
+
+  const props = buildStarterProps(routePoints, sidewalkOuter, 9);
+  const landmarks = buildStarterLandmarks(routePoints, sidewalkOuter);
 
   const world = {
     routeId: 'gastown_water_street_starter_corridor',
@@ -645,6 +749,8 @@ function makeStarterWorld(outputPath) {
       ],
     },
     buildings,
+    landmarks,
+    props,
     streetscape: {
       lamps: proceduralStreetscape(routePoints, {
         idPrefix: 'starter-lamp', strideMeters: 24, laneOffset: sidewalkOuter - 0.5, maxCount: 24,
@@ -655,7 +761,7 @@ function makeStarterWorld(outputPath) {
         mapper: (point, id) => ({ id, x: Number(point.x.toFixed(2)), z: Number(point.z.toFixed(2)), radius: 1.4 }),
       }),
       bollards: [],
-      surfaceBands: buildStarterSurfaceBands(centerline, streetWidth),
+      surfaceBands: buildStarterSurfaceBands(centerline, streetWidth, routeLength),
     },
     spawn,
     bounds: {
@@ -670,23 +776,31 @@ function makeStarterWorld(outputPath) {
 }
 
 
-function buildStarterSurfaceBands(centerline, streetWidth) {
+function buildStarterSurfaceBands(centerline, streetWidth, routeLength) {
   const bands = [];
   centerline.forEach((point, index) => {
     const next = centerline[index + 1] || centerline[index - 1];
     if (!next) return;
 
     const heading = Math.atan2(next.x - point.x, next.z - point.z);
-    const length = Math.max(7, Math.min(14, distance(point, next) * 0.9 || 9));
-    const edgeOffset = streetWidth * 0.31;
-    const jitter = ((index % 4) - 1.5) * 0.18;
+    const length = Math.max(7, Math.min(14, distance(point, next) * 0.92 || 9));
+    const progress = routeLength > 0 ? index / Math.max(1, centerline.length - 1) : 0;
+    const edgeOffset = streetWidth * 0.35;
+    const jointOffset = streetWidth * 0.22;
+    const jitter = ((index % 4) - 1.5) * 0.2;
+    const heritageBandWidth = progress > 0.42 && progress < 0.72 ? streetWidth * 0.72 : streetWidth * 0.56;
 
-    bands.push({ segment_id: point.id, width: streetWidth * 0.28, length, yaw: Number(heading.toFixed(4)), offset_x: 0, offset_z: 0, tone: 'wheel_track', opacity: 0.24, elevation: 0.032 });
-    bands.push({ segment_id: point.id, width: streetWidth * 0.22, length: Number(Math.max(5.8, length * 0.88).toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: Number(jitter.toFixed(2)), offset_z: 0, tone: index % 3 === 0 ? 'patch' : 'wet_streak', opacity: index % 3 === 0 ? 0.34 : 0.2, elevation: 0.038 });
-    bands.push({ segment_id: point.id, width: streetWidth * 0.12, length: Number(Math.max(4.8, length * 0.72).toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: Number((((index % 2 === 0) ? 1 : -1) * edgeOffset).toFixed(2)), offset_z: 0, tone: 'edge_grime', opacity: 0.26, elevation: 0.034 });
+    bands.push({ segment_id: point.id, width: Number((streetWidth * 0.3).toFixed(2)), length: Number(length.toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: 0, offset_z: 0, tone: 'wheel_track', opacity: 0.24, elevation: 0.032 });
+    bands.push({ segment_id: point.id, width: Number((streetWidth * 0.18).toFixed(2)), length: Number(Math.max(5.4, length * (progress < 0.25 ? 0.64 : 0.84)).toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: Number(jitter.toFixed(2)), offset_z: 0, tone: progress > 0.65 ? 'repair_patch_dark' : 'patch', opacity: progress > 0.65 ? 0.38 : 0.33, elevation: 0.038 });
+    bands.push({ segment_id: point.id, width: Number((streetWidth * 0.08).toFixed(2)), length: Number(Math.max(6.2, length * 1.06).toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: Number(edgeOffset.toFixed(2)), offset_z: 0, tone: 'curb_grime', opacity: 0.28, elevation: 0.034 });
+    bands.push({ segment_id: point.id, width: Number((streetWidth * 0.08).toFixed(2)), length: Number(Math.max(6.2, length * 1.04).toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: Number((-edgeOffset).toFixed(2)), offset_z: 0, tone: 'curb_grime', opacity: 0.28, elevation: 0.034 });
 
-    if (index % 3 === 1) {
-      bands.push({ segment_id: point.id, width: streetWidth * 0.18, length: Number(Math.max(4.2, length * 0.46).toFixed(2)), yaw: Number((heading + (index % 2 === 0 ? 0.08 : -0.08)).toFixed(4)), offset_x: Number((((index % 2 === 0) ? -1 : 1) * streetWidth * 0.14).toFixed(2)), offset_z: 0, tone: 'puddle', opacity: 0.16, elevation: 0.042 });
+    if (index % 2 === 0) {
+      bands.push({ segment_id: point.id, width: Number(heritageBandWidth.toFixed(2)), length: Number(Math.max(2.8, length * 0.22).toFixed(2)), yaw: Number((heading + Math.PI / 2).toFixed(4)), offset_x: Number((index % 4 === 0 ? -jointOffset : jointOffset).toFixed(2)), offset_z: 0, tone: progress > 0.42 && progress < 0.72 ? 'cobble_break' : 'paver_break', opacity: 0.34, elevation: 0.041 });
+    }
+
+    if (index === 1 || index === Math.floor((centerline.length - 1) / 2) || index === centerline.length - 2) {
+      bands.push({ segment_id: point.id, width: Number((streetWidth * 0.82).toFixed(2)), length: Number(Math.max(3.6, length * 0.3).toFixed(2)), yaw: Number((heading + Math.PI / 2).toFixed(4)), offset_x: 0, offset_z: 0, tone: 'intersection_pavers', opacity: 0.42, elevation: 0.045 });
     }
   });
   return bands;


### PR DESCRIPTION
### Motivation
- The starter fallback corridor rendered visually sterile when civic datasets were missing because `streetscape.surfaceBands` was empty, props were sparse, and building frontage was monotonous.
- Provide a deterministic, lightweight fallback that reads like a stylized Gastown corridor so the simulator feels intentional when offline civic inputs are absent.

### Description
- Enrich the deterministic starter builder in `scripts/generate-gastown-world.js` with reusable helper functions (`starterRouteFrame`, `placeStarterProp`, `buildStarterProps`, `buildStarterLandmarks`) and a richer building frontage cadence that adds corner moments, segment-style tags, varied cornice/palette/massing, and tuned frontage/depth/height patterns.
- Replace the empty starter `streetscape.surfaceBands` with a layered, deterministic band generator that emits wheel tracks, repair/patch tones, curb grime, cobble/paver breaks, and intersection pavers based on route progress. The surface bands remain deterministic and lightweight.
- Add deterministic streetscape props and landmarks placed off the walk lane: `trash_bag`, `newspaper_box`, `utility_box`, `bench`, and `planter` plus three route-beat landmarks (`Waterfront threshold`, `Steam Clock approach`, `Post-clock continuation`). These appear in both starter and default JSON outputs when the fallback builder is used.
- Add simple renderer definitions for the new prop kinds in `js/gastown-sim.js` so the simulator can visualize the fallback props.
- Update and extend the world-generator test `__tests__/gastown-world-generator.test.js` to assert that the starter fallback includes non-empty `streetscape.surfaceBands`, the new prop kinds, and route landmarks, and regenerate both `assets/world/gastown-water-street-starter.json` and `assets/world/gastown-water-street.json` from the upgraded fallback builder.

### Testing
- Ran syntax checks: `node --check scripts/generate-gastown-world.js` and `node --check js/gastown-sim.js` (OK).
- Ran generator unit test: `node --test __tests__/gastown-world-generator.test.js` (OK, updated assertions for starter fallback).
- Ran full test suite: `node --test` (all tests passed).
- Regenerated outputs via `buildWorld()` and verified both `assets/world/gastown-water-street-starter.json` and `assets/world/gastown-water-street.json` were produced by the deterministic starter fallback (both generated and include new `surfaceBands`, `props`, and `landmarks`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfb843aa04832e9a20f998ed34c25b)