### PR TITLE
Fix minimap player marker, sanitize ground polygons, and improve Water Street rendering

### DIFF
--- a/__tests__/gastown-sim-ground.test.js
+++ b/__tests__/gastown-sim-ground.test.js
@@ -66,3 +66,23 @@ test('heading-up minimap derives heading from rendered world direction instead o
   assert.doesNotMatch(src, /baseForward\.clone\(\)\.applyAxisAngle/);
   assert.match(src, /const headingRotation = minimapState\.mode === 'heading-up' \? \(-Math\.atan2\(-heading\.z, heading\.x\) - \(Math\.PI \/ 2\)\) : 0;/);
 });
+
+
+test('minimap player marker renders as a tiny person with a forward cue instead of a wedge', () => {
+  const simPath = path.join(__dirname, '..', 'js', 'gastown-sim.js');
+  const src = fs.readFileSync(simPath, 'utf8');
+
+  assert.match(src, /ctx\.arc\(playerPoint\.x, playerPoint\.y - 4\.2, 2\.2, 0, Math\.PI \* 2\)/);
+  assert.match(src, /ctx\.moveTo\(playerPoint\.x, playerPoint\.y - 1\.4\);\s*ctx\.lineTo\(playerPoint\.x, playerPoint\.y \+ 4\.3\);/s);
+  assert.match(src, /ctx\.moveTo\(playerPoint\.x \+ \(headingX \* 9\.4\), playerPoint\.y \+ \(headingY \* 9\.4\)\);/);
+  assert.doesNotMatch(src, /ctx\.arc\(playerPoint\.x, playerPoint\.y, dirLength, headingAngle - 0\.5, headingAngle \+ 0\.5\)/);
+});
+
+test('ground meshes sanitize malformed polygon rings before building shape geometry', () => {
+  const simPath = path.join(__dirname, '..', 'js', 'gastown-sim.js');
+  const src = fs.readFileSync(simPath, 'utf8');
+
+  assert.match(src, /function sanitizePolygon\(points\) \{/);
+  assert.match(src, /const shape = toShape\(points\);\s*if \(!shape\) \{\s*return null;\s*\}/s);
+  assert.match(src, /if \(cleaned.length >= 3 && polygonSignedArea\(cleaned\) < 0\) \{\s*cleaned\.reverse\(\);\s*\}/s);
+});

--- a/__tests__/gastown-world-generator.test.js
+++ b/__tests__/gastown-world-generator.test.js
@@ -292,3 +292,23 @@ test('fallback generator remains deterministic across repeated runs', () => {
   fs.rmSync(outputA, { force: true });
   fs.rmSync(outputB, { force: true });
 });
+
+
+test('fallback world splits Water Street roadway around the Cambie intersection and sanitizes zone polygons', () => {
+  const root = path.resolve(__dirname, '..');
+  const data = JSON.parse(fs.readFileSync(path.join(root, 'assets', 'world', 'gastown-water-street.json'), 'utf8'));
+
+  const streetIds = new Set(data.zones.street.map((zone) => zone.id));
+  assert.equal(streetIds.has('water-street-west-roadway'), true);
+  assert.equal(streetIds.has('water-street-east-roadway'), true);
+  assert.equal(streetIds.has('water-cambie-intersection-roadway'), true);
+
+  data.zones.street.concat(data.zones.sidewalk).forEach((zone) => {
+    const polygon = zone.polygon;
+    assert.ok(Array.isArray(polygon) && polygon.length >= 4, zone.id + ' should keep a closed polygon');
+    const first = polygon[0];
+    const last = polygon[polygon.length - 1];
+    assert.equal(first.x, last.x, zone.id + ' should be explicitly closed on x');
+    assert.equal(first.z, last.z, zone.id + ' should be explicitly closed on z');
+  });
+});

--- a/assets/world/gastown-water-street-starter.json
+++ b/assets/world/gastown-water-street-starter.json
@@ -20,7 +20,7 @@
       "buildingFootprints2015": false,
       "orthophotoImagery2015": false
     },
-    "lastBuild": "2026-03-23T02:20:57.171Z"
+    "lastBuild": "2026-03-23T02:35:15.805Z"
   },
   "route": {
     "name": "Waterfront Station → Water Street → Steam Clock working corridor",
@@ -82,80 +82,80 @@
     ],
     "walkBounds": [
       {
-        "x": 8.122232599748965,
-        "z": 9.632722231829131
+        "x": -8.12,
+        "z": -9.63
       },
       {
-        "x": 37.05538945109006,
-        "z": -14.763478980648776
+        "x": 20.97,
+        "z": -34.16
       },
       {
-        "x": 70.88115859086254,
-        "z": -42.34724288675185
+        "x": 55.32,
+        "z": -62.18
       },
       {
-        "x": 117.78994275242663,
-        "z": -77.75141912479964
+        "x": 102.7,
+        "z": -97.94
       },
       {
-        "x": 159.89558200755516,
-        "z": -108.91404162851205
+        "x": 144.73,
+        "z": -129.04
       },
       {
-        "x": 211.8946986128368,
-        "z": -148.77334146698345
+        "x": 171.07,
+        "z": -149.23
       },
       {
-        "x": 184.31270768999283,
-        "z": -154.75496700117142
+        "x": 184.31,
+        "z": -154.75
       },
       {
-        "x": 193.61507537516647,
-        "z": -131.13193665906078
+        "x": 189.35,
+        "z": -166.87
       },
       {
-        "x": 220.31813548545594,
-        "z": -165.7716318620587
+        "x": 200.36,
+        "z": -181.16
       },
       {
-        "x": 200.3599321823693,
-        "z": -181.15701846469767
+        "x": 220.32,
+        "z": -165.77
       },
       {
-        "x": 189.34702760728587,
-        "z": -166.87087836670963
+        "x": 193.62,
+        "z": -131.13
       },
       {
-        "x": 184.31270768999283,
-        "z": -154.75496700117142
+        "x": 184.31,
+        "z": -154.75
       },
       {
-        "x": 171.06740436961553,
-        "z": -149.22947355878696
+        "x": 211.89,
+        "z": -148.77
       },
       {
-        "x": 144.73336354717162,
-        "z": -129.043430071392
+        "x": 159.9,
+        "z": -108.91
       },
       {
-        "x": 102.70338926799691,
-        "z": -97.93680764567662
+        "x": 117.79,
+        "z": -77.75
       },
       {
-        "x": 55.32226171059234,
-        "z": -62.17613253156296
+        "x": 70.88,
+        "z": -42.35
       },
       {
-        "x": 20.969171607304666,
-        "z": -34.162356320337175
+        "x": 37.06,
+        "z": -14.76
       },
       {
-        "x": -8.122232599748965,
-        "z": -9.632722231829131
+        "x": 8.12,
+        "z": 9.63
       },
       {
-        "x": 8.122232599748965,
-        "z": 9.632722231829131
+        "x": -8.12,
+        "z": -9.63
       }
     ],
     "streetWidth": 10.4,
@@ -302,102 +302,68 @@
   "zones": {
     "street": [
       {
-        "id": "water-street-main-roadway",
+        "id": "water-street-west-roadway",
         "surface": "road",
         "polygon": [
           {
-            "x": 3.3520325014837,
-            "z": 3.9754091750405935
+            "x": -3.35,
+            "z": -3.98
           },
           {
-            "x": 32.331658814422916,
-            "z": -20.45997470738267
+            "x": 25.69,
+            "z": -28.47
           },
           {
-            "x": 66.31227617364034,
-            "z": -48.17001206816464
+            "x": 59.89,
+            "z": -56.35
           },
           {
-            "x": 113.3597643482687,
-            "z": -83.67887448410478
+            "x": 107.13,
+            "z": -92.01
           },
           {
-            "x": 155.44318452315682,
-            "z": -114.82505252046886
+            "x": 149.19,
+            "z": -123.13
           },
           {
-            "x": 195.1842485004153,
-            "z": -145.28808897921755
+            "x": 195.16,
+            "z": -152.67
           },
           {
-            "x": 214.45739324566065,
-            "z": -170.28956284854794
+            "x": 193.73,
+            "z": -143.4
           },
           {
-            "x": 206.2206744221646,
-            "z": -176.63908747820844
+            "x": 185.49,
+            "z": -149.74
           },
           {
-            "x": 187.77785448203704,
-            "z": -152.71472604655287
+            "x": 187.8,
+            "z": -145.33
           },
           {
-            "x": 149.18576103156997,
-            "z": -123.1324191794352
+            "x": 155.44,
+            "z": -114.83
           },
           {
-            "x": 107.13356767215484,
-            "z": -92.00935228637148
+            "x": 113.36,
+            "z": -83.68
           },
           {
-            "x": 59.89114412781455,
-            "z": -56.353363350150175
+            "x": 66.31,
+            "z": -48.17
           },
           {
-            "x": 25.692902243971805,
-            "z": -28.46586059360328
+            "x": 32.33,
+            "z": -20.46
           },
           {
-            "x": -3.3520325014837,
-            "z": -3.9754091750405935
+            "x": 3.35,
+            "z": 3.98
           },
           {
-            "x": 3.3520325014837,
-            "z": 3.9754091750405935
-          }
-        ]
-      },
-      {
-        "id": "cambie-street-crossing",
-        "surface": "road",
-        "polygon": [
-          {
-            "x": 197.8532548045305,
-            "z": -170.81530585623304
-          },
-          {
-            "x": 187.92291722650126,
-            "z": -150.95463070017456
-          },
-          {
-            "x": 176.00306018453608,
-            "z": -131.08820229689925
-          },
-          {
-            "x": 182.95904279791625,
-            "z": -126.91461272887116
-          },
-          {
-            "x": 195.03918575595108,
-            "z": -147.04818432559586
-          },
-          {
-            "x": 205.10884817792183,
-            "z": -167.18750916953738
-          },
-          {
-            "x": 197.8532548045305,
-            "z": -170.81530585623304
+            "x": -3.35,
+            "z": -3.98
           }
         ]
       },
@@ -406,24 +372,92 @@
         "surface": "road",
         "polygon": [
           {
-            "x": 184.72,
-            "z": -150.97
-          },
-          {
-            "x": 195.1,
-            "z": -142.97
+            "x": 192.17,
+            "z": -160.63
           },
           {
             "x": 202.55,
             "z": -152.63
           },
           {
-            "x": 192.17,
-            "z": -160.63
+            "x": 195.1,
+            "z": -142.97
           },
           {
             "x": 184.72,
             "z": -150.97
+          },
+          {
+            "x": 192.17,
+            "z": -160.63
+          }
+        ]
+      },
+      {
+        "id": "water-street-east-roadway",
+        "surface": "road",
+        "polygon": [
+          {
+            "x": 201.79,
+            "z": -153.84
+          },
+          {
+            "x": 188.31,
+            "z": -144.88
+          },
+          {
+            "x": 206.22,
+            "z": -176.64
+          },
+          {
+            "x": 214.46,
+            "z": -170.29
+          },
+          {
+            "x": 194.66,
+            "z": -153.12
+          },
+          {
+            "x": 193.55,
+            "z": -160.2
+          },
+          {
+            "x": 201.79,
+            "z": -153.84
+          }
+        ]
+      },
+      {
+        "id": "cambie-street-crossing",
+        "surface": "road",
+        "polygon": [
+          {
+            "x": 205.11,
+            "z": -167.19
+          },
+          {
+            "x": 195.04,
+            "z": -147.05
+          },
+          {
+            "x": 182.96,
+            "z": -126.91
+          },
+          {
+            "x": 176,
+            "z": -131.09
+          },
+          {
+            "x": 187.92,
+            "z": -150.95
+          },
+          {
+            "x": 197.85,
+            "z": -170.82
+          },
+          {
+            "x": 205.11,
+            "z": -167.19
           }
         ]
       }
@@ -434,64 +468,64 @@
         "side": "south",
         "polygon": [
           {
-            "x": 6.059443368066688,
-            "z": 7.186316585650304
+            "x": 3.35,
+            "z": 3.98
           },
           {
-            "x": 35.01269512172048,
-            "z": -17.226828484101272
+            "x": 32.33,
+            "z": -20.46
           },
           {
-            "x": 68.90542565368537,
-            "z": -44.865197127362784
+            "x": 66.31,
+            "z": -48.17
           },
           {
-            "x": 115.87418992900697,
-            "z": -80.31464306395863
+            "x": 113.36,
+            "z": -83.68
           },
           {
-            "x": 157.97022093322076,
-            "z": -111.47015444665554
+            "x": 155.44,
+            "z": -114.83
           },
           {
-            "x": 198.17529223860652,
-            "z": -142.28887016356293
+            "x": 195.18,
+            "z": -145.29
           },
           {
-            "x": 217.78376046284177,
-            "z": -167.72533174810812
+            "x": 214.46,
+            "z": -170.29
           },
           {
-            "x": 214.45739324566065,
-            "z": -170.28956284854794
+            "x": 217.78,
+            "z": -167.73
           },
           {
-            "x": 195.1842485004153,
-            "z": -145.28808897921755
+            "x": 198.18,
+            "z": -142.29
           },
           {
-            "x": 155.44318452315682,
-            "z": -114.82505252046886
+            "x": 157.97,
+            "z": -111.47
           },
           {
-            "x": 113.3597643482687,
-            "z": -83.67887448410478
+            "x": 115.87,
+            "z": -80.31
           },
           {
-            "x": 66.31227617364034,
-            "z": -48.17001206816464
+            "x": 68.91,
+            "z": -44.87
           },
           {
-            "x": 32.331658814422916,
-            "z": -20.45997470738267
+            "x": 35.01,
+            "z": -17.23
           },
           {
-            "x": 3.3520325014837,
-            "z": 3.9754091750405935
+            "x": 6.06,
+            "z": 7.19
           },
           {
-            "x": 6.059443368066688,
-            "z": 7.186316585650304
+            "x": 3.35,
+            "z": 3.98
           }
         ]
       },
@@ -500,64 +534,64 @@
         "side": "north",
         "polygon": [
           {
-            "x": -3.3520325014837,
-            "z": -3.9754091750405935
+            "x": -6.06,
+            "z": -7.19
           },
           {
-            "x": 25.692902243971805,
-            "z": -28.46586059360328
+            "x": 23.01,
+            "z": -31.7
           },
           {
-            "x": 59.89114412781455,
-            "z": -56.353363350150175
+            "x": 57.3,
+            "z": -59.66
           },
           {
-            "x": 107.13356767215484,
-            "z": -92.00935228637148
+            "x": 104.62,
+            "z": -95.37
           },
           {
-            "x": 149.18576103156997,
-            "z": -123.1324191794352
+            "x": 146.66,
+            "z": -126.49
           },
           {
-            "x": 187.77785448203704,
-            "z": -152.71472604655287
+            "x": 184.79,
+            "z": -155.71
           },
           {
-            "x": 206.2206744221646,
-            "z": -176.63908747820844
+            "x": 202.89,
+            "z": -179.2
           },
           {
-            "x": 202.89430720498348,
-            "z": -179.20331857864826
+            "x": 206.22,
+            "z": -176.64
           },
           {
-            "x": 184.78681074384582,
-            "z": -155.71394486220748
+            "x": 187.78,
+            "z": -152.71
           },
           {
-            "x": 146.65872462150602,
-            "z": -126.48731725324852
+            "x": 149.19,
+            "z": -123.13
           },
           {
-            "x": 104.61914209141656,
-            "z": -95.37358370651764
+            "x": 107.13,
+            "z": -92.01
           },
           {
-            "x": 57.297994647769514,
-            "z": -59.65817829095203
+            "x": 59.89,
+            "z": -56.35
           },
           {
-            "x": 23.01186593667424,
-            "z": -31.69900681688468
+            "x": 25.69,
+            "z": -28.47
           },
           {
-            "x": -6.059443368066688,
-            "z": -7.186316585650304
+            "x": -3.35,
+            "z": -3.98
           },
           {
-            "x": -3.3520325014837,
-            "z": -3.9754091750405935
+            "x": -6.06,
+            "z": -7.19
           }
         ]
       },
@@ -566,32 +600,32 @@
         "side": "west",
         "polygon": [
           {
-            "x": 194.25050207918284,
-            "z": -172.61668221890687
+            "x": 197.85,
+            "z": -170.82
           },
           {
-            "x": 184.38934601883068,
-            "z": -152.89437009820253
+            "x": 187.92,
+            "z": -150.95
           },
           {
-            "x": 172.54907867976596,
-            "z": -133.16059119976134
+            "x": 176,
+            "z": -131.09
           },
           {
-            "x": 176.00306018453608,
-            "z": -131.08820229689925
+            "x": 172.55,
+            "z": -133.16
           },
           {
-            "x": 187.92291722650126,
-            "z": -150.95463070017456
+            "x": 184.39,
+            "z": -152.89
           },
           {
-            "x": 197.8532548045305,
-            "z": -170.81530585623304
+            "x": 194.25,
+            "z": -172.62
           },
           {
-            "x": 194.25050207918284,
-            "z": -172.61668221890687
+            "x": 197.85,
+            "z": -170.82
           }
         ]
       },
@@ -600,24 +634,24 @@
         "side": "corner",
         "polygon": [
           {
-            "x": 184.28,
-            "z": -155.35
-          },
-          {
-            "x": 189.35,
-            "z": -151.44
+            "x": 187.82,
+            "z": -159.94
           },
           {
             "x": 192.89,
             "z": -156.03
           },
           {
-            "x": 187.82,
-            "z": -159.94
+            "x": 189.35,
+            "z": -151.44
           },
           {
             "x": 184.28,
             "z": -155.35
+          },
+          {
+            "x": 187.82,
+            "z": -159.94
           }
         ]
       },
@@ -626,24 +660,24 @@
         "side": "plaza",
         "polygon": [
           {
-            "x": 177.85,
-            "z": -153.8
-          },
-          {
-            "x": 184.66,
-            "z": -148.55
+            "x": 183.59,
+            "z": -161.25
           },
           {
             "x": 190.4,
             "z": -156
           },
           {
-            "x": 183.59,
-            "z": -161.25
+            "x": 184.66,
+            "z": -148.55
           },
           {
             "x": 177.85,
             "z": -153.8
+          },
+          {
+            "x": 183.59,
+            "z": -161.25
           }
         ]
       }
@@ -4331,442 +4365,442 @@
     "surfaceBands": [
       {
         "segment_id": "waterfront-station-threshold",
-        "width": 9.78,
+        "width": 9.98,
         "length": 19.24,
         "yaw": 2.2712,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "road_base_dark",
-        "opacity": 0.18,
+        "opacity": 0.2,
         "elevation": 0.012
       },
       {
         "segment_id": "waterfront-station-threshold",
-        "width": 3.12,
-        "length": 15.91,
+        "width": 3.54,
+        "length": 15.17,
         "yaw": 2.2712,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.08,
+        "opacity": 0.1,
         "elevation": 0.016
       },
       {
         "segment_id": "waterfront-station-threshold",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.2712,
         "offset_x": 4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "waterfront-station-threshold",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.2712,
         "offset_x": -4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "gastown-beat-1",
-        "width": 9.78,
+        "width": 9.98,
         "length": 19.24,
         "yaw": 2.2548,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "road_base_dark",
-        "opacity": 0.18,
+        "opacity": 0.2,
         "elevation": 0.012
       },
       {
         "segment_id": "gastown-beat-1",
-        "width": 3.12,
-        "length": 15.91,
+        "width": 3.54,
+        "length": 15.17,
         "yaw": 2.2548,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.08,
+        "opacity": 0.1,
         "elevation": 0.016
       },
       {
         "segment_id": "gastown-beat-1",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.2548,
         "offset_x": 4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "gastown-beat-1",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.2548,
         "offset_x": -4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "water-cordova-seam",
-        "width": 9.78,
+        "width": 9.98,
         "length": 19.24,
         "yaw": 2.2279,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "road_base_dark",
-        "opacity": 0.18,
+        "opacity": 0.2,
         "elevation": 0.012
       },
       {
         "segment_id": "water-cordova-seam",
-        "width": 3.12,
-        "length": 15.91,
+        "width": 3.54,
+        "length": 15.17,
         "yaw": 2.2279,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.11,
+        "opacity": 0.16,
         "elevation": 0.016
       },
       {
         "segment_id": "water-cordova-seam",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.2279,
         "offset_x": 4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "water-cordova-seam",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.2279,
         "offset_x": -4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "gastown-beat-3",
-        "width": 9.78,
+        "width": 9.98,
         "length": 19.24,
         "yaw": 2.213,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "road_base_dark",
-        "opacity": 0.18,
+        "opacity": 0.2,
         "elevation": 0.012
       },
       {
         "segment_id": "gastown-beat-3",
-        "width": 3.12,
-        "length": 15.91,
+        "width": 3.54,
+        "length": 15.17,
         "yaw": 2.213,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.11,
+        "opacity": 0.16,
         "elevation": 0.016
       },
       {
         "segment_id": "gastown-beat-3",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.213,
         "offset_x": 4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "gastown-beat-3",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.213,
         "offset_x": -4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "water-street-mid-block",
-        "width": 9.78,
+        "width": 9.98,
         "length": 19.24,
         "yaw": 2.2136,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "road_base_dark",
-        "opacity": 0.18,
+        "opacity": 0.2,
         "elevation": 0.012
       },
       {
         "segment_id": "water-street-mid-block",
-        "width": 3.12,
-        "length": 15.91,
+        "width": 3.54,
+        "length": 15.17,
         "yaw": 2.2136,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.11,
+        "opacity": 0.16,
         "elevation": 0.016
       },
       {
         "segment_id": "water-street-mid-block",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.2136,
         "offset_x": 4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "water-street-mid-block",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.2136,
         "offset_x": -4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "steam-clock-approach",
-        "width": 9.78,
+        "width": 9.98,
         "length": 9.57,
         "yaw": -2.4152,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "road_base_dark",
-        "opacity": 0.18,
+        "opacity": 0.24,
         "elevation": 0.012
-      },
-      {
-        "segment_id": "steam-clock-approach",
-        "width": 3.12,
-        "length": 7.91,
-        "yaw": -2.4152,
-        "offset_x": 0,
-        "offset_z": 0,
-        "tone": "wheel_track",
-        "opacity": 0.11,
-        "elevation": 0.016
-      },
-      {
-        "segment_id": "steam-clock-approach",
-        "width": 0.83,
-        "length": 9.57,
-        "yaw": -2.4152,
-        "offset_x": 4.06,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.14,
-        "elevation": 0.024
-      },
-      {
-        "segment_id": "steam-clock-approach",
-        "width": 0.83,
-        "length": 9.57,
-        "yaw": -2.4152,
-        "offset_x": -4.06,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.14,
-        "elevation": 0.024
-      },
-      {
-        "segment_id": "steam-clock-approach",
-        "width": 7.07,
-        "length": 5.2,
-        "yaw": -2.4152,
-        "offset_x": 0,
-        "offset_z": 0,
-        "tone": "intersection_pavers",
-        "opacity": 0.18,
-        "elevation": 0.02
       },
       {
         "segment_id": "steam-clock-approach",
         "width": 3.54,
-        "length": 4.1,
+        "length": 7.54,
+        "yaw": -2.4152,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.16,
+        "elevation": 0.016
+      },
+      {
+        "segment_id": "steam-clock-approach",
+        "width": 1.04,
+        "length": 9.38,
+        "yaw": -2.4152,
+        "offset_x": 4.06,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.18,
+        "elevation": 0.024
+      },
+      {
+        "segment_id": "steam-clock-approach",
+        "width": 1.04,
+        "length": 9.38,
+        "yaw": -2.4152,
+        "offset_x": -4.06,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.18,
+        "elevation": 0.024
+      },
+      {
+        "segment_id": "steam-clock-approach",
+        "width": 7.28,
+        "length": 5.8,
+        "yaw": -2.4152,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "intersection_pavers",
+        "opacity": 0.24,
+        "elevation": 0.02
+      },
+      {
+        "segment_id": "steam-clock-approach",
+        "width": 3.95,
+        "length": 4.5,
         "yaw": -2.4152,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "cobble_break",
-        "opacity": 0.12,
+        "opacity": 0.18,
         "elevation": 0.022
       },
       {
         "segment_id": "steam-clock",
-        "width": 9.78,
+        "width": 9.98,
         "length": 19.24,
         "yaw": 2.194,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "road_base_dark",
-        "opacity": 0.18,
+        "opacity": 0.24,
         "elevation": 0.012
-      },
-      {
-        "segment_id": "steam-clock",
-        "width": 3.12,
-        "length": 15.91,
-        "yaw": 2.194,
-        "offset_x": 0,
-        "offset_z": 0,
-        "tone": "wheel_track",
-        "opacity": 0.11,
-        "elevation": 0.016
-      },
-      {
-        "segment_id": "steam-clock",
-        "width": 0.83,
-        "length": 19.24,
-        "yaw": 2.194,
-        "offset_x": 4.06,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.14,
-        "elevation": 0.024
-      },
-      {
-        "segment_id": "steam-clock",
-        "width": 0.83,
-        "length": 19.24,
-        "yaw": 2.194,
-        "offset_x": -4.06,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.14,
-        "elevation": 0.024
-      },
-      {
-        "segment_id": "steam-clock",
-        "width": 7.07,
-        "length": 6.66,
-        "yaw": 2.194,
-        "offset_x": 0,
-        "offset_z": 0,
-        "tone": "intersection_pavers",
-        "opacity": 0.18,
-        "elevation": 0.02
       },
       {
         "segment_id": "steam-clock",
         "width": 3.54,
-        "length": 4.1,
+        "length": 15.17,
+        "yaw": 2.194,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.16,
+        "elevation": 0.016
+      },
+      {
+        "segment_id": "steam-clock",
+        "width": 1.04,
+        "length": 18.87,
+        "yaw": 2.194,
+        "offset_x": 4.06,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.18,
+        "elevation": 0.024
+      },
+      {
+        "segment_id": "steam-clock",
+        "width": 1.04,
+        "length": 18.87,
+        "yaw": 2.194,
+        "offset_x": -4.06,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.18,
+        "elevation": 0.024
+      },
+      {
+        "segment_id": "steam-clock",
+        "width": 7.28,
+        "length": 7.77,
+        "yaw": 2.194,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "intersection_pavers",
+        "opacity": 0.24,
+        "elevation": 0.02
+      },
+      {
+        "segment_id": "steam-clock",
+        "width": 3.95,
+        "length": 4.5,
         "yaw": 2.194,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "cobble_break",
-        "opacity": 0.12,
+        "opacity": 0.18,
         "elevation": 0.022
       },
       {
         "segment_id": "maple-tree-square-edge",
-        "width": 9.78,
+        "width": 9.98,
         "length": 19.24,
         "yaw": -0.6078,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "road_base_dark",
-        "opacity": 0.18,
+        "opacity": 0.24,
         "elevation": 0.012
       },
       {
         "segment_id": "maple-tree-square-edge",
-        "width": 3.12,
-        "length": 15.91,
+        "width": 3.54,
+        "length": 15.17,
         "yaw": -0.6078,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.11,
+        "opacity": 0.16,
         "elevation": 0.016
       },
       {
         "segment_id": "maple-tree-square-edge",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": -0.6078,
         "offset_x": 4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "maple-tree-square-edge",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": -0.6078,
         "offset_x": -4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "cambie-rise-continuation",
-        "width": 9.78,
+        "width": 9.98,
         "length": 19.24,
         "yaw": 2.5338,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "road_base_dark",
-        "opacity": 0.18,
+        "opacity": 0.24,
         "elevation": 0.012
       },
       {
         "segment_id": "cambie-rise-continuation",
-        "width": 3.12,
-        "length": 15.91,
+        "width": 3.54,
+        "length": 15.17,
         "yaw": 2.5338,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.11,
+        "opacity": 0.16,
         "elevation": 0.016
       },
       {
         "segment_id": "cambie-rise-continuation",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.5338,
         "offset_x": 4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "cambie-rise-continuation",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.5338,
         "offset_x": -4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       }
     ]

--- a/assets/world/gastown-water-street.json
+++ b/assets/world/gastown-water-street.json
@@ -20,7 +20,7 @@
       "buildingFootprints2015": false,
       "orthophotoImagery2015": false
     },
-    "lastBuild": "2026-03-23T02:20:57.154Z"
+    "lastBuild": "2026-03-23T02:35:10.016Z"
   },
   "route": {
     "name": "Waterfront Station → Water Street → Steam Clock working corridor",
@@ -82,80 +82,80 @@
     ],
     "walkBounds": [
       {
-        "x": 8.122232599748965,
-        "z": 9.632722231829131
+        "x": -8.12,
+        "z": -9.63
       },
       {
-        "x": 37.05538945109006,
-        "z": -14.763478980648776
+        "x": 20.97,
+        "z": -34.16
       },
       {
-        "x": 70.88115859086254,
-        "z": -42.34724288675185
+        "x": 55.32,
+        "z": -62.18
       },
       {
-        "x": 117.78994275242663,
-        "z": -77.75141912479964
+        "x": 102.7,
+        "z": -97.94
       },
       {
-        "x": 159.89558200755516,
-        "z": -108.91404162851205
+        "x": 144.73,
+        "z": -129.04
       },
       {
-        "x": 211.8946986128368,
-        "z": -148.77334146698345
+        "x": 171.07,
+        "z": -149.23
       },
       {
-        "x": 184.31270768999283,
-        "z": -154.75496700117142
+        "x": 184.31,
+        "z": -154.75
       },
       {
-        "x": 193.61507537516647,
-        "z": -131.13193665906078
+        "x": 189.35,
+        "z": -166.87
       },
       {
-        "x": 220.31813548545594,
-        "z": -165.7716318620587
+        "x": 200.36,
+        "z": -181.16
       },
       {
-        "x": 200.3599321823693,
-        "z": -181.15701846469767
+        "x": 220.32,
+        "z": -165.77
       },
       {
-        "x": 189.34702760728587,
-        "z": -166.87087836670963
+        "x": 193.62,
+        "z": -131.13
       },
       {
-        "x": 184.31270768999283,
-        "z": -154.75496700117142
+        "x": 184.31,
+        "z": -154.75
       },
       {
-        "x": 171.06740436961553,
-        "z": -149.22947355878696
+        "x": 211.89,
+        "z": -148.77
       },
       {
-        "x": 144.73336354717162,
-        "z": -129.043430071392
+        "x": 159.9,
+        "z": -108.91
       },
       {
-        "x": 102.70338926799691,
-        "z": -97.93680764567662
+        "x": 117.79,
+        "z": -77.75
       },
       {
-        "x": 55.32226171059234,
-        "z": -62.17613253156296
+        "x": 70.88,
+        "z": -42.35
       },
       {
-        "x": 20.969171607304666,
-        "z": -34.162356320337175
+        "x": 37.06,
+        "z": -14.76
       },
       {
-        "x": -8.122232599748965,
-        "z": -9.632722231829131
+        "x": 8.12,
+        "z": 9.63
       },
       {
-        "x": 8.122232599748965,
-        "z": 9.632722231829131
+        "x": -8.12,
+        "z": -9.63
       }
     ],
     "streetWidth": 10.4,
@@ -302,102 +302,68 @@
   "zones": {
     "street": [
       {
-        "id": "water-street-main-roadway",
+        "id": "water-street-west-roadway",
         "surface": "road",
         "polygon": [
           {
-            "x": 3.3520325014837,
-            "z": 3.9754091750405935
+            "x": -3.35,
+            "z": -3.98
           },
           {
-            "x": 32.331658814422916,
-            "z": -20.45997470738267
+            "x": 25.69,
+            "z": -28.47
           },
           {
-            "x": 66.31227617364034,
-            "z": -48.17001206816464
+            "x": 59.89,
+            "z": -56.35
           },
           {
-            "x": 113.3597643482687,
-            "z": -83.67887448410478
+            "x": 107.13,
+            "z": -92.01
           },
           {
-            "x": 155.44318452315682,
-            "z": -114.82505252046886
+            "x": 149.19,
+            "z": -123.13
           },
           {
-            "x": 195.1842485004153,
-            "z": -145.28808897921755
+            "x": 195.16,
+            "z": -152.67
           },
           {
-            "x": 214.45739324566065,
-            "z": -170.28956284854794
+            "x": 193.73,
+            "z": -143.4
           },
           {
-            "x": 206.2206744221646,
-            "z": -176.63908747820844
+            "x": 185.49,
+            "z": -149.74
           },
           {
-            "x": 187.77785448203704,
-            "z": -152.71472604655287
+            "x": 187.8,
+            "z": -145.33
           },
           {
-            "x": 149.18576103156997,
-            "z": -123.1324191794352
+            "x": 155.44,
+            "z": -114.83
           },
           {
-            "x": 107.13356767215484,
-            "z": -92.00935228637148
+            "x": 113.36,
+            "z": -83.68
           },
           {
-            "x": 59.89114412781455,
-            "z": -56.353363350150175
+            "x": 66.31,
+            "z": -48.17
           },
           {
-            "x": 25.692902243971805,
-            "z": -28.46586059360328
+            "x": 32.33,
+            "z": -20.46
           },
           {
-            "x": -3.3520325014837,
-            "z": -3.9754091750405935
+            "x": 3.35,
+            "z": 3.98
           },
           {
-            "x": 3.3520325014837,
-            "z": 3.9754091750405935
-          }
-        ]
-      },
-      {
-        "id": "cambie-street-crossing",
-        "surface": "road",
-        "polygon": [
-          {
-            "x": 197.8532548045305,
-            "z": -170.81530585623304
-          },
-          {
-            "x": 187.92291722650126,
-            "z": -150.95463070017456
-          },
-          {
-            "x": 176.00306018453608,
-            "z": -131.08820229689925
-          },
-          {
-            "x": 182.95904279791625,
-            "z": -126.91461272887116
-          },
-          {
-            "x": 195.03918575595108,
-            "z": -147.04818432559586
-          },
-          {
-            "x": 205.10884817792183,
-            "z": -167.18750916953738
-          },
-          {
-            "x": 197.8532548045305,
-            "z": -170.81530585623304
+            "x": -3.35,
+            "z": -3.98
           }
         ]
       },
@@ -406,24 +372,92 @@
         "surface": "road",
         "polygon": [
           {
-            "x": 184.72,
-            "z": -150.97
-          },
-          {
-            "x": 195.1,
-            "z": -142.97
+            "x": 192.17,
+            "z": -160.63
           },
           {
             "x": 202.55,
             "z": -152.63
           },
           {
-            "x": 192.17,
-            "z": -160.63
+            "x": 195.1,
+            "z": -142.97
           },
           {
             "x": 184.72,
             "z": -150.97
+          },
+          {
+            "x": 192.17,
+            "z": -160.63
+          }
+        ]
+      },
+      {
+        "id": "water-street-east-roadway",
+        "surface": "road",
+        "polygon": [
+          {
+            "x": 201.79,
+            "z": -153.84
+          },
+          {
+            "x": 188.31,
+            "z": -144.88
+          },
+          {
+            "x": 206.22,
+            "z": -176.64
+          },
+          {
+            "x": 214.46,
+            "z": -170.29
+          },
+          {
+            "x": 194.66,
+            "z": -153.12
+          },
+          {
+            "x": 193.55,
+            "z": -160.2
+          },
+          {
+            "x": 201.79,
+            "z": -153.84
+          }
+        ]
+      },
+      {
+        "id": "cambie-street-crossing",
+        "surface": "road",
+        "polygon": [
+          {
+            "x": 205.11,
+            "z": -167.19
+          },
+          {
+            "x": 195.04,
+            "z": -147.05
+          },
+          {
+            "x": 182.96,
+            "z": -126.91
+          },
+          {
+            "x": 176,
+            "z": -131.09
+          },
+          {
+            "x": 187.92,
+            "z": -150.95
+          },
+          {
+            "x": 197.85,
+            "z": -170.82
+          },
+          {
+            "x": 205.11,
+            "z": -167.19
           }
         ]
       }
@@ -434,64 +468,64 @@
         "side": "south",
         "polygon": [
           {
-            "x": 6.059443368066688,
-            "z": 7.186316585650304
+            "x": 3.35,
+            "z": 3.98
           },
           {
-            "x": 35.01269512172048,
-            "z": -17.226828484101272
+            "x": 32.33,
+            "z": -20.46
           },
           {
-            "x": 68.90542565368537,
-            "z": -44.865197127362784
+            "x": 66.31,
+            "z": -48.17
           },
           {
-            "x": 115.87418992900697,
-            "z": -80.31464306395863
+            "x": 113.36,
+            "z": -83.68
           },
           {
-            "x": 157.97022093322076,
-            "z": -111.47015444665554
+            "x": 155.44,
+            "z": -114.83
           },
           {
-            "x": 198.17529223860652,
-            "z": -142.28887016356293
+            "x": 195.18,
+            "z": -145.29
           },
           {
-            "x": 217.78376046284177,
-            "z": -167.72533174810812
+            "x": 214.46,
+            "z": -170.29
           },
           {
-            "x": 214.45739324566065,
-            "z": -170.28956284854794
+            "x": 217.78,
+            "z": -167.73
           },
           {
-            "x": 195.1842485004153,
-            "z": -145.28808897921755
+            "x": 198.18,
+            "z": -142.29
           },
           {
-            "x": 155.44318452315682,
-            "z": -114.82505252046886
+            "x": 157.97,
+            "z": -111.47
           },
           {
-            "x": 113.3597643482687,
-            "z": -83.67887448410478
+            "x": 115.87,
+            "z": -80.31
           },
           {
-            "x": 66.31227617364034,
-            "z": -48.17001206816464
+            "x": 68.91,
+            "z": -44.87
           },
           {
-            "x": 32.331658814422916,
-            "z": -20.45997470738267
+            "x": 35.01,
+            "z": -17.23
           },
           {
-            "x": 3.3520325014837,
-            "z": 3.9754091750405935
+            "x": 6.06,
+            "z": 7.19
           },
           {
-            "x": 6.059443368066688,
-            "z": 7.186316585650304
+            "x": 3.35,
+            "z": 3.98
           }
         ]
       },
@@ -500,64 +534,64 @@
         "side": "north",
         "polygon": [
           {
-            "x": -3.3520325014837,
-            "z": -3.9754091750405935
+            "x": -6.06,
+            "z": -7.19
           },
           {
-            "x": 25.692902243971805,
-            "z": -28.46586059360328
+            "x": 23.01,
+            "z": -31.7
           },
           {
-            "x": 59.89114412781455,
-            "z": -56.353363350150175
+            "x": 57.3,
+            "z": -59.66
           },
           {
-            "x": 107.13356767215484,
-            "z": -92.00935228637148
+            "x": 104.62,
+            "z": -95.37
           },
           {
-            "x": 149.18576103156997,
-            "z": -123.1324191794352
+            "x": 146.66,
+            "z": -126.49
           },
           {
-            "x": 187.77785448203704,
-            "z": -152.71472604655287
+            "x": 184.79,
+            "z": -155.71
           },
           {
-            "x": 206.2206744221646,
-            "z": -176.63908747820844
+            "x": 202.89,
+            "z": -179.2
           },
           {
-            "x": 202.89430720498348,
-            "z": -179.20331857864826
+            "x": 206.22,
+            "z": -176.64
           },
           {
-            "x": 184.78681074384582,
-            "z": -155.71394486220748
+            "x": 187.78,
+            "z": -152.71
           },
           {
-            "x": 146.65872462150602,
-            "z": -126.48731725324852
+            "x": 149.19,
+            "z": -123.13
           },
           {
-            "x": 104.61914209141656,
-            "z": -95.37358370651764
+            "x": 107.13,
+            "z": -92.01
           },
           {
-            "x": 57.297994647769514,
-            "z": -59.65817829095203
+            "x": 59.89,
+            "z": -56.35
           },
           {
-            "x": 23.01186593667424,
-            "z": -31.69900681688468
+            "x": 25.69,
+            "z": -28.47
           },
           {
-            "x": -6.059443368066688,
-            "z": -7.186316585650304
+            "x": -3.35,
+            "z": -3.98
           },
           {
-            "x": -3.3520325014837,
-            "z": -3.9754091750405935
+            "x": -6.06,
+            "z": -7.19
           }
         ]
       },
@@ -566,32 +600,32 @@
         "side": "west",
         "polygon": [
           {
-            "x": 194.25050207918284,
-            "z": -172.61668221890687
+            "x": 197.85,
+            "z": -170.82
           },
           {
-            "x": 184.38934601883068,
-            "z": -152.89437009820253
+            "x": 187.92,
+            "z": -150.95
           },
           {
-            "x": 172.54907867976596,
-            "z": -133.16059119976134
+            "x": 176,
+            "z": -131.09
           },
           {
-            "x": 176.00306018453608,
-            "z": -131.08820229689925
+            "x": 172.55,
+            "z": -133.16
           },
           {
-            "x": 187.92291722650126,
-            "z": -150.95463070017456
+            "x": 184.39,
+            "z": -152.89
           },
           {
-            "x": 197.8532548045305,
-            "z": -170.81530585623304
+            "x": 194.25,
+            "z": -172.62
           },
           {
-            "x": 194.25050207918284,
-            "z": -172.61668221890687
+            "x": 197.85,
+            "z": -170.82
           }
         ]
       },
@@ -600,24 +634,24 @@
         "side": "corner",
         "polygon": [
           {
-            "x": 184.28,
-            "z": -155.35
-          },
-          {
-            "x": 189.35,
-            "z": -151.44
+            "x": 187.82,
+            "z": -159.94
           },
           {
             "x": 192.89,
             "z": -156.03
           },
           {
-            "x": 187.82,
-            "z": -159.94
+            "x": 189.35,
+            "z": -151.44
           },
           {
             "x": 184.28,
             "z": -155.35
+          },
+          {
+            "x": 187.82,
+            "z": -159.94
           }
         ]
       },
@@ -626,24 +660,24 @@
         "side": "plaza",
         "polygon": [
           {
-            "x": 177.85,
-            "z": -153.8
-          },
-          {
-            "x": 184.66,
-            "z": -148.55
+            "x": 183.59,
+            "z": -161.25
           },
           {
             "x": 190.4,
             "z": -156
           },
           {
-            "x": 183.59,
-            "z": -161.25
+            "x": 184.66,
+            "z": -148.55
           },
           {
             "x": 177.85,
             "z": -153.8
+          },
+          {
+            "x": 183.59,
+            "z": -161.25
           }
         ]
       }
@@ -4331,442 +4365,442 @@
     "surfaceBands": [
       {
         "segment_id": "waterfront-station-threshold",
-        "width": 9.78,
+        "width": 9.98,
         "length": 19.24,
         "yaw": 2.2712,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "road_base_dark",
-        "opacity": 0.18,
+        "opacity": 0.2,
         "elevation": 0.012
       },
       {
         "segment_id": "waterfront-station-threshold",
-        "width": 3.12,
-        "length": 15.91,
+        "width": 3.54,
+        "length": 15.17,
         "yaw": 2.2712,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.08,
+        "opacity": 0.1,
         "elevation": 0.016
       },
       {
         "segment_id": "waterfront-station-threshold",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.2712,
         "offset_x": 4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "waterfront-station-threshold",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.2712,
         "offset_x": -4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "gastown-beat-1",
-        "width": 9.78,
+        "width": 9.98,
         "length": 19.24,
         "yaw": 2.2548,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "road_base_dark",
-        "opacity": 0.18,
+        "opacity": 0.2,
         "elevation": 0.012
       },
       {
         "segment_id": "gastown-beat-1",
-        "width": 3.12,
-        "length": 15.91,
+        "width": 3.54,
+        "length": 15.17,
         "yaw": 2.2548,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.08,
+        "opacity": 0.1,
         "elevation": 0.016
       },
       {
         "segment_id": "gastown-beat-1",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.2548,
         "offset_x": 4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "gastown-beat-1",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.2548,
         "offset_x": -4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "water-cordova-seam",
-        "width": 9.78,
+        "width": 9.98,
         "length": 19.24,
         "yaw": 2.2279,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "road_base_dark",
-        "opacity": 0.18,
+        "opacity": 0.2,
         "elevation": 0.012
       },
       {
         "segment_id": "water-cordova-seam",
-        "width": 3.12,
-        "length": 15.91,
+        "width": 3.54,
+        "length": 15.17,
         "yaw": 2.2279,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.11,
+        "opacity": 0.16,
         "elevation": 0.016
       },
       {
         "segment_id": "water-cordova-seam",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.2279,
         "offset_x": 4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "water-cordova-seam",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.2279,
         "offset_x": -4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "gastown-beat-3",
-        "width": 9.78,
+        "width": 9.98,
         "length": 19.24,
         "yaw": 2.213,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "road_base_dark",
-        "opacity": 0.18,
+        "opacity": 0.2,
         "elevation": 0.012
       },
       {
         "segment_id": "gastown-beat-3",
-        "width": 3.12,
-        "length": 15.91,
+        "width": 3.54,
+        "length": 15.17,
         "yaw": 2.213,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.11,
+        "opacity": 0.16,
         "elevation": 0.016
       },
       {
         "segment_id": "gastown-beat-3",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.213,
         "offset_x": 4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "gastown-beat-3",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.213,
         "offset_x": -4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "water-street-mid-block",
-        "width": 9.78,
+        "width": 9.98,
         "length": 19.24,
         "yaw": 2.2136,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "road_base_dark",
-        "opacity": 0.18,
+        "opacity": 0.2,
         "elevation": 0.012
       },
       {
         "segment_id": "water-street-mid-block",
-        "width": 3.12,
-        "length": 15.91,
+        "width": 3.54,
+        "length": 15.17,
         "yaw": 2.2136,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.11,
+        "opacity": 0.16,
         "elevation": 0.016
       },
       {
         "segment_id": "water-street-mid-block",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.2136,
         "offset_x": 4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "water-street-mid-block",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.2136,
         "offset_x": -4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "steam-clock-approach",
-        "width": 9.78,
+        "width": 9.98,
         "length": 9.57,
         "yaw": -2.4152,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "road_base_dark",
-        "opacity": 0.18,
+        "opacity": 0.24,
         "elevation": 0.012
-      },
-      {
-        "segment_id": "steam-clock-approach",
-        "width": 3.12,
-        "length": 7.91,
-        "yaw": -2.4152,
-        "offset_x": 0,
-        "offset_z": 0,
-        "tone": "wheel_track",
-        "opacity": 0.11,
-        "elevation": 0.016
-      },
-      {
-        "segment_id": "steam-clock-approach",
-        "width": 0.83,
-        "length": 9.57,
-        "yaw": -2.4152,
-        "offset_x": 4.06,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.14,
-        "elevation": 0.024
-      },
-      {
-        "segment_id": "steam-clock-approach",
-        "width": 0.83,
-        "length": 9.57,
-        "yaw": -2.4152,
-        "offset_x": -4.06,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.14,
-        "elevation": 0.024
-      },
-      {
-        "segment_id": "steam-clock-approach",
-        "width": 7.07,
-        "length": 5.2,
-        "yaw": -2.4152,
-        "offset_x": 0,
-        "offset_z": 0,
-        "tone": "intersection_pavers",
-        "opacity": 0.18,
-        "elevation": 0.02
       },
       {
         "segment_id": "steam-clock-approach",
         "width": 3.54,
-        "length": 4.1,
+        "length": 7.54,
+        "yaw": -2.4152,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.16,
+        "elevation": 0.016
+      },
+      {
+        "segment_id": "steam-clock-approach",
+        "width": 1.04,
+        "length": 9.38,
+        "yaw": -2.4152,
+        "offset_x": 4.06,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.18,
+        "elevation": 0.024
+      },
+      {
+        "segment_id": "steam-clock-approach",
+        "width": 1.04,
+        "length": 9.38,
+        "yaw": -2.4152,
+        "offset_x": -4.06,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.18,
+        "elevation": 0.024
+      },
+      {
+        "segment_id": "steam-clock-approach",
+        "width": 7.28,
+        "length": 5.8,
+        "yaw": -2.4152,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "intersection_pavers",
+        "opacity": 0.24,
+        "elevation": 0.02
+      },
+      {
+        "segment_id": "steam-clock-approach",
+        "width": 3.95,
+        "length": 4.5,
         "yaw": -2.4152,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "cobble_break",
-        "opacity": 0.12,
+        "opacity": 0.18,
         "elevation": 0.022
       },
       {
         "segment_id": "steam-clock",
-        "width": 9.78,
+        "width": 9.98,
         "length": 19.24,
         "yaw": 2.194,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "road_base_dark",
-        "opacity": 0.18,
+        "opacity": 0.24,
         "elevation": 0.012
-      },
-      {
-        "segment_id": "steam-clock",
-        "width": 3.12,
-        "length": 15.91,
-        "yaw": 2.194,
-        "offset_x": 0,
-        "offset_z": 0,
-        "tone": "wheel_track",
-        "opacity": 0.11,
-        "elevation": 0.016
-      },
-      {
-        "segment_id": "steam-clock",
-        "width": 0.83,
-        "length": 19.24,
-        "yaw": 2.194,
-        "offset_x": 4.06,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.14,
-        "elevation": 0.024
-      },
-      {
-        "segment_id": "steam-clock",
-        "width": 0.83,
-        "length": 19.24,
-        "yaw": 2.194,
-        "offset_x": -4.06,
-        "offset_z": 0,
-        "tone": "curb_grime",
-        "opacity": 0.14,
-        "elevation": 0.024
-      },
-      {
-        "segment_id": "steam-clock",
-        "width": 7.07,
-        "length": 6.66,
-        "yaw": 2.194,
-        "offset_x": 0,
-        "offset_z": 0,
-        "tone": "intersection_pavers",
-        "opacity": 0.18,
-        "elevation": 0.02
       },
       {
         "segment_id": "steam-clock",
         "width": 3.54,
-        "length": 4.1,
+        "length": 15.17,
+        "yaw": 2.194,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "wheel_track",
+        "opacity": 0.16,
+        "elevation": 0.016
+      },
+      {
+        "segment_id": "steam-clock",
+        "width": 1.04,
+        "length": 18.87,
+        "yaw": 2.194,
+        "offset_x": 4.06,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.18,
+        "elevation": 0.024
+      },
+      {
+        "segment_id": "steam-clock",
+        "width": 1.04,
+        "length": 18.87,
+        "yaw": 2.194,
+        "offset_x": -4.06,
+        "offset_z": 0,
+        "tone": "curb_grime",
+        "opacity": 0.18,
+        "elevation": 0.024
+      },
+      {
+        "segment_id": "steam-clock",
+        "width": 7.28,
+        "length": 7.77,
+        "yaw": 2.194,
+        "offset_x": 0,
+        "offset_z": 0,
+        "tone": "intersection_pavers",
+        "opacity": 0.24,
+        "elevation": 0.02
+      },
+      {
+        "segment_id": "steam-clock",
+        "width": 3.95,
+        "length": 4.5,
         "yaw": 2.194,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "cobble_break",
-        "opacity": 0.12,
+        "opacity": 0.18,
         "elevation": 0.022
       },
       {
         "segment_id": "maple-tree-square-edge",
-        "width": 9.78,
+        "width": 9.98,
         "length": 19.24,
         "yaw": -0.6078,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "road_base_dark",
-        "opacity": 0.18,
+        "opacity": 0.24,
         "elevation": 0.012
       },
       {
         "segment_id": "maple-tree-square-edge",
-        "width": 3.12,
-        "length": 15.91,
+        "width": 3.54,
+        "length": 15.17,
         "yaw": -0.6078,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.11,
+        "opacity": 0.16,
         "elevation": 0.016
       },
       {
         "segment_id": "maple-tree-square-edge",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": -0.6078,
         "offset_x": 4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "maple-tree-square-edge",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": -0.6078,
         "offset_x": -4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "cambie-rise-continuation",
-        "width": 9.78,
+        "width": 9.98,
         "length": 19.24,
         "yaw": 2.5338,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "road_base_dark",
-        "opacity": 0.18,
+        "opacity": 0.24,
         "elevation": 0.012
       },
       {
         "segment_id": "cambie-rise-continuation",
-        "width": 3.12,
-        "length": 15.91,
+        "width": 3.54,
+        "length": 15.17,
         "yaw": 2.5338,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "wheel_track",
-        "opacity": 0.11,
+        "opacity": 0.16,
         "elevation": 0.016
       },
       {
         "segment_id": "cambie-rise-continuation",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.5338,
         "offset_x": 4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       },
       {
         "segment_id": "cambie-rise-continuation",
-        "width": 0.83,
-        "length": 19.24,
+        "width": 1.04,
+        "length": 18.87,
         "yaw": 2.5338,
         "offset_x": -4.06,
         "offset_z": 0,
         "tone": "curb_grime",
-        "opacity": 0.14,
+        "opacity": 0.18,
         "elevation": 0.024
       }
     ]

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -1440,9 +1440,67 @@
     };
   }
 
+  function polygonSignedArea(points) {
+    if (!Array.isArray(points) || points.length < 3) {
+      return 0;
+    }
+    let area = 0;
+    for (let i = 0; i < points.length; i += 1) {
+      const current = points[i];
+      const next = points[(i + 1) % points.length];
+      area += (current.x * next.z) - (next.x * current.z);
+    }
+    return area / 2;
+  }
+
+  function sanitizePolygon(points) {
+    if (!Array.isArray(points)) {
+      return [];
+    }
+
+    const deduped = [];
+    points.forEach((point) => {
+      if (!point || !Number.isFinite(point.x) || !Number.isFinite(point.z)) {
+        return;
+      }
+      const last = deduped[deduped.length - 1];
+      if (last && Math.abs(last.x - point.x) < 0.001 && Math.abs(last.z - point.z) < 0.001) {
+        return;
+      }
+      deduped.push({ x: point.x, z: point.z });
+    });
+
+    if (deduped.length > 2) {
+      const first = deduped[0];
+      const last = deduped[deduped.length - 1];
+      if (Math.abs(first.x - last.x) < 0.001 && Math.abs(first.z - last.z) < 0.001) {
+        deduped.pop();
+      }
+    }
+
+    const cleaned = deduped.filter((point, index, arr) => {
+      if (arr.length < 3) {
+        return true;
+      }
+      const prev = arr[(index + arr.length - 1) % arr.length];
+      const next = arr[(index + 1) % arr.length];
+      const cross = ((point.x - prev.x) * (next.z - point.z)) - ((point.z - prev.z) * (next.x - point.x));
+      return Math.abs(cross) > 0.0005;
+    });
+
+    if (cleaned.length >= 3 && polygonSignedArea(cleaned) < 0) {
+      cleaned.reverse();
+    }
+    return cleaned;
+  }
+
   function toShape(points) {
+    const sanitizedPoints = sanitizePolygon(points);
+    if (sanitizedPoints.length < 3) {
+      return null;
+    }
     const shape = new THREE.Shape();
-    points.forEach((point, index) => {
+    sanitizedPoints.forEach((point, index) => {
       if (index === 0) {
         shape.moveTo(point.x, point.z);
       } else {
@@ -1454,7 +1512,11 @@
   }
 
   function createZoneMesh(points, material, y, textureKind) {
-    const geometry = new THREE.ShapeGeometry(toShape(points));
+    const shape = toShape(points);
+    if (!shape) {
+      return null;
+    }
+    const geometry = new THREE.ShapeGeometry(shape);
     if (textureKind && WORLD_TEXTURE_REPEAT[textureKind]) {
       applyWorldUvs(geometry, WORLD_TEXTURE_REPEAT[textureKind]);
     } else {
@@ -1470,9 +1532,9 @@
   }
 
   function addGround(world) {
-    visualState.roadMaterial = createGroundMaterial('street', 0x0e1319, 0.96, 0.08);
-    visualState.sidewalkMaterial = createGroundMaterial('sidewalk', 0x7c7065, 0.98, 0.02);
-    visualState.curbMaterial = new THREE.LineBasicMaterial({ color: 0xa7afb7, transparent: true, opacity: 0.42 });
+    visualState.roadMaterial = createGroundMaterial('street', 0x0a0f14, 0.94, 0.1);
+    visualState.sidewalkMaterial = createGroundMaterial('sidewalk', 0x85796d, 0.98, 0.02);
+    visualState.curbMaterial = new THREE.LineBasicMaterial({ color: 0xc2c8cf, transparent: true, opacity: 0.5 });
     visualState.laneMaterial = new THREE.MeshStandardMaterial({ color: 0x8fa0af, roughness: 0.92, metalness: 0.02, transparent: true, opacity: 0.02, depthWrite: false });
     visualState.routeGuideMaterials = [visualState.laneMaterial];
 
@@ -1498,17 +1560,17 @@
         (() => {
           const toneStyles = {
             brick: { color: 0x5c4033, roughness: 0.82, metalness: 0.06, opacity: 0.72 },
-            road_base_dark: { color: 0x23292f, roughness: 0.95, metalness: 0.03, opacity: 0.18 },
-            wheel_track: { color: 0x13181d, roughness: 0.62, metalness: 0.14, opacity: 0.14 },
+            road_base_dark: { color: 0x1c232a, roughness: 0.95, metalness: 0.03, opacity: 0.24 },
+            wheel_track: { color: 0x0d1217, roughness: 0.62, metalness: 0.14, opacity: 0.2 },
             patch: { color: 0x2f353d, roughness: 0.76, metalness: 0.12, opacity: 0.2 },
             repair_patch_dark: { color: 0x252b32, roughness: 0.72, metalness: 0.14, opacity: 0.22 },
             puddle: { color: 0x1a212a, roughness: 0.34, metalness: 0.28, opacity: 0.14 },
             wet_streak: { color: 0x202731, roughness: 0.48, metalness: 0.2, opacity: 0.18 },
             edge_grime: { color: 0x1b1d20, roughness: 0.8, metalness: 0.08, opacity: 0.18 },
-            curb_grime: { color: 0x1f2327, roughness: 0.88, metalness: 0.04, opacity: 0.13 },
-            cobble_break: { color: 0x5b4c40, roughness: 0.86, metalness: 0.04, opacity: 0.14 },
+            curb_grime: { color: 0x181c20, roughness: 0.88, metalness: 0.04, opacity: 0.18 },
+            cobble_break: { color: 0x55483d, roughness: 0.86, metalness: 0.04, opacity: 0.18 },
             paver_break: { color: 0x5d5144, roughness: 0.84, metalness: 0.05, opacity: 0.18 },
-            intersection_pavers: { color: 0x65584a, roughness: 0.9, metalness: 0.04, opacity: 0.2 },
+            intersection_pavers: { color: 0x5c5044, roughness: 0.9, metalness: 0.04, opacity: 0.26 },
             default: { color: 0x3a4048, roughness: 0.8, metalness: 0.08, opacity: 0.78 },
           };
           const style = toneStyles[band.tone] || toneStyles.default;
@@ -2713,35 +2775,51 @@
 
     ctx.restore();
 
-    const dirLength = 16;
+    const dirLength = 11;
     const headingX = minimapState.mode === 'heading-up' ? 0 : heading.x;
     const headingY = minimapState.mode === 'heading-up' ? -1 : -heading.z;
-
-    ctx.fillStyle = 'rgba(133, 205, 245, 0.3)';
-    ctx.beginPath();
-    ctx.moveTo(playerPoint.x, playerPoint.y);
-    const headingAngle = Math.atan2(headingY, headingX);
-    ctx.arc(playerPoint.x, playerPoint.y, dirLength, headingAngle - 0.5, headingAngle + 0.5);
-    ctx.closePath();
-    ctx.fill();
-
-    const arrowTipX = playerPoint.x + (headingX * 10);
-    const arrowTipY = playerPoint.y + (headingY * 10);
     const sideX = -headingY;
     const sideY = headingX;
+    const headingAngle = Math.atan2(headingY, headingX);
 
-    ctx.fillStyle = '#f2f6ff';
+    ctx.strokeStyle = 'rgba(133, 205, 245, 0.34)';
+    ctx.lineWidth = 3;
+    ctx.lineCap = 'round';
     ctx.beginPath();
-    ctx.moveTo(arrowTipX, arrowTipY);
-    ctx.lineTo(playerPoint.x - (headingX * 6) + (sideX * 4.2), playerPoint.y - (headingY * 6) + (sideY * 4.2));
-    ctx.lineTo(playerPoint.x - (headingX * 6) - (sideX * 4.2), playerPoint.y - (headingY * 6) - (sideY * 4.2));
+    ctx.moveTo(playerPoint.x + (headingX * 2.4), playerPoint.y + (headingY * 2.4));
+    ctx.lineTo(playerPoint.x + (headingX * dirLength), playerPoint.y + (headingY * dirLength));
+    ctx.stroke();
+
+    ctx.fillStyle = '#f4f8ff';
+    ctx.beginPath();
+    ctx.arc(playerPoint.x, playerPoint.y - 4.2, 2.2, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.strokeStyle = '#f4f8ff';
+    ctx.lineWidth = 1.8;
+    ctx.beginPath();
+    ctx.moveTo(playerPoint.x, playerPoint.y - 1.4);
+    ctx.lineTo(playerPoint.x, playerPoint.y + 4.3);
+    ctx.moveTo(playerPoint.x - 2.5, playerPoint.y + 0.7);
+    ctx.lineTo(playerPoint.x + 2.5, playerPoint.y + 0.7);
+    ctx.moveTo(playerPoint.x, playerPoint.y + 4.3);
+    ctx.lineTo(playerPoint.x - 2.1, playerPoint.y + 7.4);
+    ctx.moveTo(playerPoint.x, playerPoint.y + 4.3);
+    ctx.lineTo(playerPoint.x + 2.1, playerPoint.y + 7.4);
+    ctx.stroke();
+
+    ctx.fillStyle = '#9ce3ff';
+    ctx.beginPath();
+    ctx.moveTo(playerPoint.x + (headingX * 9.4), playerPoint.y + (headingY * 9.4));
+    ctx.lineTo(playerPoint.x + (headingX * 5.3) + (sideX * 1.9), playerPoint.y + (headingY * 5.3) + (sideY * 1.9));
+    ctx.lineTo(playerPoint.x + (headingX * 5.3) - (sideX * 1.9), playerPoint.y + (headingY * 5.3) - (sideY * 1.9));
     ctx.closePath();
     ctx.fill();
 
-    ctx.strokeStyle = '#9ce3ff';
-    ctx.lineWidth = 1.4;
+    ctx.strokeStyle = 'rgba(12, 23, 36, 0.68)';
+    ctx.lineWidth = 1;
     ctx.beginPath();
-    ctx.arc(playerPoint.x, playerPoint.y, 2.3, 0, Math.PI * 2);
+    ctx.arc(playerPoint.x, playerPoint.y - 4.2, 2.2, 0, Math.PI * 2);
     ctx.stroke();
 
     drawMinimapCompass(playerPoint, headingRotation);

--- a/scripts/generate-gastown-world.js
+++ b/scripts/generate-gastown-world.js
@@ -72,6 +72,59 @@ function closePolygon(points) {
   return points;
 }
 
+function polygonSignedArea(points) {
+  if (!Array.isArray(points) || points.length < 3) return 0;
+  const ring = points[0] && points[points.length - 1]
+    && points[0].x === points[points.length - 1].x
+    && points[0].z === points[points.length - 1].z
+    ? points.slice(0, -1)
+    : points.slice();
+  let area = 0;
+  for (let i = 0; i < ring.length; i += 1) {
+    const current = ring[i];
+    const next = ring[(i + 1) % ring.length];
+    area += (current.x * next.z) - (next.x * current.z);
+  }
+  return area / 2;
+}
+
+function sanitizePolygon(points) {
+  if (!Array.isArray(points)) return [];
+  const deduped = [];
+  points.forEach((point) => {
+    if (!point || !Number.isFinite(point.x) || !Number.isFinite(point.z)) return;
+    const last = deduped[deduped.length - 1];
+    if (last && Math.abs(last.x - point.x) < 0.001 && Math.abs(last.z - point.z) < 0.001) return;
+    deduped.push({ x: Number(point.x.toFixed(2)), z: Number(point.z.toFixed(2)) });
+  });
+  if (deduped.length > 2) {
+    const first = deduped[0];
+    const last = deduped[deduped.length - 1];
+    if (Math.abs(first.x - last.x) < 0.001 && Math.abs(first.z - last.z) < 0.001) {
+      deduped.pop();
+    }
+  }
+  const cleaned = deduped.filter((point, index, arr) => {
+    if (arr.length < 3) return true;
+    const prev = arr[(index + arr.length - 1) % arr.length];
+    const next = arr[(index + 1) % arr.length];
+    const cross = ((point.x - prev.x) * (next.z - point.z)) - ((point.z - prev.z) * (next.x - point.x));
+    return Math.abs(cross) > 0.0005;
+  });
+  if (cleaned.length >= 3 && polygonSignedArea(cleaned) < 0) {
+    cleaned.reverse();
+  }
+  return closePolygon(cleaned);
+}
+
+function sanitizeZonePolygon(points) {
+  const polygon = sanitizePolygon(points);
+  if (polygon.length < 4) {
+    throw new Error('Zone polygon must contain at least three unique vertices.');
+  }
+  return polygon;
+}
+
 function polygonContainsPoint(point, polygon) {
   if (!Array.isArray(polygon) || polygon.length < 3) return false;
   let inside = false;
@@ -900,13 +953,23 @@ function makeStarterWorld(outputPath, options = {}) {
     { id: 'cambie-rise-continuation', label: 'Cambie rise continuation', x: Number(layout.cambie.x.toFixed(2)), z: Number(layout.cambie.z.toFixed(2)) },
   ];
 
-  const mainStreet = ribbonPolygon(waterCenterline, streetHalf);
-  const cambieStreet = ribbonPolygon(cambieCorridor, streetHalf * 0.78);
-  const intersectionRoadway = orientedRect(intersectionPoint, intersectionFrame.tangent, 13.1, streetWidth + 1.8);
-  const southSidewalk = closePolygon(lineOffset(waterCenterline, sidewalkOuter).concat(lineOffset(waterCenterline, streetHalf).reverse()));
-  const northSidewalk = closePolygon(lineOffset(waterCenterline, -streetHalf).concat(lineOffset(waterCenterline, -sidewalkOuter).reverse()));
-  const cambieWestSidewalk = closePolygon(lineOffset(cambieCorridor, sidewalkOuter * 0.86).concat(lineOffset(cambieCorridor, streetHalf * 0.78).reverse()));
-  const curbReturn = orientedRect(
+  const westRoadwayCenterline = waterWestLeg.concat([{
+    x: Number((intersectionPoint.x - (intersectionFrame.tangent.x * 6.6)).toFixed(2)),
+    z: Number((intersectionPoint.z - (intersectionFrame.tangent.z * 6.6)).toFixed(2)),
+  }]);
+  const eastRoadwayCenterline = [{
+    x: Number((intersectionPoint.x + (intersectionFrame.tangent.x * 6.6)).toFixed(2)),
+    z: Number((intersectionPoint.z + (intersectionFrame.tangent.z * 6.6)).toFixed(2)),
+  }].concat(waterEastLeg.slice(1));
+
+  const mainStreetWest = sanitizeZonePolygon(ribbonPolygon(westRoadwayCenterline, streetHalf));
+  const mainStreetEast = sanitizeZonePolygon(ribbonPolygon(eastRoadwayCenterline, streetHalf));
+  const cambieStreet = sanitizeZonePolygon(ribbonPolygon(cambieCorridor, streetHalf * 0.78));
+  const intersectionRoadway = sanitizeZonePolygon(orientedRect(intersectionPoint, intersectionFrame.tangent, 13.1, streetWidth + 1.8));
+  const southSidewalk = sanitizeZonePolygon(closePolygon(lineOffset(waterCenterline, sidewalkOuter).concat(lineOffset(waterCenterline, streetHalf).reverse())));
+  const northSidewalk = sanitizeZonePolygon(closePolygon(lineOffset(waterCenterline, -streetHalf).concat(lineOffset(waterCenterline, -sidewalkOuter).reverse())));
+  const cambieWestSidewalk = sanitizeZonePolygon(closePolygon(lineOffset(cambieCorridor, sidewalkOuter * 0.86).concat(lineOffset(cambieCorridor, streetHalf * 0.78).reverse())));
+  const curbReturn = sanitizeZonePolygon(orientedRect(
     {
       x: intersectionPoint.x + (layout.plaza.normal.x * (streetHalf + (sidewalkWidth * 0.28))),
       z: intersectionPoint.z + (layout.plaza.normal.z * (streetHalf + (sidewalkWidth * 0.28))),
@@ -914,8 +977,8 @@ function makeStarterWorld(outputPath, options = {}) {
     layout.plaza.tangent,
     6.4,
     5.8
-  );
-  const plazaPad = orientedRect(
+  ));
+  const plazaPad = sanitizeZonePolygon(orientedRect(
     {
       x: layout.clock.x + (layout.plaza.normal.x * 0.24),
       z: layout.clock.z + (layout.plaza.normal.z * 0.24),
@@ -923,8 +986,8 @@ function makeStarterWorld(outputPath, options = {}) {
     layout.plaza.tangent,
     8.6,
     9.4
-  );
-  const walkBounds = ribbonPolygon(waterRoute, walkOuter).concat([]);
+  ));
+  const walkBounds = sanitizePolygon(ribbonPolygon(waterRoute, walkOuter).concat([]));
 
   const frontagePattern = [7.5, 9.5, 8, 12.5, 8.8, 10.4, 9.2, 14.5, 10.8, 8.4, 12.8, 9.6];
   const depthPattern = [15, 20, 14, 23, 17, 21, 18, 19, 22, 16, 24, 17];
@@ -1115,9 +1178,10 @@ function makeStarterWorld(outputPath, options = {}) {
     },
     zones: {
       street: [
-        { id: 'water-street-main-roadway', surface: 'road', polygon: mainStreet },
-        { id: 'cambie-street-crossing', surface: 'road', polygon: cambieStreet },
+        { id: 'water-street-west-roadway', surface: 'road', polygon: mainStreetWest },
         { id: 'water-cambie-intersection-roadway', surface: 'road', polygon: intersectionRoadway },
+        { id: 'water-street-east-roadway', surface: 'road', polygon: mainStreetEast },
+        { id: 'cambie-street-crossing', surface: 'road', polygon: cambieStreet },
       ],
       sidewalk: [
         { id: 'water-street-south-sidewalk', side: 'south', polygon: southSidewalk },
@@ -1166,13 +1230,13 @@ function buildStarterSurfaceBands(centerline, streetWidth, routeLength) {
     const length = Math.max(9.2, Math.min(18.5, distance(point, next) * 0.98 || 10));
     const progress = routeLength > 0 ? index / Math.max(1, centerline.length - 1) : 0;
     const edgeOffset = streetWidth * 0.39;
-    bands.push({ segment_id: point.id, width: Number((streetWidth * 0.94).toFixed(2)), length: Number((length * 1.04).toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: 0, offset_z: 0, tone: 'road_base_dark', opacity: 0.18, elevation: 0.012 });
-    bands.push({ segment_id: point.id, width: Number((streetWidth * 0.3).toFixed(2)), length: Number((length * 0.86).toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: 0, offset_z: 0, tone: 'wheel_track', opacity: progress < 0.2 ? 0.08 : 0.11, elevation: 0.016 });
-    bands.push({ segment_id: point.id, width: Number((streetWidth * 0.08).toFixed(2)), length: Number((length * 1.04).toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: Number(edgeOffset.toFixed(2)), offset_z: 0, tone: 'curb_grime', opacity: 0.14, elevation: 0.024 });
-    bands.push({ segment_id: point.id, width: Number((streetWidth * 0.08).toFixed(2)), length: Number((length * 1.04).toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: Number((-edgeOffset).toFixed(2)), offset_z: 0, tone: 'curb_grime', opacity: 0.14, elevation: 0.024 });
+    bands.push({ segment_id: point.id, width: Number((streetWidth * 0.96).toFixed(2)), length: Number((length * 1.04).toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: 0, offset_z: 0, tone: 'road_base_dark', opacity: progress > 0.55 ? 0.24 : 0.2, elevation: 0.012 });
+    bands.push({ segment_id: point.id, width: Number((streetWidth * 0.34).toFixed(2)), length: Number((length * 0.82).toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: 0, offset_z: 0, tone: 'wheel_track', opacity: progress < 0.2 ? 0.1 : 0.16, elevation: 0.016 });
+    bands.push({ segment_id: point.id, width: Number((streetWidth * 0.1).toFixed(2)), length: Number((length * 1.02).toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: Number(edgeOffset.toFixed(2)), offset_z: 0, tone: 'curb_grime', opacity: 0.18, elevation: 0.024 });
+    bands.push({ segment_id: point.id, width: Number((streetWidth * 0.1).toFixed(2)), length: Number((length * 1.02).toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: Number((-edgeOffset).toFixed(2)), offset_z: 0, tone: 'curb_grime', opacity: 0.18, elevation: 0.024 });
     if (point.id === 'steam-clock' || point.id === 'steam-clock-approach') {
-      bands.push({ segment_id: point.id, width: Number((streetWidth * 0.68).toFixed(2)), length: Number(Math.max(5.2, length * 0.36).toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: 0, offset_z: 0, tone: 'intersection_pavers', opacity: 0.18, elevation: 0.02 });
-      bands.push({ segment_id: point.id, width: Number((streetWidth * 0.34).toFixed(2)), length: Number(Math.max(4.1, length * 0.18).toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: 0, offset_z: 0, tone: 'cobble_break', opacity: 0.12, elevation: 0.022 });
+      bands.push({ segment_id: point.id, width: Number((streetWidth * 0.7).toFixed(2)), length: Number(Math.max(5.8, length * 0.42).toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: 0, offset_z: 0, tone: 'intersection_pavers', opacity: 0.24, elevation: 0.02 });
+      bands.push({ segment_id: point.id, width: Number((streetWidth * 0.38).toFixed(2)), length: Number(Math.max(4.5, length * 0.22).toFixed(2)), yaw: Number(heading.toFixed(4)), offset_x: 0, offset_z: 0, tone: 'cobble_break', opacity: 0.18, elevation: 0.022 });
     }
   });
   return bands;


### PR DESCRIPTION
### Motivation
- Replace the minimap wedge with a tiny person-style marker so the player icon reads as a walker while still communicating facing in both `north-up` and `heading-up` modes. 
- Remove the translucent/triangulation artifacts near the Steam Clock by addressing malformed zone polygons rather than hiding geometry. 
- Make Water Street read more clearly as a roadway (darker bed, clearer curb, localized intersection paving) while preserving the stylized low-poly fallback world.

### Description
- Replace minimap marker drawing in `js/gastown-sim.js` with a compact person icon and forward cue (circle head, short torso and forward guide) and remove the previous wedge/arc marker. 
- Add lightweight polygon sanitization utilities (`polygonSignedArea`, `sanitizePolygon`, `sanitizeZonePolygon`) and apply them before building `THREE.ShapeGeometry` so malformed rings are deduplicated, collinear points removed, winding normalized, and tiny/invalid shapes skipped; guard `createZoneMesh()` to skip invalid shapes. 
- Split the single Water Street roadway into `water-street-west-roadway`, `water-cambie-intersection-roadway`, and `water-street-east-roadway` in `scripts/generate-gastown-world.js`, and use sanitized zone polygons to avoid overlapping/ self-intersecting rings at the Steam Clock / Cambie approach. 
- Darken and increase contrast for fallback road materials and surface-band tones (road base, wheel tracks, curb grime, intersection pavers) and adjust surface-band widths/opacities so the road reads distinctly from sidewalks without changing layout or removing the Steam Clock plaza. 
- Regenerated the canonical fallback files `assets/world/gastown-water-street.json` and `assets/world/gastown-water-street-starter.json` to include the cleaned geometry and updated surface-bands, and add targeted tests to cover the new marker, sanitization, and roadway split (`__tests__/gastown-sim-ground.test.js`, `__tests__/gastown-world-generator.test.js`).

### Testing
- Ran the world generator with `node scripts/generate-gastown-world.js` which produced updated fallback assets (`assets/world/gastown-water-street.json`, `...-starter.json`). (succeeded) 
- Ran unit tests with `node --test __tests__/gastown-sim-ground.test.js __tests__/gastown-world-generator.test.js` and all added and existing tests passed (17/17 passing). (succeeded) 
- Verified the simulator JS lints/executes without runtime parse errors (`node -c js/gastown-sim.js` and `node -c scripts/generate-gastown-world.js`). (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0a5fbb36c832e8ea9e504c04a4500)