### PR TITLE
Fix Gastown simulator landmark startup crash

### DIFF
--- a/__tests__/gastown-sim-resilience.test.js
+++ b/__tests__/gastown-sim-resilience.test.js
@@ -1,0 +1,50 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const simPath = path.join(__dirname, '..', 'js', 'gastown-sim.js');
+const src = fs.readFileSync(simPath, 'utf8');
+
+test('landmark visual state updates guard optional marker, halo, and reflection materials', () => {
+  assert.match(src, /function applyLandmarkVisualState\(landmarkVisuals, lightingState\) \{/);
+  assert.match(src, /if \(landmarkVisual\.markerMaterial\) \{/);
+  assert.match(src, /landmarkVisual\.markerMaterial\.emissiveIntensity = markerGlow;/);
+  assert.match(src, /if \(landmarkVisual\.haloMaterial\) \{/);
+  assert.match(src, /landmarkVisual\.haloMaterial\.opacity = haloOpacity;/);
+  assert.match(src, /if \(landmarkVisual\.reflectionMaterial\) \{/);
+  assert.match(src, /landmarkVisual\.reflectionMaterial\.opacity = reflectionOpacity;/);
+  assert.match(src, /applyLandmarkVisualState\(visualState\.landmarkVisuals, \{ mood, weather, timeOfDay \}\);/);
+});
+
+test('suppressed landmark markers only push marker visuals when generic markers are actually rendered', () => {
+  const addLandmarksStart = src.indexOf('function addLandmarks(world) {');
+  const addLandmarksEnd = src.indexOf('function addDebugRoute(world) {', addLandmarksStart);
+  const block = src.slice(addLandmarksStart, addLandmarksEnd);
+
+  assert.notEqual(addLandmarksStart, -1, 'expected addLandmarks function');
+  assert.match(block, /if \(state\.debugEnabled \|\| !suppressGenericMarker\) \{/);
+  assert.match(block, /visualState\.landmarkVisuals\.push\(\{ markerMaterial, haloMaterial \}\);/);
+  assert.match(block, /visualState\.landmarkVisuals\.push\(\{ reflectionMaterial \}\);/);
+});
+
+test('audio setup wraps howl creation in a soft-fail guard so missing files do not abort init', () => {
+  assert.match(src, /function setupAudio\(world\) \{/);
+  assert.match(src, /try \{/);
+  assert.match(src, /state\.sounds\.thunder = createSafeHowl\(\{ src: src\('weather\/thunder_roll'\), volume: 0\.22 \}\);/);
+  assert.match(src, /state\.sounds\.beds\[id\] = createSafeHowl\(\{ src: src\('beds\/' \+ id\), loop: true, volume: 0, html5: false \}\);/);
+  assert.match(src, /warnAudioUnavailable\('Gastown audio setup failed; simulator continuing without ambient audio\.', error\);/);
+});
+
+test('init still sequences NPC, minimap, landmark, and audio setup inside one startup try/catch', () => {
+  const initStart = src.indexOf('async function init() {');
+  const initEnd = src.indexOf('init();', initStart);
+  const block = src.slice(initStart, initEnd);
+
+  assert.notEqual(initStart, -1, 'expected init function');
+  assert.match(block, /addNpcs\(state\.world\);/);
+  assert.match(block, /addLandmarks\(state\.world\);/);
+  assert.match(block, /setupAudio\(state\.world\);/);
+  assert.match(block, /minimapState\.worldMetrics = getWorldMetrics\(\);/);
+  assert.match(block, /setStatus\('Unable to start simulator: ' \+ error\.message\);/);
+});

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -175,6 +175,34 @@
     steamClockVisuals: [],
   };
 
+  function applyLandmarkVisualState(landmarkVisuals, lightingState) {
+    if (!Array.isArray(landmarkVisuals) || !lightingState || typeof lightingState !== 'object') {
+      return;
+    }
+
+    const mood = lightingState.mood || {};
+    const weather = lightingState.weather || {};
+    const timeOfDay = lightingState.timeOfDay || {};
+    const markerGlow = (timeOfDay.landmarkGlow || 0.3) * (0.6 + ((mood.lightIntensity || 0) * 0.5));
+    const haloOpacity = 0.08 + ((timeOfDay.landmarkGlow || 0.3) * 0.18);
+    const reflectionOpacity = 0.12 + ((timeOfDay.landmarkGlow || 0.3) * 0.18) + ((weather.rainIntensity || 0) * 0.12);
+
+    landmarkVisuals.forEach((landmarkVisual) => {
+      if (!landmarkVisual || typeof landmarkVisual !== 'object') {
+        return;
+      }
+      if (landmarkVisual.markerMaterial) {
+        landmarkVisual.markerMaterial.emissiveIntensity = markerGlow;
+      }
+      if (landmarkVisual.haloMaterial) {
+        landmarkVisual.haloMaterial.opacity = haloOpacity;
+      }
+      if (landmarkVisual.reflectionMaterial) {
+        landmarkVisual.reflectionMaterial.opacity = reflectionOpacity;
+      }
+    });
+  }
+
   const LOOK_PITCH_LIMIT = Math.PI / 2.25;
   const WHEEL_PITCH_SENSITIVITY = 0.00085;
   const KEYBOARD_PITCH_STEP = 0.045;
@@ -2531,16 +2559,23 @@
     const base = (config.audioBaseUrl || '').replace(/\/$/, '');
     const src = (name) => [base + '/' + name + '.mp3', base + '/' + name + '.ogg'];
 
-    ['quiet_night', 'eerie_drones', 'nightlife_hum', 'commuter_mix'].forEach((id) => {
-      state.sounds.beds[id] = createSafeHowl({ src: src('beds/' + id), loop: true, volume: 0, html5: false });
-    });
+    try {
+      ['quiet_night', 'eerie_drones', 'nightlife_hum', 'commuter_mix'].forEach((id) => {
+        state.sounds.beds[id] = createSafeHowl({ src: src('beds/' + id), loop: true, volume: 0, html5: false });
+      });
 
-    state.sounds.rainLoop = createSafeHowl({ src: src('weather/rain_pavement'), loop: true, volume: 0 });
-    state.sounds.thunder = createSafeHowl({ src: src('weather/thunder_roll'), volume: 0.22 });
+      state.sounds.rainLoop = createSafeHowl({ src: src('weather/rain_pavement'), loop: true, volume: 0 });
+      state.sounds.thunder = createSafeHowl({ src: src('weather/thunder_roll'), volume: 0.22 });
 
-    (world.audioZones || []).forEach((zone) => {
-      state.sounds.zoneBeds[zone.id] = createSafeHowl({ src: src('zones/' + zone.bed), loop: true, volume: 0 });
-    });
+      (world.audioZones || []).forEach((zone) => {
+        if (!zone || !zone.id || !zone.bed) {
+          return;
+        }
+        state.sounds.zoneBeds[zone.id] = createSafeHowl({ src: src('zones/' + zone.bed), loop: true, volume: 0 });
+      });
+    } catch (error) {
+      warnAudioUnavailable('Gastown audio setup failed; simulator continuing without ambient audio.', error);
+    }
   }
 
   function applyVisualState() {
@@ -2593,11 +2628,7 @@
       visualState.laneMaterial.opacity = Math.min(0.14, 0.035 + ((timeOfDay.pathBrightness || 0.2) * 0.12));
     }
 
-    visualState.landmarkVisuals.forEach((landmarkVisual) => {
-      landmarkVisual.markerMaterial.emissiveIntensity = (timeOfDay.landmarkGlow || 0.3) * (0.6 + (mood.lightIntensity * 0.5));
-      landmarkVisual.haloMaterial.opacity = 0.08 + ((timeOfDay.landmarkGlow || 0.3) * 0.18);
-      landmarkVisual.reflectionMaterial.opacity = 0.12 + ((timeOfDay.landmarkGlow || 0.3) * 0.18) + ((weather.rainIntensity || 0) * 0.12);
-    });
+    applyLandmarkVisualState(visualState.landmarkVisuals, { mood, weather, timeOfDay });
 
     rebuildClouds(weather, timeOfDay);
     rebuildRain((weather.rainIntensity || 0) * (timeOfDay.rainVisibility || 1));


### PR DESCRIPTION
### Motivation
- Fix the startup crash `Cannot set properties of undefined (setting 'emissiveIntensity')` caused by mixed-shaped entries in `visualState.landmarkVisuals` where the styling pass assumed every entry had `markerMaterial`, `haloMaterial`, and `reflectionMaterial`.
- Ensure missing audio assets remain soft-fail so absent ambient files do not abort simulator init and preserve existing hero-landmark suppression behavior.

### Description
- Add `applyLandmarkVisualState(landmarkVisuals, lightingState)` which guards each optional material (`markerMaterial`, `haloMaterial`, `reflectionMaterial`) before mutating it and centralizes landmark visual updates called from `applyVisualState()`.
- Replace the unguarded `visualState.landmarkVisuals.forEach(...)` with a call to `applyLandmarkVisualState(...)` in `js/gastown-sim.js` so mixed marker-only / reflection-only entries no longer crash.
- Harden `setupAudio()` in `js/gastown-sim.js` by wrapping howl creation in a `try/catch` and skipping malformed `audioZones` entries so missing or failing audio assets only emit warnings via the existing `createSafeHowl()`/`warnAudioUnavailable()` paths.
- Add regression tests in `__tests__/gastown-sim-resilience.test.js` asserting guarded landmark updates, preserved suppression behavior (hero Steam Clock still suppresses generic marker/halo rendering), soft-fail audio setup, and that init sequencing remains inside the startup `try/catch`.

### Testing
- Ran the targeted test command `node --test ./__tests__/gastown-sim-resilience.test.js ./__tests__/gastown-sim-ground.test.js ./__tests__/gastown-dialog.test.js` and all tests passed.
- Ran the full suite with `npm test` and the suite completed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c05f6fc304832e8e1fc73440bb51f7)