### PR TITLE
Fix Steam Clock minimap landmark anchor

### DIFF
--- a/__tests__/gastown-sim-ground.test.js
+++ b/__tests__/gastown-sim-ground.test.js
@@ -211,6 +211,61 @@ test('minimap locks Steam Clock corridor side to a canonical route-relative help
   assert.ok(Math.abs(headingSteam.y - northCambie.y) < 20, 'expected heading-up projection to keep the Steam Clock laterally beside the corridor near Water/Cambie');
 });
 
+
+test('minimap Steam Clock uses a dedicated plaza anchor that moves farther onto the canonical right curb side than the raw node', () => {
+  const simPath = path.join(__dirname, '..', 'js', 'gastown-sim.js');
+  const worldPath = path.join(__dirname, '..', 'assets', 'world', 'gastown-water-street.json');
+  const src = fs.readFileSync(simPath, 'utf8');
+  const world = JSON.parse(fs.readFileSync(worldPath, 'utf8'));
+
+  assert.match(src, /function getMinimapLandmarkAnchor\(landmark, world\) \{/);
+  assert.match(src, /const plazaZone = getZoneById\(world, 'steam-clock-plaza-sidewalk', 'sidewalk'\);/);
+  assert.match(src, /const targetSide = Math\.max\(rawSide, sidewalkTarget, heroTarget, rawSide \+ Math\.max\(1\.2, \(rightmostSide - rawSide\) \* 0\.45\)\);/);
+  assert.match(src, /const markerPoint = node\.id === 'steam-clock' \? getMinimapLandmarkAnchor\(node, state\.world\) : node;/);
+
+  const midBlock = world.nodes.find((node) => node.id === 'water-street-mid-block');
+  const cambie = world.nodes.find((node) => node.id === 'water-cambie-intersection');
+  const steamClock = world.nodes.find((node) => node.id === 'steam-clock');
+  const steamHero = world.hero_landmarks.find((landmark) => landmark.id === 'steam-clock-hero');
+  const plazaZone = world.zones.sidewalk.find((zone) => zone.id === 'steam-clock-plaza-sidewalk');
+  assert.ok(midBlock && cambie && steamClock && steamHero && plazaZone);
+
+  const tangent = { x: cambie.x - midBlock.x, z: cambie.z - midBlock.z };
+  const tangentLength = Math.hypot(tangent.x, tangent.z) || 1;
+  tangent.x /= tangentLength;
+  tangent.z /= tangentLength;
+  const corridor = {
+    end: cambie,
+    tangent,
+    rightNormal: { x: tangent.z, z: -tangent.x },
+  };
+
+  const getCorridorSideValue = (point) => {
+    const relX = point.x - corridor.end.x;
+    const relZ = point.z - corridor.end.z;
+    return (corridor.tangent.x * relZ) - (corridor.tangent.z * relX);
+  };
+  const getAlongValue = (point) => ((point.x - corridor.end.x) * corridor.tangent.x) + ((point.z - corridor.end.z) * corridor.tangent.z);
+  const rawSide = Math.abs(getCorridorSideValue(steamClock));
+  const rightmostSide = Math.max(...plazaZone.polygon.map((point) => Math.abs(Math.min(getCorridorSideValue(point), 0))));
+  const curbTarget = world.route.streetWidth / 2;
+  const sidewalkTarget = curbTarget + (world.route.sidewalkWidth * 0.85);
+  const heroTarget = steamHero.plaza.radius + (steamHero.plaza.apronWidth * 0.35);
+  const targetSide = Math.max(rawSide, sidewalkTarget, heroTarget, rawSide + Math.max(1.2, (rightmostSide - rawSide) * 0.45));
+  const rawAlong = getAlongValue(steamClock);
+  const anchor = {
+    x: corridor.end.x + (corridor.tangent.x * rawAlong) + (corridor.rightNormal.x * targetSide),
+    z: corridor.end.z + (corridor.tangent.z * rawAlong) + (corridor.rightNormal.z * targetSide),
+  };
+
+  const anchorSide = Math.abs(getCorridorSideValue(anchor));
+  const anchorAlong = getAlongValue(anchor);
+  assert.ok(anchorSide > rawSide + 1, `expected dedicated anchor to push the Steam Clock farther off the centerline than the raw node (${anchorSide} <= ${rawSide})`);
+  assert.ok(anchorSide < rightmostSide + 0.01, `expected dedicated anchor to stay inside the outer plaza envelope (${anchorSide} > ${rightmostSide})`);
+  assert.ok(Math.abs(anchorAlong - rawAlong) < 1e-6, `expected dedicated anchor to preserve along-corridor placement (${anchorAlong} vs ${rawAlong})`);
+  assert.ok(anchor.x < steamClock.x && anchor.z < steamClock.z, 'expected dedicated anchor to move the Steam Clock farther onto the east/south plaza side in world space');
+});
+
 test('minimap player marker renders as a tiny person with a forward cue instead of a wedge', () => {
   const simPath = path.join(__dirname, '..', 'js', 'gastown-sim.js');
   const src = fs.readFileSync(simPath, 'utf8');

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -2759,13 +2759,71 @@
     };
   }
 
+  function getLandmarkById(world, id) {
+    if (!world || !id) {
+      return null;
+    }
+    return (Array.isArray(world.landmarks) ? world.landmarks : []).find((landmark) => landmark.id === id)
+      || (Array.isArray(world.nodes) ? world.nodes : []).find((node) => node.id === id)
+      || (Array.isArray(world.hero_landmarks) ? world.hero_landmarks : []).find((landmark) => landmark.id === id);
+  }
+
+  function getZoneById(world, id, zoneType) {
+    if (!world || !world.zones || !id) {
+      return null;
+    }
+    const zones = zoneType && Array.isArray(world.zones[zoneType])
+      ? world.zones[zoneType]
+      : Object.values(world.zones).flatMap((entry) => (Array.isArray(entry) ? entry : []));
+    return zones.find((zone) => zone.id === id) || null;
+  }
+
+  function getMinimapLandmarkAnchor(landmark, world) {
+    if (!landmark || !world) {
+      return landmark;
+    }
+    if (landmark.id !== 'steam-clock') {
+      return landmark;
+    }
+
+    const corridor = getCanonicalCorridorSegment(world);
+    if (!corridor) {
+      return landmark;
+    }
+
+    const plazaZone = getZoneById(world, 'steam-clock-plaza-sidewalk', 'sidewalk');
+    const hero = getLandmarkById(world, 'steam-clock-hero');
+    const plazaPoints = plazaZone && Array.isArray(plazaZone.polygon) ? plazaZone.polygon.filter(Boolean) : [];
+    const rawAlong = ((landmark.x - corridor.end.x) * corridor.tangent.x) + ((landmark.z - corridor.end.z) * corridor.tangent.z);
+    const rawSide = Math.abs(getCorridorSideValue(landmark, corridor, corridor.end));
+    const rightmostPlazaPoint = plazaPoints.reduce((best, point) => {
+      const sideValue = getCorridorSideValue(point, corridor, corridor.end);
+      if (!best || sideValue < best.sideValue) {
+        return { point, sideValue };
+      }
+      return best;
+    }, null);
+    const rightmostSide = rightmostPlazaPoint ? Math.abs(rightmostPlazaPoint.sideValue) : rawSide;
+    const curbTarget = ((world.route && world.route.streetWidth) || 0) / 2;
+    const sidewalkTarget = curbTarget + ((((world.route && world.route.sidewalkWidth) || 0) * 0.85));
+    const heroTarget = hero && hero.plaza
+      ? (hero.plaza.radius || 0) + ((hero.plaza.apronWidth || 0) * 0.35)
+      : 0;
+    const targetSide = Math.max(rawSide, sidewalkTarget, heroTarget, rawSide + Math.max(1.2, (rightmostSide - rawSide) * 0.45));
+
+    return {
+      x: corridor.end.x + (corridor.tangent.x * rawAlong) + (corridor.rightNormal.x * targetSide),
+      z: corridor.end.z + (corridor.tangent.z * rawAlong) + (corridor.rightNormal.z * targetSide),
+    };
+  }
+
   function getMinimapDebugVectors(world, metrics, padding, view, projectionOptions) {
     const corridor = getCanonicalCorridorSegment(world);
     if (!corridor) {
       return null;
     }
-    const steamClock = (Array.isArray(world.landmarks) ? world.landmarks : []).find((landmark) => landmark.id === 'steam-clock')
-      || (Array.isArray(world.nodes) ? world.nodes : []).find((node) => node.id === 'steam-clock');
+    const steamClock = getLandmarkById(world, 'steam-clock');
+    const steamClockAnchor = steamClock ? getMinimapLandmarkAnchor(steamClock, world) : null;
     const tangentAnchor = corridor.end;
     const tangentTip = {
       x: tangentAnchor.x + (corridor.tangent.x * 10),
@@ -2782,8 +2840,11 @@
       tangentTip: projectWorldToMinimap(tangentTip, metrics, padding, view, projectionOptions),
       rightTip: projectWorldToMinimap(rightTip, metrics, padding, view, projectionOptions),
       steamClock: steamClock ? projectWorldToMinimap(steamClock, metrics, padding, view, projectionOptions) : null,
+      steamClockAnchor: steamClockAnchor ? projectWorldToMinimap(steamClockAnchor, metrics, padding, view, projectionOptions) : null,
       steamClockWorld: steamClock,
+      steamClockAnchorWorld: steamClockAnchor,
       steamClockSide: steamClock ? classifyCorridorSide(steamClock, corridor, corridor.end) : null,
+      steamClockAnchorSide: steamClockAnchor ? classifyCorridorSide(steamClockAnchor, corridor, corridor.end) : null,
     };
   }
 
@@ -2926,7 +2987,8 @@
     const majorNodes = ['waterfront-station-threshold', 'water-street-mid-block', 'water-cambie-intersection', 'steam-clock', 'maple-tree-square-edge'];
     state.world.nodes.forEach((node) => {
       if (!majorNodes.includes(node.id)) return;
-      const mini = projectWorldToMinimap(node, metrics, pad, view, projectionOptions);
+      const markerPoint = node.id === 'steam-clock' ? getMinimapLandmarkAnchor(node, state.world) : node;
+      const mini = projectWorldToMinimap(markerPoint, metrics, pad, view, projectionOptions);
       ctx.fillStyle = node.id === 'steam-clock' ? '#d8a968' : node.id === 'water-cambie-intersection' ? '#9cc7e4' : '#b7d4ea';
       ctx.beginPath();
       ctx.arc(mini.x, mini.y, node.id === 'steam-clock' ? 5.2 : 4.1, 0, Math.PI * 2);
@@ -2940,7 +3002,12 @@
         ctx.fillText('Station', mini.x + 6, mini.y - 5);
       }
       if (node.id === 'steam-clock') {
-        ctx.fillText('Steam Clock', mini.x + 6, mini.y - 5);
+        const steamClockLabelAnchor = {
+          x: markerPoint.x + 1.9,
+          z: markerPoint.z + (minimapState.mode === 'heading-up' ? 0.4 : -2.1),
+        };
+        const labelMini = projectWorldToMinimap(steamClockLabelAnchor, metrics, pad, view, projectionOptions);
+        ctx.fillText('Steam Clock', labelMini.x + 5, labelMini.y - 4);
       }
       if (node.id === 'water-cambie-intersection') {
         ctx.fillText('Cambie', mini.x + 6, mini.y - 5);


### PR DESCRIPTION
### Motivation

- The Steam Clock minimap marker was being drawn from the raw `steam-clock` node and visually collapsed toward the corridor centerline instead of sitting on the plaza/curb side. 
- The intent is to make minimap landmark placement match the 3D world curb/plaza side using existing corridor helpers rather than a screen-space label nudge. 
- Keep north-up correctness as primary and preserve handedness for heading-up so the minimap agrees with world geometry.

### Description

- Add helper lookups `getLandmarkById(world, id)` and `getZoneById(world, id, zoneType)` and a world-space solver `getMinimapLandmarkAnchor(landmark, world)` that computes a stable plaza/curb anchor for the Steam Clock using the canonical corridor (`getCanonicalCorridorSegment`) plus plaza and hero geometry. 
- Wire `getMinimapLandmarkAnchor` into debug helpers (`getMinimapDebugVectors`) to expose both the raw world point and the computed anchor. 
- Stop drawing the Steam Clock dot from the raw node in `drawMinimap()`; for the Steam Clock use the `markerPoint = getMinimapLandmarkAnchor(node, state.world)` and project that to minimap space. 
- Move the Steam Clock label to follow the new marker anchor (computed `steamClockLabelAnchor`) so the icon and text are readable and do not overlap the route line or corridor fill. 
- Preserve along-corridor placement while pushing the marker further onto the canonical right/east plaza side (world-space solution), keeping handedness consistent with street/sidewalk polygons.

### Testing

- Added a regression test `minimap Steam Clock uses a dedicated plaza anchor that moves farther onto the canonical right curb side than the raw node` in `__tests__/gastown-sim-ground.test.js` that asserts the anchor is farther off the centerline, stays inside the plaza envelope, and preserves along-corridor placement. 
- Ran the targeted suite with `node --test __tests__/gastown-sim-ground.test.js` and the full project tests with `npm test`; both completed successfully with no failures. 
- The fix is implemented in `js/gastown-sim.js` and the corresponding test updates are in `__tests__/gastown-sim-ground.test.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0d10e8164832e9035ff895f917254)