### PR TITLE
Suppress Water Street mid-block landmark marker visuals

### DIFF
--- a/__tests__/gastown-sim-ground.test.js
+++ b/__tests__/gastown-sim-ground.test.js
@@ -37,7 +37,7 @@ test('default clear and afternoon play keeps rain as particles without divider b
   assert.doesNotMatch(src, /new THREE\.PlaneGeometry\(0\.05, 2\.8 \+ \(intensity \* 2\.4\)\)/);
 });
 
-test('production landmark rendering suppresses generic cylinder and halo markers for hero and intersection landmarks', () => {
+test('production landmark rendering suppresses generic cylinder and halo markers for hero, intersection, and Water Street route-cue landmarks', () => {
   const simPath = path.join(__dirname, '..', 'js', 'gastown-sim.js');
   const src = fs.readFileSync(simPath, 'utf8');
 
@@ -46,9 +46,10 @@ test('production landmark rendering suppresses generic cylinder and halo markers
   assert.match(src, /if \(state\.debugEnabled \|\| !suppressGenericMarker\) \{/);
   assert.match(src, /landmark\.id === 'steam-clock'/);
   assert.match(src, /landmark\.id === 'water-cambie-intersection'/);
+  assert.match(src, /landmark\.id === 'water-street-mid-block'/);
 });
 
-test('production landmark rendering also suppresses reflection discs for suppressed hero/intersection markers', () => {
+test('production landmark rendering also suppresses reflection discs for suppressed production-only route and hero/intersection markers', () => {
   const simPath = path.join(__dirname, '..', 'js', 'gastown-sim.js');
   const src = fs.readFileSync(simPath, 'utf8');
 

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -1917,7 +1917,8 @@
       const suppressGenericMarker = heroLandmarkIds.has(landmark.id)
         || suppressedKinds.has(landmark.kind)
         || landmark.id === 'steam-clock'
-        || landmark.id === 'water-cambie-intersection';
+        || landmark.id === 'water-cambie-intersection'
+        || landmark.id === 'water-street-mid-block';
 
       if (state.debugEnabled || !suppressGenericMarker) {
         const markerMaterial = new THREE.MeshStandardMaterial({ color: col, emissive: col, emissiveIntensity: 0.2 });


### PR DESCRIPTION
### Motivation
- Prevent the generic cylinder/halo and reflection disc from rendering at `water-street-mid-block` in production while keeping the landmark data available for nearest-landmark, minimap, and route logic.

### Description
- Add an explicit `landmark.id === 'water-street-mid-block'` check to the `suppressGenericMarker` condition in `addLandmarks(world)` so the generic marker, halo, and reflection disc are suppressed in normal mode while preserving debug rendering and existing hero/intersection suppression behavior.
- Update the lightweight source-based test in `__tests__/gastown-sim-ground.test.js` to assert that `water-street-mid-block` is included in the suppression logic for generic landmark visuals.

### Testing
- Ran `node --test __tests__/gastown-sim-ground.test.js`, and all tests passed (6/6 subtests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c09f1f1408832e979c6333bb3d2d72)