### PR TITLE
Improve Gastown simulator runtime usability

### DIFF
--- a/__tests__/gastown-sim-config.test.js
+++ b/__tests__/gastown-sim-config.test.js
@@ -36,6 +36,10 @@ test('simulator page exposes aligned supported mood options and daytime defaults
     assert.match(php, new RegExp(`<option value="${mood}"`));
   });
   assert.match(php, /<option value="calm" selected>Calm<\/option>/);
+  assert.match(php, /data-sim-world-status/);
+  assert.match(php, /data-sim-minimap-mode-status/);
+  assert.match(php, /Route line/);
+  assert.match(php, /Sidewalk \/ plaza/);
   assert.doesNotMatch(php, /<option value="quiet"/);
   assert.doesNotMatch(php, /<option value="nightlife"/);
 });
@@ -46,7 +50,8 @@ test('clock chime system initializes or fails softly without blocking startup', 
 
   assert.match(src, /function unlockSteamClockAudio\(\)/);
   assert.match(src, /function ensureNpcLoop\(npcState\)/);
-  assert.match(src, /Tone\.PluckSynth/);
+  assert.match(src, /Tone\.PolySynth/);
+  assert.match(src, /Tone\.MembraneSynth/);
   assert.doesNotMatch(src, /oscillator\.type = 'triangle'/);
   assert.doesNotMatch(src, /overtone\.type = 'sine'/);
   assert.match(src, /return false;\n\s*}\n\s*try \{/s);

--- a/__tests__/gastown-sim-ground.test.js
+++ b/__tests__/gastown-sim-ground.test.js
@@ -215,10 +215,20 @@ test('minimap player marker renders as a tiny person with a forward cue instead 
   const simPath = path.join(__dirname, '..', 'js', 'gastown-sim.js');
   const src = fs.readFileSync(simPath, 'utf8');
 
-  assert.match(src, /ctx\.arc\(playerPoint\.x, playerPoint\.y - 4\.2, 2\.2, 0, Math\.PI \* 2\)/);
+  assert.match(src, /ctx\.arc\(playerPoint\.x, playerPoint\.y - 4\.2, 2\.8, 0, Math\.PI \* 2\)/);
   assert.match(src, /ctx\.moveTo\(playerPoint\.x, playerPoint\.y - 1\.4\);\s*ctx\.lineTo\(playerPoint\.x, playerPoint\.y \+ 4\.3\);/s);
   assert.match(src, /ctx\.moveTo\(playerPoint\.x \+ \(headingX \* 9\.4\), playerPoint\.y \+ \(headingY \* 9\.4\)\);/);
   assert.doesNotMatch(src, /ctx\.arc\(playerPoint\.x, playerPoint\.y, dirLength, headingAngle - 0\.5, headingAngle \+ 0\.5\)/);
+});
+
+test('minimap mode control includes a plain-language status label for north-up and heading-up', () => {
+  const simPath = path.join(__dirname, '..', 'js', 'gastown-sim.js');
+  const src = fs.readFileSync(simPath, 'utf8');
+
+  assert.match(src, /const minimapModeStatusEl = app\.querySelector\('\[data-sim-minimap-mode-status\]'\);/);
+  assert.match(src, /minimapModeBtn\.dataset\.minimapMode = minimapState\.mode;/);
+  assert.match(src, /Heading-up — the top of the map follows the way you are facing\./);
+  assert.match(src, /North-up — the top of the map is geographic north\./);
 });
 
 test('ground meshes sanitize malformed polygon rings before building shape geometry', () => {

--- a/__tests__/gastown-sim-resilience.test.js
+++ b/__tests__/gastown-sim-resilience.test.js
@@ -36,6 +36,31 @@ test('audio setup wraps howl creation in a soft-fail guard so missing files do n
   assert.match(src, /warnAudioUnavailable\('Gastown audio setup failed; simulator continuing without ambient audio\.', error\);/);
 });
 
+test('fallback-world disclosure stays explicit instead of pretending the corridor is precise civic data', () => {
+  const worldPath = path.join(__dirname, '..', 'assets', 'world', 'gastown-water-street.json');
+  const world = JSON.parse(fs.readFileSync(worldPath, 'utf8'));
+
+  assert.equal(world.meta.fallbackMode, 'working-gastown-corridor');
+  assert.equal(world.meta.isRealCivicBuild, false);
+  assert.equal(world.meta.buildClassification, 'approximate-fallback');
+  assert.match(world.meta.provenanceSummary, /Approximate fallback corridor retained/);
+  assert.deepEqual(Object.values(world.meta.openDataInputs).every((value) => value === false), true);
+  assert.match(src, /function isApproximateWorld\(world\) \{/);
+  assert.match(src, /Approximate fallback world loaded\. This playable corridor is believable, but not survey-precise\./);
+  assert.match(src, /World data status: /);
+});
+
+test('runtime init keeps the active js\\/gastown-sim.js path responsible for world disclosure, minimap UI, and audio fallback setup', () => {
+  const functionsPath = path.join(__dirname, '..', 'functions.php');
+  const php = fs.readFileSync(functionsPath, 'utf8');
+
+  assert.match(php, /'se-gastown-sim',\s*\$uri \. \$app_path/s);
+  assert.doesNotMatch(php, /gastown-sim-classic\.js[\s\S]*page-gastown-sim\.php/s);
+  assert.match(src, /setWorldModeStatus\(state\.world\);/);
+  assert.match(src, /updateMinimapModeButton\(\);/);
+  assert.match(src, /ensureNpcLoop\(npcState\);/);
+});
+
 test('init still sequences NPC, minimap, landmark, and audio setup inside one startup try/catch', () => {
   const initStart = src.indexOf('async function init() {');
   const initEnd = src.indexOf('init();', initStart);

--- a/__tests__/gastown-world-generator.test.js
+++ b/__tests__/gastown-world-generator.test.js
@@ -118,6 +118,8 @@ test('generator keeps world polygons valid with existing or generated output', (
       }, {});
       assert.deepEqual(roleCounts, { guide: 1, busker: 1, pedestrian: 2, skateboarder: 1, cyclist: 1, tourist: 5, photographer: 1 }, 'working fallback role mix should remain deterministic');
       assert.equal(data.routeId, 'gastown_water_street_working_corridor');
+      assert.equal(data.meta.buildClassification, 'approximate-fallback');
+      assert.match(data.meta.provenanceSummary, /Approximate fallback corridor retained/);
     }
   }
 
@@ -138,6 +140,8 @@ test('committed world json files include the expanded intersection-based fallbac
     assert.ok(data.landmarks.some((landmark) => landmark.id === 'steam-clock'), relPath + ' should include the Steam Clock landmark');
     assert.equal(data.routeId, 'gastown_water_street_working_corridor', relPath + ' should treat fallback as the working corridor');
     assert.equal(data.meta.fallbackMode, 'working-gastown-corridor', relPath + ' should identify the working fallback mode');
+    assert.equal(data.meta.buildClassification, 'approximate-fallback', relPath + ' should keep fallback build classification explicit');
+    assert.match(data.meta.provenanceSummary, /Approximate fallback corridor retained/, relPath + ' should keep fallback provenance explicit');
     assert.ok(data.nodes.some((node) => node.id === 'water-cordova-seam'), relPath + ' should include the Water/Cordova seam node');
     assert.ok(data.nodes.some((node) => node.id === 'maple-tree-square-edge'), relPath + ' should include the Maple Tree Square edge node');
     assert.ok(data.nodes.some((node) => node.id === 'water-cambie-intersection'), relPath + ' should include the Water/Cambie intersection node');

--- a/__tests__/gastown-world-loader-normalize.test.js
+++ b/__tests__/gastown-world-loader-normalize.test.js
@@ -51,6 +51,8 @@ test('normalizeWorldData adds safe defaults for missing optional sections', () =
   assert.equal(Array.isArray(normalized.streetscape.surfaceBands), true);
   assert.equal(Array.isArray(normalized.props), true);
   assert.equal(Array.isArray(normalized.npcs), true);
+  assert.equal(normalized.meta.buildClassification, 'offline-civic-build');
+  assert.match(normalized.meta.provenanceSummary, /Offline civic-data build normalized for runtime use\./);
 });
 
 test('starter-like world with no landmarks or audioZones normalizes without crashing', () => {
@@ -65,6 +67,20 @@ test('starter-like world with no landmarks or audioZones normalizes without cras
   assert.equal(Array.isArray(normalized.audioZones), true);
   assert.equal(normalized.landmarks.length, 0);
   assert.equal(normalized.audioZones.length, 0);
+});
+
+test('normalizeWorldData preserves explicit fallback provenance metadata for runtime disclosure', () => {
+  const normalizeWorldData = loadNormalizeWorldData();
+  const normalized = normalizeWorldData(minimalValidWorld({
+    meta: {
+      isRealCivicBuild: false,
+      openDataInputs: { publicStreets: false },
+    },
+  }));
+
+  assert.equal(normalized.meta.buildClassification, 'approximate-fallback');
+  assert.match(normalized.meta.provenanceSummary, /Approximate fallback corridor retained/);
+  assert.deepEqual(normalized.meta.openDataInputs, { publicStreets: false });
 });
 
 test('normalizeWorldData guarantees required mood/weather/time presets and fields', () => {

--- a/assets/css/gastown-sim.css
+++ b/assets/css/gastown-sim.css
@@ -97,12 +97,31 @@
 }
 
 .gastown-status,
+.gastown-world-status,
 .gastown-pointer-status,
 .gastown-landmark,
 .gastown-route-segment {
   padding: 0.2rem 0.55rem;
   border-left: 2px solid rgba(192, 211, 237, 0.45);
   background: rgba(10, 14, 22, 0.35);
+}
+
+.gastown-world-status {
+  margin-top: 0.35rem;
+  border-left-color: rgba(255, 196, 120, 0.88);
+  background: rgba(39, 24, 7, 0.42);
+  color: #ffe2bf;
+}
+
+.gastown-world-status.is-approximate {
+  border-left-color: #ffbf7c;
+  box-shadow: inset 0 0 0 1px rgba(255, 191, 124, 0.14);
+}
+
+.gastown-world-status.is-civic {
+  border-left-color: rgba(149, 234, 199, 0.88);
+  background: rgba(12, 35, 28, 0.38);
+  color: #dcfff2;
 }
 
 .gastown-pointer-status {
@@ -148,6 +167,7 @@
   width: 100%;
   height: auto;
   border-radius: 8px;
+  border: 1px solid rgba(172, 201, 230, 0.24);
 }
 
 .gastown-minimap-label {
@@ -155,6 +175,21 @@
   font-size: 0.75rem;
   line-height: 1.2;
   color: #dbe9ff;
+}
+
+.gastown-minimap-mode-status {
+  margin: 0;
+  padding: 0.35rem 0.45rem;
+  border-radius: 8px;
+  background: rgba(18, 28, 41, 0.96);
+  border: 1px solid rgba(126, 178, 226, 0.24);
+  color: #ecf5ff;
+  font-size: 0.71rem;
+  line-height: 1.35;
+}
+
+.gastown-minimap-mode-status strong {
+  color: #9ed6ff;
 }
 
 @media (max-width: 740px) {
@@ -192,6 +227,17 @@
 .gastown-minimap-mode {
   min-width: 5.6rem;
   padding: 0 0.55rem;
+}
+
+.gastown-minimap-mode[data-minimap-mode="north-up"] {
+  border-color: rgba(137, 189, 245, 0.7);
+  box-shadow: inset 0 0 0 1px rgba(137, 189, 245, 0.18);
+}
+
+.gastown-minimap-mode[data-minimap-mode="heading-up"] {
+  border-color: rgba(255, 197, 126, 0.78);
+  color: #fff3de;
+  box-shadow: inset 0 0 0 1px rgba(255, 197, 126, 0.18);
 }
 
 .gastown-minimap-zoom {
@@ -235,7 +281,19 @@
 }
 
 .gastown-minimap-legend .dot.player {
-  background: #f2f6ff;
+  background: radial-gradient(circle at 35% 35%, #ffffff 0, #b7ecff 58%, #3f8fca 100%);
+}
+
+.gastown-minimap-legend .dot.route {
+  background: #ffd28f;
+}
+
+.gastown-minimap-legend .dot.sidewalk {
+  background: #6c7f95;
+}
+
+.gastown-minimap-legend .dot.street {
+  background: #203344;
 }
 
 .gastown-minimap-legend .dot.station {

--- a/assets/world/gastown-water-street-starter.json
+++ b/assets/world/gastown-water-street-starter.json
@@ -20,7 +20,9 @@
       "buildingFootprints2015": false,
       "orthophotoImagery2015": false
     },
-    "lastBuild": "2026-03-23T02:35:15.805Z"
+    "lastBuild": "2026-03-23T02:35:15.805Z",
+    "buildClassification": "approximate-fallback",
+    "provenanceSummary": "Approximate fallback corridor retained because the offline civic/open-data pipeline did not have all required local inputs."
   },
   "route": {
     "name": "Waterfront Station → Water Street → Steam Clock working corridor",

--- a/assets/world/gastown-water-street.json
+++ b/assets/world/gastown-water-street.json
@@ -20,7 +20,9 @@
       "buildingFootprints2015": false,
       "orthophotoImagery2015": false
     },
-    "lastBuild": "2026-03-23T02:35:10.016Z"
+    "lastBuild": "2026-03-23T02:35:10.016Z",
+    "buildClassification": "approximate-fallback",
+    "provenanceSummary": "Approximate fallback corridor retained because the offline civic/open-data pipeline did not have all required local inputs."
   },
   "route": {
     "name": "Waterfront Station → Water Street → Steam Clock working corridor",

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -36,6 +36,7 @@
 
   const canvasWrap = app.querySelector('[data-sim-canvas]');
   const pointerStatusEl = app.querySelector('[data-sim-pointer-status]');
+  const worldStatusEl = app.querySelector('[data-sim-world-status]');
   const landmarkEl = app.querySelector('[data-sim-landmark]');
   const pauseBtn = app.querySelector('[data-action="pause"]');
   const resetBtn = app.querySelector('[data-action="reset"]');
@@ -47,6 +48,7 @@
   const routeDebugOverlay = app.querySelector('[data-route-debug-overlay]');
   const minimapCanvas = app.querySelector('[data-sim-minimap]');
   const minimapLandmarkEl = app.querySelector('[data-sim-minimap-landmark]');
+  const minimapModeStatusEl = app.querySelector('[data-sim-minimap-mode-status]');
   const routeSegmentEl = app.querySelector('[data-sim-route-segment]');
   const minimapZoomInBtn = app.querySelector('[data-action="minimap-zoom-in"]');
   const minimapZoomOutBtn = app.querySelector('[data-action="minimap-zoom-out"]');
@@ -124,6 +126,7 @@
     clockTimer: null,
     boundaryNoticeTimer: null,
     audioWarningIssued: false,
+    worldBuildStatus: null,
   };
 
   const DEFAULT_EYE_HEIGHT = 1.7;
@@ -358,12 +361,40 @@
     landmarkEl.textContent = text;
   }
 
+  function isApproximateWorld(world) {
+    return !!(world && world.meta && (
+      world.meta.fallbackMode === 'working-gastown-corridor'
+      || world.meta.runtimeFallbackActive
+      || world.meta.isRealCivicBuild === false
+    ));
+  }
+
+  function getOpenDataCoverageSummary(meta) {
+    const inputs = meta && meta.openDataInputs && typeof meta.openDataInputs === 'object' ? meta.openDataInputs : {};
+    const values = Object.keys(inputs).map((key) => !!inputs[key]);
+    if (!values.length) return '0/0 civic inputs';
+    const enabled = values.filter(Boolean).length;
+    return enabled + '/' + values.length + ' civic inputs';
+  }
+
   function setWorldModeStatus(world) {
     if (!world || !world.meta) return;
-    const isWorkingFallback = world.meta.fallbackMode === 'working-gastown-corridor' || world.meta.runtimeFallbackActive || world.meta.isRealCivicBuild === false;
-    if (!isWorkingFallback) return;
+    const approximate = isApproximateWorld(world);
     const buildNote = (world.meta.buildNotes && world.meta.buildNotes[0]) || 'Working fallback Gastown corridor active.';
-    setStatus('Working fallback Gastown corridor active: ' + buildNote);
+    const coverage = getOpenDataCoverageSummary(world.meta);
+    state.worldBuildStatus = approximate
+      ? 'Approximate fallback build: ' + buildNote + ' (' + coverage + ').'
+      : 'Offline civic-data build loaded with ' + coverage + '.';
+
+    if (worldStatusEl) {
+      worldStatusEl.textContent = 'World data status: ' + state.worldBuildStatus;
+      worldStatusEl.classList.toggle('is-approximate', approximate);
+      worldStatusEl.classList.toggle('is-civic', !approximate);
+    }
+
+    if (approximate) {
+      setStatus('Approximate fallback world loaded. This playable corridor is believable, but not survey-precise.');
+    }
   }
 
   function updateAttribution(world) {
@@ -512,6 +543,9 @@
       color: baseColor,
       roughness: roughness,
       metalness: metalness,
+      polygonOffset: true,
+      polygonOffsetFactor: kind === 'street' ? 1 : 0.5,
+      polygonOffsetUnits: kind === 'street' ? 1 : 0.5,
     }, maps));
   }
 
@@ -557,10 +591,10 @@
       const segmentLength = Math.max(8.5, Math.min(18, Math.hypot(anchor.x - point.x, anchor.z - point.z) * 0.96 || 10));
       const steamZone = point.id === 'steam-clock' || index >= Math.max(1, centerline.length - 4);
 
-      bands.push({ segment_id: point.id, width: streetWidth * 0.94, length: segmentLength * 1.02, yaw: heading, offset_x: 0, offset_z: 0, tone: 'road_base_dark', opacity: 0.18, elevation: 0.012 });
-      bands.push({ segment_id: point.id, width: streetWidth * 0.3, length: Math.max(6.8, segmentLength * 0.78), yaw: heading, offset_x: 0, offset_z: 0, tone: steamZone ? 'intersection_pavers' : 'wheel_track', opacity: steamZone ? 0.16 : 0.1, elevation: 0.016 });
-      bands.push({ segment_id: point.id, width: streetWidth * 0.14, length: Math.max(5, segmentLength * 0.72), yaw: heading, offset_x: streetWidth * 0.33, offset_z: 0, tone: 'curb_grime', opacity: 0.12, elevation: 0.02 });
-      bands.push({ segment_id: point.id, width: streetWidth * 0.14, length: Math.max(5, segmentLength * 0.72), yaw: heading, offset_x: -streetWidth * 0.33, offset_z: 0, tone: 'curb_grime', opacity: 0.12, elevation: 0.02 });
+      bands.push({ segment_id: point.id, width: streetWidth * 0.96, length: segmentLength * 1.04, yaw: heading, offset_x: 0, offset_z: 0, tone: 'road_base_dark', opacity: 0.26, elevation: 0.012 });
+      bands.push({ segment_id: point.id, width: streetWidth * 0.34, length: Math.max(6.8, segmentLength * 0.82), yaw: heading, offset_x: 0, offset_z: 0, tone: steamZone ? 'intersection_pavers' : 'wheel_track', opacity: steamZone ? 0.24 : 0.2, elevation: 0.016 });
+      bands.push({ segment_id: point.id, width: streetWidth * 0.17, length: Math.max(5.8, segmentLength * 0.76), yaw: heading, offset_x: streetWidth * 0.34, offset_z: 0, tone: 'curb_grime', opacity: 0.2, elevation: 0.025 });
+      bands.push({ segment_id: point.id, width: streetWidth * 0.17, length: Math.max(5.8, segmentLength * 0.76), yaw: heading, offset_x: -streetWidth * 0.34, offset_z: 0, tone: 'curb_grime', opacity: 0.2, elevation: 0.025 });
 
       if (steamZone) {
         bands.push({ segment_id: point.id, width: streetWidth * 0.66, length: Math.max(5.2, segmentLength * 0.34), yaw: heading, offset_x: 0, offset_z: 0, tone: 'cobble_break', opacity: 0.12, elevation: 0.02 });
@@ -1157,12 +1191,29 @@
     }
     try {
       state.sounds.npcAudio[npcState.id] = {
-        mode: 'sparse_busker_motif',
-        radius: 10.5,
+        mode: 'busker_soft_duet',
+        radius: 11.5,
         lastGestureAt: -Infinity,
         nextGestureAt: 0,
-        synth: new Tone.PluckSynth({ attackNoise: 0.7, dampening: 2800, resonance: 0.8 }).toDestination(),
-        motif: ['G3', 'B3', 'D4', 'G4'],
+        intervalSeconds: 5.6,
+        chordIndex: 0,
+        synth: new Tone.PolySynth(Tone.Synth, {
+          oscillator: { type: 'triangle6' },
+          envelope: { attack: 0.02, decay: 0.3, sustain: 0.18, release: 1.6 },
+          volume: -24,
+        }).toDestination(),
+        accent: new Tone.MembraneSynth({
+          pitchDecay: 0.05,
+          octaves: 2,
+          envelope: { attack: 0.001, decay: 0.22, sustain: 0, release: 0.08 },
+          volume: -34,
+        }).toDestination(),
+        motif: [
+          ['G3', 'D4', 'B4'],
+          ['E3', 'B3', 'G4'],
+          ['C4', 'G4', 'E4'],
+          ['D3', 'A3', 'F#4'],
+        ],
       };
     } catch (error) {
       state.sounds.npcAudio[npcState.id] = { muted: true, mode: 'silent_busker' };
@@ -1177,16 +1228,20 @@
       visual.position.set(start.x, 0, start.z);
       worldGroup.add(visual);
       const swaySeed = deterministicUnit(npc.id + '-sway');
+      const startYaw = typeof npc.yaw === 'number' ? npc.yaw : deterministicUnit(npc.id + '-yaw') * Math.PI * 2;
       const npcState = Object.assign({
         mesh: visual,
         patrolIndex: 0,
         direction: 1,
         baseY: 0,
+        baseYaw: startYaw,
+        currentYaw: startYaw,
         speed: npc.role === 'pedestrian' || npc.role === 'tourist' || npc.role === 'photographer' ? 0.84 + (deterministicUnit(npc.id) * 0.34) : npc.role === 'guide' ? 0.18 : npc.role === 'skateboarder' ? 2.35 : npc.role === 'cyclist' ? 3.1 : 0,
         pauseUntil: 0,
         animPhase: swaySeed * Math.PI * 2,
-        swayAmount: 0.018 + (swaySeed * 0.028),
+        swayAmount: 0.012 + (swaySeed * 0.014),
       }, npc);
+      visual.rotation.y = startYaw;
       ensureNpcLoop(npcState);
       visualState.npcMeshes.push(visual);
       return npcState;
@@ -1218,13 +1273,14 @@
           const step = Math.min(distance, npc.speed * delta);
           npc.mesh.position.x += (dx / distance) * step;
           npc.mesh.position.z += (dz / distance) * step;
-          npc.mesh.rotation.y = Math.atan2(dx, dz);
+          const desiredYaw = Math.atan2(dx, dz);
+          npc.currentYaw += THREE.MathUtils.clamp(desiredYaw - npc.currentYaw, -0.08, 0.08);
         }
       } else if (npc.idleSpot) {
         npc.mesh.position.x = npc.idleSpot.x;
         npc.mesh.position.z = npc.idleSpot.z;
         if (npc.behavior === 'photo_idle') {
-          npc.mesh.rotation.y = -0.45;
+          npc.currentYaw = -0.45;
         }
       }
 
@@ -1254,8 +1310,9 @@
           rig.heldProp.rotation.x = npc.pose === 'taking_photo' ? -0.42 : -0.18;
         }
       }
+      npc.currentYaw = Number.isFinite(npc.currentYaw) ? npc.currentYaw : (npc.baseYaw || 0);
       if (npc.role === 'busker') {
-        npc.mesh.rotation.y += Math.sin((nowSeconds * 1.3) + npc.animPhase) * 0.002;
+        npc.currentYaw = (npc.baseYaw || 0) + (Math.sin((nowSeconds * 1.3) + npc.animPhase) * 0.01);
       }
       if (rollingMover) {
         npc.mesh.rotation.z = Math.sin((nowSeconds * (npc.role === 'cyclist' ? 1.8 : 2.6)) + npc.animPhase) * (npc.role === 'cyclist' ? 0.012 : 0.028);
@@ -1268,22 +1325,27 @@
         }
       }
       if (npc.pose === 'being_photographed') {
-        npc.mesh.rotation.y = -0.24;
+        npc.currentYaw = -0.24;
       }
       if (npc.pose === 'group_gather' || npc.pose === 'gathered') {
-        npc.mesh.rotation.y += Math.sin((nowSeconds * 0.8) + npc.animPhase) * 0.0015;
+        npc.currentYaw += Math.sin((nowSeconds * 0.8) + npc.animPhase) * 0.0015;
       }
+      npc.mesh.rotation.y = npc.currentYaw;
 
       const loop = state.sounds.npcAudio[npc.id];
-      if (loop && loop.mode === 'sparse_busker_motif' && loop.synth && state.steamClockState.enabled) {
+      if (loop && loop.mode === 'busker_soft_duet' && loop.synth && state.steamClockState.enabled) {
         const distance = Math.hypot(player.position.x - npc.mesh.position.x, player.position.z - npc.mesh.position.z);
-        const nearFactor = Math.max(0, 1 - (distance / (loop.radius || 10.5)));
-        if (nearFactor > 0.2 && nowSeconds >= (loop.nextGestureAt || 0)) {
-          const noteIndex = Math.floor(deterministicUnit(npc.id + ':' + Math.floor(nowSeconds / 3)) * loop.motif.length) % loop.motif.length;
+        const nearFactor = Math.max(0, 1 - (distance / (loop.radius || 11.5)));
+        if (nearFactor > 0.24 && nowSeconds >= (loop.nextGestureAt || 0)) {
+          const chord = loop.motif[loop.chordIndex % loop.motif.length];
           try {
-            loop.synth.triggerAttackRelease(loop.motif[noteIndex], '16n', getTone().now(), -18 + (nearFactor * 4));
+            loop.synth.triggerAttackRelease(chord, '2n', getTone().now(), 0.28 + (nearFactor * 0.16));
+            if (loop.accent) {
+              loop.accent.triggerAttackRelease('G2', '16n', getTone().now() + 0.02, 0.08 + (nearFactor * 0.08));
+            }
             loop.lastGestureAt = nowSeconds;
-            loop.nextGestureAt = nowSeconds + 4.2 + (deterministicUnit(npc.id + '-gesture-' + Math.floor(nowSeconds)) * 2.4);
+            loop.chordIndex = (loop.chordIndex + 1) % loop.motif.length;
+            loop.nextGestureAt = nowSeconds + loop.intervalSeconds + (deterministicUnit(npc.id + '-gesture-' + Math.floor(nowSeconds)) * 0.9);
           } catch (error) {
             warnAudioUnavailable('Busker motif playback failed; simulator continuing without busker audio.', error);
             loop.mode = 'silent_busker';
@@ -2452,12 +2514,18 @@
     }
     const isHeadingUp = minimapState.mode === 'heading-up';
     minimapModeBtn.textContent = isHeadingUp ? 'Heading up' : 'North up';
+    minimapModeBtn.dataset.minimapMode = minimapState.mode;
     minimapModeBtn.setAttribute('aria-pressed', isHeadingUp ? 'true' : 'false');
     minimapModeBtn.setAttribute(
       'aria-label',
       isHeadingUp ? 'Switch minimap to north-up mode' : 'Switch minimap to heading-up mode'
     );
     minimapModeBtn.title = isHeadingUp ? 'Switch minimap to north-up mode' : 'Switch minimap to heading-up mode';
+    if (minimapModeStatusEl) {
+      minimapModeStatusEl.innerHTML = isHeadingUp
+        ? '<strong>Map mode:</strong> Heading-up — the top of the map follows the way you are facing.'
+        : '<strong>Map mode:</strong> North-up — the top of the map is geographic north.';
+    }
   }
 
   function setMinimapMode(nextMode) {
@@ -2795,19 +2863,34 @@
     ctx.strokeRect(0.5, 0.5, minimapState.width - 1, minimapState.height - 1);
 
     (state.world.zones.sidewalk || []).forEach((zone) => {
-      drawPolygon(zone.polygon, metrics, pad, '#3f4d60', 'rgba(136, 161, 188, 0.4)', 1, view, projectionOptions);
+      drawPolygon(zone.polygon, metrics, pad, '#5d7083', 'rgba(211, 226, 242, 0.5)', 1.2, view, projectionOptions);
     });
     (state.world.zones.street || []).forEach((zone) => {
-      drawPolygon(zone.polygon, metrics, pad, '#1b2735', 'rgba(125, 148, 173, 0.45)', 1.1, view, projectionOptions);
+      drawPolygon(zone.polygon, metrics, pad, '#1a2f41', 'rgba(86, 117, 149, 0.68)', 1.15, view, projectionOptions);
     });
 
     (state.world.buildings || []).forEach((building) => {
-      drawPolygon(getBuildingPolygon(building), metrics, pad, '#6f5047', 'rgba(219, 194, 173, 0.24)', 0.8, view, projectionOptions);
+      drawPolygon(getBuildingPolygon(building), metrics, pad, '#7d5e53', 'rgba(245, 218, 197, 0.34)', 0.95, view, projectionOptions);
     });
 
     if (state.world.navigator && Array.isArray(state.world.navigator.focusCorridor) && state.world.navigator.focusCorridor.length) {
-      ctx.strokeStyle = 'rgba(197, 154, 95, 0.55)';
-      ctx.lineWidth = 1.3;
+      ctx.strokeStyle = 'rgba(255, 194, 112, 0.92)';
+      ctx.lineWidth = 2.8;
+      state.world.navigator.focusCorridor.forEach((corridor) => {
+        if (!Array.isArray(corridor.points) || corridor.points.length < 2) return;
+        ctx.beginPath();
+        corridor.points.forEach((point, index) => {
+          const mini = projectWorldToMinimap(point, metrics, pad, view, projectionOptions);
+          if (index === 0) {
+            ctx.moveTo(mini.x, mini.y);
+          } else {
+            ctx.lineTo(mini.x, mini.y);
+          }
+        });
+        ctx.stroke();
+      });
+      ctx.strokeStyle = 'rgba(74, 35, 6, 0.3)';
+      ctx.lineWidth = 1.05;
       state.world.navigator.focusCorridor.forEach((corridor) => {
         if (!Array.isArray(corridor.points) || corridor.points.length < 2) return;
         ctx.beginPath();
@@ -2824,9 +2907,9 @@
     }
 
     if (state.world.route && Array.isArray(state.world.route.centerline) && state.world.route.centerline.length > 1) {
-      ctx.strokeStyle = 'rgba(158, 212, 240, 0.48)';
-      ctx.setLineDash([5, 4]);
-      ctx.lineWidth = 1.2;
+      ctx.strokeStyle = 'rgba(179, 234, 255, 0.68)';
+      ctx.setLineDash([6, 4]);
+      ctx.lineWidth = 1.6;
       ctx.beginPath();
       state.world.route.centerline.forEach((point, index) => {
         const mini = projectWorldToMinimap(point, metrics, pad, view, projectionOptions);
@@ -2846,7 +2929,7 @@
       const mini = projectWorldToMinimap(node, metrics, pad, view, projectionOptions);
       ctx.fillStyle = node.id === 'steam-clock' ? '#d8a968' : node.id === 'water-cambie-intersection' ? '#9cc7e4' : '#b7d4ea';
       ctx.beginPath();
-      ctx.arc(mini.x, mini.y, node.id === 'steam-clock' ? 4.6 : 3.8, 0, Math.PI * 2);
+      ctx.arc(mini.x, mini.y, node.id === 'steam-clock' ? 5.2 : 4.1, 0, Math.PI * 2);
       ctx.fill();
 
       ctx.fillStyle = 'rgba(228, 240, 255, 0.92)';
@@ -2867,28 +2950,28 @@
       }
     });
 
-    const dirLength = 11;
+    const dirLength = 13;
     const headingX = minimapState.mode === 'heading-up' ? 0 : heading.x;
     const headingY = minimapState.mode === 'heading-up' ? -1 : -heading.z;
     const sideX = -headingY;
     const sideY = headingX;
     const headingAngle = Math.atan2(headingY, headingX);
 
-    ctx.strokeStyle = 'rgba(133, 205, 245, 0.34)';
-    ctx.lineWidth = 3;
+    ctx.strokeStyle = 'rgba(110, 212, 255, 0.6)';
+    ctx.lineWidth = 4;
     ctx.lineCap = 'round';
     ctx.beginPath();
     ctx.moveTo(playerPoint.x + (headingX * 2.4), playerPoint.y + (headingY * 2.4));
     ctx.lineTo(playerPoint.x + (headingX * dirLength), playerPoint.y + (headingY * dirLength));
     ctx.stroke();
 
-    ctx.fillStyle = '#f4f8ff';
+    ctx.fillStyle = '#ffffff';
     ctx.beginPath();
-    ctx.arc(playerPoint.x, playerPoint.y - 4.2, 2.2, 0, Math.PI * 2);
+    ctx.arc(playerPoint.x, playerPoint.y - 4.2, 2.8, 0, Math.PI * 2);
     ctx.fill();
 
     ctx.strokeStyle = '#f4f8ff';
-    ctx.lineWidth = 1.8;
+    ctx.lineWidth = 2.2;
     ctx.beginPath();
     ctx.moveTo(playerPoint.x, playerPoint.y - 1.4);
     ctx.lineTo(playerPoint.x, playerPoint.y + 4.3);
@@ -2911,7 +2994,7 @@
     ctx.strokeStyle = 'rgba(12, 23, 36, 0.68)';
     ctx.lineWidth = 1;
     ctx.beginPath();
-    ctx.arc(playerPoint.x, playerPoint.y - 4.2, 2.2, 0, Math.PI * 2);
+    ctx.arc(playerPoint.x, playerPoint.y - 4.2, 2.8, 0, Math.PI * 2);
     ctx.stroke();
 
     if (state.debugEnabled) {

--- a/js/gastown-world-loader.js
+++ b/js/gastown-world-loader.js
@@ -183,6 +183,18 @@
 
   function normalizeWorldData(data) {
     const normalized = data || {};
+    normalized.meta = normalized.meta && typeof normalized.meta === 'object' ? normalized.meta : {};
+    normalized.meta.buildClassification = typeof normalized.meta.buildClassification === 'string'
+      ? normalized.meta.buildClassification
+      : (normalized.meta.isRealCivicBuild === false ? 'approximate-fallback' : 'offline-civic-build');
+    normalized.meta.provenanceSummary = typeof normalized.meta.provenanceSummary === 'string'
+      ? normalized.meta.provenanceSummary
+      : (normalized.meta.isRealCivicBuild === false
+        ? 'Approximate fallback corridor retained because civic/open-data inputs were unavailable.'
+        : 'Offline civic-data build normalized for runtime use.');
+    normalized.meta.openDataInputs = normalized.meta.openDataInputs && typeof normalized.meta.openDataInputs === 'object'
+      ? normalized.meta.openDataInputs
+      : {};
 
     normalized.landmarks = Array.isArray(normalized.landmarks) ? normalized.landmarks : [];
     normalized.audioZones = Array.isArray(normalized.audioZones) ? normalized.audioZones : [];

--- a/page-gastown-sim.php
+++ b/page-gastown-sim.php
@@ -61,6 +61,7 @@ get_header();
     </section>
 
     <p class="gastown-status" data-sim-status aria-live="polite">Loading simulator...</p>
+    <p class="gastown-world-status" data-sim-world-status aria-live="polite">World data status: checking build provenance…</p>
     <p class="gastown-pointer-status" data-sim-pointer-status aria-live="polite">Pointer unlocked.</p>
     <p class="gastown-landmark" data-sim-landmark aria-live="polite">Nearest landmark: Station threshold</p>
     <p class="gastown-route-segment" data-sim-route-segment aria-live="polite">Route segment: Waterfront Station Threshold</p>
@@ -73,9 +74,13 @@ get_header();
           <button type="button" class="gastown-minimap-zoom" data-action="minimap-zoom-in" aria-label="Zoom in minimap">+</button>
           <button type="button" class="gastown-minimap-zoom" data-action="minimap-zoom-out" aria-label="Zoom out minimap">−</button>
         </div>
+        <p class="gastown-minimap-mode-status" data-sim-minimap-mode-status aria-live="polite">Map mode: North-up — the top of the map is geographic north.</p>
         <canvas data-sim-minimap width="220" height="220"></canvas>
         <ul class="gastown-minimap-legend" aria-label="Minimap legend">
           <li><span class="dot player"></span> Player</li>
+          <li><span class="dot route"></span> Route line</li>
+          <li><span class="dot sidewalk"></span> Sidewalk / plaza</li>
+          <li><span class="dot street"></span> Street</li>
           <li><span class="dot station"></span> Station</li>
           <li><span class="dot steam"></span> Steam Clock</li>
           <li><span class="dot nearest"></span> Nearest landmark</li>

--- a/scripts/build-gastown-world.js
+++ b/scripts/build-gastown-world.js
@@ -34,6 +34,7 @@ const importManifest = {
     '5) fit nearby building footprints and optional streetscape points',
     '6) write compact runtime JSON (no external dependencies)',
   ],
+  fallbackDisclosure: 'If required local civic/open-data files are missing, the build intentionally keeps the deterministic working corridor fallback and should disclose that approximation in the runtime UI.',
 };
 
 const referenceTemplate = {
@@ -69,6 +70,10 @@ function runScaffold() {
     'Supports hero_landmarks + facade_profiles to prioritize recognizability over photoreal detail.',
     'Scaffold includes reference-driven world notes for segment style, silhouette, and storefront cadence.',
   ];
+  world.meta.buildClassification = world.meta.isRealCivicBuild === false ? 'approximate-fallback' : 'offline-civic-build';
+  world.meta.provenanceSummary = world.meta.isRealCivicBuild === false
+    ? 'Approximate fallback corridor retained because civic/open-data inputs were unavailable at build time.'
+    : 'Offline civic/open-data build generated from local source exports.';
   world.meta.importManifest = world.meta.importManifest || importManifest;
 
   (world.buildings || []).forEach((building) => applyReferenceScaffold(building));
@@ -91,6 +96,7 @@ function run() {
 
   process.stdout.write('Offline source data missing; keeping scaffold behavior.\n');
   process.stdout.write(generated.reason + '\n');
+  process.stdout.write('Expected local inputs are documented in meta.importManifest and any retained fallback build should stay visibly disclosed in the simulator UI.\n');
   runScaffold();
 }
 

--- a/scripts/generate-gastown-world.js
+++ b/scripts/generate-gastown-world.js
@@ -1137,6 +1137,7 @@ function makeStarterWorld(outputPath, options = {}) {
     routeId: 'gastown_water_street_working_corridor',
     meta: {
       title: 'Gastown Working Corridor (deterministic fallback)', units: 'meters', source: 'deterministic fallback with optional open reference inputs', fallbackMode: 'working-gastown-corridor', isRealCivicBuild: false,
+      buildClassification: 'approximate-fallback',
       buildNotes: [
         'Working fallback corridor is active because required offline civic source files are missing.',
         'This fallback now stages Water Street, a real Water/Cambie corner condition, and a Steam Clock plaza pad outside the carriageway instead of a single bent ribbon corridor.',
@@ -1151,6 +1152,7 @@ function makeStarterWorld(outputPath, options = {}) {
         buildingFootprints2015: !!(reference.buildingFootprints2015 && Array.isArray(reference.buildingFootprints2015.features) && reference.buildingFootprints2015.features.length),
         orthophotoImagery2015: !!(reference.orthophotoImagery2015 && Array.isArray(reference.orthophotoImagery2015.features) && reference.orthophotoImagery2015.features.length),
       },
+      provenanceSummary: 'Approximate fallback corridor retained because the offline civic/open-data pipeline did not have all required local inputs.',
       lastBuild: new Date().toISOString(),
     },
     route: { name: 'Waterfront Station → Water Street → Steam Clock working corridor', centerline, walkBounds, streetWidth, sidewalkWidth, softBoundary, hardResetDistance: 12 },
@@ -1489,6 +1491,7 @@ function buildWorld(options = {}) {
       title: existingMeta.title || 'Waterfront Station to Steam Clock Corridor',
       units: 'meters',
       source: 'Offline City of Vancouver Open Data exports',
+      buildClassification: 'offline-civic-build',
       lastBuild: new Date().toISOString(),
       importManifest: existingMeta.importManifest || {
         inputs: {
@@ -1525,6 +1528,7 @@ function buildWorld(options = {}) {
         buildingFootprints2015: (buildingsPath || '').includes('building-footprints-2015.geojson'),
         orthophotoImagery2015: fs.existsSync(path.join(root, 'data', 'cov', 'orthophoto-imagery-2015.geojson')),
       },
+      provenanceSummary: 'Offline civic-data build generated from local source exports and normalized for the runtime simulator.',
     },
     route: {
       ...(existingWorld.route || {}),


### PR DESCRIPTION
### Motivation
- The playable simulator exposed fallback/deterministic world data and subtle minimap/NPC/audio UX issues that made real play confusing despite unit tests passing.
- The fallback world provenance and minimap mode were not visible to players, and busker audio + NPC facing felt synthetic and jittery in runtime play.
- Ground and surface rendering lacked clear layering so roadway/curb/sidewalk distinctions were hard to read at a glance.
- The world-generation pipeline and loader needed clearer provenance metadata so runtime disclosure and regeneration are robust and self-documenting.

### Description
- Surface, minimap, and UI: added a visible world-status line and an inline plain-language minimap mode label, strengthened minimap visuals (contrast, route line, player cue), and added legend dots for route/sidewalk/street; files: `page-gastown-sim.php`, `assets/css/gastown-sim.css`, `js/gastown-sim.js`.
- World provenance: made fallback classification/provenance explicit in generated and committed world JSON and in the build scaffold, and normalized defaults in the loader so runtime always has `buildClassification`/`provenanceSummary` and `openDataInputs`; files: `assets/world/*.json`, `scripts/generate-gastown-world.js`, `scripts/build-gastown-world.js`, `js/gastown-world-loader.js`.
- Ground readability: improved ground material layering with `polygonOffset`, tuned fallback `surfaceBands` to increase separation between roadway, curb, and sidewalk while preserving performance; file: `js/gastown-sim.js`.
- NPC stability & busker audio: deterministic base yaw/current yaw and smoother facing interpolation for NPCs, reduced sway; replaced sparse PluckSynth motif with a restrained `PolySynth` + `MembraneSynth` duet fallback that degrades gracefully if Tone/Howler is missing; file: `js/gastown-sim.js`.
- Minimap behavior and Steam Clock side: preserved canonical corridor-side logic and heading/north-up math, but made mode obvious via UI state and testable attributes; file: `js/gastown-sim.js`.
- Tests and loader hardening: added/updated tests to assert fallback disclosure, minimap mode labeling, committed world provenance metadata, and loader normalization behavior; files: `__tests__/*.test.js` (updates include `gastown-sim-ground.test.js`, `gastown-sim-resilience.test.js`, `gastown-sim-config.test.js`, `gastown-world-loader-normalize.test.js`, `gastown-world-generator.test.js`).

### Testing
- Ran `npm test`; the full suite passed with all tests green (69 tests passing) after changes.
- Added unit tests verifying: fallback-world disclosure and provenance metadata, minimap mode status label and toggling, loader normalization of provenance metadata, and that the runtime uses `js/gastown-sim.js` for disclosure and audio fallback; test files updated are listed above and all assertions succeeded under `node --test`.
- Existing minimap orientation, Steam Clock corridor-side checks, ground mesh sanitization, and audio soft-fail guards were preserved and re-verified by the expanded test suite.
- No runtime/browser screenshots were taken in this environment; behavior was validated via tests and committed metadata updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0c9db1b44832ead0bcc1fd607e31e)