### PR TITLE
Add heading-up minimap mode with UI toggle and persistence

### DIFF
--- a/assets/css/gastown-sim.css
+++ b/assets/css/gastown-sim.css
@@ -172,22 +172,36 @@
 .gastown-minimap-toolbar {
   display: flex;
   justify-content: flex-end;
+  align-items: center;
   gap: 0.35rem;
 }
 
+.gastown-minimap-mode,
 .gastown-minimap-zoom {
-  width: 1.7rem;
   height: 1.7rem;
+  font-size: 0.72rem;
+  font-weight: 700;
   border-radius: 6px;
   border: 1px solid rgba(174, 207, 239, 0.5);
   background: rgba(18, 28, 41, 0.95);
   color: #e8f3ff;
-  font-size: 1rem;
-  font-weight: 700;
   line-height: 1;
   cursor: pointer;
 }
 
+.gastown-minimap-mode {
+  min-width: 5.6rem;
+  padding: 0 0.55rem;
+}
+
+.gastown-minimap-zoom {
+  width: 1.7rem;
+  padding: 0;
+  font-size: 1rem;
+}
+
+.gastown-minimap-mode:hover,
+.gastown-minimap-mode:focus-visible,
 .gastown-minimap-zoom:hover,
 .gastown-minimap-zoom:focus-visible {
   background: rgba(36, 53, 74, 0.95);

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -50,6 +50,7 @@
   const routeSegmentEl = app.querySelector('[data-sim-route-segment]');
   const minimapZoomInBtn = app.querySelector('[data-action="minimap-zoom-in"]');
   const minimapZoomOutBtn = app.querySelector('[data-action="minimap-zoom-out"]');
+  const minimapModeBtn = app.querySelector('[data-action="minimap-mode-toggle"]');
   const osmAttributionEl = app.querySelector('[data-gastown-osm-attribution]');
   const interactPromptEl = app.querySelector('[data-sim-interact-prompt]');
   const dialogModalEl = app.querySelector('[data-dialog-modal]');
@@ -230,6 +231,7 @@
     minZoom: 0.8,
     maxZoom: 3.2,
     zoomStep: 0.2,
+    mode: 'north-up',
   };
 
   function updateSize() {
@@ -2261,6 +2263,41 @@
     }
   }
 
+  function isValidMinimapMode(value) {
+    return value === 'north-up' || value === 'heading-up';
+  }
+
+  function updateMinimapModeButton() {
+    if (!minimapModeBtn) {
+      return;
+    }
+    const isHeadingUp = minimapState.mode === 'heading-up';
+    minimapModeBtn.textContent = isHeadingUp ? 'Heading up' : 'North up';
+    minimapModeBtn.setAttribute('aria-pressed', isHeadingUp ? 'true' : 'false');
+    minimapModeBtn.setAttribute(
+      'aria-label',
+      isHeadingUp ? 'Switch minimap to north-up mode' : 'Switch minimap to heading-up mode'
+    );
+    minimapModeBtn.title = isHeadingUp ? 'Switch minimap to north-up mode' : 'Switch minimap to heading-up mode';
+  }
+
+  function setMinimapMode(nextMode) {
+    if (!isValidMinimapMode(nextMode)) {
+      return;
+    }
+    minimapState.mode = nextMode;
+    updateMinimapModeButton();
+    try {
+      window.sessionStorage.setItem('gastownMinimapMode', minimapState.mode);
+    } catch (error) {
+      // ignore session storage failures
+    }
+  }
+
+  function toggleMinimapMode() {
+    setMinimapMode(minimapState.mode === 'heading-up' ? 'north-up' : 'heading-up');
+  }
+
   function restoreMinimapZoom() {
     try {
       const stored = parseFloat(window.sessionStorage.getItem('gastownMinimapZoom') || '');
@@ -2270,6 +2307,18 @@
     } catch (error) {
       // ignore session storage failures
     }
+  }
+
+  function restoreMinimapMode() {
+    try {
+      const stored = window.sessionStorage.getItem('gastownMinimapMode') || '';
+      if (isValidMinimapMode(stored)) {
+        minimapState.mode = stored;
+      }
+    } catch (error) {
+      // ignore session storage failures
+    }
+    updateMinimapModeButton();
   }
 
   function getWorldMetrics() {
@@ -2387,8 +2436,9 @@
     const worldCenterZ = (metrics.minZ + metrics.maxZ) / 2;
     const playerX = player.position.x || worldCenterX;
     const playerZ = player.position.z || worldCenterZ;
-    const centerX = ((playerX - worldCenterX) * 0.8) + worldCenterX;
-    const centerZ = ((playerZ - worldCenterZ) * 0.8) + worldCenterZ;
+    const isHeadingUp = minimapState.mode === 'heading-up';
+    const centerX = isHeadingUp ? playerX : (((playerX - worldCenterX) * 0.8) + worldCenterX);
+    const centerZ = isHeadingUp ? playerZ : (((playerZ - worldCenterZ) * 0.8) + worldCenterZ);
 
     const zoom = minimapState.zoom || 1;
     const viewWidth = metrics.width / zoom;
@@ -2416,6 +2466,45 @@
     };
   }
 
+  function rotateMinimapVector(x, y, angle) {
+    const sin = Math.sin(angle);
+    const cos = Math.cos(angle);
+    return {
+      x: (x * cos) - (y * sin),
+      y: (x * sin) + (y * cos),
+    };
+  }
+
+  function drawMinimapCompass(playerPoint, rotation) {
+    const ctx = minimapState.ctx;
+    ctx.save();
+    ctx.fillStyle = 'rgba(221, 236, 255, 0.82)';
+    ctx.font = '700 11px ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+
+    if (minimapState.mode !== 'heading-up') {
+      ctx.fillText('N', minimapState.width / 2, 9);
+      ctx.fillText('S', minimapState.width / 2, minimapState.height - 9);
+      ctx.fillText('W', 10, minimapState.height / 2);
+      ctx.fillText('E', minimapState.width - 10, minimapState.height / 2);
+      ctx.restore();
+      return;
+    }
+
+    const radius = (Math.min(minimapState.width, minimapState.height) / 2) - 11;
+    [
+      { label: 'N', x: 0, y: -1 },
+      { label: 'E', x: 1, y: 0 },
+      { label: 'S', x: 0, y: 1 },
+      { label: 'W', x: -1, y: 0 },
+    ].forEach((entry) => {
+      const rotated = rotateMinimapVector(entry.x, entry.y, rotation);
+      ctx.fillText(entry.label, playerPoint.x + (rotated.x * radius), playerPoint.y + (rotated.y * radius));
+    });
+    ctx.restore();
+  }
+
   function drawMinimap() {
     if (!minimapState.ctx || !state.world || !minimapState.worldMetrics) {
       return;
@@ -2425,12 +2514,22 @@
     const metrics = minimapState.worldMetrics;
     const view = getMinimapView(metrics);
     const pad = 16;
+    const playerPoint = toMinimapPoint({ x: player.position.x, z: player.position.z }, metrics, pad, view);
+    const heading = getHeadingVector();
+    const headingRotation = minimapState.mode === 'heading-up' ? (-Math.atan2(-heading.z, heading.x) - (Math.PI / 2)) : 0;
     ctx.clearRect(0, 0, minimapState.width, minimapState.height);
 
     ctx.fillStyle = '#08101a';
     ctx.fillRect(0, 0, minimapState.width, minimapState.height);
     ctx.strokeStyle = 'rgba(181, 201, 224, 0.34)';
     ctx.strokeRect(0.5, 0.5, minimapState.width - 1, minimapState.height - 1);
+
+    ctx.save();
+    if (headingRotation) {
+      ctx.translate(playerPoint.x, playerPoint.y);
+      ctx.rotate(headingRotation);
+      ctx.translate(-playerPoint.x, -playerPoint.y);
+    }
 
     (state.world.zones.sidewalk || []).forEach((zone) => {
       drawPolygon(zone.polygon, metrics, pad, '#3f4d60', 'rgba(136, 161, 188, 0.4)', 1, view);
@@ -2505,11 +2604,11 @@
       }
     });
 
-    const playerPoint = toMinimapPoint({ x: player.position.x, z: player.position.z }, metrics, pad, view);
-    const heading = getHeadingVector();
+    ctx.restore();
+
     const dirLength = 16;
-    const headingX = heading.x;
-    const headingY = -heading.z;
+    const headingX = minimapState.mode === 'heading-up' ? 0 : heading.x;
+    const headingY = minimapState.mode === 'heading-up' ? -1 : -heading.z;
 
     ctx.fillStyle = 'rgba(133, 205, 245, 0.3)';
     ctx.beginPath();
@@ -2538,14 +2637,7 @@
     ctx.arc(playerPoint.x, playerPoint.y, 2.3, 0, Math.PI * 2);
     ctx.stroke();
 
-    ctx.fillStyle = 'rgba(221, 236, 255, 0.82)';
-    ctx.font = '700 11px ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif';
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.fillText('N', minimapState.width / 2, 9);
-    ctx.fillText('S', minimapState.width / 2, minimapState.height - 9);
-    ctx.fillText('W', 10, minimapState.height / 2);
-    ctx.fillText('E', minimapState.width - 10, minimapState.height / 2);
+    drawMinimapCompass(playerPoint, headingRotation);
 
     if (minimapState.nearestNode) {
       const nearestPoint = toMinimapPoint(minimapState.nearestNode, metrics, pad, view);
@@ -2852,6 +2944,9 @@
     if (minimapZoomOutBtn) {
       minimapZoomOutBtn.addEventListener('click', () => setMinimapZoom(minimapState.zoom - minimapState.zoomStep));
     }
+    if (minimapModeBtn) {
+      minimapModeBtn.addEventListener('click', toggleMinimapMode);
+    }
 
     pauseBtn.addEventListener('click', pauseSim);
     resetBtn.addEventListener('click', resetToStart);
@@ -3016,6 +3111,7 @@
       setupAudio(state.world);
       minimapState.worldMetrics = getWorldMetrics();
       restoreMinimapZoom();
+      restoreMinimapMode();
       updateSize();
       applyTimeOfDay(state.activeTimeOfDay);
       applyMood(state.activeMood);

--- a/page-gastown-sim.php
+++ b/page-gastown-sim.php
@@ -68,7 +68,8 @@ get_header();
 
     <div class="gastown-sim-canvas" data-sim-canvas tabindex="-1">
       <aside class="gastown-minimap" aria-label="Route navigator minimap">
-        <div class="gastown-minimap-toolbar" role="group" aria-label="Minimap zoom controls">
+        <div class="gastown-minimap-toolbar" role="group" aria-label="Minimap controls">
+          <button type="button" class="gastown-minimap-mode" data-action="minimap-mode-toggle" aria-pressed="false" aria-label="Switch minimap to heading-up mode">North up</button>
           <button type="button" class="gastown-minimap-zoom" data-action="minimap-zoom-in" aria-label="Zoom in minimap">+</button>
           <button type="button" class="gastown-minimap-zoom" data-action="minimap-zoom-out" aria-label="Zoom out minimap">−</button>
         </div>


### PR DESCRIPTION
### Motivation
- Provide a second minimap orientation so users can choose between `north-up` (default) and `heading-up` where the player’s forward direction appears at the top of the minimap. 

### Description
- Add `minimapState.mode` with `'north-up'` default, a `toggleMinimapMode()` helper, `setMinimapMode()`/`restoreMinimapMode()` persistence via `sessionStorage`, and an `updateMinimapModeButton()` helper to keep the control state in sync. 
- Implement rotation of drawn minimap geometry around the centered player marker in `heading-up` mode by saving/restoring canvas transforms and applying a rotation based on the player heading, while keeping the player marker centered. 
- Keep compass/labels readable by drawing N/E/S/W separately in `drawMinimapCompass()` (redraws labels in rotated positions for `heading-up`); add a toolbar button in the minimap UI (`data-action=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c07beed090832e8e5c1b9dfb279eaf)