### PR TITLE
Minimap: derive player heading from gameplay forward (fix minimap facing)

### DIFF
--- a/__tests__/gastown-sim-ground.test.js
+++ b/__tests__/gastown-sim-ground.test.js
@@ -57,14 +57,16 @@ test('production landmark rendering also suppresses reflection discs for suppres
   assert.equal(src.includes('visualState.landmarkVisuals.push({ reflectionMaterial });\n      }'), true);
 });
 
-test('heading-up minimap derives heading from rendered world direction instead of mirrored yaw math', () => {
+test('minimap heading derives from gameplay forward yaw instead of mirrored player rig world direction', () => {
   const simPath = path.join(__dirname, '..', 'js', 'gastown-sim.js');
   const src = fs.readFileSync(simPath, 'utf8');
 
-  assert.match(src, /function getHeadingVector\(\) \{\s*const direction = new THREE\.Vector3\(\);\s*player\.getWorldDirection\(direction\);/s);
-  assert.match(src, /const planarLength = Math\.hypot\(direction\.x, direction\.z\) \|\| 1;/);
-  assert.doesNotMatch(src, /baseForward\.clone\(\)\.applyAxisAngle/);
+  assert.match(src, /function getHeadingVector\(\) \{\s*const forward = new THREE\.Vector3\(0, 0, -1\);\s*forward\.applyAxisAngle\(new THREE\.Vector3\(0, 1, 0\), state\.yaw\);/s);
+  assert.match(src, /const planarLength = Math\.hypot\(forward\.x, forward\.z\) \|\| 1;/);
+  assert.doesNotMatch(src, /player\.getWorldDirection\(direction\)/);
   assert.match(src, /const headingRotation = minimapState\.mode === 'heading-up' \? \(-Math\.atan2\(-heading\.z, heading\.x\) - \(Math\.PI \/ 2\)\) : 0;/);
+  assert.match(src, /const headingX = minimapState\.mode === 'heading-up' \? 0 : heading\.x;/);
+  assert.match(src, /const headingY = minimapState\.mode === 'heading-up' \? -1 : -heading\.z;/);
 });
 
 

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -2413,10 +2413,10 @@
 
 
   function getHeadingVector() {
-    const direction = new THREE.Vector3();
-    player.getWorldDirection(direction);
-    const planarLength = Math.hypot(direction.x, direction.z) || 1;
-    return { x: direction.x / planarLength, z: direction.z / planarLength };
+    const forward = new THREE.Vector3(0, 0, -1);
+    forward.applyAxisAngle(new THREE.Vector3(0, 1, 0), state.yaw);
+    const planarLength = Math.hypot(forward.x, forward.z) || 1;
+    return { x: forward.x / planarLength, z: forward.z / planarLength };
   }
 
   function clampMinimapZoom(nextZoom) {


### PR DESCRIPTION
### Motivation

- The minimap player icon was using the player rig's world-forward vector which produced a mirrored/opposite heading from actual movement/camera forward, causing the marker to face backwards relative to travel.
- The goal is to make the minimap heading match the gameplay convention where forward input maps to local `(0, 0, -1)` rotated by `state.yaw`, without flipping the map or regressing recent landmark/road fixes.

### Description

- Replaced `getHeadingVector()` to compute heading from the gameplay local forward `new THREE.Vector3(0, 0, -1)` rotated by `state.yaw` so minimap heading matches movement/camera forward (file: `js/gastown-sim.js`).
- Kept existing minimap rotation and player-icon math intact (`headingRotation`, `headingX`/`headingY`, and compass drawing) so north-up and heading-up behaviors remain consistent.
- Added/updated a regression test to assert the heading source is the gameplay-forward yaw and to guard against using `player.getWorldDirection(...)` (file: `__tests__/gastown-sim-ground.test.js`).

### Testing

- Ran the focused test suite with `node --test __tests__/gastown-sim-ground.test.js`; all tests passed (9/9).
- The new regression test verifies the code contains the gameplay-forward `forward.applyAxisAngle(new THREE.Vector3(0, 1, 0), state.yaw)` usage and no longer contains `player.getWorldDirection(...)`.
- No browser screenshots were produced as part of automated tests, but the unit assertions confirm the minimap heading source and related heading math were updated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0a88910a8832eb72299d7916e888e)