### PR TITLE
Improve Gastown fallback Steam Clock anchor, model, audio, and NPC staging

### DIFF
--- a/__tests__/gastown-sim-config.test.js
+++ b/__tests__/gastown-sim-config.test.js
@@ -36,4 +36,7 @@ test('clock chime system initializes or fails softly without blocking startup', 
   assert.match(src, /return false;\n\s*}\n\s*try \{/s);
   assert.match(src, /warnAudioUnavailable\('Tone\.js steam clock chimes unavailable; simulator continuing without musical chimes\.'/);
   assert.match(src, /STEAM_CLOCK_CHIME_MOTIF/);
+  assert.doesNotMatch(src, /clockBurst/);
+  assert.match(src, /Tone\.MetalSynth/);
+  assert.match(src, /heroLandmarks\.find\(\(hero\) => hero\.id === 'steam-clock-hero'\)/);
 });

--- a/__tests__/gastown-world-generator.test.js
+++ b/__tests__/gastown-world-generator.test.js
@@ -56,12 +56,24 @@ test('generator keeps world polygons valid with existing or generated output', (
 
       assert.ok(Array.isArray(data.landmarks));
       assert.equal(data.landmarks.length >= 3, true, 'starter fallback should expose route beats as landmarks');
+      assert.equal(Array.isArray(data.hero_landmarks), true, 'starter fallback should expose hero landmarks');
+      assert.equal(data.hero_landmarks.some((hero) => hero.id === 'steam-clock-hero'), true, 'starter fallback should expose a Steam Clock hero anchor');
+      assert.equal(data.landmarks.some((landmark) => landmark.id === 'steam-clock'), true, 'starter fallback should expose a Steam Clock landmark');
+      assert.equal(data.nodes.some((node) => node.id === 'steam-clock'), true, 'starter fallback should expose a Steam Clock node');
       assert.ok(Array.isArray(data.npcs));
-      assert.equal(data.npcs.length >= 9, true, 'starter fallback should expose a denser deterministic NPC set');
+      assert.equal(data.npcs.length >= 10, true, 'starter fallback should expose a denser deterministic NPC set');
       const touristCluster = data.npcs.filter((npc) => String(npc.id).includes('tourist-clock'));
-      assert.equal(touristCluster.length >= 5, true, 'starter fallback should expose a tourist cluster near the Steam Clock');
+      assert.equal(touristCluster.length >= 6, true, 'starter fallback should expose a tourist cluster near the Steam Clock');
       assert.equal(touristCluster.some((npc) => npc.pose === 'taking_photo'), true, 'tourist cluster should include a photo pose');
+      assert.equal(touristCluster.some((npc) => npc.pose === 'being_photographed'), true, 'tourist cluster should include a photographed pose');
+      assert.equal(touristCluster.some((npc) => npc.heldProp === 'camera'), true, 'tourist cluster should include a held camera prop');
       assert.equal(touristCluster.filter((npc) => Array.isArray(npc.patrol) && npc.patrol.length > 1).length >= 2, true, 'tourist cluster should include multiple walkers');
+      assert.equal(data.npcs.some((npc) => npc.role === 'busker' && npc.heldProp === 'guitar'), true, 'busker should carry a guitar');
+      const roleCounts = data.npcs.reduce((acc, npc) => {
+        acc[npc.role] = (acc[npc.role] || 0) + 1;
+        return acc;
+      }, {});
+      assert.deepEqual(roleCounts, { guide: 1, busker: 1, pedestrian: 2, tourist: 5, photographer: 1 }, 'starter fallback role mix should remain deterministic');
     }
   }
 
@@ -76,5 +88,9 @@ test('committed world json files include expanded npc arrays', () => {
     const data = JSON.parse(fs.readFileSync(path.join(root, relPath), 'utf8'));
     assert.ok(Array.isArray(data.npcs), relPath + ' should include npcs');
     assert.ok(data.npcs.length > 4, relPath + ' should have more than the original 4 npcs');
+    assert.ok(Array.isArray(data.hero_landmarks), relPath + ' should include hero_landmarks');
+    assert.ok(data.hero_landmarks.some((hero) => hero.id === 'steam-clock-hero'), relPath + ' should include the Steam Clock hero anchor');
+    assert.ok(data.nodes.some((node) => node.id === 'steam-clock'), relPath + ' should include the Steam Clock node');
+    assert.ok(data.landmarks.some((landmark) => landmark.id === 'steam-clock'), relPath + ' should include the Steam Clock landmark');
   });
 });

--- a/__tests__/gastown-world-loader-normalize.test.js
+++ b/__tests__/gastown-world-loader-normalize.test.js
@@ -117,7 +117,7 @@ test('normalizeWorldData safely defaults missing or partial props and npcs', () 
   const normalizeWorldData = loadNormalizeWorldData();
   const normalized = normalizeWorldData(minimalValidWorld({
     props: [{ id: 'bag-1', kind: 'trash_bag', x: 1, z: 2 }],
-    npcs: [{ id: 'guide-1', role: 'guide', dialogId: 'guide_intro' }],
+    npcs: [{ id: 'guide-1', role: 'guide', dialogId: 'guide_intro', heldProp: 'camera', voiceCue: 'photo-direction' }],
   }));
 
   assert.equal(normalized.props.length, 1);
@@ -128,4 +128,7 @@ test('normalizeWorldData safely defaults missing or partial props and npcs', () 
   assert.equal(Array.isArray(normalized.npcs[0].patrol), true);
   assert.equal(typeof normalized.npcs[0].idleSpot.x, 'number');
   assert.equal(typeof normalized.npcs[0].idleSpot.z, 'number');
+  assert.equal(normalized.npcs[0].heldProp, 'camera');
+  assert.equal(normalized.npcs[0].voiceCue, 'photo-direction');
+  assert.equal(normalized.npcs[0].silhouetteScale, 1);
 });

--- a/assets/world/gastown-water-street-starter.json
+++ b/assets/world/gastown-water-street-starter.json
@@ -10,7 +10,7 @@
       "Starter corridor fallback is active because required offline civic source files are missing.",
       "This world is intentionally human-scaled and deterministic for readability; it is not GIS-accurate Gastown reconstruction."
     ],
-    "lastBuild": "2026-03-22T10:42:16.870Z"
+    "lastBuild": "2026-03-22T11:05:07.419Z"
   },
   "route": {
     "name": "Gastown starter block corridor",
@@ -52,10 +52,10 @@
         "z": -93.97
       },
       {
-        "id": "starter-beat-6",
-        "label": "Starter Beat 6",
-        "x": 9.21,
-        "z": -112.79
+        "id": "steam-clock",
+        "label": "Steam Clock reveal",
+        "x": -2.57,
+        "z": -106.81
       },
       {
         "id": "starter-beat-7",
@@ -145,6 +145,12 @@
       "label": "Starter mid block",
       "x": 7.92,
       "z": -93.97
+    },
+    {
+      "id": "steam-clock",
+      "label": "Steam Clock plaza",
+      "x": -2.57,
+      "z": -108.41
     },
     {
       "id": "starter-corridor-end",
@@ -2209,11 +2215,39 @@
       "mass_inset": 0.93
     }
   ],
+  "hero_landmarks": [
+    {
+      "id": "steam-clock-hero",
+      "label": "Gastown Steam Clock",
+      "x": -2.57,
+      "y": 0,
+      "z": -108.41,
+      "yaw": 2.2885,
+      "ground_emphasis_radius": 4.8,
+      "steamVentOffsets": [
+        {
+          "x": -0.42,
+          "z": 0.64,
+          "y": 8.72
+        },
+        {
+          "x": 0.42,
+          "z": -0.64,
+          "y": 8.72
+        }
+      ],
+      "plaza": {
+        "radius": 5.1,
+        "depth": 6.2,
+        "apronWidth": 2.2
+      }
+    }
+  ],
   "landmarks": [
     {
-      "id": "starter-landmark-threshold-anchor",
+      "id": "starter-waterfront-threshold",
       "label": "Waterfront threshold",
-      "kind": "cardboard_box",
+      "kind": "district_gate",
       "x": -9.62,
       "y": 0,
       "z": -12.88,
@@ -2221,22 +2255,23 @@
       "cue": "Station canopies give way to brick-front Gastown blocks."
     },
     {
-      "id": "starter-landmark-clock-anchor",
-      "label": "Steam Clock approach",
-      "kind": "cardboard_box",
-      "x": 19.06,
+      "id": "steam-clock",
+      "label": "Gastown Steam Clock",
+      "kind": "clock",
+      "x": -2.57,
       "y": 0,
-      "z": -102.93,
-      "scale": 1.25,
-      "cue": "Denser storefront rhythm, pavers, and curb clutter build toward the clock node."
+      "z": -108.41,
+      "radius": 4.8,
+      "scale": 1.28,
+      "cue": "A small brick-paved plaza opens on the heritage sidewalk and reveals the Steam Clock on the proper approach side."
     },
     {
-      "id": "starter-landmark-postclock-anchor",
+      "id": "starter-post-clock-continuation",
       "label": "Post-clock continuation",
-      "kind": "cardboard_box",
-      "x": 2.75,
+      "kind": "view-axis",
+      "x": 23.17,
       "y": 0,
-      "z": -166.39,
+      "z": -164.59,
       "scale": 1.18,
       "cue": "The corridor loosens into longer facades and a quieter continuation east."
     }
@@ -2328,21 +2363,36 @@
     {
       "id": "starter-guide-threshold",
       "role": "guide",
+      "behavior": "guide_pace",
       "dialogId": "guide_intro",
       "interactRadius": 2.8,
       "idleSpot": {
         "x": -2.79,
         "z": -16.3
-      }
+      },
+      "patrol": [
+        {
+          "x": -2.97,
+          "z": -14.31
+        },
+        {
+          "x": -2.63,
+          "z": -19.3
+        }
+      ]
     },
     {
       "id": "starter-busker-clock",
       "role": "busker",
+      "behavior": "busker_perform",
+      "pose": "strum",
+      "heldProp": "guitar",
+      "voiceCue": "busker-hook",
       "dialogId": "busker_clock_corner",
       "interactRadius": 3,
       "idleSpot": {
-        "x": 12.83,
-        "z": -101.35
+        "x": 3.57,
+        "z": -101.98
       }
     },
     {
@@ -2391,20 +2441,23 @@
       "id": "starter-tourist-clock-west",
       "role": "tourist",
       "behavior": "tourist_pause",
+      "pose": "group_gather",
+      "companionGroup": "clock-family-a",
+      "voiceCue": "tourist-cluster",
       "dialogId": "pedestrian_clock_hint",
       "interactRadius": 2.2,
       "idleSpot": {
-        "x": -1.02,
-        "z": -97.28
+        "x": -0.88,
+        "z": -97.27
       },
       "patrol": [
         {
-          "x": -1.2,
-          "z": -94.4
+          "x": -1.06,
+          "z": -94.39
         },
         {
-          "x": -0.78,
-          "z": -101.27
+          "x": -0.64,
+          "z": -101.26
         }
       ]
     },
@@ -2412,20 +2465,23 @@
       "id": "starter-tourist-clock-east",
       "role": "tourist",
       "behavior": "tourist_pause",
+      "pose": "being_photographed",
+      "companionGroup": "clock-family-a",
+      "voiceCue": "tourist-cluster",
       "dialogId": "pedestrian_clock_hint",
       "interactRadius": 2.2,
       "idleSpot": {
-        "x": 18,
-        "z": -108.02
+        "x": -0.71,
+        "z": -110.29
       },
       "patrol": [
         {
-          "x": 17.69,
-          "z": -104.03
+          "x": -0.94,
+          "z": -106.29
         },
         {
-          "x": 18.4,
-          "z": -113
+          "x": -0.56,
+          "z": -114.29
         }
       ]
     },
@@ -2434,31 +2490,37 @@
       "role": "photographer",
       "behavior": "photo_idle",
       "pose": "taking_photo",
+      "heldProp": "camera",
+      "voiceCue": "photo-direction",
+      "companionGroup": "clock-family-a",
       "dialogId": "pedestrian_clock_hint",
       "interactRadius": 2.4,
       "idleSpot": {
-        "x": -1.08,
-        "z": -106.3
+        "x": -1.87,
+        "z": -104.35
       }
     },
     {
       "id": "starter-tourist-clock-stroller",
       "role": "tourist",
-      "behavior": "tourist_pause",
+      "behavior": "tourist_wander",
+      "pose": "group_gather",
+      "companionGroup": "clock-family-b",
+      "voiceCue": "tourist-cluster",
       "dialogId": "pedestrian_clock_hint",
       "interactRadius": 2.2,
       "idleSpot": {
-        "x": 0.16,
-        "z": -116.24
+        "x": 0.3,
+        "z": -116.23
       },
       "patrol": [
         {
-          "x": -0.14,
-          "z": -111.25
+          "x": 0,
+          "z": -111.24
         },
         {
-          "x": 0.35,
-          "z": -120.24
+          "x": 0.49,
+          "z": -120.23
         }
       ]
     },
@@ -2467,12 +2529,39 @@
       "role": "tourist",
       "behavior": "photo_idle",
       "pose": "gathered",
+      "companionGroup": "clock-family-b",
+      "voiceCue": "tourist-cluster",
       "dialogId": "pedestrian_clock_hint",
       "interactRadius": 2.2,
       "idleSpot": {
-        "x": 18.09,
-        "z": -97.99
+        "x": -1.77,
+        "z": -99.33
       }
+    },
+    {
+      "id": "starter-tourist-clock-child",
+      "role": "tourist",
+      "behavior": "tourist_pause",
+      "pose": "group_gather",
+      "silhouetteScale": 0.82,
+      "companionGroup": "clock-family-b",
+      "voiceCue": "tourist-cluster",
+      "dialogId": "pedestrian_clock_hint",
+      "interactRadius": 2,
+      "idleSpot": {
+        "x": -1.05,
+        "z": -112.32
+      },
+      "patrol": [
+        {
+          "x": -1.19,
+          "z": -109.32
+        },
+        {
+          "x": -0.93,
+          "z": -115.31
+        }
+      ]
     }
   ],
   "streetscape": {
@@ -2842,7 +2931,7 @@
         "segment_id": "starter-mid-block",
         "width": 3.33,
         "length": 14.4,
-        "yaw": 3.0732,
+        "yaw": -2.4566,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
@@ -2853,7 +2942,7 @@
         "segment_id": "starter-mid-block",
         "width": 0.69,
         "length": 15.3,
-        "yaw": 3.0732,
+        "yaw": -2.4566,
         "offset_x": 3.63,
         "offset_z": 0,
         "tone": "curb_grime",
@@ -2864,7 +2953,7 @@
         "segment_id": "starter-mid-block",
         "width": 0.69,
         "length": 15.3,
-        "yaw": 3.0732,
+        "yaw": -2.4566,
         "offset_x": -3.63,
         "offset_z": 0,
         "tone": "curb_grime",
@@ -2875,7 +2964,7 @@
         "segment_id": "starter-mid-block",
         "width": 6.66,
         "length": 3.6,
-        "yaw": 4.644,
+        "yaw": -0.8858,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "intersection_pavers",
@@ -2883,10 +2972,10 @@
         "elevation": 0.03
       },
       {
-        "segment_id": "starter-beat-6",
+        "segment_id": "steam-clock",
         "width": 3.33,
         "length": 14.4,
-        "yaw": 3.0742,
+        "yaw": 2.657,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
@@ -2894,10 +2983,10 @@
         "elevation": 0.024
       },
       {
-        "segment_id": "starter-beat-6",
+        "segment_id": "steam-clock",
         "width": 0.69,
         "length": 15.3,
-        "yaw": 3.0742,
+        "yaw": 2.657,
         "offset_x": 3.63,
         "offset_z": 0,
         "tone": "curb_grime",
@@ -2905,10 +2994,10 @@
         "elevation": 0.026
       },
       {
-        "segment_id": "starter-beat-6",
+        "segment_id": "steam-clock",
         "width": 0.69,
         "length": 15.3,
-        "yaw": 3.0742,
+        "yaw": 2.657,
         "offset_x": -3.63,
         "offset_z": 0,
         "tone": "curb_grime",

--- a/assets/world/gastown-water-street.json
+++ b/assets/world/gastown-water-street.json
@@ -10,7 +10,7 @@
       "Starter corridor fallback is active because required offline civic source files are missing.",
       "This world is intentionally human-scaled and deterministic for readability; it is not GIS-accurate Gastown reconstruction."
     ],
-    "lastBuild": "2026-03-22T10:42:16.870Z"
+    "lastBuild": "2026-03-22T11:05:07.406Z"
   },
   "route": {
     "name": "Gastown starter block corridor",
@@ -52,10 +52,10 @@
         "z": -93.97
       },
       {
-        "id": "starter-beat-6",
-        "label": "Starter Beat 6",
-        "x": 9.21,
-        "z": -112.79
+        "id": "steam-clock",
+        "label": "Steam Clock reveal",
+        "x": -2.57,
+        "z": -106.81
       },
       {
         "id": "starter-beat-7",
@@ -145,6 +145,12 @@
       "label": "Starter mid block",
       "x": 7.92,
       "z": -93.97
+    },
+    {
+      "id": "steam-clock",
+      "label": "Steam Clock plaza",
+      "x": -2.57,
+      "z": -108.41
     },
     {
       "id": "starter-corridor-end",
@@ -2209,11 +2215,39 @@
       "mass_inset": 0.93
     }
   ],
+  "hero_landmarks": [
+    {
+      "id": "steam-clock-hero",
+      "label": "Gastown Steam Clock",
+      "x": -2.57,
+      "y": 0,
+      "z": -108.41,
+      "yaw": 2.2885,
+      "ground_emphasis_radius": 4.8,
+      "steamVentOffsets": [
+        {
+          "x": -0.42,
+          "z": 0.64,
+          "y": 8.72
+        },
+        {
+          "x": 0.42,
+          "z": -0.64,
+          "y": 8.72
+        }
+      ],
+      "plaza": {
+        "radius": 5.1,
+        "depth": 6.2,
+        "apronWidth": 2.2
+      }
+    }
+  ],
   "landmarks": [
     {
-      "id": "starter-landmark-threshold-anchor",
+      "id": "starter-waterfront-threshold",
       "label": "Waterfront threshold",
-      "kind": "cardboard_box",
+      "kind": "district_gate",
       "x": -9.62,
       "y": 0,
       "z": -12.88,
@@ -2221,22 +2255,23 @@
       "cue": "Station canopies give way to brick-front Gastown blocks."
     },
     {
-      "id": "starter-landmark-clock-anchor",
-      "label": "Steam Clock approach",
-      "kind": "cardboard_box",
-      "x": 19.06,
+      "id": "steam-clock",
+      "label": "Gastown Steam Clock",
+      "kind": "clock",
+      "x": -2.57,
       "y": 0,
-      "z": -102.93,
-      "scale": 1.25,
-      "cue": "Denser storefront rhythm, pavers, and curb clutter build toward the clock node."
+      "z": -108.41,
+      "radius": 4.8,
+      "scale": 1.28,
+      "cue": "A small brick-paved plaza opens on the heritage sidewalk and reveals the Steam Clock on the proper approach side."
     },
     {
-      "id": "starter-landmark-postclock-anchor",
+      "id": "starter-post-clock-continuation",
       "label": "Post-clock continuation",
-      "kind": "cardboard_box",
-      "x": 2.75,
+      "kind": "view-axis",
+      "x": 23.17,
       "y": 0,
-      "z": -166.39,
+      "z": -164.59,
       "scale": 1.18,
       "cue": "The corridor loosens into longer facades and a quieter continuation east."
     }
@@ -2328,21 +2363,36 @@
     {
       "id": "starter-guide-threshold",
       "role": "guide",
+      "behavior": "guide_pace",
       "dialogId": "guide_intro",
       "interactRadius": 2.8,
       "idleSpot": {
         "x": -2.79,
         "z": -16.3
-      }
+      },
+      "patrol": [
+        {
+          "x": -2.97,
+          "z": -14.31
+        },
+        {
+          "x": -2.63,
+          "z": -19.3
+        }
+      ]
     },
     {
       "id": "starter-busker-clock",
       "role": "busker",
+      "behavior": "busker_perform",
+      "pose": "strum",
+      "heldProp": "guitar",
+      "voiceCue": "busker-hook",
       "dialogId": "busker_clock_corner",
       "interactRadius": 3,
       "idleSpot": {
-        "x": 12.83,
-        "z": -101.35
+        "x": 3.57,
+        "z": -101.98
       }
     },
     {
@@ -2391,20 +2441,23 @@
       "id": "starter-tourist-clock-west",
       "role": "tourist",
       "behavior": "tourist_pause",
+      "pose": "group_gather",
+      "companionGroup": "clock-family-a",
+      "voiceCue": "tourist-cluster",
       "dialogId": "pedestrian_clock_hint",
       "interactRadius": 2.2,
       "idleSpot": {
-        "x": -1.02,
-        "z": -97.28
+        "x": -0.88,
+        "z": -97.27
       },
       "patrol": [
         {
-          "x": -1.2,
-          "z": -94.4
+          "x": -1.06,
+          "z": -94.39
         },
         {
-          "x": -0.78,
-          "z": -101.27
+          "x": -0.64,
+          "z": -101.26
         }
       ]
     },
@@ -2412,20 +2465,23 @@
       "id": "starter-tourist-clock-east",
       "role": "tourist",
       "behavior": "tourist_pause",
+      "pose": "being_photographed",
+      "companionGroup": "clock-family-a",
+      "voiceCue": "tourist-cluster",
       "dialogId": "pedestrian_clock_hint",
       "interactRadius": 2.2,
       "idleSpot": {
-        "x": 18,
-        "z": -108.02
+        "x": -0.71,
+        "z": -110.29
       },
       "patrol": [
         {
-          "x": 17.69,
-          "z": -104.03
+          "x": -0.94,
+          "z": -106.29
         },
         {
-          "x": 18.4,
-          "z": -113
+          "x": -0.56,
+          "z": -114.29
         }
       ]
     },
@@ -2434,31 +2490,37 @@
       "role": "photographer",
       "behavior": "photo_idle",
       "pose": "taking_photo",
+      "heldProp": "camera",
+      "voiceCue": "photo-direction",
+      "companionGroup": "clock-family-a",
       "dialogId": "pedestrian_clock_hint",
       "interactRadius": 2.4,
       "idleSpot": {
-        "x": -1.08,
-        "z": -106.3
+        "x": -1.87,
+        "z": -104.35
       }
     },
     {
       "id": "starter-tourist-clock-stroller",
       "role": "tourist",
-      "behavior": "tourist_pause",
+      "behavior": "tourist_wander",
+      "pose": "group_gather",
+      "companionGroup": "clock-family-b",
+      "voiceCue": "tourist-cluster",
       "dialogId": "pedestrian_clock_hint",
       "interactRadius": 2.2,
       "idleSpot": {
-        "x": 0.16,
-        "z": -116.24
+        "x": 0.3,
+        "z": -116.23
       },
       "patrol": [
         {
-          "x": -0.14,
-          "z": -111.25
+          "x": 0,
+          "z": -111.24
         },
         {
-          "x": 0.35,
-          "z": -120.24
+          "x": 0.49,
+          "z": -120.23
         }
       ]
     },
@@ -2467,12 +2529,39 @@
       "role": "tourist",
       "behavior": "photo_idle",
       "pose": "gathered",
+      "companionGroup": "clock-family-b",
+      "voiceCue": "tourist-cluster",
       "dialogId": "pedestrian_clock_hint",
       "interactRadius": 2.2,
       "idleSpot": {
-        "x": 18.09,
-        "z": -97.99
+        "x": -1.77,
+        "z": -99.33
       }
+    },
+    {
+      "id": "starter-tourist-clock-child",
+      "role": "tourist",
+      "behavior": "tourist_pause",
+      "pose": "group_gather",
+      "silhouetteScale": 0.82,
+      "companionGroup": "clock-family-b",
+      "voiceCue": "tourist-cluster",
+      "dialogId": "pedestrian_clock_hint",
+      "interactRadius": 2,
+      "idleSpot": {
+        "x": -1.05,
+        "z": -112.32
+      },
+      "patrol": [
+        {
+          "x": -1.19,
+          "z": -109.32
+        },
+        {
+          "x": -0.93,
+          "z": -115.31
+        }
+      ]
     }
   ],
   "streetscape": {
@@ -2842,7 +2931,7 @@
         "segment_id": "starter-mid-block",
         "width": 3.33,
         "length": 14.4,
-        "yaw": 3.0732,
+        "yaw": -2.4566,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
@@ -2853,7 +2942,7 @@
         "segment_id": "starter-mid-block",
         "width": 0.69,
         "length": 15.3,
-        "yaw": 3.0732,
+        "yaw": -2.4566,
         "offset_x": 3.63,
         "offset_z": 0,
         "tone": "curb_grime",
@@ -2864,7 +2953,7 @@
         "segment_id": "starter-mid-block",
         "width": 0.69,
         "length": 15.3,
-        "yaw": 3.0732,
+        "yaw": -2.4566,
         "offset_x": -3.63,
         "offset_z": 0,
         "tone": "curb_grime",
@@ -2875,7 +2964,7 @@
         "segment_id": "starter-mid-block",
         "width": 6.66,
         "length": 3.6,
-        "yaw": 4.644,
+        "yaw": -0.8858,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "intersection_pavers",
@@ -2883,10 +2972,10 @@
         "elevation": 0.03
       },
       {
-        "segment_id": "starter-beat-6",
+        "segment_id": "steam-clock",
         "width": 3.33,
         "length": 14.4,
-        "yaw": 3.0742,
+        "yaw": 2.657,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
@@ -2894,10 +2983,10 @@
         "elevation": 0.024
       },
       {
-        "segment_id": "starter-beat-6",
+        "segment_id": "steam-clock",
         "width": 0.69,
         "length": 15.3,
-        "yaw": 3.0742,
+        "yaw": 2.657,
         "offset_x": 3.63,
         "offset_z": 0,
         "tone": "curb_grime",
@@ -2905,10 +2994,10 @@
         "elevation": 0.026
       },
       {
-        "segment_id": "starter-beat-6",
+        "segment_id": "steam-clock",
         "width": 0.69,
         "length": 15.3,
-        "yaw": 3.0742,
+        "yaw": 2.657,
         "offset_x": -3.63,
         "offset_z": 0,
         "tone": "curb_grime",

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -93,7 +93,6 @@
       beds: {},
       zoneBeds: {},
       rainLoop: null,
-      clockBurst: null,
       npcAudio: {},
       steamClockChime: null,
     },
@@ -102,7 +101,7 @@
       plume: null,
       toneReady: false,
       enabled: false,
-      lastBurstAt: -Infinity,
+      lastChimeAt: -Infinity,
       nextChimeAt: 0,
       proximityCooldownUntil: 0,
       lastPlayerNear: false,
@@ -113,7 +112,9 @@
     dialogLastFocusEl: null,
     hoveredNpcId: '',
     audioContext: null,
-    barkTimer: null,
+    npcVoiceTimer: null,
+    lastNpcVoiceAt: -Infinity,
+    npcVoiceIndex: 0,
     clockTimer: null,
     boundaryNoticeTimer: null,
     audioWarningIssued: false,
@@ -445,8 +446,14 @@
   }
 
   function getSteamClockAnchor(world) {
-    if (!world || !Array.isArray(world.hero_landmarks) || !Array.isArray(world.landmarks)) return null;
-    return world.hero_landmarks.find((hero) => hero.id === 'steam-clock-hero') || world.landmarks.find((landmark) => landmark.id === 'steam-clock') || null;
+    if (!world) return null;
+    const heroLandmarks = Array.isArray(world.hero_landmarks) ? world.hero_landmarks : [];
+    const landmarks = Array.isArray(world.landmarks) ? world.landmarks : [];
+    const nodes = Array.isArray(world.nodes) ? world.nodes : [];
+    return heroLandmarks.find((hero) => hero.id === 'steam-clock-hero')
+      || landmarks.find((landmark) => landmark.id === 'steam-clock')
+      || nodes.find((node) => node.id === 'steam-clock')
+      || null;
   }
 
   async function loadDialogData() {
@@ -538,6 +545,44 @@
       howl.fade(howl.volume(), toVolume, duration);
     } catch (error) {
       warnAudioUnavailable('Gastown audio fade failed; simulator continuing without some audio.', error);
+    }
+  }
+
+  function maybeTriggerNpcVoice(voiceFreq) {
+    if (!state.isRunning || !Array.isArray(state.npcs) || !window.speechSynthesis || voiceFreq <= 0.05) {
+      return false;
+    }
+    if (window.speechSynthesis.speaking || ((performance.now() / 1000) - state.lastNpcVoiceAt) < 10) {
+      return false;
+    }
+    const nearby = state.npcs.filter((npc) => npc.voiceCue && npc.mesh && Math.hypot(player.position.x - npc.mesh.position.x, player.position.z - npc.mesh.position.z) < 15);
+    if (!nearby.length) {
+      return false;
+    }
+    const selected = nearby[state.npcVoiceIndex % nearby.length];
+    state.npcVoiceIndex += 1;
+    const snippetsByCue = {
+      'busker-hook': ['Clock corner tune, folks.', 'Gather round the clock.'],
+      'tourist-cluster': ['One more picture here.', 'Stand by the clock, please.'],
+      'photo-direction': ['Hold still by the clock.', 'Okay, one more shot.'],
+    };
+    const options = snippetsByCue[selected.voiceCue] || [];
+    if (!options.length) {
+      return false;
+    }
+    const utterance = new window.SpeechSynthesisUtterance(options[state.npcVoiceIndex % options.length]);
+    utterance.volume = 0.18;
+    utterance.rate = 0.96;
+    utterance.pitch = selected.role === 'busker' ? 0.84 : 1;
+    utterance.onstart = function onNpcVoiceStart() {
+      state.lastNpcVoiceAt = performance.now() / 1000;
+    };
+    try {
+      window.speechSynthesis.speak(utterance);
+      return true;
+    } catch (error) {
+      warnAudioUnavailable('NPC voice ambience unavailable; simulator continuing without speech snippets.', error);
+      return false;
     }
   }
 
@@ -698,27 +743,87 @@
     showDialog();
   }
 
-  function makeNpcVisual(role) {
-    const style = NPC_ROLE_STYLE[role] || NPC_ROLE_STYLE.pedestrian;
+  function createNpcProp(propId, accentMaterial) {
+    if (propId === 'guitar') {
+      const prop = new THREE.Group();
+      const body = new THREE.Mesh(new THREE.BoxGeometry(0.34, 0.5, 0.12), accentMaterial.clone());
+      const neck = new THREE.Mesh(new THREE.BoxGeometry(0.08, 0.46, 0.08), accentMaterial.clone());
+      body.position.set(0, -0.06, 0);
+      neck.position.set(0.16, 0.28, 0);
+      neck.rotation.z = -0.38;
+      prop.add(body);
+      prop.add(neck);
+      prop.rotation.z = 0.72;
+      prop.position.set(0.22, 1.08, 0.19);
+      return prop;
+    }
+    if (propId === 'camera') {
+      const prop = new THREE.Group();
+      const body = new THREE.Mesh(new THREE.BoxGeometry(0.16, 0.12, 0.12), accentMaterial.clone());
+      const lens = new THREE.Mesh(new THREE.CylinderGeometry(0.04, 0.04, 0.08, 10), new THREE.MeshStandardMaterial({ color: 0x191d21, roughness: 0.64, metalness: 0.16 }));
+      lens.rotation.x = Math.PI / 2;
+      lens.position.z = 0.08;
+      prop.add(body);
+      prop.add(lens);
+      prop.position.set(0.16, 1.4, 0.28);
+      return prop;
+    }
+    return null;
+  }
+
+  function makeNpcVisual(npc) {
+    const style = NPC_ROLE_STYLE[npc.role] || NPC_ROLE_STYLE.pedestrian;
+    const scaleFactor = Math.max(0.72, Math.min(1.15, npc.silhouetteScale || 1));
     const root = new THREE.Group();
+    const bodyMaterial = new THREE.MeshStandardMaterial({ color: style.color, roughness: 0.86, metalness: 0.08 });
+    const skinMaterial = new THREE.MeshStandardMaterial({ color: 0xe0c7aa, roughness: 0.92, metalness: 0.02 });
+    const accentMaterial = new THREE.MeshStandardMaterial({ color: style.accent, roughness: 0.8, metalness: 0.1 });
     const body = new THREE.Mesh(
       new THREE.CapsuleGeometry(0.22, Math.max(0.6, style.height - 1), 4, 8),
-      new THREE.MeshStandardMaterial({ color: style.color, roughness: 0.86, metalness: 0.08 })
+      bodyMaterial
     );
     body.position.y = style.height * 0.5;
     const head = new THREE.Mesh(
       new THREE.SphereGeometry(0.17, 10, 10),
-      new THREE.MeshStandardMaterial({ color: 0xe0c7aa, roughness: 0.92, metalness: 0.02 })
+      skinMaterial
     );
     head.position.y = style.height - 0.12;
     const accent = new THREE.Mesh(
       new THREE.BoxGeometry(0.36, 0.14, 0.18),
-      new THREE.MeshStandardMaterial({ color: style.accent, roughness: 0.8, metalness: 0.1 })
+      accentMaterial
     );
     accent.position.set(0, style.height * 0.58, 0.2);
+    const leftArm = new THREE.Mesh(new THREE.BoxGeometry(0.08, 0.54, 0.08), bodyMaterial);
+    leftArm.position.set(-0.22, style.height * 0.63, 0.02);
+    const rightArm = new THREE.Mesh(new THREE.BoxGeometry(0.08, 0.54, 0.08), bodyMaterial);
+    rightArm.position.set(0.22, style.height * 0.63, 0.02);
+    const leftLeg = new THREE.Mesh(new THREE.BoxGeometry(0.09, 0.58, 0.09), accentMaterial);
+    leftLeg.position.set(-0.09, 0.34, 0);
+    const rightLeg = new THREE.Mesh(new THREE.BoxGeometry(0.09, 0.58, 0.09), accentMaterial);
+    rightLeg.position.set(0.09, 0.34, 0);
     root.add(body);
     root.add(head);
     root.add(accent);
+    root.add(leftArm);
+    root.add(rightArm);
+    root.add(leftLeg);
+    root.add(rightLeg);
+    const heldProp = createNpcProp(npc.heldProp, accentMaterial);
+    if (heldProp) {
+      root.add(heldProp);
+    }
+    root.userData = {
+      body,
+      head,
+      accent,
+      leftArm,
+      rightArm,
+      leftLeg,
+      rightLeg,
+      heldProp,
+      scaleFactor,
+    };
+    root.scale.setScalar(scaleFactor);
     return root;
   }
 
@@ -797,7 +902,7 @@
 
   function addNpcs(world) {
     state.npcs = (world.npcs || []).map((npc) => {
-      const visual = makeNpcVisual(npc.role);
+      const visual = makeNpcVisual(npc);
       const start = npc.idleSpot || npc.patrol[0] || { x: 0, z: 0 };
       visual.position.set(start.x, 0, start.z);
       worldGroup.add(visual);
@@ -807,7 +912,7 @@
         patrolIndex: 0,
         direction: 1,
         baseY: 0,
-        speed: npc.role === 'pedestrian' || npc.role === 'tourist' || npc.role === 'photographer' ? 0.84 + (deterministicUnit(npc.id) * 0.34) : 0,
+        speed: npc.role === 'pedestrian' || npc.role === 'tourist' || npc.role === 'photographer' ? 0.84 + (deterministicUnit(npc.id) * 0.34) : npc.role === 'guide' ? 0.18 : 0,
         pauseUntil: 0,
         animPhase: swaySeed * Math.PI * 2,
         swayAmount: 0.018 + (swaySeed * 0.028),
@@ -824,9 +929,11 @@
     state.npcs.forEach((npc) => {
       if (!npc.mesh) return;
       const isWalker = Array.isArray(npc.patrol) && npc.patrol.length > 1;
-      const touristPause = npc.behavior === 'tourist_pause' || npc.behavior === 'photo_idle';
+      const touristPause = npc.behavior === 'tourist_pause' || npc.behavior === 'photo_idle' || npc.behavior === 'tourist_wander';
+      const subtleWalker = npc.role === 'guide';
+      const canWalk = isWalker && (npc.role === 'pedestrian' || npc.role === 'tourist' || npc.role === 'photographer' || subtleWalker);
 
-      if (isWalker && (npc.role === 'pedestrian' || npc.role === 'tourist' || npc.role === 'photographer')) {
+      if (canWalk) {
         const target = npc.patrol[npc.patrolIndex] || npc.patrol[0];
         const dx = target.x - npc.mesh.position.x;
         const dz = target.z - npc.mesh.position.z;
@@ -850,12 +957,39 @@
         }
       }
 
-      const motionStrength = isWalker && nowSeconds >= (npc.pauseUntil || 0) ? 1 : 0.35;
+      const motionStrength = canWalk && nowSeconds >= (npc.pauseUntil || 0) ? 1 : npc.role === 'busker' ? 0.8 : 0.45;
       npc.mesh.position.y = npc.baseY + (Math.sin((nowSeconds * 3.4) + npc.animPhase) * npc.swayAmount * motionStrength);
       npc.mesh.rotation.z = Math.sin((nowSeconds * 2.2) + npc.animPhase) * 0.02;
-      npc.mesh.children.forEach((child, index) => {
-        child.rotation.y = (index === 1 ? 1 : -1) * Math.sin((nowSeconds * 1.4) + npc.animPhase) * 0.04;
-      });
+      const rig = npc.mesh.userData || {};
+      const stride = Math.sin((nowSeconds * (canWalk ? 7.4 : 3.1)) + npc.animPhase);
+      if (rig.leftArm && rig.rightArm) {
+        rig.leftArm.rotation.x = stride * (canWalk ? 0.6 : 0.18);
+        rig.rightArm.rotation.x = -stride * (canWalk ? 0.6 : 0.18);
+      }
+      if (rig.leftLeg && rig.rightLeg) {
+        rig.leftLeg.rotation.x = -stride * (canWalk ? 0.52 : 0.1);
+        rig.rightLeg.rotation.x = stride * (canWalk ? 0.52 : 0.1);
+      }
+      if (rig.head) {
+        rig.head.rotation.y = Math.sin((nowSeconds * 0.9) + npc.animPhase) * 0.12;
+      }
+      if (rig.heldProp) {
+        if (npc.heldProp === 'guitar') {
+          rig.heldProp.rotation.y = Math.sin((nowSeconds * 2.6) + npc.animPhase) * 0.12;
+        } else if (npc.heldProp === 'camera') {
+          rig.heldProp.position.y = (npc.pose === 'taking_photo' ? 1.48 : 1.32) + (Math.sin((nowSeconds * 1.2) + npc.animPhase) * 0.03);
+          rig.heldProp.rotation.x = npc.pose === 'taking_photo' ? -0.42 : -0.18;
+        }
+      }
+      if (npc.role === 'busker') {
+        npc.mesh.rotation.y += Math.sin((nowSeconds * 1.3) + npc.animPhase) * 0.002;
+      }
+      if (npc.pose === 'being_photographed') {
+        npc.mesh.rotation.y = -0.24;
+      }
+      if (npc.pose === 'group_gather' || npc.pose === 'gathered') {
+        npc.mesh.rotation.y += Math.sin((nowSeconds * 0.8) + npc.animPhase) * 0.0015;
+      }
 
       const loop = state.sounds.npcAudio[npc.id];
       if (loop) {
@@ -1370,75 +1504,104 @@
   function addHeroLandmarks(world) {
     (world.hero_landmarks || []).forEach((hero) => {
       if (hero.id === 'steam-clock-hero') {
-        const ironMaterial = new THREE.MeshStandardMaterial({ color: 0x2e3138, roughness: 0.54, metalness: 0.58 });
-        const brassMaterial = new THREE.MeshStandardMaterial({ color: 0xae8f52, roughness: 0.42, metalness: 0.62 });
-        const glassMaterial = new THREE.MeshStandardMaterial({ color: 0xa9c0bb, roughness: 0.18, metalness: 0.08, transparent: true, opacity: 0.34, emissive: 0x1b2c2c, emissiveIntensity: 0.16 });
-        const accentMaterial = new THREE.MeshStandardMaterial({ color: 0x5a4633, roughness: 0.7, metalness: 0.2 });
+        const ironMaterial = new THREE.MeshStandardMaterial({ color: 0x24282d, roughness: 0.48, metalness: 0.68 });
+        const brassMaterial = new THREE.MeshStandardMaterial({ color: 0xb08b48, roughness: 0.34, metalness: 0.72 });
+        const glassMaterial = new THREE.MeshStandardMaterial({ color: 0xabc4c0, roughness: 0.12, metalness: 0.08, transparent: true, opacity: 0.32, emissive: 0x223333, emissiveIntensity: 0.22 });
+        const accentMaterial = new THREE.MeshStandardMaterial({ color: 0x6a4c31, roughness: 0.76, metalness: 0.14 });
         const clockRoot = new THREE.Group();
         clockRoot.position.set(hero.x, 0, hero.z);
+        clockRoot.rotation.y = hero.yaw || 0;
 
-        const plinth = new THREE.Mesh(new THREE.CylinderGeometry(1.32, 1.54, 0.72, 12), accentMaterial);
+        const plazaRadius = (hero.plaza && hero.plaza.radius) || (hero.ground_emphasis_radius || 4.2);
+        const plinth = new THREE.Mesh(new THREE.CylinderGeometry(1.52, 1.74, 0.84, 16), accentMaterial);
         plinth.position.y = 0.36;
         clockRoot.add(plinth);
-        const pedestal = new THREE.Mesh(new THREE.BoxGeometry(1.36, 1.18, 1.36), ironMaterial);
-        pedestal.position.y = 1.22;
+        const pedestal = new THREE.Mesh(new THREE.BoxGeometry(1.54, 1.28, 1.54), ironMaterial);
+        pedestal.position.y = 1.26;
         clockRoot.add(pedestal);
-        const shaft = new THREE.Mesh(new THREE.BoxGeometry(1.02, 5.2, 1.02), ironMaterial);
-        shaft.position.y = 4.12;
+        const pedestalTrim = new THREE.Mesh(new THREE.BoxGeometry(1.76, 0.22, 1.76), brassMaterial);
+        pedestalTrim.position.y = 1.88;
+        clockRoot.add(pedestalTrim);
+        const shaft = new THREE.Mesh(new THREE.BoxGeometry(1.08, 5.56, 1.08), ironMaterial);
+        shaft.position.y = 4.32;
         clockRoot.add(shaft);
-        const glassCore = new THREE.Mesh(new THREE.BoxGeometry(0.76, 2.48, 0.76), glassMaterial);
-        glassCore.position.y = 3.96;
+        const glassCore = new THREE.Mesh(new THREE.BoxGeometry(0.82, 2.92, 0.82), glassMaterial);
+        glassCore.position.y = 4.16;
         clockRoot.add(glassCore);
-        const clockHousing = new THREE.Mesh(new THREE.BoxGeometry(1.78, 1.48, 1.78), ironMaterial);
-        clockHousing.position.y = 6.46;
+        const cagePosts = [
+          [-0.38, -0.38], [0.38, -0.38], [-0.38, 0.38], [0.38, 0.38],
+        ];
+        cagePosts.forEach((post) => {
+          const cage = new THREE.Mesh(new THREE.BoxGeometry(0.08, 2.8, 0.08), brassMaterial);
+          cage.position.set(post[0], 4.18, post[1]);
+          clockRoot.add(cage);
+        });
+        const clockHousing = new THREE.Mesh(new THREE.BoxGeometry(1.94, 1.62, 1.94), ironMaterial);
+        clockHousing.position.y = 6.74;
         clockRoot.add(clockHousing);
-        const crown = new THREE.Mesh(new THREE.CylinderGeometry(0.9, 1.12, 0.54, 12), brassMaterial);
-        crown.position.y = 7.44;
+        const clockCornice = new THREE.Mesh(new THREE.BoxGeometry(2.18, 0.24, 2.18), brassMaterial);
+        clockCornice.position.y = 7.44;
+        clockRoot.add(clockCornice);
+        const crown = new THREE.Mesh(new THREE.CylinderGeometry(0.98, 1.24, 0.58, 14), brassMaterial);
+        crown.position.y = 7.88;
         clockRoot.add(crown);
-        const cap = new THREE.Mesh(new THREE.ConeGeometry(0.96, 1.18, 12), ironMaterial);
-        cap.position.y = 8.28;
+        const cap = new THREE.Mesh(new THREE.ConeGeometry(1.08, 1.26, 14), ironMaterial);
+        cap.position.y = 8.74;
         clockRoot.add(cap);
-        const steamStack = new THREE.Mesh(new THREE.CylinderGeometry(0.12, 0.16, 1.1, 8), brassMaterial);
-        steamStack.position.set(0, 8.92, 0);
+        const finial = new THREE.Mesh(new THREE.SphereGeometry(0.14, 10, 10), brassMaterial);
+        finial.position.set(0, 9.5, 0);
+        clockRoot.add(finial);
+        const steamStack = new THREE.Mesh(new THREE.CylinderGeometry(0.12, 0.18, 1.18, 8), brassMaterial);
+        steamStack.position.set(0, 9.06, 0);
         clockRoot.add(steamStack);
 
         [0, Math.PI / 2, Math.PI, -Math.PI / 2].forEach((rotation) => {
-          const frame = new THREE.Mesh(new THREE.CylinderGeometry(0.56, 0.56, 0.08, 24), brassMaterial);
+          const frame = new THREE.Mesh(new THREE.CylinderGeometry(0.62, 0.62, 0.12, 24), brassMaterial);
           frame.rotation.x = Math.PI / 2;
           frame.rotation.z = rotation;
-          frame.position.set(Math.sin(rotation) * 0.92, 6.48, Math.cos(rotation) * 0.92);
+          frame.position.set(Math.sin(rotation) * 1.02, 6.76, Math.cos(rotation) * 1.02);
           clockRoot.add(frame);
 
-          const face = new THREE.Mesh(new THREE.CircleGeometry(0.46, 24), new THREE.MeshStandardMaterial({ color: 0xf0e2b4, emissive: 0x7d6639, emissiveIntensity: 0.26, roughness: 0.62, metalness: 0.04 }));
-          face.position.set(Math.sin(rotation) * 0.94, 6.48, Math.cos(rotation) * 0.94);
+          const face = new THREE.Mesh(new THREE.CircleGeometry(0.5, 24), new THREE.MeshStandardMaterial({ color: 0xf2e4b6, emissive: 0x7d6639, emissiveIntensity: 0.28, roughness: 0.62, metalness: 0.04 }));
+          face.position.set(Math.sin(rotation) * 1.04, 6.76, Math.cos(rotation) * 1.04);
           face.rotation.y = rotation;
           clockRoot.add(face);
 
-          const hand = new THREE.Mesh(new THREE.BoxGeometry(0.04, 0.34, 0.03), new THREE.MeshStandardMaterial({ color: 0x2b2420, roughness: 0.5, metalness: 0.22 }));
-          hand.position.set(Math.sin(rotation) * 0.98, 6.48, Math.cos(rotation) * 0.98);
+          const hand = new THREE.Mesh(new THREE.BoxGeometry(0.04, 0.4, 0.03), new THREE.MeshStandardMaterial({ color: 0x2b2420, roughness: 0.5, metalness: 0.22 }));
+          hand.position.set(Math.sin(rotation) * 1.08, 6.76, Math.cos(rotation) * 1.08);
           hand.rotation.set(0, rotation, Math.PI / 5);
           clockRoot.add(hand);
         });
 
-        [-1, 1].forEach((side) => {
+        const steamVents = Array.isArray(hero.steamVentOffsets) && hero.steamVentOffsets.length
+          ? hero.steamVentOffsets
+          : [{ x: -0.42, z: 0.64, y: 8.72 }, { x: 0.42, z: -0.64, y: 8.72 }];
+        steamVents.forEach((vent, index) => {
           const pipe = new THREE.Mesh(new THREE.CylinderGeometry(0.09, 0.09, 1.8, 8), brassMaterial);
-          pipe.position.set(side * 0.62, 5.48, 0.72);
+          pipe.position.set(vent.x, 5.62, index % 2 === 0 ? 0.82 : -0.82);
           pipe.rotation.x = Math.PI / 2.45;
           clockRoot.add(pipe);
           const elbow = new THREE.Mesh(new THREE.TorusGeometry(0.18, 0.04, 8, 16, Math.PI), brassMaterial);
-          elbow.position.set(side * 0.62, 4.9, 1.1);
-          elbow.rotation.y = side > 0 ? Math.PI / 2 : -Math.PI / 2;
+          elbow.position.set(vent.x, 5.02, index % 2 === 0 ? 1.2 : -1.2);
+          elbow.rotation.y = index % 2 === 0 ? -Math.PI / 2 : Math.PI / 2;
           clockRoot.add(elbow);
+          const ventCap = new THREE.Mesh(new THREE.CylinderGeometry(0.1, 0.14, 0.3, 8), brassMaterial);
+          ventCap.position.set(vent.x, vent.y, vent.z);
+          clockRoot.add(ventCap);
         });
 
-        const plaza = new THREE.Mesh(new THREE.CircleGeometry((hero.ground_emphasis_radius || 3.2), 28), new THREE.MeshStandardMaterial({ color: 0x382f27, roughness: 0.9, metalness: 0.03 }));
+        const plaza = new THREE.Mesh(new THREE.CircleGeometry(plazaRadius, 32), new THREE.MeshStandardMaterial({ color: 0x4c3d32, roughness: 0.92, metalness: 0.02 }));
         plaza.rotation.x = -Math.PI / 2;
         plaza.position.y = 0.03;
         clockRoot.add(plaza);
+        const plazaApron = new THREE.Mesh(new THREE.RingGeometry(plazaRadius * 0.66, plazaRadius + 0.65, 32), new THREE.MeshStandardMaterial({ color: 0x7a6a5b, roughness: 0.96, metalness: 0.01 }));
+        plazaApron.rotation.x = -Math.PI / 2;
+        plazaApron.position.y = 0.031;
+        clockRoot.add(plazaApron);
 
         const steamMaterial = new THREE.MeshBasicMaterial({ color: 0xd8dfdf, transparent: true, opacity: 0.18, depthWrite: false });
-        const steamPlume = new THREE.Mesh(new THREE.SphereGeometry(0.56, 10, 10), steamMaterial);
-        steamPlume.position.set(0, 9.52, 0.18);
+        const steamPlume = new THREE.Mesh(new THREE.SphereGeometry(0.62, 10, 10), steamMaterial);
+        steamPlume.position.set(0, 9.72, 0.08);
         clockRoot.add(steamPlume);
 
         worldGroup.add(clockRoot);
@@ -2164,7 +2327,6 @@
     });
 
     state.sounds.rainLoop = createSafeHowl({ src: src('weather/rain_pavement'), loop: true, volume: 0 });
-    state.sounds.clockBurst = createSafeHowl({ src: src('events/steam_clock_burst'), volume: 0.22 });
     state.sounds.thunder = createSafeHowl({ src: src('weather/thunder_roll'), volume: 0.22 });
 
     (world.audioZones || []).forEach((zone) => {
@@ -2248,22 +2410,12 @@
       fadeHowl(howl, id === preset.ambientBed ? 0.45 * preset.audioDensity : 0, 420);
     });
 
-    if (state.barkTimer) {
-      clearInterval(state.barkTimer);
+    if (state.npcVoiceTimer) {
+      clearInterval(state.npcVoiceTimer);
     }
-    const barkInterval = Math.max(4500, 15000 - (preset.voiceFreq * 12000));
-    state.barkTimer = setInterval(() => {
-      if (!state.isRunning || Math.random() > preset.voiceFreq) {
-        return;
-      }
-      const bark = createSafeHowl({
-        src: [
-          (config.audioBaseUrl || '').replace(/\/$/, '') + '/barks/hey_you.mp3',
-          (config.audioBaseUrl || '').replace(/\/$/, '') + '/barks/hey_you.ogg'
-        ],
-        volume: 0.38 + (Math.random() * 0.2)
-      });
-      playHowl(bark);
+    const barkInterval = Math.max(7000, 18000 - (preset.voiceFreq * 9000));
+    state.npcVoiceTimer = setInterval(() => {
+      maybeTriggerNpcVoice(preset.voiceFreq);
     }, barkInterval);
   }
 
@@ -2513,13 +2665,17 @@
         state.sounds.steamClockChime = {
           synth: new Tone.PolySynth(Tone.Synth, {
             oscillator: { type: 'triangle8' },
-            envelope: { attack: 0.01, decay: 0.22, sustain: 0.16, release: 1.4 },
-            volume: -13,
+            envelope: { attack: 0.01, decay: 0.34, sustain: 0.1, release: 1.8 },
+            volume: -12,
           }).toDestination(),
-          bell: new Tone.Synth({
-            oscillator: { type: 'sine' },
-            envelope: { attack: 0.01, decay: 0.35, sustain: 0, release: 1.8 },
-            volume: -16,
+          bell: new Tone.MetalSynth({
+            frequency: 220,
+            envelope: { attack: 0.001, decay: 1.2, release: 1.6 },
+            harmonicity: 7.1,
+            modulationIndex: 18,
+            resonance: 3000,
+            octaves: 1.4,
+            volume: -18,
           }).toDestination(),
         };
       }
@@ -2546,13 +2702,16 @@
       let cursor = now + 0.05;
       STEAM_CLOCK_CHIME_MOTIF.forEach((phrase, phraseIndex) => {
         phrase.forEach((note, noteIndex) => {
-          state.sounds.steamClockChime.synth.triggerAttackRelease(note, 0.55, cursor + (noteIndex * 0.36), phraseIndex === 0 ? 0.82 : 0.7);
+          state.sounds.steamClockChime.synth.triggerAttackRelease(note, 0.62, cursor + (noteIndex * 0.38), phraseIndex === 0 ? 0.9 : 0.74);
         });
-        cursor += 1.62;
+        if (phraseIndex < STEAM_CLOCK_CHIME_MOTIF.length - 1) {
+          state.sounds.steamClockChime.bell.triggerAttackRelease('16n', cursor + 1.46, 0.22);
+        }
+        cursor += 1.78;
       });
-      state.sounds.steamClockChime.bell.triggerAttackRelease('B2', 1.6, now, 0.42);
-      state.steamClockState.lastBurstAt = performance.now() / 1000;
-      state.steamClockState.nextChimeAt = (performance.now() / 1000) + (reason === 'proximity' ? 34 : 52);
+      state.sounds.steamClockChime.bell.triggerAttackRelease('2n', now, 0.32);
+      state.steamClockState.lastChimeAt = performance.now() / 1000;
+      state.steamClockState.nextChimeAt = (performance.now() / 1000) + (reason === 'proximity' ? 42 : 58);
       return true;
     } catch (error) {
       warnAudioUnavailable('Tone.js steam clock chime playback failed; simulator continuing without musical chimes.', error);
@@ -2565,7 +2724,7 @@
       const pulse = 0.65 + (Math.sin(nowSeconds * 1.8) * 0.12);
       state.steamClockState.plume.scale.setScalar(pulse);
       state.steamClockState.plume.position.y = 9.4 + (Math.sin(nowSeconds * 2.4) * 0.16);
-      state.steamClockState.plume.material.opacity = 0.1 + Math.max(0, 0.12 - ((nowSeconds - state.steamClockState.lastBurstAt) * 0.05));
+      state.steamClockState.plume.material.opacity = 0.08 + Math.max(0, 0.18 - ((nowSeconds - state.steamClockState.lastChimeAt) * 0.07));
     }
 
     const steamClock = state.steamClockState.anchor || getSteamClockAnchor(state.world);
@@ -2577,9 +2736,9 @@
 
     if (playerNear && !state.steamClockState.lastPlayerNear && nowSeconds >= state.steamClockState.proximityCooldownUntil) {
       if (triggerSteamClockChime('proximity')) {
-        state.steamClockState.proximityCooldownUntil = nowSeconds + 36;
+        state.steamClockState.proximityCooldownUntil = nowSeconds + 44;
       }
-    } else if (state.steamClockState.enabled && nowSeconds >= state.steamClockState.nextChimeAt && distance < 34) {
+    } else if (state.steamClockState.enabled && nowSeconds >= state.steamClockState.nextChimeAt && distance < 30) {
       triggerSteamClockChime('interval');
     }
     state.steamClockState.lastPlayerNear = playerNear;
@@ -2590,7 +2749,7 @@
       clearInterval(state.clockTimer);
     }
     state.steamClockState.anchor = getSteamClockAnchor(state.world);
-    state.steamClockState.nextChimeAt = 24;
+    state.steamClockState.nextChimeAt = 28;
     state.clockTimer = window.setInterval(() => {}, 60000);
   }
 

--- a/js/gastown-world-loader.js
+++ b/js/gastown-world-loader.js
@@ -80,6 +80,7 @@
       throw new Error('Gastown world data is malformed: npcs[' + index + '].role is required.');
     }
     assertFiniteNumberIfPresent(npc.interactRadius, 'npcs[' + index + '].interactRadius');
+    assertFiniteNumberIfPresent(npc.silhouetteScale, 'npcs[' + index + '].silhouetteScale');
     if (npc.idleSpot) {
       validatePointLike(npc.idleSpot, 'npcs[' + index + '].idleSpot');
     }
@@ -222,6 +223,10 @@
         role: typeof npc.role === 'string' && npc.role ? npc.role : 'pedestrian',
         behavior: typeof npc.behavior === 'string' ? npc.behavior : '',
         pose: typeof npc.pose === 'string' ? npc.pose : '',
+        heldProp: typeof npc.heldProp === 'string' ? npc.heldProp : '',
+        companionGroup: typeof npc.companionGroup === 'string' ? npc.companionGroup : '',
+        voiceCue: typeof npc.voiceCue === 'string' ? npc.voiceCue : '',
+        silhouetteScale: isFiniteNumber(npc.silhouetteScale) ? npc.silhouetteScale : 1,
         interactRadius: isFiniteNumber(npc.interactRadius) ? npc.interactRadius : 2.4,
         dialogId: typeof npc.dialogId === 'string' ? npc.dialogId : '',
         idleSpot: normalizePoint(npc.idleSpot || fallbackPoint, fallbackPoint.x, fallbackPoint.z),

--- a/scripts/generate-gastown-world.js
+++ b/scripts/generate-gastown-world.js
@@ -551,44 +551,66 @@ function buildStarterProps(routePoints, sidewalkOuter, spawnDistance) {
 }
 
 function buildStarterLandmarks(routePoints, sidewalkOuter) {
-  return [
+  const threshold = placeStarterProp(routePoints, 12, -1 * (sidewalkOuter + 2.6), 'starter-landmark-threshold-anchor', 'cardboard_box', { scale: 1 });
+  const steamClock = placeStarterProp(routePoints, 108, -1 * (sidewalkOuter + 3.35), 'steam-clock-anchor', 'cardboard_box', { scale: 1 });
+  const continuation = placeStarterProp(routePoints, 166, sidewalkOuter + 2.1, 'starter-landmark-postclock-anchor', 'cardboard_box', { scale: 1 });
+  const heroRadius = 4.8;
+
+  return {
+    landmarks: [
     {
       id: 'starter-waterfront-threshold',
       label: 'Waterfront threshold',
       kind: 'district_gate',
-      ...placeStarterProp(routePoints, 12, -1 * (sidewalkOuter + 2.6), 'starter-landmark-threshold-anchor', 'cardboard_box', { scale: 1 }),
+      x: threshold.x,
       y: 0,
+      z: threshold.z,
       scale: 1.35,
       cue: 'Station canopies give way to brick-front Gastown blocks.',
     },
     {
-      id: 'starter-steam-clock-approach',
-      label: 'Steam Clock approach',
-      kind: 'clock-approach',
-      ...placeStarterProp(routePoints, 104, sidewalkOuter + 2.4, 'starter-landmark-clock-anchor', 'cardboard_box', { scale: 1 }),
+      id: 'steam-clock',
+      label: 'Gastown Steam Clock',
+      kind: 'clock',
+      x: steamClock.x,
       y: 0,
-      scale: 1.25,
-      cue: 'Denser storefront rhythm, pavers, and curb clutter build toward the clock node.',
+      z: steamClock.z,
+      radius: heroRadius,
+      scale: 1.28,
+      cue: 'A small brick-paved plaza opens on the heritage sidewalk and reveals the Steam Clock on the proper approach side.',
     },
     {
       id: 'starter-post-clock-continuation',
       label: 'Post-clock continuation',
       kind: 'view-axis',
-      ...placeStarterProp(routePoints, 166, -1 * (sidewalkOuter + 2.2), 'starter-landmark-postclock-anchor', 'cardboard_box', { scale: 1 }),
+      x: continuation.x,
       y: 0,
+      z: continuation.z,
       scale: 1.18,
       cue: 'The corridor loosens into longer facades and a quieter continuation east.',
     },
-  ].map((landmark) => ({
-    id: landmark.id,
-    label: landmark.label,
-    kind: landmark.kind,
-    x: landmark.x,
-    y: landmark.y,
-    z: landmark.z,
-    scale: landmark.scale,
-    cue: landmark.cue,
-  }));
+    ],
+    heroLandmarks: [
+      {
+        id: 'steam-clock-hero',
+        label: 'Gastown Steam Clock',
+        x: steamClock.x,
+        y: 0,
+        z: steamClock.z,
+        yaw: Number((steamClock.yaw + Math.PI * 0.25).toFixed(4)),
+        ground_emphasis_radius: heroRadius,
+        steamVentOffsets: [
+          { x: -0.42, z: 0.64, y: 8.72 },
+          { x: 0.42, z: -0.64, y: 8.72 },
+        ],
+        plaza: {
+          radius: 5.1,
+          depth: 6.2,
+          apronWidth: 2.2,
+        },
+      },
+    ],
+  };
 }
 
 
@@ -598,7 +620,7 @@ function buildStarterNpcs(routePoints, streetWidth, sidewalkOuter) {
     const placement = placeStarterProp(routePoints, distanceMeters, (side * (laneOffset + extraOffset)), id, 'cardboard_box', { scale: 1 });
     return { x: placement.x, z: placement.z };
   };
-  const clockTouristOffset = sidewalkOuter + 0.9;
+  const clockTouristOffset = sidewalkOuter + 0.76;
   const placeClockTourist = (distanceMeters, side, extraOffset, id) => {
     const placement = placeStarterProp(routePoints, distanceMeters, side * (clockTouristOffset + extraOffset), id, 'cardboard_box', { scale: 1 });
     return { x: placement.x, z: placement.z };
@@ -608,16 +630,25 @@ function buildStarterNpcs(routePoints, streetWidth, sidewalkOuter) {
     {
       id: 'starter-guide-threshold',
       role: 'guide',
+      behavior: 'guide_pace',
       dialogId: 'guide_intro',
       interactRadius: 2.8,
       idleSpot: placeNpc(16, -1, 1.45, 'starter-npc-guide-anchor'),
+      patrol: [
+        placeNpc(14, -1, 1.45, 'starter-npc-guide-a'),
+        placeNpc(19, -1, 1.55, 'starter-npc-guide-b'),
+      ],
     },
     {
       id: 'starter-busker-clock',
       role: 'busker',
+      behavior: 'busker_perform',
+      pose: 'strum',
+      heldProp: 'guitar',
+      voiceCue: 'busker-hook',
       dialogId: 'busker_clock_corner',
       interactRadius: 3,
-      idleSpot: placeNpc(102, 1, 1.65, 'starter-npc-busker-anchor'),
+      idleSpot: placeNpc(102, -1, 2.15, 'starter-npc-busker-anchor'),
     },
     {
       id: 'starter-pedestrian-west',
@@ -647,6 +678,9 @@ function buildStarterNpcs(routePoints, streetWidth, sidewalkOuter) {
       id: 'starter-tourist-clock-west',
       role: 'tourist',
       behavior: 'tourist_pause',
+      pose: 'group_gather',
+      companionGroup: 'clock-family-a',
+      voiceCue: 'tourist-cluster',
       dialogId: 'pedestrian_clock_hint',
       interactRadius: 2.2,
       idleSpot: placeClockTourist(97, -1, 0.15, 'starter-tourist-clock-west-idle'),
@@ -659,12 +693,15 @@ function buildStarterNpcs(routePoints, streetWidth, sidewalkOuter) {
       id: 'starter-tourist-clock-east',
       role: 'tourist',
       behavior: 'tourist_pause',
+      pose: 'being_photographed',
+      companionGroup: 'clock-family-a',
+      voiceCue: 'tourist-cluster',
       dialogId: 'pedestrian_clock_hint',
       interactRadius: 2.2,
-      idleSpot: placeClockTourist(109, 1, 0.1, 'starter-tourist-clock-east-idle'),
+      idleSpot: placeClockTourist(110, -1, 0.86, 'starter-tourist-clock-east-idle'),
       patrol: [
-        placeClockTourist(105, 1, 0.06, 'starter-tourist-clock-east-a'),
-        placeClockTourist(114, 1, 0.16, 'starter-tourist-clock-east-b'),
+        placeClockTourist(106, -1, 0.82, 'starter-tourist-clock-east-a'),
+        placeClockTourist(114, -1, 0.98, 'starter-tourist-clock-east-b'),
       ],
     },
     {
@@ -672,14 +709,20 @@ function buildStarterNpcs(routePoints, streetWidth, sidewalkOuter) {
       role: 'photographer',
       behavior: 'photo_idle',
       pose: 'taking_photo',
+      heldProp: 'camera',
+      voiceCue: 'photo-direction',
+      companionGroup: 'clock-family-a',
       dialogId: 'pedestrian_clock_hint',
       interactRadius: 2.4,
-      idleSpot: placeClockTourist(106, -1, 0.82, 'starter-tourist-clock-photo-idle'),
+      idleSpot: placeClockTourist(104, -1, 1.62, 'starter-tourist-clock-photo-idle'),
     },
     {
       id: 'starter-tourist-clock-stroller',
       role: 'tourist',
-      behavior: 'tourist_pause',
+      behavior: 'tourist_wander',
+      pose: 'group_gather',
+      companionGroup: 'clock-family-b',
+      voiceCue: 'tourist-cluster',
       dialogId: 'pedestrian_clock_hint',
       interactRadius: 2.2,
       idleSpot: placeClockTourist(116, -1, 0.26, 'starter-tourist-clock-stroller-idle'),
@@ -693,9 +736,27 @@ function buildStarterNpcs(routePoints, streetWidth, sidewalkOuter) {
       role: 'tourist',
       behavior: 'photo_idle',
       pose: 'gathered',
+      companionGroup: 'clock-family-b',
+      voiceCue: 'tourist-cluster',
       dialogId: 'pedestrian_clock_hint',
       interactRadius: 2.2,
-      idleSpot: placeClockTourist(99, 1, 0.86, 'starter-tourist-clock-bench-idle'),
+      idleSpot: placeClockTourist(99, -1, 1.18, 'starter-tourist-clock-bench-idle'),
+    },
+    {
+      id: 'starter-tourist-clock-child',
+      role: 'tourist',
+      behavior: 'tourist_pause',
+      pose: 'group_gather',
+      silhouetteScale: 0.82,
+      companionGroup: 'clock-family-b',
+      voiceCue: 'tourist-cluster',
+      dialogId: 'pedestrian_clock_hint',
+      interactRadius: 2,
+      idleSpot: placeClockTourist(112, -1, 1.34, 'starter-tourist-clock-child-idle'),
+      patrol: [
+        placeClockTourist(109, -1, 1.28, 'starter-tourist-clock-child-a'),
+        placeClockTourist(115, -1, 1.42, 'starter-tourist-clock-child-b'),
+      ],
     },
   ];
 }
@@ -820,8 +881,18 @@ function makeStarterWorld(outputPath) {
   };
 
   const props = buildStarterProps(routePoints, sidewalkOuter, 9);
-  const landmarks = buildStarterLandmarks(routePoints, sidewalkOuter);
+  const landmarkBundle = buildStarterLandmarks(routePoints, sidewalkOuter);
+  const landmarks = landmarkBundle.landmarks;
+  const heroLandmarks = landmarkBundle.heroLandmarks;
   const npcs = buildStarterNpcs(routePoints, streetWidth, sidewalkOuter);
+  const steamClockNode = landmarks.find((landmark) => landmark.id === 'steam-clock');
+
+  centerline[Math.max(1, Math.min(centerline.length - 2, Math.round(beatCount * 0.6)))] = {
+    id: 'steam-clock',
+    label: 'Steam Clock reveal',
+    x: steamClockNode.x,
+    z: Number((steamClockNode.z + 1.6).toFixed(2)),
+  };
 
   const world = {
     routeId: 'gastown_water_street_starter_corridor',
@@ -849,6 +920,7 @@ function makeStarterWorld(outputPath) {
     nodes: [
       { ...centerline[0], label: 'Starter start' },
       { ...centerline[Math.floor(centerline.length / 2)], label: 'Starter mid block' },
+      { id: 'steam-clock', label: 'Steam Clock plaza', x: steamClockNode.x, z: steamClockNode.z },
       { ...centerline[centerline.length - 1], label: 'Starter end' },
     ],
     zones: {
@@ -859,6 +931,7 @@ function makeStarterWorld(outputPath) {
       ],
     },
     buildings,
+    hero_landmarks: heroLandmarks,
     landmarks,
     props,
     npcs,

--- a/scripts/refresh-gastown-reference-data.ps1
+++ b/scripts/refresh-gastown-reference-data.ps1
@@ -1,0 +1,107 @@
+param(
+    [string]$RouteAnchorsPath = "data/reference/route-anchors.json",
+    [string]$OutputDir = "data/reference/refresh",
+    [switch]$SkipOverpass
+)
+
+<#
+.SYNOPSIS
+Refreshes lightweight reference inputs for future Gastown world rebuilds.
+
+.DESCRIPTION
+This helper does not replace the deterministic fallback pipeline. It fetches
+open reference data into local JSON/GeoJSON files so the project can evolve
+toward a less fake build when civic datasets are available.
+
+Inputs:
+ - data/reference/route-anchors.json
+
+Outputs:
+ - data/reference/refresh/gastown-route-reference.geojson
+ - data/reference/refresh/gastown-overpass-buildings.json (optional)
+
+Typical use:
+  pwsh ./scripts/refresh-gastown-reference-data.ps1
+  pwsh ./scripts/refresh-gastown-reference-data.ps1 -SkipOverpass
+
+After refreshing these files, review them and then feed the cleaned inputs into
+scripts/generate-gastown-world.js or follow-up build tooling.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $RouteAnchorsPath)) {
+    throw "Missing route anchors file: $RouteAnchorsPath"
+}
+
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+
+$anchors = Get-Content -Raw -Path $RouteAnchorsPath | ConvertFrom-Json
+
+function New-FeatureCollection {
+    param([array]$Features)
+    return @{
+        type = 'FeatureCollection'
+        features = $Features
+    }
+}
+
+$origin = @($anchors.origin.lon, $anchors.origin.lat)
+$dest = @($anchors.dest.lon, $anchors.dest.lat)
+
+$routeReference = New-FeatureCollection @(
+    @{
+        type = 'Feature'
+        properties = @{
+            id = 'gastown-origin'
+            label = 'Waterfront origin anchor'
+        }
+        geometry = @{
+            type = 'Point'
+            coordinates = $origin
+        }
+    },
+    @{
+        type = 'Feature'
+        properties = @{
+            id = 'gastown-destination'
+            label = 'Steam Clock destination anchor'
+        }
+        geometry = @{
+            type = 'Point'
+            coordinates = $dest
+        }
+    },
+    @{
+        type = 'Feature'
+        properties = @{
+            id = 'gastown-reference-line'
+            label = 'Route anchor line for future map cleaning'
+        }
+        geometry = @{
+            type = 'LineString'
+            coordinates = @($origin, $dest)
+        }
+    }
+)
+
+$routeReferencePath = Join-Path $OutputDir 'gastown-route-reference.geojson'
+$routeReference | ConvertTo-Json -Depth 8 | Set-Content -Path $routeReferencePath
+
+if (-not $SkipOverpass) {
+    $minLon = [Math]::Min($anchors.origin.lon, $anchors.dest.lon) - 0.003
+    $minLat = [Math]::Min($anchors.origin.lat, $anchors.dest.lat) - 0.003
+    $maxLon = [Math]::Max($anchors.origin.lon, $anchors.dest.lon) + 0.003
+    $maxLat = [Math]::Max($anchors.origin.lat, $anchors.dest.lat) + 0.003
+    $bbox = "$minLat,$minLon,$maxLat,$maxLon"
+    $query = "[out:json][timeout:25];(way[""building""]($bbox);node(w););out body;"
+    $encoded = [System.Uri]::EscapeDataString($query)
+    $overpassUrl = "https://overpass-api.de/api/interpreter?data=$encoded"
+    $overpassPath = Join-Path $OutputDir 'gastown-overpass-buildings.json'
+    Invoke-WebRequest -Uri $overpassUrl -OutFile $overpassPath
+}
+
+Write-Host "Saved route reference to $routeReferencePath"
+if (-not $SkipOverpass) {
+    Write-Host "Saved optional Overpass building reference into $OutputDir"
+}


### PR DESCRIPTION
### Motivation
- The deterministic fallback world emitted only generic starter landmarks and nodes while the simulator expected a `steam-clock-hero` hero anchor or a `steam-clock` landmark/node, causing the Steam Clock model/audio logic to miss the clock anchor and appear on the wrong side of the route. 
- The Steam Clock felt like a placeholder and the audio was a persistent droney burst rather than a ceremonial chime, and NPCs lacked readable held props and lively poses for tourist/busker scenarios. 
- This change aligns fallback data with simulator expectations so the starter world reads and sounds more convincingly like the Gastown slice while keeping fallback determinism and safe failure modes. 

### Description
- Update the fallback generator to emit a real Steam Clock anchor pair by producing `hero_landmarks: [{ id: "steam-clock-hero", ... }]` plus a `steam-clock` landmark and a `steam-clock` node, and regenerate the committed JSON assets `assets/world/gastown-water-street.json` and `assets/world/gastown-water-street-starter.json`. 
- Move and stage the clock on the intended approach side with a small plaza, upgrade the procedural clock model (heavier iron body, four faces, glass core, ornate crown, steam vents, plaza apron), and attach the model to the new hero anchor. 
- Replace the old burst-style clock identity by removing the obsolete `clockBurst` usage and making the Tone.js chime system the primary clock sound (motif implemented, MetalSynth for bell, cooldown/proximity gating, fail-soft when Tone is unavailable). 
- Improve NPCs and world loader: NPC metadata now supports `heldProp`, `voiceCue`, `companionGroup`, and `silhouetteScale`; busker holds a guitar and performs, photographer holds a camera and does `taking_photo`/`being_photographed` poses, guide paces, tourists gather and include a child silhouette; runtime visuals and gait/arm/leg/head motion were added to read these states. 
- Add a small PowerShell helper `scripts/refresh-gastown-reference-data.ps1` to fetch and write lightweight route reference GeoJSON and optionally an Overpass buildings snapshot for future map-refresh workflows. 
- Files changed: `scripts/generate-gastown-world.js`, `assets/world/gastown-water-street.json`, `assets/world/gastown-water-street-starter.json`, `js/gastown-sim.js`, `js/gastown-world-loader.js`, `__tests__/gastown-world-generator.test.js`, `__tests__/gastown-world-loader-normalize.test.js`, `__tests__/gastown-sim-config.test.js`, and `scripts/refresh-gastown-reference-data.ps1`. 

### Testing
- Ran the world generator with `buildWorld` to regenerate `assets/world/gastown-water-street.json` and `assets/world/gastown-water-street-starter.json`, which produced updated files including `hero_landmarks` and the `steam-clock` node (generation succeeded). 
- Ran the full test suite with `npm test` and all automated tests passed (`41` tests run, `0` failures). 
- Added/updated unit tests ensuring the fallback world includes `hero_landmarks`, a `steam-clock` landmark/node, NPC held props/poses, and loader normalization behavior; these tests passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfcb6b2528832eb43c26bf3243f3c3)