### PR TITLE
Suppress landmark reflection artifacts; record CoV open-data inputs and regenerate fallback world

### DIFF
--- a/__tests__/gastown-sim-ground.test.js
+++ b/__tests__/gastown-sim-ground.test.js
@@ -47,3 +47,11 @@ test('production landmark rendering suppresses generic cylinder and halo markers
   assert.match(src, /landmark\.id === 'steam-clock'/);
   assert.match(src, /landmark\.id === 'water-cambie-intersection'/);
 });
+
+test('production landmark rendering also suppresses reflection discs for suppressed hero/intersection markers', () => {
+  const simPath = path.join(__dirname, '..', 'js', 'gastown-sim.js');
+  const src = fs.readFileSync(simPath, 'utf8');
+
+  assert.match(src, /if \(state\.debugEnabled \|\| !suppressGenericMarker\) \{\s*const reflectionMaterial = new THREE\.MeshStandardMaterial/s);
+  assert.equal(src.includes('visualState.landmarkVisuals.push({ reflectionMaterial });\n      }'), true);
+});

--- a/__tests__/gastown-world-generator.test.js
+++ b/__tests__/gastown-world-generator.test.js
@@ -176,9 +176,60 @@ test('generator consumes refreshed reference inputs when present', () => {
     'gastown-building-cues.geojson',
     'gastown-poi-reference.geojson',
   ]);
+  assert.deepEqual(data.meta.openDataInputs, {
+    publicStreets: false,
+    streetIntersections: false,
+    rightOfWayWidths: false,
+    streetLightingPoles: false,
+    buildingFootprints2015: false,
+    orthophotoImagery2015: false,
+  });
 
   fs.rmSync(refreshDir, { recursive: true, force: true });
   fs.rmSync(tmpPath, { force: true });
+});
+
+
+test('generator records direct open-data inputs when present', () => {
+  const root = path.resolve(__dirname, '..');
+  const covDir = path.join(root, 'data', 'cov');
+  fs.mkdirSync(covDir, { recursive: true });
+
+  const files = {
+    'public-streets.geojson': { type: 'FeatureCollection', features: [{ type: 'Feature', properties: { id: 'street', hblock: '100 W CORDOVA ST', streetuse: 'Arterial' }, geometry: { type: 'LineString', coordinates: [[-123.1117, 49.2858], [-123.1095, 49.2848]] } }] },
+    'street-intersections.geojson': { type: 'FeatureCollection', features: [{ type: 'Feature', properties: { id: 'intersection' }, geometry: { type: 'Point', coordinates: [-123.1091, 49.2846] } }] },
+    'right-of-way-widths.geojson': { type: 'FeatureCollection', features: [{ type: 'Feature', properties: { id: 'row', right_of_way_width: 18.4 }, geometry: { type: 'Point', coordinates: [-123.1091, 49.2846] } }] },
+    'street-lighting-poles.geojson': { type: 'FeatureCollection', features: [{ type: 'Feature', properties: { id: 'lamp' }, geometry: { type: 'Point', coordinates: [-123.1094, 49.2847] } }] },
+    'building-footprints-2015.geojson': { type: 'FeatureCollection', features: [{ type: 'Feature', properties: { id: 'building' }, geometry: { type: 'Polygon', coordinates: [[[-123.1108, 49.2852], [-123.1105, 49.2852], [-123.1105, 49.2850], [-123.1108, 49.2850], [-123.1108, 49.2852]]] } }] },
+    'orthophoto-imagery-2015.geojson': { type: 'FeatureCollection', features: [{ type: 'Feature', properties: { id: 'ortho-tile' }, geometry: { type: 'Polygon', coordinates: [[[-123.1109, 49.2853], [-123.1103, 49.2853], [-123.1103, 49.2849], [-123.1109, 49.2849], [-123.1109, 49.2853]]] } }] },
+  };
+
+  try {
+    Object.entries(files).forEach(([name, data]) => {
+      fs.writeFileSync(path.join(covDir, name), JSON.stringify(data), 'utf8');
+    });
+
+    const tmpPath = path.join(root, 'assets', 'world', 'gastown-water-street.opendata-test.json');
+    const result = buildWorld({ root, outputPath: tmpPath });
+    const sourcePath = result.generated ? result.outputPath : path.join(root, 'assets', 'world', 'gastown-water-street.json');
+    const data = JSON.parse(fs.readFileSync(sourcePath, 'utf8'));
+
+    ['public-streets.geojson', 'street-intersections.geojson', 'right-of-way-widths.geojson', 'street-lighting-poles.geojson', 'building-footprints-2015.geojson', 'orthophoto-imagery-2015.geojson'].forEach((name) => {
+      assert.equal(data.meta.referenceInputsUsed.includes(name), true, name + ' should be tracked in referenceInputsUsed when present');
+    });
+    assert.deepEqual(data.meta.openDataInputs, {
+      publicStreets: true,
+      streetIntersections: true,
+      rightOfWayWidths: true,
+      streetLightingPoles: true,
+      buildingFootprints2015: true,
+      orthophotoImagery2015: true,
+    });
+
+    fs.rmSync(tmpPath, { force: true });
+  } finally {
+    Object.keys(files).forEach((name) => fs.rmSync(path.join(covDir, name), { force: true }));
+  }
 });
 
 test('refresh helper documents expanded expected output files', () => {

--- a/assets/world/gastown-water-street-starter.json
+++ b/assets/world/gastown-water-street-starter.json
@@ -12,7 +12,15 @@
       "No refreshed reference inputs were present; deterministic default route staging was used."
     ],
     "referenceInputsUsed": [],
-    "lastBuild": "2026-03-22T21:18:50.464Z"
+    "openDataInputs": {
+      "publicStreets": false,
+      "streetIntersections": false,
+      "rightOfWayWidths": false,
+      "streetLightingPoles": false,
+      "buildingFootprints2015": false,
+      "orthophotoImagery2015": false
+    },
+    "lastBuild": "2026-03-22T22:16:42.851Z"
   },
   "route": {
     "name": "Waterfront Station → Water Street → Steam Clock working corridor",

--- a/assets/world/gastown-water-street.json
+++ b/assets/world/gastown-water-street.json
@@ -12,7 +12,15 @@
       "No refreshed reference inputs were present; deterministic default route staging was used."
     ],
     "referenceInputsUsed": [],
-    "lastBuild": "2026-03-22T21:18:50.464Z"
+    "openDataInputs": {
+      "publicStreets": false,
+      "streetIntersections": false,
+      "rightOfWayWidths": false,
+      "streetLightingPoles": false,
+      "buildingFootprints2015": false,
+      "orthophotoImagery2015": false
+    },
+    "lastBuild": "2026-03-22T22:16:42.851Z"
   },
   "route": {
     "name": "Waterfront Station → Water Street → Steam Clock working corridor",

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -1836,13 +1836,15 @@
         visualState.landmarkVisuals.push({ markerMaterial, haloMaterial });
       }
 
-      const reflectionMaterial = new THREE.MeshStandardMaterial({ color: col, emissive: 0x1b2533, emissiveIntensity: 0.45, transparent: true, opacity: 0.22, roughness: 0.55, metalness: 0.3 });
-      const reflection = new THREE.Mesh(new THREE.CircleGeometry(landmark.radius || 2.7, 24), reflectionMaterial);
-      reflection.rotation.x = -Math.PI / 2;
-      reflection.position.set(landmark.x, 0.11, landmark.z);
-      worldGroup.add(reflection);
+      if (state.debugEnabled || !suppressGenericMarker) {
+        const reflectionMaterial = new THREE.MeshStandardMaterial({ color: col, emissive: 0x1b2533, emissiveIntensity: 0.45, transparent: true, opacity: 0.22, roughness: 0.55, metalness: 0.3 });
+        const reflection = new THREE.Mesh(new THREE.CircleGeometry(landmark.radius || 2.7, 24), reflectionMaterial);
+        reflection.rotation.x = -Math.PI / 2;
+        reflection.position.set(landmark.x, 0.11, landmark.z);
+        worldGroup.add(reflection);
 
-      visualState.landmarkVisuals.push({ reflectionMaterial });
+        visualState.landmarkVisuals.push({ reflectionMaterial });
+      }
     });
   }
 

--- a/scripts/generate-gastown-world.js
+++ b/scripts/generate-gastown-world.js
@@ -20,6 +20,13 @@ function tryReadGeoJsonFeatures(filePath) {
   return json.features;
 }
 
+function firstExistingPath(paths) {
+  for (const filePath of paths) {
+    if (filePath && fs.existsSync(filePath)) return filePath;
+  }
+  return paths[0] || null;
+}
+
 function getFeatureCollectionById(collection, id) {
   const features = collection && Array.isArray(collection.features) ? collection.features : [];
   return features.find((feature) => getProps(feature).id === id) || null;
@@ -778,12 +785,19 @@ function buildStarterNpcs(layout, streetWidth, sidewalkOuter) {
 
 function buildStarterReferenceBundle(root) {
   const refreshDir = path.join(root, 'data', 'reference', 'refresh');
+  const covDir = path.join(root, 'data', 'cov');
   return {
     routeReference: tryReadJson(path.join(refreshDir, 'gastown-route-reference.geojson')),
     streetContext: tryReadJson(path.join(refreshDir, 'gastown-street-context.geojson')),
     landmarkReference: tryReadJson(path.join(refreshDir, 'gastown-landmark-reference.geojson')),
     buildingCues: tryReadJson(path.join(refreshDir, 'gastown-building-cues.geojson')),
     poiReference: tryReadJson(path.join(refreshDir, 'gastown-poi-reference.geojson')),
+    publicStreets: tryReadJson(path.join(covDir, 'public-streets.geojson')),
+    streetIntersections: tryReadJson(path.join(covDir, 'street-intersections.geojson')),
+    rightOfWayWidths: tryReadJson(path.join(covDir, 'right-of-way-widths.geojson')),
+    streetLightingPoles: tryReadJson(path.join(covDir, 'street-lighting-poles.geojson')),
+    buildingFootprints2015: tryReadJson(firstExistingPath([path.join(covDir, 'building-footprints-2015.geojson'), path.join(covDir, 'building-footprints.geojson')])),
+    orthophotoImagery2015: tryReadJson(path.join(covDir, 'orthophoto-imagery-2015.geojson')),
   };
 }
 
@@ -1036,6 +1050,12 @@ function makeStarterWorld(outputPath, options = {}) {
     ...(reference.landmarkReference && Array.isArray(reference.landmarkReference.features) ? ['gastown-landmark-reference.geojson'] : []),
     ...(reference.buildingCues && Array.isArray(reference.buildingCues.features) ? ['gastown-building-cues.geojson'] : []),
     ...(reference.poiReference && Array.isArray(reference.poiReference.features) ? ['gastown-poi-reference.geojson'] : []),
+    ...(reference.publicStreets && Array.isArray(reference.publicStreets.features) ? ['public-streets.geojson'] : []),
+    ...(reference.streetIntersections && Array.isArray(reference.streetIntersections.features) ? ['street-intersections.geojson'] : []),
+    ...(reference.rightOfWayWidths && Array.isArray(reference.rightOfWayWidths.features) ? ['right-of-way-widths.geojson'] : []),
+    ...(reference.streetLightingPoles && Array.isArray(reference.streetLightingPoles.features) ? ['street-lighting-poles.geojson'] : []),
+    ...(reference.buildingFootprints2015 && Array.isArray(reference.buildingFootprints2015.features) ? ['building-footprints-2015.geojson'] : []),
+    ...(reference.orthophotoImagery2015 && Array.isArray(reference.orthophotoImagery2015.features) ? ['orthophoto-imagery-2015.geojson'] : []),
   ];
 
   const lampFeatures = getFeatureCollectionByKind(reference.poiReference, 'heritage_lamp');
@@ -1056,6 +1076,14 @@ function makeStarterWorld(outputPath, options = {}) {
         referenceFeaturesUsed.length ? `Optional refreshed reference inputs were present: ${referenceFeaturesUsed.join(', ')}.` : 'No refreshed reference inputs were present; deterministic default route staging was used.',
       ],
       referenceInputsUsed: referenceFeaturesUsed,
+      openDataInputs: {
+        publicStreets: !!(reference.publicStreets && Array.isArray(reference.publicStreets.features) && reference.publicStreets.features.length),
+        streetIntersections: !!(reference.streetIntersections && Array.isArray(reference.streetIntersections.features) && reference.streetIntersections.features.length),
+        rightOfWayWidths: !!(reference.rightOfWayWidths && Array.isArray(reference.rightOfWayWidths.features) && reference.rightOfWayWidths.features.length),
+        streetLightingPoles: !!(reference.streetLightingPoles && Array.isArray(reference.streetLightingPoles.features) && reference.streetLightingPoles.features.length),
+        buildingFootprints2015: !!(reference.buildingFootprints2015 && Array.isArray(reference.buildingFootprints2015.features) && reference.buildingFootprints2015.features.length),
+        orthophotoImagery2015: !!(reference.orthophotoImagery2015 && Array.isArray(reference.orthophotoImagery2015.features) && reference.orthophotoImagery2015.features.length),
+      },
       lastBuild: new Date().toISOString(),
     },
     route: { name: 'Waterfront Station → Water Street → Steam Clock working corridor', centerline, walkBounds, streetWidth, sidewalkWidth, softBoundary, hardResetDistance: 12 },
@@ -1152,7 +1180,7 @@ function buildWorld(options = {}) {
   const outputPath = options.outputPath || path.join(root, 'assets', 'world', 'gastown-water-street.json');
   const routeAnchorsPath = path.join(root, 'data', 'reference', 'route-anchors.json');
   const streetsPath = path.join(root, 'data', 'cov', 'public-streets.geojson');
-  const buildingsPath = path.join(root, 'data', 'cov', 'building-footprints.geojson');
+  const buildingsPath = firstExistingPath([path.join(root, 'data', 'cov', 'building-footprints-2015.geojson'), path.join(root, 'data', 'cov', 'building-footprints.geojson')]);
   const polesPath = path.join(root, 'data', 'cov', 'street-lighting-poles.geojson');
   const treesPath = path.join(root, 'data', 'cov', 'public-trees.geojson');
   const heritagePath = path.join(root, 'data', 'cov', 'heritage-sites.geojson');
@@ -1398,7 +1426,7 @@ function buildWorld(options = {}) {
         inputs: {
           cityOfVancouver: {
             streetCenterlines: 'data/cov/public-streets.geojson',
-            buildingFootprints: 'data/cov/building-footprints.geojson',
+            buildingFootprints: 'data/cov/building-footprints-2015.geojson (or legacy data/cov/building-footprints.geojson)',
             lightingPolesOptional: 'data/cov/street-lighting-poles.geojson',
             publicTreesOptional: 'data/cov/public-trees.geojson',
             heritageSitesOptional: 'data/cov/heritage-sites.geojson',
@@ -1412,6 +1440,22 @@ function buildWorld(options = {}) {
         buildings: 'renderer-compatible derived geometry from footprint centroids/extents/headings (footprints preserved)',
         streetscapeTrees: treeSource,
         streetscapeLamps: lampSource,
+      },
+      referenceInputsUsed: [
+        'public-streets.geojson',
+        ...(fs.existsSync(path.join(root, 'data', 'cov', 'street-intersections.geojson')) ? ['street-intersections.geojson'] : []),
+        ...(fs.existsSync(path.join(root, 'data', 'cov', 'right-of-way-widths.geojson')) ? ['right-of-way-widths.geojson'] : []),
+        ...(poles ? ['street-lighting-poles.geojson'] : []),
+        ...((buildingsPath || '').includes('building-footprints-2015.geojson') ? ['building-footprints-2015.geojson'] : ['building-footprints.geojson']),
+        ...(fs.existsSync(path.join(root, 'data', 'cov', 'orthophoto-imagery-2015.geojson')) ? ['orthophoto-imagery-2015.geojson'] : []),
+      ],
+      openDataInputs: {
+        publicStreets: true,
+        streetIntersections: fs.existsSync(path.join(root, 'data', 'cov', 'street-intersections.geojson')),
+        rightOfWayWidths: fs.existsSync(path.join(root, 'data', 'cov', 'right-of-way-widths.geojson')),
+        streetLightingPoles: !!(poles && Array.isArray(poles.features) && poles.features.length),
+        buildingFootprints2015: (buildingsPath || '').includes('building-footprints-2015.geojson'),
+        orthophotoImagery2015: fs.existsSync(path.join(root, 'data', 'cov', 'orthophoto-imagery-2015.geojson')),
       },
     },
     route: {


### PR DESCRIPTION
### Motivation
- Remove lingering translucent/gray "ghost" artifacts around hero/intersection landmarks in normal play by preventing generic reflection discs from being rendered unless debug mode is enabled. 
- Make the fallback world generator explicitly recognize and record City of Vancouver open-data inputs (including `building-footprints-2015` and optional `orthophoto-imagery-2015`) so runtime assets reflect which inputs were consumed. 
- Keep the deterministic starter fallback behavior while improving metadata and test coverage so the Water/Cambie corner, Steam Clock plaza, and minimap are better supported and auditable.

### Description
- Suppress production-only landmark reflections by wrapping the reflection mesh/material creation in the same `debugEnabled || !suppressGenericMarker` guard in `js/gastown-sim.js`. 
- Add a `firstExistingPath` helper and extend `scripts/generate-gastown-world.js` to read direct CoV open-data files (`public-streets`, `street-intersections`, `right-of-way-widths`, `street-lighting-poles`, `building-footprints-2015` with legacy alias fallback, and `orthophoto-imagery-2015`) and to expose `openDataInputs` and richer `referenceInputsUsed` metadata in both starter and civic builds. 
- Regenerated the committed fallback assets `assets/world/gastown-water-street.json` and `assets/world/gastown-water-street-starter.json` so the world JSON now contains `openDataInputs` and accurate `referenceInputsUsed` information. 
- Add/adjust tests: `__tests__/gastown-sim-ground.test.js` now asserts reflection-disc suppression, and `__tests__/gastown-world-generator.test.js` now verifies `openDataInputs` defaults and direct open-data-file tracking when files are present.

### Testing
- Ran targeted generator and sim ground tests with `node --test __tests__/gastown-world-generator.test.js __tests__/gastown-sim-ground.test.js` and the suites completed successfully. 
- Rebuilt the deterministic fallback with `node scripts/build-gastown-world.js` and copied the output to the starter JSON, which completed and produced updated committed JSON files. 
- Ran the full test suite with `npm test` and all automated tests passed (`54` tests in final run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c064a348e4832e83d2f03cdca00ba9)