### PR TITLE
Fix Gastown minimap projection handedness

### DIFF
--- a/__tests__/gastown-sim-ground.test.js
+++ b/__tests__/gastown-sim-ground.test.js
@@ -64,11 +64,105 @@ test('minimap heading derives from gameplay forward yaw instead of mirrored play
   assert.match(src, /function getHeadingVector\(\) \{\s*const forward = new THREE\.Vector3\(0, 0, -1\);\s*forward\.applyAxisAngle\(new THREE\.Vector3\(0, 1, 0\), state\.yaw\);/s);
   assert.match(src, /const planarLength = Math\.hypot\(forward\.x, forward\.z\) \|\| 1;/);
   assert.doesNotMatch(src, /player\.getWorldDirection\(direction\)/);
-  assert.match(src, /const headingRotation = minimapState\.mode === 'heading-up' \? \(-Math\.atan2\(-heading\.z, heading\.x\) - \(Math\.PI \/ 2\)\) : 0;/);
+  assert.match(src, /function getMinimapHeadingRotation\(heading\) \{\s*return minimapState\.mode === 'heading-up' \? \(-Math\.atan2\(-heading\.z, heading\.x\) - \(Math\.PI \/ 2\)\) : 0;\s*\}/s);
+  assert.match(src, /const headingRotation = getMinimapHeadingRotation\(heading\);/);
   assert.match(src, /const headingX = minimapState\.mode === 'heading-up' \? 0 : heading\.x;/);
   assert.match(src, /const headingY = minimapState\.mode === 'heading-up' \? -1 : -heading\.z;/);
 });
 
+
+
+test('minimap uses the same world-to-map handedness for Steam Clock corridor landmarks in north-up and heading-up modes', () => {
+  const simPath = path.join(__dirname, '..', 'js', 'gastown-sim.js');
+  const worldPath = path.join(__dirname, '..', 'assets', 'world', 'gastown-water-street.json');
+  const src = fs.readFileSync(simPath, 'utf8');
+  const world = JSON.parse(fs.readFileSync(worldPath, 'utf8'));
+
+  assert.match(src, /function projectWorldToMinimap\(point, metrics, padding, view, options = \{\}\) \{/);
+  assert.match(src, /drawPolygon\(zone\.polygon, metrics, pad, '#3f4d60', 'rgba\(136, 161, 188, 0\.4\)', 1, view, projectionOptions\);/);
+  assert.match(src, /const mini = projectWorldToMinimap\(node, metrics, pad, view, projectionOptions\);/);
+  assert.doesNotMatch(src, /ctx\.translate\(playerPoint\.x, playerPoint\.y\);\s*ctx\.rotate\(headingRotation\);/s);
+
+  const midBlock = world.nodes.find((node) => node.id === 'water-street-mid-block');
+  const approach = world.route.centerline.find((point) => point.id === 'steam-clock-approach');
+  const steamClock = world.landmarks.find((landmark) => landmark.id === 'steam-clock');
+
+  assert.ok(midBlock && approach && steamClock);
+
+  const metrics = {
+    minX: -20,
+    maxX: 240,
+    minZ: -210,
+    maxZ: 20,
+    width: 260,
+    height: 230,
+  };
+  const view = metrics;
+  const minimap = { width: 240, height: 240 };
+  const padding = 16;
+
+  function toMinimapPoint(point) {
+    const usableW = minimap.width - (padding * 2);
+    const usableH = minimap.height - (padding * 2);
+    return {
+      x: padding + (((point.x - view.minX) / view.width) * usableW),
+      y: minimap.height - (padding + (((point.z - view.minZ) / view.height) * usableH)),
+    };
+  }
+
+  function rotateMinimapVector(x, y, angle) {
+    const sin = Math.sin(angle);
+    const cos = Math.cos(angle);
+    return {
+      x: (x * cos) - (y * sin),
+      y: (x * sin) + (y * cos),
+    };
+  }
+
+  function projectWorldToMinimap(point, options = {}) {
+    const basePoint = toMinimapPoint(point);
+    const rotation = options.rotation || 0;
+    const anchor = options.anchor;
+    if (!rotation || !anchor) {
+      return basePoint;
+    }
+    const offsetX = basePoint.x - anchor.x;
+    const offsetY = basePoint.y - anchor.y;
+    const rotated = rotateMinimapVector(offsetX, offsetY, rotation);
+    return {
+      x: anchor.x + rotated.x,
+      y: anchor.y + rotated.y,
+    };
+  }
+
+  const northMid = projectWorldToMinimap(midBlock);
+  const northApproach = projectWorldToMinimap(approach);
+  const northSteam = projectWorldToMinimap(steamClock);
+  const northCorridor = {
+    x: northApproach.x - northMid.x,
+    y: northApproach.y - northMid.y,
+  };
+  const northOffset = {
+    x: northSteam.x - northApproach.x,
+    y: northSteam.y - northApproach.y,
+  };
+  const northScreenCross = (northCorridor.x * northOffset.y) - (northCorridor.y * northOffset.x);
+  assert.ok(northScreenCross > 0, `expected Steam Clock to stay on the right side of the corridor in north-up, got ${northScreenCross}`);
+
+  const heading = {
+    x: approach.x - midBlock.x,
+    z: approach.z - midBlock.z,
+  };
+  const planarLength = Math.hypot(heading.x, heading.z) || 1;
+  heading.x /= planarLength;
+  heading.z /= planarLength;
+  const headingRotation = -Math.atan2(-heading.z, heading.x) - (Math.PI / 2);
+  const headingApproach = projectWorldToMinimap(approach);
+  const headingSteam = projectWorldToMinimap(steamClock, { rotation: headingRotation, anchor: headingApproach });
+
+  assert.ok(headingSteam.x > headingApproach.x, `expected Steam Clock to stay on the right side of the corridor in heading-up, got ${headingSteam.x} <= ${headingApproach.x}`);
+  assert.ok(headingSteam.y > headingApproach.y - 20 && headingSteam.y < headingApproach.y + 20, 'expected heading-up projection to keep the Steam Clock laterally beside the corridor near Water/Cambie');
+});
 
 test('minimap player marker renders as a tiny person with a forward cue instead of a wedge', () => {
   const simPath = path.join(__dirname, '..', 'js', 'gastown-sim.js');

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -2574,14 +2574,14 @@
     }));
   }
 
-  function drawPolygon(points, metrics, padding, fillColor, strokeColor, lineWidth, view) {
+  function drawPolygon(points, metrics, padding, fillColor, strokeColor, lineWidth, view, projectionOptions) {
     if (!points || points.length < 3) {
       return;
     }
     const ctx = minimapState.ctx;
     ctx.beginPath();
     points.forEach((point, index) => {
-      const mini = toMinimapPoint(point, metrics, padding, view);
+      const mini = projectWorldToMinimap(point, metrics, padding, view, projectionOptions);
       if (index === 0) {
         ctx.moveTo(mini.x, mini.y);
       } else {
@@ -2635,6 +2635,26 @@
     };
   }
 
+  function getMinimapHeadingRotation(heading) {
+    return minimapState.mode === 'heading-up' ? (-Math.atan2(-heading.z, heading.x) - (Math.PI / 2)) : 0;
+  }
+
+  function projectWorldToMinimap(point, metrics, padding, view, options = {}) {
+    const basePoint = toMinimapPoint(point, metrics, padding, view);
+    const rotation = options.rotation || 0;
+    const anchor = options.anchor;
+    if (!rotation || !anchor) {
+      return basePoint;
+    }
+    const offsetX = basePoint.x - anchor.x;
+    const offsetY = basePoint.y - anchor.y;
+    const rotated = rotateMinimapVector(offsetX, offsetY, rotation);
+    return {
+      x: anchor.x + rotated.x,
+      y: anchor.y + rotated.y,
+    };
+  }
+
   function rotateMinimapVector(x, y, angle) {
     const sin = Math.sin(angle);
     const cos = Math.cos(angle);
@@ -2683,9 +2703,10 @@
     const metrics = minimapState.worldMetrics;
     const view = getMinimapView(metrics);
     const pad = 16;
-    const playerPoint = toMinimapPoint({ x: player.position.x, z: player.position.z }, metrics, pad, view);
     const heading = getHeadingVector();
-    const headingRotation = minimapState.mode === 'heading-up' ? (-Math.atan2(-heading.z, heading.x) - (Math.PI / 2)) : 0;
+    const headingRotation = getMinimapHeadingRotation(heading);
+    const playerPoint = toMinimapPoint({ x: player.position.x, z: player.position.z }, metrics, pad, view);
+    const projectionOptions = { rotation: headingRotation, anchor: playerPoint };
     ctx.clearRect(0, 0, minimapState.width, minimapState.height);
 
     ctx.fillStyle = '#08101a';
@@ -2693,22 +2714,15 @@
     ctx.strokeStyle = 'rgba(181, 201, 224, 0.34)';
     ctx.strokeRect(0.5, 0.5, minimapState.width - 1, minimapState.height - 1);
 
-    ctx.save();
-    if (headingRotation) {
-      ctx.translate(playerPoint.x, playerPoint.y);
-      ctx.rotate(headingRotation);
-      ctx.translate(-playerPoint.x, -playerPoint.y);
-    }
-
     (state.world.zones.sidewalk || []).forEach((zone) => {
-      drawPolygon(zone.polygon, metrics, pad, '#3f4d60', 'rgba(136, 161, 188, 0.4)', 1, view);
+      drawPolygon(zone.polygon, metrics, pad, '#3f4d60', 'rgba(136, 161, 188, 0.4)', 1, view, projectionOptions);
     });
     (state.world.zones.street || []).forEach((zone) => {
-      drawPolygon(zone.polygon, metrics, pad, '#1b2735', 'rgba(125, 148, 173, 0.45)', 1.1, view);
+      drawPolygon(zone.polygon, metrics, pad, '#1b2735', 'rgba(125, 148, 173, 0.45)', 1.1, view, projectionOptions);
     });
 
     (state.world.buildings || []).forEach((building) => {
-      drawPolygon(getBuildingPolygon(building), metrics, pad, '#6f5047', 'rgba(219, 194, 173, 0.24)', 0.8, view);
+      drawPolygon(getBuildingPolygon(building), metrics, pad, '#6f5047', 'rgba(219, 194, 173, 0.24)', 0.8, view, projectionOptions);
     });
 
     if (state.world.navigator && Array.isArray(state.world.navigator.focusCorridor) && state.world.navigator.focusCorridor.length) {
@@ -2718,7 +2732,7 @@
         if (!Array.isArray(corridor.points) || corridor.points.length < 2) return;
         ctx.beginPath();
         corridor.points.forEach((point, index) => {
-          const mini = toMinimapPoint(point, metrics, pad, view);
+          const mini = projectWorldToMinimap(point, metrics, pad, view, projectionOptions);
           if (index === 0) {
             ctx.moveTo(mini.x, mini.y);
           } else {
@@ -2735,7 +2749,7 @@
       ctx.lineWidth = 1.2;
       ctx.beginPath();
       state.world.route.centerline.forEach((point, index) => {
-        const mini = toMinimapPoint(point, metrics, pad, view);
+        const mini = projectWorldToMinimap(point, metrics, pad, view, projectionOptions);
         if (index === 0) {
           ctx.moveTo(mini.x, mini.y);
         } else {
@@ -2749,7 +2763,7 @@
     const majorNodes = ['waterfront-station-threshold', 'water-street-mid-block', 'water-cambie-intersection', 'steam-clock', 'maple-tree-square-edge'];
     state.world.nodes.forEach((node) => {
       if (!majorNodes.includes(node.id)) return;
-      const mini = toMinimapPoint(node, metrics, pad, view);
+      const mini = projectWorldToMinimap(node, metrics, pad, view, projectionOptions);
       ctx.fillStyle = node.id === 'steam-clock' ? '#d8a968' : node.id === 'water-cambie-intersection' ? '#9cc7e4' : '#b7d4ea';
       ctx.beginPath();
       ctx.arc(mini.x, mini.y, node.id === 'steam-clock' ? 4.6 : 3.8, 0, Math.PI * 2);
@@ -2772,8 +2786,6 @@
         ctx.fillText('Water St', mini.x + 6, mini.y + 7);
       }
     });
-
-    ctx.restore();
 
     const dirLength = 11;
     const headingX = minimapState.mode === 'heading-up' ? 0 : heading.x;
@@ -2825,7 +2837,7 @@
     drawMinimapCompass(playerPoint, headingRotation);
 
     if (minimapState.nearestNode) {
-      const nearestPoint = toMinimapPoint(minimapState.nearestNode, metrics, pad, view);
+      const nearestPoint = projectWorldToMinimap(minimapState.nearestNode, metrics, pad, view, projectionOptions);
       ctx.strokeStyle = '#8af7cb';
       ctx.lineWidth = 1.2;
       ctx.beginPath();


### PR DESCRIPTION
### Motivation
- The minimap/legend showed the Steam Clock on the wrong side of the corridor due to an inconsistent world->minimap transform / handedness difference between how streets/blocks and landmarks were plotted.
- The intention is to treat world geometry as the source of truth and apply a single consistent projection so north-up and heading-up modes do not mirror or flip features relative to the 3D scene.

### Description
- Added a shared `projectWorldToMinimap(point, metrics, padding, view, options = {})` helper and `getMinimapHeadingRotation(heading)` helper and used them across all minimap plotting paths in `js/gastown-sim.js` so polygons, buildings, route centerline, navigator corridors, nodes/landmarks, nearest-node highlighting, and the player marker use the same transform and handedness.
- Removed the previous canvas rotation path (translate/rotate/translate) and instead apply heading rotation at projection time so geometry is consistently rotated around the player anchor rather than raster-canvas rotated separately.
- Updated `drawPolygon` and all minimap plotting calls to accept `projectionOptions` so every feature is projected with the same rules; ensured `toMinimapPoint` remains the canonical base mapping from world X/Z to minimap X/Y.
- Added a regression test in `__tests__/gastown-sim-ground.test.js` that asserts the Steam Clock / Water-Cambie corridor placement uses the same screen-side handedness in north-up and heading-up modes and updated the heading-related test expectations to reference the new helpers.

### Testing
- Ran the targeted test pattern with `npm test -- --test-name-pattern=minimap`, which executed the new minimap regression and related minimap tests and they passed.
- Ran the full suite with `npm test` and all automated tests completed successfully (no failures).
- The new regression test `minimap uses the same world-to-map handedness for Steam Clock corridor landmarks in north-up and heading-up modes` was added and passed as part of the CI-local test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0aa8581c4832ea4d8cf97f7238645)