### PR TITLE
Fix Gastown fallback corridor defaults, restore NPCs, and improve weather/route visuals

### DIFF
--- a/__tests__/gastown-sim-config.test.js
+++ b/__tests__/gastown-sim-config.test.js
@@ -1,0 +1,21 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+test('localized simulator defaults boot into morning clear mode', () => {
+  const functionsPath = path.join(__dirname, '..', 'functions.php');
+  const php = fs.readFileSync(functionsPath, 'utf8');
+
+  assert.match(php, /'defaultWeather'\s*=>\s*'clear'/);
+  assert.match(php, /'defaultTimeOfDay'\s*=>\s*'morning'/);
+});
+
+test('simulator page exposes morning clear defaults and thunderstorm option', () => {
+  const pagePath = path.join(__dirname, '..', 'page-gastown-sim.php');
+  const php = fs.readFileSync(pagePath, 'utf8');
+
+  assert.match(php, /<option value="morning" selected>Morning<\/option>/);
+  assert.match(php, /<option value="clear" selected>Clear<\/option>/);
+  assert.match(php, /<option value="thunderstorm">Thunderstorm<\/option>/);
+});

--- a/__tests__/gastown-sim-ground.test.js
+++ b/__tests__/gastown-sim-ground.test.js
@@ -16,6 +16,24 @@ test('ground rendering builds curb border lines from closed polygon points helpe
   const src = fs.readFileSync(simPath, 'utf8');
 
   assert.equal(src.includes('function buildClosedBorderPoints(points, y)'), true);
-  assert.equal(src.includes("borderPoints.push(new THREE.Vector3(first.x, y, first.z));"), true);
-  assert.equal(src.includes("const borderPoints = buildClosedBorderPoints(zone.polygon, 0.16);"), true);
+  assert.equal(src.includes('borderPoints.push(new THREE.Vector3(first.x, y, first.z));'), true);
+  assert.equal(src.includes('const borderPoints = buildClosedBorderPoints(zone.polygon, 0.16);'), true);
+});
+
+test('route guidance uses a single subtle marker treatment instead of centerline plus stripe clutter', () => {
+  const simPath = path.join(__dirname, '..', 'js', 'gastown-sim.js');
+  const src = fs.readFileSync(simPath, 'utf8');
+
+  assert.equal(src.includes('const routePoints = world.route.centerline.map((point) => new THREE.Vector3(point.x, 0.14, point.z));'), false);
+  assert.equal(src.includes('const line = new THREE.Line(new THREE.BufferGeometry().setFromPoints(routePoints), visualState.laneMaterial);'), false);
+  assert.equal(src.includes('new THREE.PlaneGeometry(0.18, 1.9)'), false);
+  assert.equal(src.includes('new THREE.PlaneGeometry(0.7, 2.2)'), true);
+});
+
+test('sim default mode falls back to bright morning clear startup values', () => {
+  const simPath = path.join(__dirname, '..', 'js', 'gastown-sim.js');
+  const src = fs.readFileSync(simPath, 'utf8');
+
+  assert.equal(src.includes("activeWeather: config.defaultWeather || 'clear'"), true);
+  assert.equal(src.includes("activeTimeOfDay: config.defaultTimeOfDay || 'morning'"), true);
 });

--- a/__tests__/gastown-world-generator.test.js
+++ b/__tests__/gastown-world-generator.test.js
@@ -5,6 +5,13 @@ const path = require('path');
 
 const { buildWorld } = require('../scripts/generate-gastown-world');
 
+function assertFinitePoints(points) {
+  points.forEach((point) => {
+    assert.equal(Number.isFinite(point.x), true);
+    assert.equal(Number.isFinite(point.z), true);
+  });
+}
+
 test('generator keeps world polygons valid with existing or generated output', () => {
   const root = path.resolve(__dirname, '..');
   const tmpPath = path.join(root, 'assets', 'world', 'gastown-water-street.test-output.json');
@@ -19,13 +26,6 @@ test('generator keeps world polygons valid with existing or generated output', (
   assert.ok(data.zones.street[0].polygon.length >= 3);
   assert.ok(Array.isArray(data.zones.sidewalk[0].polygon));
   assert.ok(data.zones.sidewalk[0].polygon.length >= 3);
-
-  function assertFinitePoints(points) {
-    points.forEach((point) => {
-      assert.equal(Number.isFinite(point.x), true);
-      assert.equal(Number.isFinite(point.z), true);
-    });
-  }
 
   assertFinitePoints(data.route.walkBounds);
   data.zones.street.forEach((zone) => assertFinitePoints(zone.polygon));
@@ -56,10 +56,27 @@ test('generator keeps world polygons valid with existing or generated output', (
 
       assert.ok(Array.isArray(data.landmarks));
       assert.equal(data.landmarks.length >= 3, true, 'starter fallback should expose route beats as landmarks');
+      assert.ok(Array.isArray(data.npcs));
+      assert.equal(data.npcs.length >= 4, true, 'starter fallback should expose deterministic NPCs');
+      assert.deepEqual(data.npcs.map((npc) => npc.id), [
+        'starter-guide-threshold',
+        'starter-busker-clock',
+        'starter-pedestrian-west',
+        'starter-pedestrian-east',
+      ]);
     }
   }
 
   if (fs.existsSync(tmpPath)) {
     fs.unlinkSync(tmpPath);
   }
+});
+
+test('committed world json files include non-empty npc arrays', () => {
+  const root = path.resolve(__dirname, '..');
+  ['assets/world/gastown-water-street.json', 'assets/world/gastown-water-street-starter.json'].forEach((relPath) => {
+    const data = JSON.parse(fs.readFileSync(path.join(root, relPath), 'utf8'));
+    assert.ok(Array.isArray(data.npcs), relPath + ' should include npcs');
+    assert.ok(data.npcs.length > 0, relPath + ' should have at least one npc');
+  });
 });

--- a/__tests__/gastown-world-loader-normalize.test.js
+++ b/__tests__/gastown-world-loader-normalize.test.js
@@ -72,7 +72,7 @@ test('normalizeWorldData guarantees required mood/weather/time presets and field
   const normalized = normalizeWorldData(minimalValidWorld());
 
   const requiredMoodKeys = ['ambientBed', 'audioDensity', 'voiceFreq', 'lightIntensity'];
-  const requiredWeatherKeys = ['rainIntensity', 'fogDensity'];
+  const requiredWeatherKeys = ['rainIntensity', 'fogDensity', 'cloudCoverage', 'cloudDarkness', 'cloudAltitude', 'lightningFrequency', 'lightningIntensity', 'thunderEnabled'];
   const requiredTimeKeys = [
     'sky', 'ambientColor', 'ambientIntensity', 'keyColor', 'keyIntensity', 'fillColor',
     'fillIntensity', 'buildingContrast', 'buildingEdgeColor', 'roadColor', 'sidewalkColor',
@@ -85,7 +85,7 @@ test('normalizeWorldData guarantees required mood/weather/time presets and field
     requiredMoodKeys.forEach((key) => assert.notEqual(preset[key], undefined));
   });
 
-  ['clear', 'rain', 'fog'].forEach((id) => {
+  ['clear', 'rain', 'fog', 'thunderstorm'].forEach((id) => {
     const preset = normalized.weatherPresets[id];
     assert.ok(preset, `missing weather preset ${id}`);
     requiredWeatherKeys.forEach((key) => assert.notEqual(preset[key], undefined));

--- a/assets/world/gastown-water-street-starter.json
+++ b/assets/world/gastown-water-street-starter.json
@@ -10,7 +10,7 @@
       "Starter corridor fallback is active because required offline civic source files are missing.",
       "This world is intentionally human-scaled and deterministic for readability; it is not GIS-accurate Gastown reconstruction."
     ],
-    "lastBuild": "2026-03-22T09:40:47.244Z"
+    "lastBuild": "2026-03-22T10:25:26.683Z"
   },
   "route": {
     "name": "Gastown starter block corridor",
@@ -2324,6 +2324,68 @@
       "scale": 1
     }
   ],
+  "npcs": [
+    {
+      "id": "starter-guide-threshold",
+      "role": "guide",
+      "dialogId": "guide_intro",
+      "interactRadius": 2.8,
+      "idleSpot": {
+        "x": -2.79,
+        "z": -16.3
+      }
+    },
+    {
+      "id": "starter-busker-clock",
+      "role": "busker",
+      "dialogId": "busker_clock_corner",
+      "interactRadius": 3,
+      "idleSpot": {
+        "x": 12.83,
+        "z": -101.35
+      }
+    },
+    {
+      "id": "starter-pedestrian-west",
+      "role": "pedestrian",
+      "dialogId": "pedestrian_route_tip",
+      "interactRadius": 2.2,
+      "idleSpot": {
+        "x": -0.07,
+        "z": -44.17
+      },
+      "patrol": [
+        {
+          "x": -0.59,
+          "z": -38.19
+        },
+        {
+          "x": 0.75,
+          "z": -56.12
+        }
+      ]
+    },
+    {
+      "id": "starter-pedestrian-east",
+      "role": "pedestrian",
+      "dialogId": "pedestrian_clock_hint",
+      "interactRadius": 2.2,
+      "idleSpot": {
+        "x": 14.67,
+        "z": -135.3
+      },
+      "patrol": [
+        {
+          "x": 13.99,
+          "z": -125.33
+        },
+        {
+          "x": 15.66,
+          "z": -147.27
+        }
+      ]
+    }
+  ],
   "streetscape": {
     "lamps": [
       {
@@ -2513,586 +2575,421 @@
     "surfaceBands": [
       {
         "segment_id": "starter-corridor-start",
-        "width": 2.94,
-        "length": 14,
+        "width": 3.33,
+        "length": 14.4,
         "yaw": 3.0551,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.24,
-        "elevation": 0.032
+        "opacity": 0.16,
+        "elevation": 0.024
       },
       {
         "segment_id": "starter-corridor-start",
-        "width": 1.76,
-        "length": 8.96,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0551,
-        "offset_x": -0.3,
+        "offset_x": 3.63,
         "offset_z": 0,
-        "tone": "patch",
-        "opacity": 0.33,
-        "elevation": 0.038
+        "tone": "curb_grime",
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-corridor-start",
-        "width": 0.78,
-        "length": 14.84,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0551,
-        "offset_x": 3.43,
+        "offset_x": -3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-corridor-start",
-        "width": 0.78,
-        "length": 14.56,
-        "yaw": 3.0551,
-        "offset_x": -3.43,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-corridor-start",
-        "width": 5.49,
-        "length": 3.08,
-        "yaw": 4.6259,
-        "offset_x": -2.16,
-        "offset_z": 0,
-        "tone": "paver_break",
-        "opacity": 0.34,
-        "elevation": 0.041
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-1",
-        "width": 2.94,
-        "length": 14,
+        "width": 3.33,
+        "length": 14.4,
         "yaw": 3.0545,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.24,
-        "elevation": 0.032
+        "opacity": 0.16,
+        "elevation": 0.024
       },
       {
         "segment_id": "starter-beat-1",
-        "width": 1.76,
-        "length": 8.96,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0545,
-        "offset_x": -0.1,
+        "offset_x": 3.63,
         "offset_z": 0,
-        "tone": "patch",
-        "opacity": 0.33,
-        "elevation": 0.038
+        "tone": "curb_grime",
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-1",
-        "width": 0.78,
-        "length": 14.84,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0545,
-        "offset_x": 3.43,
+        "offset_x": -3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-beat-1",
-        "width": 0.78,
-        "length": 14.56,
-        "yaw": 3.0545,
-        "offset_x": -3.43,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-beat-1",
-        "width": 8.04,
-        "length": 4.2,
-        "yaw": 4.6253,
-        "offset_x": 0,
-        "offset_z": 0,
-        "tone": "intersection_pavers",
-        "opacity": 0.42,
-        "elevation": 0.045
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-2",
-        "width": 2.94,
-        "length": 14,
+        "width": 3.33,
+        "length": 14.4,
         "yaw": 3.0577,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.24,
-        "elevation": 0.032
+        "opacity": 0.21,
+        "elevation": 0.024
       },
       {
         "segment_id": "starter-beat-2",
-        "width": 1.76,
-        "length": 8.96,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0577,
-        "offset_x": 0.1,
-        "offset_z": 0,
-        "tone": "patch",
-        "opacity": 0.33,
-        "elevation": 0.038
-      },
-      {
-        "segment_id": "starter-beat-2",
-        "width": 0.78,
-        "length": 14.84,
-        "yaw": 3.0577,
-        "offset_x": 3.43,
+        "offset_x": 3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-2",
-        "width": 0.78,
-        "length": 14.56,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0577,
-        "offset_x": -3.43,
+        "offset_x": -3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-beat-2",
-        "width": 5.49,
-        "length": 3.08,
-        "yaw": 4.6285,
-        "offset_x": 2.16,
-        "offset_z": 0,
-        "tone": "paver_break",
-        "opacity": 0.34,
-        "elevation": 0.041
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-3",
-        "width": 2.94,
-        "length": 14,
+        "width": 3.33,
+        "length": 14.4,
         "yaw": 3.0604,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.24,
-        "elevation": 0.032
+        "opacity": 0.21,
+        "elevation": 0.024
       },
       {
         "segment_id": "starter-beat-3",
-        "width": 1.76,
-        "length": 11.76,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0604,
-        "offset_x": 0.3,
-        "offset_z": 0,
-        "tone": "patch",
-        "opacity": 0.33,
-        "elevation": 0.038
-      },
-      {
-        "segment_id": "starter-beat-3",
-        "width": 0.78,
-        "length": 14.84,
-        "yaw": 3.0604,
-        "offset_x": 3.43,
+        "offset_x": 3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-3",
-        "width": 0.78,
-        "length": 14.56,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0604,
-        "offset_x": -3.43,
+        "offset_x": -3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-4",
-        "width": 2.94,
-        "length": 14,
+        "width": 3.33,
+        "length": 14.4,
         "yaw": 3.0599,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.24,
-        "elevation": 0.032
+        "opacity": 0.21,
+        "elevation": 0.024
       },
       {
         "segment_id": "starter-beat-4",
-        "width": 1.76,
-        "length": 11.76,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0599,
-        "offset_x": -0.3,
+        "offset_x": 3.63,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.17,
+        "elevation": 0.026
+      },
+      {
+        "segment_id": "starter-beat-4",
+        "width": 0.69,
+        "length": 15.3,
+        "yaw": 3.0599,
+        "offset_x": -3.63,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.17,
+        "elevation": 0.026
+      },
+      {
+        "segment_id": "starter-beat-4",
+        "width": 1.47,
+        "length": 8.7,
+        "yaw": 3.0899,
+        "offset_x": 0,
         "offset_z": 0,
         "tone": "patch",
-        "opacity": 0.33,
-        "elevation": 0.038
-      },
-      {
-        "segment_id": "starter-beat-4",
-        "width": 0.78,
-        "length": 14.84,
-        "yaw": 3.0599,
-        "offset_x": 3.43,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-beat-4",
-        "width": 0.78,
-        "length": 14.56,
-        "yaw": 3.0599,
-        "offset_x": -3.43,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-beat-4",
-        "width": 5.49,
-        "length": 3.08,
-        "yaw": 4.6307,
-        "offset_x": -2.16,
-        "offset_z": 0,
-        "tone": "paver_break",
-        "opacity": 0.34,
-        "elevation": 0.041
+        "opacity": 0.18,
+        "elevation": 0.028
       },
       {
         "segment_id": "starter-mid-block",
-        "width": 2.94,
-        "length": 14,
+        "width": 3.33,
+        "length": 14.4,
         "yaw": 3.0732,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.24,
-        "elevation": 0.032
+        "opacity": 0.21,
+        "elevation": 0.024
       },
       {
         "segment_id": "starter-mid-block",
-        "width": 1.76,
-        "length": 11.76,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0732,
-        "offset_x": -0.1,
-        "offset_z": 0,
-        "tone": "patch",
-        "opacity": 0.33,
-        "elevation": 0.038
-      },
-      {
-        "segment_id": "starter-mid-block",
-        "width": 0.78,
-        "length": 14.84,
-        "yaw": 3.0732,
-        "offset_x": 3.43,
+        "offset_x": 3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-mid-block",
-        "width": 0.78,
-        "length": 14.56,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0732,
-        "offset_x": -3.43,
+        "offset_x": -3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-mid-block",
-        "width": 8.04,
-        "length": 4.2,
+        "width": 6.66,
+        "length": 3.6,
         "yaw": 4.644,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "intersection_pavers",
-        "opacity": 0.42,
-        "elevation": 0.045
+        "opacity": 0.24,
+        "elevation": 0.03
       },
       {
         "segment_id": "starter-beat-6",
-        "width": 2.94,
-        "length": 14,
+        "width": 3.33,
+        "length": 14.4,
         "yaw": 3.0742,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.24,
-        "elevation": 0.032
+        "opacity": 0.21,
+        "elevation": 0.024
       },
       {
         "segment_id": "starter-beat-6",
-        "width": 1.76,
-        "length": 11.76,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0742,
-        "offset_x": 0.1,
-        "offset_z": 0,
-        "tone": "patch",
-        "opacity": 0.33,
-        "elevation": 0.038
-      },
-      {
-        "segment_id": "starter-beat-6",
-        "width": 0.78,
-        "length": 14.84,
-        "yaw": 3.0742,
-        "offset_x": 3.43,
+        "offset_x": 3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-6",
-        "width": 0.78,
-        "length": 14.56,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0742,
-        "offset_x": -3.43,
+        "offset_x": -3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-beat-6",
-        "width": 7.06,
-        "length": 3.08,
-        "yaw": 4.645,
-        "offset_x": 2.16,
-        "offset_z": 0,
-        "tone": "cobble_break",
-        "opacity": 0.34,
-        "elevation": 0.041
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-7",
-        "width": 2.94,
-        "length": 14,
+        "width": 3.33,
+        "length": 14.4,
         "yaw": 3.0737,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.24,
-        "elevation": 0.032
+        "opacity": 0.21,
+        "elevation": 0.024
       },
       {
         "segment_id": "starter-beat-7",
-        "width": 1.76,
-        "length": 11.76,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0737,
-        "offset_x": 0.3,
+        "offset_x": 3.63,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.17,
+        "elevation": 0.026
+      },
+      {
+        "segment_id": "starter-beat-7",
+        "width": 0.69,
+        "length": 15.3,
+        "yaw": 3.0737,
+        "offset_x": -3.63,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.17,
+        "elevation": 0.026
+      },
+      {
+        "segment_id": "starter-beat-7",
+        "width": 1.47,
+        "length": 8.7,
+        "yaw": 3.0437,
+        "offset_x": 0,
         "offset_z": 0,
         "tone": "repair_patch_dark",
-        "opacity": 0.38,
-        "elevation": 0.038
-      },
-      {
-        "segment_id": "starter-beat-7",
-        "width": 0.78,
-        "length": 14.84,
-        "yaw": 3.0737,
-        "offset_x": 3.43,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-beat-7",
-        "width": 0.78,
-        "length": 14.56,
-        "yaw": 3.0737,
-        "offset_x": -3.43,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
+        "opacity": 0.2,
+        "elevation": 0.028
       },
       {
         "segment_id": "starter-beat-8",
-        "width": 2.94,
-        "length": 14,
+        "width": 3.33,
+        "length": 14.4,
         "yaw": 3.0577,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.24,
-        "elevation": 0.032
+        "opacity": 0.21,
+        "elevation": 0.024
       },
       {
         "segment_id": "starter-beat-8",
-        "width": 1.76,
-        "length": 11.76,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0577,
-        "offset_x": -0.3,
-        "offset_z": 0,
-        "tone": "repair_patch_dark",
-        "opacity": 0.38,
-        "elevation": 0.038
-      },
-      {
-        "segment_id": "starter-beat-8",
-        "width": 0.78,
-        "length": 14.84,
-        "yaw": 3.0577,
-        "offset_x": 3.43,
+        "offset_x": 3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-8",
-        "width": 0.78,
-        "length": 14.56,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0577,
-        "offset_x": -3.43,
+        "offset_x": -3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-beat-8",
-        "width": 5.49,
-        "length": 3.08,
-        "yaw": 4.6285,
-        "offset_x": -2.16,
-        "offset_z": 0,
-        "tone": "paver_break",
-        "opacity": 0.34,
-        "elevation": 0.041
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-9",
-        "width": 2.94,
-        "length": 14,
+        "width": 3.33,
+        "length": 14.4,
         "yaw": 3.0535,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.24,
-        "elevation": 0.032
+        "opacity": 0.21,
+        "elevation": 0.024
       },
       {
         "segment_id": "starter-beat-9",
-        "width": 1.76,
-        "length": 11.76,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0535,
-        "offset_x": -0.1,
-        "offset_z": 0,
-        "tone": "repair_patch_dark",
-        "opacity": 0.38,
-        "elevation": 0.038
-      },
-      {
-        "segment_id": "starter-beat-9",
-        "width": 0.78,
-        "length": 14.84,
-        "yaw": 3.0535,
-        "offset_x": 3.43,
+        "offset_x": 3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-9",
-        "width": 0.78,
-        "length": 14.56,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0535,
-        "offset_x": -3.43,
+        "offset_x": -3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-9",
-        "width": 8.04,
-        "length": 4.2,
+        "width": 6.66,
+        "length": 3.6,
         "yaw": 4.6243,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "intersection_pavers",
-        "opacity": 0.42,
-        "elevation": 0.045
+        "opacity": 0.24,
+        "elevation": 0.03
       },
       {
         "segment_id": "starter-corridor-end",
-        "width": 2.94,
-        "length": 14,
+        "width": 3.33,
+        "length": 14.4,
         "yaw": -0.0881,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.24,
-        "elevation": 0.032
+        "opacity": 0.21,
+        "elevation": 0.024
       },
       {
         "segment_id": "starter-corridor-end",
-        "width": 1.76,
-        "length": 11.76,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": -0.0881,
-        "offset_x": 0.1,
+        "offset_x": 3.63,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.17,
+        "elevation": 0.026
+      },
+      {
+        "segment_id": "starter-corridor-end",
+        "width": 0.69,
+        "length": 15.3,
+        "yaw": -0.0881,
+        "offset_x": -3.63,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.17,
+        "elevation": 0.026
+      },
+      {
+        "segment_id": "starter-corridor-end",
+        "width": 1.47,
+        "length": 8.7,
+        "yaw": -0.0581,
+        "offset_x": 0,
         "offset_z": 0,
         "tone": "repair_patch_dark",
-        "opacity": 0.38,
-        "elevation": 0.038
-      },
-      {
-        "segment_id": "starter-corridor-end",
-        "width": 0.78,
-        "length": 14.84,
-        "yaw": -0.0881,
-        "offset_x": 3.43,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-corridor-end",
-        "width": 0.78,
-        "length": 14.56,
-        "yaw": -0.0881,
-        "offset_x": -3.43,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-corridor-end",
-        "width": 5.49,
-        "length": 3.08,
-        "yaw": 1.4827,
-        "offset_x": 2.16,
-        "offset_z": 0,
-        "tone": "paver_break",
-        "opacity": 0.34,
-        "elevation": 0.041
+        "opacity": 0.2,
+        "elevation": 0.028
       }
     ]
   },

--- a/assets/world/gastown-water-street.json
+++ b/assets/world/gastown-water-street.json
@@ -10,7 +10,7 @@
       "Starter corridor fallback is active because required offline civic source files are missing.",
       "This world is intentionally human-scaled and deterministic for readability; it is not GIS-accurate Gastown reconstruction."
     ],
-    "lastBuild": "2026-03-22T09:40:47.254Z"
+    "lastBuild": "2026-03-22T10:25:26.599Z"
   },
   "route": {
     "name": "Gastown starter block corridor",
@@ -2324,6 +2324,68 @@
       "scale": 1
     }
   ],
+  "npcs": [
+    {
+      "id": "starter-guide-threshold",
+      "role": "guide",
+      "dialogId": "guide_intro",
+      "interactRadius": 2.8,
+      "idleSpot": {
+        "x": -2.79,
+        "z": -16.3
+      }
+    },
+    {
+      "id": "starter-busker-clock",
+      "role": "busker",
+      "dialogId": "busker_clock_corner",
+      "interactRadius": 3,
+      "idleSpot": {
+        "x": 12.83,
+        "z": -101.35
+      }
+    },
+    {
+      "id": "starter-pedestrian-west",
+      "role": "pedestrian",
+      "dialogId": "pedestrian_route_tip",
+      "interactRadius": 2.2,
+      "idleSpot": {
+        "x": -0.07,
+        "z": -44.17
+      },
+      "patrol": [
+        {
+          "x": -0.59,
+          "z": -38.19
+        },
+        {
+          "x": 0.75,
+          "z": -56.12
+        }
+      ]
+    },
+    {
+      "id": "starter-pedestrian-east",
+      "role": "pedestrian",
+      "dialogId": "pedestrian_clock_hint",
+      "interactRadius": 2.2,
+      "idleSpot": {
+        "x": 14.67,
+        "z": -135.3
+      },
+      "patrol": [
+        {
+          "x": 13.99,
+          "z": -125.33
+        },
+        {
+          "x": 15.66,
+          "z": -147.27
+        }
+      ]
+    }
+  ],
   "streetscape": {
     "lamps": [
       {
@@ -2513,586 +2575,421 @@
     "surfaceBands": [
       {
         "segment_id": "starter-corridor-start",
-        "width": 2.94,
-        "length": 14,
+        "width": 3.33,
+        "length": 14.4,
         "yaw": 3.0551,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.24,
-        "elevation": 0.032
+        "opacity": 0.16,
+        "elevation": 0.024
       },
       {
         "segment_id": "starter-corridor-start",
-        "width": 1.76,
-        "length": 8.96,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0551,
-        "offset_x": -0.3,
+        "offset_x": 3.63,
         "offset_z": 0,
-        "tone": "patch",
-        "opacity": 0.33,
-        "elevation": 0.038
+        "tone": "curb_grime",
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-corridor-start",
-        "width": 0.78,
-        "length": 14.84,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0551,
-        "offset_x": 3.43,
+        "offset_x": -3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-corridor-start",
-        "width": 0.78,
-        "length": 14.56,
-        "yaw": 3.0551,
-        "offset_x": -3.43,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-corridor-start",
-        "width": 5.49,
-        "length": 3.08,
-        "yaw": 4.6259,
-        "offset_x": -2.16,
-        "offset_z": 0,
-        "tone": "paver_break",
-        "opacity": 0.34,
-        "elevation": 0.041
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-1",
-        "width": 2.94,
-        "length": 14,
+        "width": 3.33,
+        "length": 14.4,
         "yaw": 3.0545,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.24,
-        "elevation": 0.032
+        "opacity": 0.16,
+        "elevation": 0.024
       },
       {
         "segment_id": "starter-beat-1",
-        "width": 1.76,
-        "length": 8.96,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0545,
-        "offset_x": -0.1,
+        "offset_x": 3.63,
         "offset_z": 0,
-        "tone": "patch",
-        "opacity": 0.33,
-        "elevation": 0.038
+        "tone": "curb_grime",
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-1",
-        "width": 0.78,
-        "length": 14.84,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0545,
-        "offset_x": 3.43,
+        "offset_x": -3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-beat-1",
-        "width": 0.78,
-        "length": 14.56,
-        "yaw": 3.0545,
-        "offset_x": -3.43,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-beat-1",
-        "width": 8.04,
-        "length": 4.2,
-        "yaw": 4.6253,
-        "offset_x": 0,
-        "offset_z": 0,
-        "tone": "intersection_pavers",
-        "opacity": 0.42,
-        "elevation": 0.045
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-2",
-        "width": 2.94,
-        "length": 14,
+        "width": 3.33,
+        "length": 14.4,
         "yaw": 3.0577,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.24,
-        "elevation": 0.032
+        "opacity": 0.21,
+        "elevation": 0.024
       },
       {
         "segment_id": "starter-beat-2",
-        "width": 1.76,
-        "length": 8.96,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0577,
-        "offset_x": 0.1,
-        "offset_z": 0,
-        "tone": "patch",
-        "opacity": 0.33,
-        "elevation": 0.038
-      },
-      {
-        "segment_id": "starter-beat-2",
-        "width": 0.78,
-        "length": 14.84,
-        "yaw": 3.0577,
-        "offset_x": 3.43,
+        "offset_x": 3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-2",
-        "width": 0.78,
-        "length": 14.56,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0577,
-        "offset_x": -3.43,
+        "offset_x": -3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-beat-2",
-        "width": 5.49,
-        "length": 3.08,
-        "yaw": 4.6285,
-        "offset_x": 2.16,
-        "offset_z": 0,
-        "tone": "paver_break",
-        "opacity": 0.34,
-        "elevation": 0.041
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-3",
-        "width": 2.94,
-        "length": 14,
+        "width": 3.33,
+        "length": 14.4,
         "yaw": 3.0604,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.24,
-        "elevation": 0.032
+        "opacity": 0.21,
+        "elevation": 0.024
       },
       {
         "segment_id": "starter-beat-3",
-        "width": 1.76,
-        "length": 11.76,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0604,
-        "offset_x": 0.3,
-        "offset_z": 0,
-        "tone": "patch",
-        "opacity": 0.33,
-        "elevation": 0.038
-      },
-      {
-        "segment_id": "starter-beat-3",
-        "width": 0.78,
-        "length": 14.84,
-        "yaw": 3.0604,
-        "offset_x": 3.43,
+        "offset_x": 3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-3",
-        "width": 0.78,
-        "length": 14.56,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0604,
-        "offset_x": -3.43,
+        "offset_x": -3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-4",
-        "width": 2.94,
-        "length": 14,
+        "width": 3.33,
+        "length": 14.4,
         "yaw": 3.0599,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.24,
-        "elevation": 0.032
+        "opacity": 0.21,
+        "elevation": 0.024
       },
       {
         "segment_id": "starter-beat-4",
-        "width": 1.76,
-        "length": 11.76,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0599,
-        "offset_x": -0.3,
+        "offset_x": 3.63,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.17,
+        "elevation": 0.026
+      },
+      {
+        "segment_id": "starter-beat-4",
+        "width": 0.69,
+        "length": 15.3,
+        "yaw": 3.0599,
+        "offset_x": -3.63,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.17,
+        "elevation": 0.026
+      },
+      {
+        "segment_id": "starter-beat-4",
+        "width": 1.47,
+        "length": 8.7,
+        "yaw": 3.0899,
+        "offset_x": 0,
         "offset_z": 0,
         "tone": "patch",
-        "opacity": 0.33,
-        "elevation": 0.038
-      },
-      {
-        "segment_id": "starter-beat-4",
-        "width": 0.78,
-        "length": 14.84,
-        "yaw": 3.0599,
-        "offset_x": 3.43,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-beat-4",
-        "width": 0.78,
-        "length": 14.56,
-        "yaw": 3.0599,
-        "offset_x": -3.43,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-beat-4",
-        "width": 5.49,
-        "length": 3.08,
-        "yaw": 4.6307,
-        "offset_x": -2.16,
-        "offset_z": 0,
-        "tone": "paver_break",
-        "opacity": 0.34,
-        "elevation": 0.041
+        "opacity": 0.18,
+        "elevation": 0.028
       },
       {
         "segment_id": "starter-mid-block",
-        "width": 2.94,
-        "length": 14,
+        "width": 3.33,
+        "length": 14.4,
         "yaw": 3.0732,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.24,
-        "elevation": 0.032
+        "opacity": 0.21,
+        "elevation": 0.024
       },
       {
         "segment_id": "starter-mid-block",
-        "width": 1.76,
-        "length": 11.76,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0732,
-        "offset_x": -0.1,
-        "offset_z": 0,
-        "tone": "patch",
-        "opacity": 0.33,
-        "elevation": 0.038
-      },
-      {
-        "segment_id": "starter-mid-block",
-        "width": 0.78,
-        "length": 14.84,
-        "yaw": 3.0732,
-        "offset_x": 3.43,
+        "offset_x": 3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-mid-block",
-        "width": 0.78,
-        "length": 14.56,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0732,
-        "offset_x": -3.43,
+        "offset_x": -3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-mid-block",
-        "width": 8.04,
-        "length": 4.2,
+        "width": 6.66,
+        "length": 3.6,
         "yaw": 4.644,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "intersection_pavers",
-        "opacity": 0.42,
-        "elevation": 0.045
+        "opacity": 0.24,
+        "elevation": 0.03
       },
       {
         "segment_id": "starter-beat-6",
-        "width": 2.94,
-        "length": 14,
+        "width": 3.33,
+        "length": 14.4,
         "yaw": 3.0742,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.24,
-        "elevation": 0.032
+        "opacity": 0.21,
+        "elevation": 0.024
       },
       {
         "segment_id": "starter-beat-6",
-        "width": 1.76,
-        "length": 11.76,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0742,
-        "offset_x": 0.1,
-        "offset_z": 0,
-        "tone": "patch",
-        "opacity": 0.33,
-        "elevation": 0.038
-      },
-      {
-        "segment_id": "starter-beat-6",
-        "width": 0.78,
-        "length": 14.84,
-        "yaw": 3.0742,
-        "offset_x": 3.43,
+        "offset_x": 3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-6",
-        "width": 0.78,
-        "length": 14.56,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0742,
-        "offset_x": -3.43,
+        "offset_x": -3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-beat-6",
-        "width": 7.06,
-        "length": 3.08,
-        "yaw": 4.645,
-        "offset_x": 2.16,
-        "offset_z": 0,
-        "tone": "cobble_break",
-        "opacity": 0.34,
-        "elevation": 0.041
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-7",
-        "width": 2.94,
-        "length": 14,
+        "width": 3.33,
+        "length": 14.4,
         "yaw": 3.0737,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.24,
-        "elevation": 0.032
+        "opacity": 0.21,
+        "elevation": 0.024
       },
       {
         "segment_id": "starter-beat-7",
-        "width": 1.76,
-        "length": 11.76,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0737,
-        "offset_x": 0.3,
+        "offset_x": 3.63,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.17,
+        "elevation": 0.026
+      },
+      {
+        "segment_id": "starter-beat-7",
+        "width": 0.69,
+        "length": 15.3,
+        "yaw": 3.0737,
+        "offset_x": -3.63,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.17,
+        "elevation": 0.026
+      },
+      {
+        "segment_id": "starter-beat-7",
+        "width": 1.47,
+        "length": 8.7,
+        "yaw": 3.0437,
+        "offset_x": 0,
         "offset_z": 0,
         "tone": "repair_patch_dark",
-        "opacity": 0.38,
-        "elevation": 0.038
-      },
-      {
-        "segment_id": "starter-beat-7",
-        "width": 0.78,
-        "length": 14.84,
-        "yaw": 3.0737,
-        "offset_x": 3.43,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-beat-7",
-        "width": 0.78,
-        "length": 14.56,
-        "yaw": 3.0737,
-        "offset_x": -3.43,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
+        "opacity": 0.2,
+        "elevation": 0.028
       },
       {
         "segment_id": "starter-beat-8",
-        "width": 2.94,
-        "length": 14,
+        "width": 3.33,
+        "length": 14.4,
         "yaw": 3.0577,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.24,
-        "elevation": 0.032
+        "opacity": 0.21,
+        "elevation": 0.024
       },
       {
         "segment_id": "starter-beat-8",
-        "width": 1.76,
-        "length": 11.76,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0577,
-        "offset_x": -0.3,
-        "offset_z": 0,
-        "tone": "repair_patch_dark",
-        "opacity": 0.38,
-        "elevation": 0.038
-      },
-      {
-        "segment_id": "starter-beat-8",
-        "width": 0.78,
-        "length": 14.84,
-        "yaw": 3.0577,
-        "offset_x": 3.43,
+        "offset_x": 3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-8",
-        "width": 0.78,
-        "length": 14.56,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0577,
-        "offset_x": -3.43,
+        "offset_x": -3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-beat-8",
-        "width": 5.49,
-        "length": 3.08,
-        "yaw": 4.6285,
-        "offset_x": -2.16,
-        "offset_z": 0,
-        "tone": "paver_break",
-        "opacity": 0.34,
-        "elevation": 0.041
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-9",
-        "width": 2.94,
-        "length": 14,
+        "width": 3.33,
+        "length": 14.4,
         "yaw": 3.0535,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.24,
-        "elevation": 0.032
+        "opacity": 0.21,
+        "elevation": 0.024
       },
       {
         "segment_id": "starter-beat-9",
-        "width": 1.76,
-        "length": 11.76,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0535,
-        "offset_x": -0.1,
-        "offset_z": 0,
-        "tone": "repair_patch_dark",
-        "opacity": 0.38,
-        "elevation": 0.038
-      },
-      {
-        "segment_id": "starter-beat-9",
-        "width": 0.78,
-        "length": 14.84,
-        "yaw": 3.0535,
-        "offset_x": 3.43,
+        "offset_x": 3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-9",
-        "width": 0.78,
-        "length": 14.56,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": 3.0535,
-        "offset_x": -3.43,
+        "offset_x": -3.63,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
+        "opacity": 0.17,
+        "elevation": 0.026
       },
       {
         "segment_id": "starter-beat-9",
-        "width": 8.04,
-        "length": 4.2,
+        "width": 6.66,
+        "length": 3.6,
         "yaw": 4.6243,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "intersection_pavers",
-        "opacity": 0.42,
-        "elevation": 0.045
+        "opacity": 0.24,
+        "elevation": 0.03
       },
       {
         "segment_id": "starter-corridor-end",
-        "width": 2.94,
-        "length": 14,
+        "width": 3.33,
+        "length": 14.4,
         "yaw": -0.0881,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.24,
-        "elevation": 0.032
+        "opacity": 0.21,
+        "elevation": 0.024
       },
       {
         "segment_id": "starter-corridor-end",
-        "width": 1.76,
-        "length": 11.76,
+        "width": 0.69,
+        "length": 15.3,
         "yaw": -0.0881,
-        "offset_x": 0.1,
+        "offset_x": 3.63,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.17,
+        "elevation": 0.026
+      },
+      {
+        "segment_id": "starter-corridor-end",
+        "width": 0.69,
+        "length": 15.3,
+        "yaw": -0.0881,
+        "offset_x": -3.63,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.17,
+        "elevation": 0.026
+      },
+      {
+        "segment_id": "starter-corridor-end",
+        "width": 1.47,
+        "length": 8.7,
+        "yaw": -0.0581,
+        "offset_x": 0,
         "offset_z": 0,
         "tone": "repair_patch_dark",
-        "opacity": 0.38,
-        "elevation": 0.038
-      },
-      {
-        "segment_id": "starter-corridor-end",
-        "width": 0.78,
-        "length": 14.84,
-        "yaw": -0.0881,
-        "offset_x": 3.43,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-corridor-end",
-        "width": 0.78,
-        "length": 14.56,
-        "yaw": -0.0881,
-        "offset_x": -3.43,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.28,
-        "elevation": 0.034
-      },
-      {
-        "segment_id": "starter-corridor-end",
-        "width": 5.49,
-        "length": 3.08,
-        "yaw": 1.4827,
-        "offset_x": 2.16,
-        "offset_z": 0,
-        "tone": "paver_break",
-        "opacity": 0.34,
-        "elevation": 0.041
+        "opacity": 0.2,
+        "elevation": 0.028
       }
     ]
   },

--- a/functions.php
+++ b/functions.php
@@ -263,9 +263,9 @@ function se_enqueue_gastown_sim_assets() {
                 'audioBaseUrl'   => esc_url_raw( $uri . '/assets/audio/gastown' ),
                 'textureBaseUrl' => esc_url_raw( $uri . '/assets/textures' ),
                 'dialogDataUrl'  => esc_url_raw( $uri . '/assets/dialog/gastown.json' ),
-                'defaultWeather' => 'drizzle',
+                'defaultWeather' => 'clear',
                 'defaultMood'    => 'eerie',
-                'defaultTimeOfDay' => 'dusk',
+                'defaultTimeOfDay' => 'morning',
             )
         );
     }

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -86,8 +86,8 @@
     velocity: new THREE.Vector3(),
     lastSafePosition: new THREE.Vector3(),
     debugEnabled: new URLSearchParams(window.location.search).get('gastownDebug') === '1',
-    activeWeather: config.defaultWeather || 'drizzle',
-    activeTimeOfDay: config.defaultTimeOfDay || 'dusk',
+    activeWeather: config.defaultWeather || 'clear',
+    activeTimeOfDay: config.defaultTimeOfDay || 'morning',
     activeMood: config.defaultMood || 'eerie',
     sounds: {
       beds: {},
@@ -127,13 +127,18 @@
   const fillLight = new THREE.DirectionalLight(0x5f7695, 0.3);
   fillLight.position.set(-11, 10, -12);
   scene.add(fillLight);
+  const lightningLight = new THREE.DirectionalLight(0xe7efff, 0);
+  lightningLight.position.set(4, 30, 6);
+  scene.add(lightningLight);
 
   const rainGroup = new THREE.Group();
+  const cloudGroup = new THREE.Group();
   const worldGroup = new THREE.Group();
   const debugGroup = new THREE.Group();
   debugGroup.visible = state.debugEnabled;
   scene.add(worldGroup);
   scene.add(rainGroup);
+  scene.add(cloudGroup);
   scene.add(debugGroup);
 
   const visualState = {
@@ -150,6 +155,9 @@
     groundTextures: {},
     instancedProps: [],
     npcMeshes: [],
+    routeGuideMaterials: [],
+    weatherMaterials: [],
+    lightningOverlay: null,
   };
 
   const LOOK_PITCH_LIMIT = Math.PI / 2.25;
@@ -371,6 +379,16 @@
 
   function segmentHeading(a, b) {
     return Math.atan2(b.x - a.x, b.z - a.z);
+  }
+
+  function deterministicUnit(seed) {
+    const str = String(seed || 'seed');
+    let hash = 2166136261;
+    for (let i = 0; i < str.length; i += 1) {
+      hash ^= str.charCodeAt(i);
+      hash = Math.imul(hash, 16777619);
+    }
+    return ((hash >>> 0) % 1000) / 1000;
   }
 
   function buildFallbackSurfaceBands(world) {
@@ -762,7 +780,7 @@
         mesh: visual,
         patrolIndex: 0,
         direction: 1,
-        speed: npc.role === 'pedestrian' ? 0.7 + Math.random() * 0.45 : 0,
+        speed: npc.role === 'pedestrian' ? 0.72 + (deterministicUnit(npc.id) * 0.28) : 0,
       }, npc);
       ensureNpcLoop(npcState);
       visualState.npcMeshes.push(visual);
@@ -976,7 +994,8 @@
     visualState.roadMaterial = createGroundMaterial('street', 0x171c22, 0.86, 0.16);
     visualState.sidewalkMaterial = createGroundMaterial('sidewalk', 0x978c81, 0.92, 0.02);
     visualState.curbMaterial = new THREE.LineBasicMaterial({ color: 0x9ea5ad, transparent: true, opacity: 0.5 });
-    visualState.laneMaterial = new THREE.LineBasicMaterial({ color: 0x8da2b3, transparent: true, opacity: 0.22 });
+    visualState.laneMaterial = new THREE.MeshStandardMaterial({ color: 0x94a7b6, roughness: 0.84, metalness: 0.08, transparent: true, opacity: 0.08 });
+    visualState.routeGuideMaterials = [visualState.laneMaterial];
 
     world.zones.street.forEach((zone) => createZoneMesh(zone.polygon, visualState.roadMaterial, 0, 'street'));
     world.zones.sidewalk.forEach((zone) => createZoneMesh(zone.polygon, visualState.sidewalkMaterial, 0.12, 'sidewalk'));
@@ -988,25 +1007,21 @@
       worldGroup.add(curbLine);
     });
 
-    const routePoints = world.route.centerline.map((point) => new THREE.Vector3(point.x, 0.14, point.z));
-    const line = new THREE.Line(new THREE.BufferGeometry().setFromPoints(routePoints), visualState.laneMaterial);
-    worldGroup.add(line);
-
     world.route.centerline.forEach((point, index) => {
-      if (index % 2 !== 0 || index === world.route.centerline.length - 1) {
+      if (index === world.route.centerline.length - 1 || index % 3 !== 1) {
         return;
       }
       const next = world.route.centerline[index + 1];
       if (!next) return;
       const heading = Math.atan2(next.x - point.x, next.z - point.z);
-      const stripe = new THREE.Mesh(
-        new THREE.PlaneGeometry(0.18, 1.9),
-        new THREE.MeshStandardMaterial({ color: 0x7f95a6, roughness: 0.78, metalness: 0.16, transparent: true, opacity: 0.14 })
+      const marker = new THREE.Mesh(
+        new THREE.PlaneGeometry(0.7, 2.2),
+        visualState.laneMaterial
       );
-      stripe.rotation.x = -Math.PI / 2;
-      stripe.rotation.y = heading;
-      stripe.position.set(point.x, 0.11, point.z);
-      worldGroup.add(stripe);
+      marker.rotation.x = -Math.PI / 2;
+      marker.rotation.y = heading;
+      marker.position.set(point.x, 0.105, point.z);
+      worldGroup.add(marker);
     });
 
     const surfaceBands = (world.streetscape && world.streetscape.surfaceBands && world.streetscape.surfaceBands.length)
@@ -1020,13 +1035,18 @@
         new THREE.PlaneGeometry(band.width || world.route.streetWidth, band.length || 14),
         (() => {
           const toneStyles = {
-            brick: { color: 0x5c4033, roughness: 0.82, metalness: 0.06, opacity: 0.9 },
-            wheel_track: { color: 0x161b20, roughness: 0.52, metalness: 0.22, opacity: 0.24 },
-            patch: { color: 0x2e343b, roughness: 0.74, metalness: 0.14, opacity: 0.34 },
-            puddle: { color: 0x1a212a, roughness: 0.34, metalness: 0.28, opacity: 0.18 },
-            wet_streak: { color: 0x202731, roughness: 0.48, metalness: 0.2, opacity: 0.22 },
-            edge_grime: { color: 0x1b1d20, roughness: 0.8, metalness: 0.08, opacity: 0.26 },
-            default: { color: 0x3a4048, roughness: 0.8, metalness: 0.08, opacity: 0.86 },
+            brick: { color: 0x5c4033, roughness: 0.82, metalness: 0.06, opacity: 0.72 },
+            wheel_track: { color: 0x161b20, roughness: 0.58, metalness: 0.2, opacity: 0.2 },
+            patch: { color: 0x2f353d, roughness: 0.76, metalness: 0.12, opacity: 0.2 },
+            repair_patch_dark: { color: 0x252b32, roughness: 0.72, metalness: 0.14, opacity: 0.22 },
+            puddle: { color: 0x1a212a, roughness: 0.34, metalness: 0.28, opacity: 0.14 },
+            wet_streak: { color: 0x202731, roughness: 0.48, metalness: 0.2, opacity: 0.18 },
+            edge_grime: { color: 0x1b1d20, roughness: 0.8, metalness: 0.08, opacity: 0.18 },
+            curb_grime: { color: 0x202326, roughness: 0.86, metalness: 0.05, opacity: 0.18 },
+            cobble_break: { color: 0x56473b, roughness: 0.84, metalness: 0.06, opacity: 0.18 },
+            paver_break: { color: 0x5d5144, roughness: 0.84, metalness: 0.05, opacity: 0.18 },
+            intersection_pavers: { color: 0x615547, roughness: 0.88, metalness: 0.05, opacity: 0.24 },
+            default: { color: 0x3a4048, roughness: 0.8, metalness: 0.08, opacity: 0.78 },
           };
           const style = toneStyles[band.tone] || toneStyles.default;
           return new THREE.MeshStandardMaterial({
@@ -1497,38 +1517,151 @@
     }
   }
 
+  function rebuildClouds(weather, timeOfDay) {
+    while (cloudGroup.children.length) {
+      cloudGroup.remove(cloudGroup.children[0]);
+    }
+
+    const coverage = weather.cloudCoverage || 0;
+    if (coverage <= 0.08) {
+      return;
+    }
+
+    const cloudColor = new THREE.Color(timeOfDay.sky || '#8ea4b5');
+    cloudColor.lerp(new THREE.Color('#f1f3f6'), 0.2 - Math.min(0.16, coverage * 0.08));
+    cloudColor.multiplyScalar(1 - Math.min(0.42, weather.cloudDarkness || 0));
+    const cloudMaterial = new THREE.MeshBasicMaterial({ color: cloudColor, transparent: true, opacity: Math.min(0.48, 0.14 + (coverage * 0.26)), depthWrite: false, fog: false });
+    visualState.weatherMaterials.push(cloudMaterial);
+
+    const count = Math.max(4, Math.round(coverage * 9));
+    for (let i = 0; i < count; i += 1) {
+      const shell = new THREE.Group();
+      const baseX = ((i % 3) - 1) * 36;
+      const baseZ = -30 - (Math.floor(i / 3) * 28);
+      const width = 26 + (deterministicUnit('cloud-width-' + i) * 20);
+      const height = 8 + (deterministicUnit('cloud-height-' + i) * 4);
+      for (let puff = 0; puff < 3; puff += 1) {
+        const plane = new THREE.Mesh(new THREE.PlaneGeometry(width * (0.7 + (puff * 0.16)), height * (0.8 + (puff * 0.08))), cloudMaterial);
+        plane.position.set(baseX + (puff * 5) - 4, (weather.cloudAltitude || 62) + (deterministicUnit('cloud-y-' + i + '-' + puff) * 6), baseZ - (puff * 6));
+        plane.rotation.x = -0.42;
+        shell.add(plane);
+      }
+      shell.position.x += (deterministicUnit('cloud-jitter-' + i) - 0.5) * 20;
+      cloudGroup.add(shell);
+    }
+  }
+
+  function ensureLightningOverlay() {
+    if (visualState.lightningOverlay) {
+      return visualState.lightningOverlay;
+    }
+    const overlay = new THREE.Mesh(
+      new THREE.SphereGeometry(280, 18, 16),
+      new THREE.MeshBasicMaterial({ color: 0xdfe8ff, transparent: true, opacity: 0, side: THREE.BackSide, depthWrite: false, fog: false })
+    );
+    overlay.position.set(0, 20, 0);
+    scene.add(overlay);
+    visualState.lightningOverlay = overlay;
+    return overlay;
+  }
+
+  function maybeTriggerLightning(weather) {
+    if (!weather || !weather.lightningFrequency || state.lightning && state.lightning.activeUntil > performance.now()) {
+      return;
+    }
+    if (Math.random() > weather.lightningFrequency * 0.012) {
+      return;
+    }
+    const now = performance.now();
+    state.lightning = {
+      activeUntil: now + 120 + (Math.random() * 140),
+      intensity: weather.lightningIntensity || 1,
+      thunderAt: now + 380 + (Math.random() * 820),
+      thunderPlayed: false,
+    };
+  }
+
+  function updateLightning(weather) {
+    const overlay = ensureLightningOverlay();
+    const now = performance.now();
+    const flash = state.lightning;
+    if (!flash || now >= flash.activeUntil) {
+      overlay.material.opacity = 0;
+      lightningLight.intensity = 0;
+      return;
+    }
+    const remaining = Math.max(0, flash.activeUntil - now);
+    const pulse = Math.min(1, remaining / 220);
+    const intensity = (0.08 + (pulse * 0.2)) * (flash.intensity || 1);
+    overlay.material.opacity = Math.min(0.2, intensity);
+    lightningLight.intensity = intensity * 1.8;
+
+    if (weather && weather.thunderEnabled && !flash.thunderPlayed && now >= flash.thunderAt) {
+      flash.thunderPlayed = true;
+      if (state.sounds.thunder && typeof state.sounds.thunder.play === 'function') {
+        playHowl(state.sounds.thunder);
+      }
+    }
+  }
+
   function rebuildRain(intensity) {
     while (rainGroup.children.length) {
       rainGroup.remove(rainGroup.children[0]);
     }
 
-    if (intensity <= 0.05) {
+    if (intensity <= 0.02) {
       return;
     }
 
-    const count = Math.floor(450 * intensity);
+    const dropCount = Math.floor(520 + (intensity * 980));
     const geom = new THREE.BufferGeometry();
-    const points = new Float32Array(count * 3);
+    const points = new Float32Array(dropCount * 3);
+    const velocities = new Float32Array(dropCount);
 
-    for (let i = 0; i < count; i += 1) {
-      points[i * 3] = (Math.random() - 0.5) * 140;
-      points[i * 3 + 1] = Math.random() * 40 + 4;
-      points[i * 3 + 2] = (Math.random() - 0.5) * 180 - 45;
+    for (let i = 0; i < dropCount; i += 1) {
+      points[i * 3] = (Math.random() - 0.5) * 150;
+      points[(i * 3) + 1] = Math.random() * 42 + 5;
+      points[(i * 3) + 2] = (Math.random() - 0.5) * 190 - 40;
+      velocities[i] = 16 + (Math.random() * 11) + (intensity * 10);
     }
 
     geom.setAttribute('position', new THREE.BufferAttribute(points, 3));
-    const rain = new THREE.Points(geom, new THREE.PointsMaterial({ color: 0x9dc3db, size: 0.09, transparent: true, opacity: 0.7 }));
+    geom.setAttribute('velocity', new THREE.BufferAttribute(velocities, 1));
+    const rain = new THREE.Points(geom, new THREE.PointsMaterial({ color: 0xa9c6d9, size: 0.1 + (intensity * 0.07), transparent: true, opacity: 0.32 + (intensity * 0.4) }));
+    rain.userData.kind = 'rain-core';
     rainGroup.add(rain);
+
+    const streakCount = Math.floor(30 + (intensity * 80));
+    for (let i = 0; i < streakCount; i += 1) {
+      const streak = new THREE.Mesh(
+        new THREE.PlaneGeometry(0.05, 2.8 + (intensity * 2.4)),
+        new THREE.MeshBasicMaterial({ color: 0xc7d9e6, transparent: true, opacity: 0.06 + (intensity * 0.08), depthWrite: false })
+      );
+      streak.rotation.x = -0.18;
+      streak.position.set((Math.random() - 0.5) * 70, 10 + (Math.random() * 16), -4 - (Math.random() * 30));
+      streak.userData.fallSpeed = 18 + (Math.random() * 10) + (intensity * 12);
+      rainGroup.add(streak);
+    }
   }
 
   function animateRain(delta) {
-    rainGroup.children.forEach((points) => {
-      const pos = points.geometry.attributes.position;
-      for (let i = 0; i < pos.count; i += 1) {
-        const y = pos.getY(i) - (18 * delta);
-        pos.setY(i, y < 0.5 ? Math.random() * 40 + 5 : y);
+    rainGroup.children.forEach((node) => {
+      if (node.isPoints) {
+        const pos = node.geometry.attributes.position;
+        const velocities = node.geometry.attributes.velocity;
+        for (let i = 0; i < pos.count; i += 1) {
+          const speed = velocities ? velocities.getX(i) : 18;
+          const y = pos.getY(i) - (speed * delta);
+          pos.setY(i, y < 0.5 ? Math.random() * 42 + 5 : y);
+        }
+        pos.needsUpdate = true;
+        return;
       }
-      pos.needsUpdate = true;
+
+      node.position.y -= (node.userData.fallSpeed || 18) * delta;
+      if (node.position.y < 0.5) {
+        node.position.y = 14 + (Math.random() * 14);
+      }
     });
   }
 
@@ -1975,6 +2108,7 @@
 
     state.sounds.rainLoop = createSafeHowl({ src: src('weather/rain_pavement'), loop: true, volume: 0 });
     state.sounds.clockBurst = createSafeHowl({ src: src('events/steam_clock_burst'), volume: 0.45 });
+    state.sounds.thunder = createSafeHowl({ src: src('weather/thunder_roll'), volume: 0.22 });
 
     (world.audioZones || []).forEach((zone) => {
       state.sounds.zoneBeds[zone.id] = createSafeHowl({ src: src('zones/' + zone.bed), loop: true, volume: 0 });
@@ -1990,7 +2124,7 @@
     const weather = state.world.weatherPresets[state.activeWeather] || state.world.weatherPresets.drizzle || state.world.weatherPresets.rain;
     const timeOfDay = state.world.timeOfDayPresets[state.activeTimeOfDay] || state.world.timeOfDayPresets.night;
 
-    const weatherFogBoost = state.activeWeather === 'fog' ? 0.006 : state.activeWeather === 'rain' ? 0.002 : 0;
+    const weatherFogBoost = state.activeWeather === 'fog' ? 0.006 : state.activeWeather === 'rain' ? 0.002 : state.activeWeather === 'thunderstorm' ? 0.004 : 0;
     const fogDensity = Math.max(0.0035, (weather.fogDensity || 0.009) + (timeOfDay.fogBoost || 0) + weatherFogBoost);
     scene.fog = new THREE.FogExp2(timeOfDay.sky, fogDensity);
     renderer.setClearColor(timeOfDay.sky, 1);
@@ -2028,7 +2162,7 @@
     }
     if (visualState.laneMaterial) {
       visualState.laneMaterial.color.set(timeOfDay.laneColor || '#aab1b8');
-      visualState.laneMaterial.opacity = 0.08 + ((timeOfDay.pathBrightness || 0.2) * 0.22);
+      visualState.laneMaterial.opacity = Math.min(0.14, 0.035 + ((timeOfDay.pathBrightness || 0.2) * 0.12));
     }
 
     visualState.landmarkVisuals.forEach((landmarkVisual) => {
@@ -2037,7 +2171,9 @@
       landmarkVisual.reflectionMaterial.opacity = 0.12 + ((timeOfDay.landmarkGlow || 0.3) * 0.18) + ((weather.rainIntensity || 0) * 0.12);
     });
 
+    rebuildClouds(weather, timeOfDay);
     rebuildRain((weather.rainIntensity || 0) * (timeOfDay.rainVisibility || 1));
+    updateLightning(weather);
 
     playHowl(state.sounds.rainLoop);
     fadeHowl(state.sounds.rainLoop, (weather.rainIntensity || 0) * 0.45, 380);
@@ -2361,6 +2497,7 @@
           movePlayer(delta);
         }
 
+        maybeTriggerLightning(state.world.weatherPresets[state.activeWeather] || null);
         updateNpcs(delta);
         updateInteractionTarget();
         animateRain(delta);

--- a/js/gastown-world-loader.js
+++ b/js/gastown-world-loader.js
@@ -237,6 +237,14 @@
     const defaultWeatherPreset = {
       rainIntensity: 0,
       fogDensity: 0.01,
+      cloudCoverage: 0.32,
+      cloudDarkness: 0.28,
+      cloudAltitude: 62,
+      rainSpeed: 1,
+      rainOpacity: 0.7,
+      lightningFrequency: 0,
+      lightningIntensity: 0,
+      thunderEnabled: false,
     };
 
     const defaultTimeOfDayPreset = {
@@ -264,13 +272,14 @@
     normalized.moodPresets.lively = mergePreset(defaultMoodPreset, Object.assign({ ambientBed: 'nightlife_hum', audioDensity: 0.84, voiceFreq: 0.35, lightIntensity: 0.96 }, normalized.moodPresets.lively));
 
     normalized.weatherPresets = normalized.weatherPresets && typeof normalized.weatherPresets === 'object' ? normalized.weatherPresets : {};
-    normalized.weatherPresets.clear = mergePreset(defaultWeatherPreset, Object.assign({ rainIntensity: 0, fogDensity: 0.007 }, normalized.weatherPresets.clear));
-    normalized.weatherPresets.drizzle = mergePreset(defaultWeatherPreset, Object.assign({ rainIntensity: 0.28, fogDensity: 0.009 }, normalized.weatherPresets.drizzle));
-    normalized.weatherPresets.rain = mergePreset(defaultWeatherPreset, Object.assign({ rainIntensity: 0.7, fogDensity: 0.014 }, normalized.weatherPresets.rain));
-    normalized.weatherPresets.fog = mergePreset(defaultWeatherPreset, Object.assign({ rainIntensity: 0.06, fogDensity: 0.02 }, normalized.weatherPresets.fog));
+    normalized.weatherPresets.clear = mergePreset(defaultWeatherPreset, Object.assign({ rainIntensity: 0, fogDensity: 0.0065, cloudCoverage: 0.38, cloudDarkness: 0.22, cloudAltitude: 68, rainOpacity: 0.16, rainSpeed: 0.65 }, normalized.weatherPresets.clear));
+    normalized.weatherPresets.drizzle = mergePreset(defaultWeatherPreset, Object.assign({ rainIntensity: 0.34, fogDensity: 0.0085, cloudCoverage: 0.58, cloudDarkness: 0.34, cloudAltitude: 64, rainOpacity: 0.4, rainSpeed: 0.9 }, normalized.weatherPresets.drizzle));
+    normalized.weatherPresets.rain = mergePreset(defaultWeatherPreset, Object.assign({ rainIntensity: 0.78, fogDensity: 0.013, cloudCoverage: 0.78, cloudDarkness: 0.48, cloudAltitude: 60, rainOpacity: 0.66, rainSpeed: 1.18 }, normalized.weatherPresets.rain));
+    normalized.weatherPresets.fog = mergePreset(defaultWeatherPreset, Object.assign({ rainIntensity: 0.08, fogDensity: 0.019, cloudCoverage: 0.7, cloudDarkness: 0.4, cloudAltitude: 58, rainOpacity: 0.28, rainSpeed: 0.72 }, normalized.weatherPresets.fog));
+    normalized.weatherPresets.thunderstorm = mergePreset(defaultWeatherPreset, Object.assign({ rainIntensity: 1, fogDensity: 0.018, cloudCoverage: 0.94, cloudDarkness: 0.72, cloudAltitude: 54, rainOpacity: 0.86, rainSpeed: 1.5, lightningFrequency: 0.18, lightningIntensity: 1.3, thunderEnabled: true }, normalized.weatherPresets.thunderstorm));
 
     normalized.timeOfDayPresets = normalized.timeOfDayPresets && typeof normalized.timeOfDayPresets === 'object' ? normalized.timeOfDayPresets : {};
-    normalized.timeOfDayPresets.morning = mergePreset(defaultTimeOfDayPreset, Object.assign({ sky: '#7d97af', ambientColor: '#b8c7d6', ambientIntensity: 0.82, keyColor: '#efd8b3', keyIntensity: 0.62, fillColor: '#6b8096', fillIntensity: 0.22, buildingContrast: 0.98, buildingEdgeColor: '#273240', roadColor: '#38414a', sidewalkColor: '#92887d', laneColor: '#bcc1c7', landmarkGlow: 0.2, rainVisibility: 0.72, pathBrightness: 0.22, fogBoost: -0.001 }, normalized.timeOfDayPresets.morning));
+    normalized.timeOfDayPresets.morning = mergePreset(defaultTimeOfDayPreset, Object.assign({ sky: '#8ea4b5', ambientColor: '#c2ced8', ambientIntensity: 0.94, keyColor: '#d8d8cc', keyIntensity: 0.7, fillColor: '#708398', fillIntensity: 0.3, buildingContrast: 1.02, buildingEdgeColor: '#314150', roadColor: '#3c464f', sidewalkColor: '#9b9185', laneColor: '#b6bfc7', landmarkGlow: 0.18, rainVisibility: 0.88, pathBrightness: 0.16, fogBoost: -0.0022 }, normalized.timeOfDayPresets.morning));
     normalized.timeOfDayPresets.dusk = mergePreset(defaultTimeOfDayPreset, Object.assign({ sky: '#2d3447', ambientColor: '#76879c', ambientIntensity: 0.56, keyColor: '#d5a06e', keyIntensity: 0.56, fillColor: '#40546b', fillIntensity: 0.18, buildingContrast: 1.14, buildingEdgeColor: '#162230', roadColor: '#242a31', sidewalkColor: '#7f756b', laneColor: '#9da6ae', landmarkGlow: 0.4, rainVisibility: 0.88, pathBrightness: 0.12, fogBoost: 0.001 }, normalized.timeOfDayPresets.dusk));
     normalized.timeOfDayPresets.night = mergePreset(defaultTimeOfDayPreset, Object.assign({ sky: '#0d131d', ambientColor: '#5e7389', ambientIntensity: 0.46, keyColor: '#8aa8c5', keyIntensity: 0.48, fillColor: '#31475c', fillIntensity: 0.16, buildingContrast: 1.22, buildingEdgeColor: '#131b27', roadColor: '#1d232a', sidewalkColor: '#746b63', laneColor: '#8d99a3', landmarkGlow: 0.46, rainVisibility: 1, pathBrightness: 0.1, fogBoost: 0.004 }, normalized.timeOfDayPresets.night));
 

--- a/page-gastown-sim.php
+++ b/page-gastown-sim.php
@@ -19,17 +19,18 @@ get_header();
       <label>
         Time of day
         <select name="time-of-day">
-          <option value="morning">Morning</option>
-          <option value="dusk" selected>Dusk</option>
+          <option value="morning" selected>Morning</option>
+          <option value="dusk">Dusk</option>
           <option value="night">Night</option>
         </select>
       </label>
       <label>
         Weather
         <select name="weather">
-          <option value="clear">Clear</option>
-          <option value="drizzle" selected>Drizzle</option>
+          <option value="clear" selected>Clear</option>
+          <option value="drizzle">Drizzle</option>
           <option value="rain">Rain</option>
+          <option value="thunderstorm">Thunderstorm</option>
           <option value="fog">Fog</option>
         </select>
       </label>

--- a/scripts/generate-gastown-world.js
+++ b/scripts/generate-gastown-world.js
@@ -591,6 +591,54 @@ function buildStarterLandmarks(routePoints, sidewalkOuter) {
   }));
 }
 
+
+function buildStarterNpcs(routePoints, streetWidth, sidewalkOuter) {
+  const laneOffset = Math.max((streetWidth * 0.28), 2.1);
+  const placeNpc = (distanceMeters, side, extraOffset, id) => {
+    const placement = placeStarterProp(routePoints, distanceMeters, (side * (laneOffset + extraOffset)), id, 'cardboard_box', { scale: 1 });
+    return { x: placement.x, z: placement.z };
+  };
+
+  return [
+    {
+      id: 'starter-guide-threshold',
+      role: 'guide',
+      dialogId: 'guide_intro',
+      interactRadius: 2.8,
+      idleSpot: placeNpc(16, -1, 1.45, 'starter-npc-guide-anchor'),
+    },
+    {
+      id: 'starter-busker-clock',
+      role: 'busker',
+      dialogId: 'busker_clock_corner',
+      interactRadius: 3,
+      idleSpot: placeNpc(102, 1, 1.65, 'starter-npc-busker-anchor'),
+    },
+    {
+      id: 'starter-pedestrian-west',
+      role: 'pedestrian',
+      dialogId: 'pedestrian_route_tip',
+      interactRadius: 2.2,
+      idleSpot: placeNpc(44, -1, 1.15, 'starter-npc-west-idle'),
+      patrol: [
+        placeNpc(38, -1, 1.15, 'starter-npc-west-a'),
+        placeNpc(56, -1, 1.32, 'starter-npc-west-b'),
+      ],
+    },
+    {
+      id: 'starter-pedestrian-east',
+      role: 'pedestrian',
+      dialogId: 'pedestrian_clock_hint',
+      interactRadius: 2.2,
+      idleSpot: placeNpc(136, 1, 1.18, 'starter-npc-east-idle'),
+      patrol: [
+        placeNpc(126, 1, 1.18, 'starter-npc-east-a'),
+        placeNpc(148, 1, 1.36, 'starter-npc-east-b'),
+      ],
+    },
+  ];
+}
+
 function makeStarterWorld(outputPath) {
   const routePoints = [
     { x: 0, z: 0 },
@@ -712,6 +760,7 @@ function makeStarterWorld(outputPath) {
 
   const props = buildStarterProps(routePoints, sidewalkOuter, 9);
   const landmarks = buildStarterLandmarks(routePoints, sidewalkOuter);
+  const npcs = buildStarterNpcs(routePoints, streetWidth, sidewalkOuter);
 
   const world = {
     routeId: 'gastown_water_street_starter_corridor',
@@ -751,6 +800,7 @@ function makeStarterWorld(outputPath) {
     buildings,
     landmarks,
     props,
+    npcs,
     streetscape: {
       lamps: proceduralStreetscape(routePoints, {
         idPrefix: 'starter-lamp', strideMeters: 24, laneOffset: sidewalkOuter - 0.5, maxCount: 24,
@@ -783,24 +833,25 @@ function buildStarterSurfaceBands(centerline, streetWidth, routeLength) {
     if (!next) return;
 
     const heading = Math.atan2(next.x - point.x, next.z - point.z);
-    const length = Math.max(7, Math.min(14, distance(point, next) * 0.92 || 9));
+    const length = Math.max(8, Math.min(15, distance(point, next) * 0.94 || 10));
     const progress = routeLength > 0 ? index / Math.max(1, centerline.length - 1) : 0;
-    const edgeOffset = streetWidth * 0.35;
-    const jointOffset = streetWidth * 0.22;
-    const jitter = ((index % 4) - 1.5) * 0.2;
-    const heritageBandWidth = progress > 0.42 && progress < 0.72 ? streetWidth * 0.72 : streetWidth * 0.56;
+    const edgeOffset = streetWidth * 0.37;
+    const patchOffset = ((index % 3) - 1) * 0.34;
 
-    bands.push({ segment_id: point.id, width: Number((streetWidth * 0.3).toFixed(2)), length: Number(length.toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: 0, offset_z: 0, tone: 'wheel_track', opacity: 0.24, elevation: 0.032 });
-    bands.push({ segment_id: point.id, width: Number((streetWidth * 0.18).toFixed(2)), length: Number(Math.max(5.4, length * (progress < 0.25 ? 0.64 : 0.84)).toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: Number(jitter.toFixed(2)), offset_z: 0, tone: progress > 0.65 ? 'repair_patch_dark' : 'patch', opacity: progress > 0.65 ? 0.38 : 0.33, elevation: 0.038 });
-    bands.push({ segment_id: point.id, width: Number((streetWidth * 0.08).toFixed(2)), length: Number(Math.max(6.2, length * 1.06).toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: Number(edgeOffset.toFixed(2)), offset_z: 0, tone: 'curb_grime', opacity: 0.28, elevation: 0.034 });
-    bands.push({ segment_id: point.id, width: Number((streetWidth * 0.08).toFixed(2)), length: Number(Math.max(6.2, length * 1.04).toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: Number((-edgeOffset).toFixed(2)), offset_z: 0, tone: 'curb_grime', opacity: 0.28, elevation: 0.034 });
+    bands.push({ segment_id: point.id, width: Number((streetWidth * 0.34).toFixed(2)), length: Number((length * 0.96).toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: 0, offset_z: 0, tone: 'wheel_track', opacity: progress < 0.2 ? 0.16 : 0.21, elevation: 0.024 });
+    bands.push({ segment_id: point.id, width: Number((streetWidth * 0.07).toFixed(2)), length: Number(Math.max(6.8, length * 1.02).toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: Number(edgeOffset.toFixed(2)), offset_z: 0, tone: 'curb_grime', opacity: 0.17, elevation: 0.026 });
+    bands.push({ segment_id: point.id, width: Number((streetWidth * 0.07).toFixed(2)), length: Number(Math.max(6.8, length * 1.02).toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: Number((-edgeOffset).toFixed(2)), offset_z: 0, tone: 'curb_grime', opacity: 0.17, elevation: 0.026 });
 
-    if (index % 2 === 0) {
-      bands.push({ segment_id: point.id, width: Number(heritageBandWidth.toFixed(2)), length: Number(Math.max(2.8, length * 0.22).toFixed(2)), yaw: Number((heading + Math.PI / 2).toFixed(4)), offset_x: Number((index % 4 === 0 ? -jointOffset : jointOffset).toFixed(2)), offset_z: 0, tone: progress > 0.42 && progress < 0.72 ? 'cobble_break' : 'paver_break', opacity: 0.34, elevation: 0.041 });
+    if (progress > 0.22 && (index % 3 === 1)) {
+      bands.push({ segment_id: point.id, width: Number((streetWidth * 0.15).toFixed(2)), length: Number(Math.max(5.6, length * 0.58).toFixed(2)), yaw: Number((heading + ((index % 2 === 0) ? 0.03 : -0.03)).toFixed(4)), offset_x: Number(patchOffset.toFixed(2)), offset_z: 0, tone: progress > 0.68 ? 'repair_patch_dark' : 'patch', opacity: progress > 0.68 ? 0.2 : 0.18, elevation: 0.028 });
     }
 
-    if (index === 1 || index === Math.floor((centerline.length - 1) / 2) || index === centerline.length - 2) {
-      bands.push({ segment_id: point.id, width: Number((streetWidth * 0.82).toFixed(2)), length: Number(Math.max(3.6, length * 0.3).toFixed(2)), yaw: Number((heading + Math.PI / 2).toFixed(4)), offset_x: 0, offset_z: 0, tone: 'intersection_pavers', opacity: 0.42, elevation: 0.045 });
+    if (progress > 0.46 && progress < 0.78 && index % 4 === 0) {
+      bands.push({ segment_id: point.id, width: Number((streetWidth * 0.62).toFixed(2)), length: Number(Math.max(2.2, length * 0.18).toFixed(2)), yaw: Number((heading + Math.PI / 2).toFixed(4)), offset_x: 0, offset_z: 0, tone: 'cobble_break', opacity: 0.18, elevation: 0.029 });
+    }
+
+    if (index === Math.floor((centerline.length - 1) / 2) || index === centerline.length - 2) {
+      bands.push({ segment_id: point.id, width: Number((streetWidth * 0.68).toFixed(2)), length: Number(Math.max(3.2, length * 0.24).toFixed(2)), yaw: Number((heading + Math.PI / 2).toFixed(4)), offset_x: 0, offset_z: 0, tone: 'intersection_pavers', opacity: 0.24, elevation: 0.03 });
     }
   });
   return bands;


### PR DESCRIPTION
### Motivation
- Restore a readable, deterministic starter fallback so the corridor has people to interact with and the surface/route visuals feel grounded. 
- Remove the synthetic divider/spike artifacts caused by overlapping route guidance treatments and tone down aggressive surface-band overlays. 
- Make the out-of-box experience brighter and richer by default and add a dramatic but safe `thunderstorm` weather option.

### Description
- Restore deterministic NPCs in the starter fallback by adding `buildStarterNpcs()` and injecting an `npcs` array into generated starter worlds containing a guide, a busker, and two pedestrians with deterministic `idleSpot`, `patrol`, `dialogId`, and `interactRadius` values; regenerated `assets/world/gastown-water-street.json` and `assets/world/gastown-water-street-starter.json` now include these NPCs. (`scripts/generate-gastown-world.js`, `assets/world/*.json`)
- Simplify route guidance in `addGround()` so it no longer draws both a center `THREE.Line` and dense thin stripe planes; it now uses a single subtle marker treatment with reduced opacity and a less dominant material so the road surface remains primary. (`js/gastown-sim.js`)
- Rebalance starter fallback surface bands to use fewer, broader, lower-opacity overlays and push cobble/paver emphasis later in the corridor so bands appear visually glued to the road and do not float or overpower the base material; kept deterministic generation. (`scripts/generate-gastown-world.js`, `assets/world/*.json`)
- Switch default boot mode to a brighter daytime preset by changing localized defaults to `defaultWeather: 'clear'` and `defaultTimeOfDay: 'morning'`, retune the morning preset for a grounded overcast daytime appearance, and update the page UI default selections. (`functions.php`, `page-gastown-sim.php`, `js/gastown-sim.js`, `js/gastown-world-loader.js`)
- Improve weather system and add thunderstorm support: extended weather preset schema (cloud coverage/darkness/altitude, rainSpeed/rainOpacity, lightningFrequency/lightningIntensity, `thunderEnabled`), added a `thunderstorm` preset with heavy rain, dense clouds, and lightning parameters, and implemented lightweight cloud cards, denser rain (points + streaks), lightning flash overlay/light adjustment, and an optional thunder audio hook that fails softly. (`js/gastown-world-loader.js`, `js/gastown-sim.js`, `page-gastown-sim.php`)
- Make NPC behavior deterministic (deterministic speed seeding) and ensure spawn safety; preserve dark modes and available options but no longer boot into dusk by default. (`js/gastown-sim.js`) 
- Added and updated automated tests to enforce: presence of deterministic NPCs in generated and committed worlds, `thunderstorm` in normalized weather presets, route-guide simplification (single marker), and localized boot defaults. (`__tests__/gastown-world-generator.test.js`, `__tests__/gastown-world-loader-normalize.test.js`, `__tests__/gastown-sim-ground.test.js`, `__tests__/gastown-sim-config.test.js`)

### Testing
- Ran syntax checks: `node --check js/gastown-sim.js && node --check js/gastown-world-loader.js && node --check scripts/generate-gastown-world.js` and they passed. 
- Regenerated starter and primary fallback worlds with the generator and verified both `assets/world/gastown-water-street.json` and `assets/world/gastown-water-street-starter.json` now include a non-empty `npcs` array. 
- Executed the full test suite for the modified concerns with `node --test __tests__/gastown-world-generator.test.js __tests__/gastown-world-loader-normalize.test.js __tests__/gastown-sim-ground.test.js __tests__/gastown-sim-config.test.js` and all tests passed (13/13 passing in the run performed). 

Exact new defaults: `defaultWeather = 'clear'` and `defaultTimeOfDay = 'morning'`.

Thunderstorm additions: a new `thunderstorm` weather preset (heavy `rainIntensity`, higher `fogDensity`, `cloudCoverage` ≈ 0.94, `cloudDarkness`, lower `cloudAltitude`, `lightningFrequency` and `lightningIntensity`, and `thunderEnabled: true`) plus in-sim support for cloud cards, richer rain (particles + streak meshes), lightning flash overlay + brief global light boost, and an optional `weather/thunder_roll` audio hook that is safe when absent.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfc2336a70832e9df2c18c46caea73)