### PR TITLE
Simplify Gastown simulator world config (single canonical world URL)

### DIFF
--- a/__tests__/gastown-sim-config.test.js
+++ b/__tests__/gastown-sim-config.test.js
@@ -3,13 +3,15 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
 
-test('localized simulator defaults boot into morning clear mode', () => {
+test('localized simulator defaults boot into morning clear mode with one canonical world URL', () => {
   const functionsPath = path.join(__dirname, '..', 'functions.php');
   const php = fs.readFileSync(functionsPath, 'utf8');
 
   assert.match(php, /'defaultWeather'\s*=>\s*'clear'/);
   assert.match(php, /'defaultTimeOfDay'\s*=>\s*'morning'/);
   assert.match(php, /'defaultMood'\s*=>\s*'calm'/);
+  assert.match(php, /'worldDataUrl'\s*=>\s*esc_url_raw\( \$uri \. '\/assets\/world\/gastown-water-street\.json' \)/);
+  assert.doesNotMatch(php, /'starterWorldDataUrl'\s*=>/);
   assert.match(php, /'conversationEndpoint'\s*=>\s*esc_url_raw\( rest_url\( 'se\/v1\/gastown-npc-chat' \) \)/);
   assert.doesNotMatch(php, /'defaultMood'\s*=>\s*'eerie'/);
 });
@@ -63,4 +65,19 @@ test('simulator mood fallbacks no longer default back to eerie and eerie bed is 
   assert.match(src, /state\.world\.moodPresets\[state\.activeMood\] \|\| state\.world\.moodPresets\.calm \|\| state\.world\.moodPresets\.eerie/);
   assert.match(src, /state\.world\.moodPresets\[moodId\] \|\| state\.world\.moodPresets\.calm \|\| state\.world\.moodPresets\.eerie/);
   assert.match(src, /\['quiet_night', 'eerie_drones', 'nightlife_hum', 'commuter_mix'\]/);
+});
+
+
+test('simulator and classic simulator both request exactly one world URL', () => {
+  const root = path.join(__dirname, '..');
+  const simSrc = fs.readFileSync(path.join(root, 'js', 'gastown-sim.js'), 'utf8');
+  const classicSrc = fs.readFileSync(path.join(root, 'js', 'gastown-sim-classic.js'), 'utf8');
+  const loaderSrc = fs.readFileSync(path.join(root, 'js', 'gastown-world-loader.js'), 'utf8');
+
+  assert.match(simSrc, /GastownWorldLoader\.load\(config\.worldDataUrl\)/);
+  assert.match(classicSrc, /GastownWorldLoader\.load\(config\.worldDataUrl\)/);
+  assert.doesNotMatch(simSrc, /starterWorldDataUrl/);
+  assert.doesNotMatch(classicSrc, /starterWorldDataUrl/);
+  assert.doesNotMatch(loaderSrc, /fallbackUrl/);
+  assert.match(loaderSrc, /Missing Gastown world data URL\./);
 });

--- a/__tests__/gastown-world-loader-normalize.test.js
+++ b/__tests__/gastown-world-loader-normalize.test.js
@@ -137,3 +137,41 @@ test('normalizeWorldData safely defaults missing or partial props and npcs', () 
   assert.equal(normalized.npcs[0].voiceCue, 'photo-direction');
   assert.equal(normalized.npcs[0].silhouetteScale, 1);
 });
+
+
+test('load surfaces a clear error when the canonical world URL is missing', async () => {
+  const loaderPath = path.join(__dirname, '..', 'js', 'gastown-world-loader.js');
+  const src = fs.readFileSync(loaderPath, 'utf8');
+  const sandbox = {
+    window: {},
+    fetch: async () => { throw new Error('network down'); },
+  };
+
+  vm.runInNewContext(src, sandbox);
+
+  await assert.rejects(
+    sandbox.window.GastownWorldLoader.load(),
+    /Missing Gastown world data URL\./
+  );
+});
+
+test('load does not attempt fallback selection logic when fetch fails', async () => {
+  const loaderPath = path.join(__dirname, '..', 'js', 'gastown-world-loader.js');
+  const src = fs.readFileSync(loaderPath, 'utf8');
+  const requests = [];
+  const sandbox = {
+    window: {},
+    fetch: async (url) => {
+      requests.push(url);
+      return { ok: false, status: 404, json: async () => ({}) };
+    },
+  };
+
+  vm.runInNewContext(src, sandbox);
+
+  await assert.rejects(
+    sandbox.window.GastownWorldLoader.load('/assets/world/missing.json'),
+    /Could not load Gastown world data from \/assets\/world\/missing\.json \(HTTP 404\)\./
+  );
+  assert.deepEqual(requests, ['/assets/world/missing.json']);
+});

--- a/functions.php
+++ b/functions.php
@@ -267,7 +267,6 @@ function se_enqueue_gastown_sim_assets() {
             'seGastownSim',
             array(
                 'worldDataUrl'   => esc_url_raw( $uri . '/assets/world/gastown-water-street.json' ),
-                'starterWorldDataUrl' => esc_url_raw( $uri . '/assets/world/gastown-water-street-starter.json' ),
                 'audioBaseUrl'   => esc_url_raw( $uri . '/assets/audio/gastown' ),
                 'textureBaseUrl' => esc_url_raw( $uri . '/assets/textures' ),
                 'dialogDataUrl'  => esc_url_raw( $uri . '/assets/dialog/gastown.json' ),

--- a/js/gastown-sim-classic.js
+++ b/js/gastown-sim-classic.js
@@ -1646,7 +1646,7 @@ console.log('[Gastown Sim] classic runtime build 2026-03-15 recovery 2');
 
   async function init() {
     try {
-      state.world = await window.GastownWorldLoader.load(config.worldDataUrl, config.starterWorldDataUrl);
+      state.world = await window.GastownWorldLoader.load(config.worldDataUrl);
       updateAttribution(state.world);
       try {
         addGround(state.world);

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -3000,7 +3000,7 @@
 
   async function init() {
     try {
-      const loadedWorld = await window.GastownWorldLoader.load(config.worldDataUrl, config.starterWorldDataUrl);
+      const loadedWorld = await window.GastownWorldLoader.load(config.worldDataUrl);
       const dialogData = await loadDialogData().catch(() => null);
       state.world = loadedWorld;
       state.dialogData = dialogData && typeof dialogData === 'object' ? dialogData : {};

--- a/js/gastown-world-loader.js
+++ b/js/gastown-world-loader.js
@@ -2,31 +2,26 @@
   'use strict';
 
   async function fetchWorld(url) {
-    const response = await fetch(url, { credentials: 'same-origin' });
+    let response;
+    try {
+      response = await fetch(url, { credentials: 'same-origin' });
+    } catch (error) {
+      throw new Error('Could not load Gastown world data from ' + url + '.');
+    }
     if (!response.ok) {
-      throw new Error('Could not load Gastown world data.');
+      throw new Error('Could not load Gastown world data from ' + url + ' (HTTP ' + response.status + ').');
     }
     const data = await response.json();
     validateWorldData(data);
     return normalizeWorldData(data);
   }
 
-  async function loadGastownWorldData(url, fallbackUrl) {
+  async function loadGastownWorldData(url) {
     if (!url) {
-      throw new Error('Missing world data URL.');
+      throw new Error('Missing Gastown world data URL.');
     }
 
-    try {
-      return await fetchWorld(url);
-    } catch (primaryError) {
-      if (!fallbackUrl || fallbackUrl === url) {
-        throw primaryError;
-      }
-      const fallback = await fetchWorld(fallbackUrl);
-      fallback.meta = fallback.meta || {};
-      fallback.meta.runtimeFallbackActive = true;
-      return fallback;
-    }
+    return fetchWorld(url);
   }
 
 


### PR DESCRIPTION
### Motivation
- The simulator previously exposed two world URLs (`worldDataUrl` and `starterWorldDataUrl`) and included runtime fallback-selection logic, which added complexity and unclear failure modes. 
- The intent is to standardize on a single canonical world JSON URL so the runtime always loads one explicit world and surfaces clear errors when that resource is unavailable.

### Description
- Remove `starterWorldDataUrl` from the localized simulator config in `functions.php` so only `worldDataUrl` is exposed to the client. 
- Update both simulator entrypoints to call the loader with a single argument (`GastownWorldLoader.load(config.worldDataUrl)`) in `js/gastown-sim.js` and `js/gastown-sim-classic.js`. 
- Simplify `js/gastown-world-loader.js` by removing fallback-selection logic, making `loadGastownWorldData` accept only one URL, and adding clearer error messages for a missing URL and for failed fetches. 
- Update tests in `__tests__/gastown-sim-config.test.js` and `__tests__/gastown-world-loader-normalize.test.js` to assert the single-world contract, verify absence of `starterWorldDataUrl` and fallback code paths, and validate the new error messages.

### Testing
- Ran the loader/config unit tests with `node --test __tests__/gastown-sim-config.test.js __tests__/gastown-world-loader-normalize.test.js`, and all tests passed (13/13). 
- The loader tests assert the missing-URL error message and that failed fetches only request the canonical URL and do not attempt fallback selection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c07bfcb9b8832e8cc5b6dfa30271c4)