### PR TITLE
Refactor Gastown sim camera/ player height handling

### DIFF
--- a/js/gastown-sim-classic.js
+++ b/js/gastown-sim-classic.js
@@ -81,9 +81,11 @@ console.log('[Gastown Sim] classic runtime build 2026-03-15 recovery 2');
     boundaryNoticeTimer: null,
   };
 
+  const DEFAULT_EYE_HEIGHT = 1.7;
+
   const scene = new THREE.Scene();
   const camera = new THREE.PerspectiveCamera(68, 1, 0.08, 700);
-  camera.position.set(0, 1.7, 0);
+  camera.position.set(0, DEFAULT_EYE_HEIGHT, 0);
   const renderer = new THREE.WebGLRenderer({ antialias: true });
   renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
   canvasWrap.appendChild(renderer.domElement);
@@ -802,7 +804,7 @@ console.log('[Gastown Sim] classic runtime build 2026-03-15 recovery 2');
 
     if (world.spawn) {
       const spawnMarker = new THREE.Mesh(new THREE.ConeGeometry(0.35, 1.2, 12), new THREE.MeshBasicMaterial({ color: 0xffdb6b }));
-      spawnMarker.position.set(world.spawn.x, 0.95, world.spawn.z);
+      spawnMarker.position.set(world.spawn.x, (typeof world.spawn.y === 'number' ? world.spawn.y : 0) + 0.95, world.spawn.z);
       spawnMarker.rotation.x = Math.PI;
       debugGroup.add(spawnMarker);
     }
@@ -922,6 +924,14 @@ console.log('[Gastown Sim] classic runtime build 2026-03-15 recovery 2');
     return best;
   }
 
+  function getGroundY() {
+    return (state.world && state.world.bounds && typeof state.world.bounds.floorY === 'number') ? state.world.bounds.floorY : 0;
+  }
+
+  function getWorldSpawn() {
+    return state.world && state.world.spawn ? state.world.spawn : { x: -23, y: getGroundY(), z: 20, yaw: -0.25 };
+  }
+
   function enforceWorldBounds() {
     const walkBounds = state.world.route.walkBounds;
     const point = { x: player.position.x, z: player.position.z };
@@ -935,7 +945,8 @@ console.log('[Gastown Sim] classic runtime build 2026-03-15 recovery 2');
     player.position.z = clamped.z;
 
     if (clamped.distance > state.world.route.hardResetDistance) {
-      player.position.copy(state.lastSafePosition.lengthSq() ? state.lastSafePosition : new THREE.Vector3(state.world.spawn.x, state.world.spawn.y, state.world.spawn.z));
+      const fallbackSpawn = getWorldSpawn();
+      player.position.copy(state.lastSafePosition.lengthSq() ? state.lastSafePosition : new THREE.Vector3(fallbackSpawn.x, fallbackSpawn.y, fallbackSpawn.z));
       flashBoundaryStatus((state.world.bounds && state.world.bounds.resetMessage) || 'Returned to the route.');
       return;
     }
@@ -993,7 +1004,7 @@ console.log('[Gastown Sim] classic runtime build 2026-03-15 recovery 2');
   }
 
   function resolveSafeSpawn() {
-    const worldSpawn = state.world.spawn || { x: -23, y: 1.7, z: 20, yaw: -0.25 };
+    const worldSpawn = getWorldSpawn();
     const fallbackCandidates = [
       { x: worldSpawn.x, z: worldSpawn.z },
       { x: worldSpawn.x + 1.2, z: worldSpawn.z + 1.2 },
@@ -1004,11 +1015,11 @@ console.log('[Gastown Sim] classic runtime build 2026-03-15 recovery 2');
 
     const safePoint = fallbackCandidates.find((candidate) => isSpawnSafe(candidate));
     if (safePoint) {
-      return { x: safePoint.x, y: worldSpawn.y || 1.7, z: safePoint.z, yaw: worldSpawn.yaw || -0.25 };
+      return { x: safePoint.x, y: Number.isFinite(worldSpawn.y) ? worldSpawn.y : getGroundY(), z: safePoint.z, yaw: worldSpawn.yaw || -0.25 };
     }
 
     const routeStart = state.world.route.centerline[0] || { x: -22, z: 18 };
-    return { x: routeStart.x, y: worldSpawn.y || 1.7, z: routeStart.z + 3.6, yaw: -0.3 };
+    return { x: routeStart.x, y: Number.isFinite(worldSpawn.y) ? worldSpawn.y : getGroundY(), z: routeStart.z + 3.6, yaw: -0.3 };
   }
 
 
@@ -1462,7 +1473,7 @@ console.log('[Gastown Sim] classic runtime build 2026-03-15 recovery 2');
 
     player.position.x += state.velocity.x * delta;
     player.position.z += state.velocity.z * delta;
-    player.position.y = Math.max((state.world.bounds && state.world.bounds.floorY) || 0, 1.7);
+    player.position.y = getGroundY();
 
     enforceWorldBounds();
     updateNearestNode();

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -122,9 +122,11 @@
     audioWarningIssued: false,
   };
 
+  const DEFAULT_EYE_HEIGHT = 1.7;
+
   const scene = new THREE.Scene();
   const camera = new THREE.PerspectiveCamera(68, 1, 0.08, 700);
-  camera.position.set(0, 1.7, 0);
+  camera.position.set(0, DEFAULT_EYE_HEIGHT, 0);
   const renderer = new THREE.WebGLRenderer({ antialias: true });
   renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
   canvasWrap.appendChild(renderer.domElement);
@@ -1914,7 +1916,7 @@
 
     if (world.spawn) {
       const spawnMarker = new THREE.Mesh(new THREE.ConeGeometry(0.35, 1.2, 12), new THREE.MeshBasicMaterial({ color: 0xffdb6b }));
-      spawnMarker.position.set(world.spawn.x, 0.95, world.spawn.z);
+      spawnMarker.position.set(world.spawn.x, (typeof world.spawn.y === 'number' ? world.spawn.y : 0) + 0.95, world.spawn.z);
       spawnMarker.rotation.x = Math.PI;
       debugGroup.add(spawnMarker);
     }
@@ -2151,6 +2153,14 @@
     return best;
   }
 
+  function getGroundY() {
+    return (state.world && state.world.bounds && typeof state.world.bounds.floorY === 'number') ? state.world.bounds.floorY : 0;
+  }
+
+  function getWorldSpawn() {
+    return state.world && state.world.spawn ? state.world.spawn : { x: -23, y: getGroundY(), z: 20, yaw: -0.25 };
+  }
+
   function enforceWorldBounds() {
     const walkBounds = state.world.route.walkBounds;
     const point = { x: player.position.x, z: player.position.z };
@@ -2164,7 +2174,8 @@
     player.position.z = clamped.z;
 
     if (clamped.distance > state.world.route.hardResetDistance) {
-      player.position.copy(state.lastSafePosition.lengthSq() ? state.lastSafePosition : new THREE.Vector3(state.world.spawn.x, state.world.spawn.y, state.world.spawn.z));
+      const fallbackSpawn = getWorldSpawn();
+      player.position.copy(state.lastSafePosition.lengthSq() ? state.lastSafePosition : new THREE.Vector3(fallbackSpawn.x, fallbackSpawn.y, fallbackSpawn.z));
       flashBoundaryStatus((state.world.bounds && state.world.bounds.resetMessage) || 'Returned to the route.');
       return;
     }
@@ -2222,7 +2233,7 @@
   }
 
   function resolveSafeSpawn() {
-    const worldSpawn = state.world.spawn || { x: -23, y: 1.7, z: 20, yaw: -0.25 };
+    const worldSpawn = getWorldSpawn();
     const fallbackCandidates = [
       { x: worldSpawn.x, z: worldSpawn.z },
       { x: worldSpawn.x + 1.2, z: worldSpawn.z + 1.2 },
@@ -2233,11 +2244,11 @@
 
     const safePoint = fallbackCandidates.find((candidate) => isSpawnSafe(candidate));
     if (safePoint) {
-      return { x: safePoint.x, y: worldSpawn.y || 1.7, z: safePoint.z, yaw: worldSpawn.yaw || -0.25 };
+      return { x: safePoint.x, y: Number.isFinite(worldSpawn.y) ? worldSpawn.y : getGroundY(), z: safePoint.z, yaw: worldSpawn.yaw || -0.25 };
     }
 
     const routeStart = state.world.route.centerline[0] || { x: -22, z: 18 };
-    return { x: routeStart.x, y: worldSpawn.y || 1.7, z: routeStart.z + 3.6, yaw: -0.3 };
+    return { x: routeStart.x, y: Number.isFinite(worldSpawn.y) ? worldSpawn.y : getGroundY(), z: routeStart.z + 3.6, yaw: -0.3 };
   }
 
 
@@ -2708,7 +2719,7 @@
 
     player.position.x += state.velocity.x * delta;
     player.position.z += state.velocity.z * delta;
-    player.position.y = Math.max((state.world.bounds && state.world.bounds.floorY) || 0, 1.7);
+    player.position.y = getGroundY();
 
     enforceWorldBounds();
     updateNearestNode();


### PR DESCRIPTION
### Motivation
- The first-person camera height was effectively applied twice (on `player.position.y` and `camera.position.y`), making the view sit too high above the street.
- Make player objects track the world ground plane and move the single source of eye height onto the camera so head-level aligns with NPCs and scene props.

### Description
- Added `DEFAULT_EYE_HEIGHT = 1.7` and set `camera.position` to use that value in both `js/gastown-sim.js` and `js/gastown-sim-classic.js` so eye height lives on the camera rig.
- Introduced `getGroundY()` and `getWorldSpawn()` helpers and changed movement/reset logic so `player.position.y` follows `world.bounds.floorY` (default `0`) while `world.spawn.y` is treated as ground elevation.
- Updated spawn resolution, fallback spawn usage, and debug `spawnMarker` placement to use ground Y rather than assuming an eye height of `1.7`.
- Replaced hardcoded `1.7` usages for player vertical positioning with calls to `getGroundY()` and adjusted safe-spawn returns to use `Number.isFinite(worldSpawn.y) ? worldSpawn.y : getGroundY()`.

### Testing
- Ran `node --check js/gastown-sim.js` and the file passed syntax checks.
- Ran `node --check js/gastown-sim-classic.js` and the file passed syntax checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c07bc77ae8832ea8916438beb380c4)