### PR TITLE
Rework Gastown into an explorable district (micro-areas & short loops)

### DIFF
--- a/assets/world/gastown-water-street.json
+++ b/assets/world/gastown-water-street.json
@@ -6,9 +6,10 @@
     "source": "deterministic fallback with optional open reference inputs",
     "fallbackMode": "working-gastown-corridor",
     "isRealCivicBuild": false,
+    "buildClassification": "approximate-fallback",
     "buildNotes": [
       "Working fallback corridor is active because required offline civic source files are missing.",
-      "This fallback now stages Water Street, a real Water/Cambie corner condition, and a Steam Clock plaza pad outside the carriageway instead of a single bent ribbon corridor.",
+      "This fallback now stages Water Street as a compact exploration district with plaza, storefront edge, alley threshold, transit edge, and landmark corner micro-areas instead of a single bent ribbon corridor.",
       "No refreshed reference inputs were present; deterministic default route staging was used."
     ],
     "referenceInputsUsed": [],
@@ -20,12 +21,11 @@
       "buildingFootprints2015": false,
       "orthophotoImagery2015": false
     },
-    "lastBuild": "2026-03-23T02:35:10.016Z",
-    "buildClassification": "approximate-fallback",
-    "provenanceSummary": "Approximate fallback corridor retained because the offline civic/open-data pipeline did not have all required local inputs."
+    "provenanceSummary": "Approximate fallback corridor retained because the offline civic/open-data pipeline did not have all required local inputs.",
+    "lastBuild": "2026-03-23T06:54:42.055Z"
   },
   "route": {
-    "name": "Waterfront Station \u2192 Water Street \u2192 Steam Clock working corridor",
+    "name": "Explorable Gastown: Water Street loops",
     "centerline": [
       {
         "id": "waterfront-station-threshold",
@@ -84,80 +84,44 @@
     ],
     "walkBounds": [
       {
-        "x": -8.12,
-        "z": -9.63
+        "x": -12,
+        "z": -11
       },
       {
-        "x": 20.97,
-        "z": -34.16
+        "x": 28,
+        "z": -36
       },
       {
-        "x": 55.32,
-        "z": -62.18
+        "x": 139.25,
+        "z": -186.87
       },
       {
-        "x": 102.7,
-        "z": -97.94
+        "x": 189.31,
+        "z": -178.75
       },
       {
-        "x": 144.73,
-        "z": -129.04
+        "x": 232.34,
+        "z": -179.46
       },
       {
-        "x": 171.07,
-        "z": -149.23
+        "x": 228.34,
+        "z": -158.46
       },
       {
-        "x": 184.31,
-        "z": -154.75
+        "x": 173.48,
+        "z": -118.6
       },
       {
-        "x": 189.35,
-        "z": -166.87
+        "x": 81.25,
+        "z": -62.87
       },
       {
-        "x": 200.36,
-        "z": -181.16
+        "x": -18,
+        "z": 10
       },
       {
-        "x": 220.32,
-        "z": -165.77
-      },
-      {
-        "x": 193.62,
-        "z": -131.13
-      },
-      {
-        "x": 184.31,
-        "z": -154.75
-      },
-      {
-        "x": 211.89,
-        "z": -148.77
-      },
-      {
-        "x": 159.9,
-        "z": -108.91
-      },
-      {
-        "x": 117.79,
-        "z": -77.75
-      },
-      {
-        "x": 70.88,
-        "z": -42.35
-      },
-      {
-        "x": 37.06,
-        "z": -14.76
-      },
-      {
-        "x": 8.12,
-        "z": 9.63
-      },
-      {
-        "x": -8.12,
-        "z": -9.63
+        "x": -12,
+        "z": -11
       }
     ],
     "streetWidth": 10.4,
@@ -173,10 +137,22 @@
       "z": 0
     },
     {
+      "id": "station-plaza",
+      "label": "Station plaza",
+      "x": 1.55,
+      "z": -5.62
+    },
+    {
       "id": "water-cordova-seam",
       "label": "Water/Cordova seam",
       "x": 54.73,
       "z": -45.43
+    },
+    {
+      "id": "storefront-edge",
+      "label": "Storefront edge",
+      "x": 126.2,
+      "z": -110.3
     },
     {
       "id": "water-street-mid-block",
@@ -185,16 +161,34 @@
       "z": -104.87
     },
     {
+      "id": "alley-threshold",
+      "label": "Alley threshold",
+      "x": 195.11,
+      "z": -139.55
+    },
+    {
       "id": "steam-clock",
       "label": "Steam Clock plaza",
       "x": 184.31,
       "z": -154.75
     },
     {
+      "id": "landmark-corner",
+      "label": "Landmark corner",
+      "x": 183.98,
+      "z": -156.78
+    },
+    {
       "id": "maple-tree-square-edge",
       "label": "Maple Tree Square edge",
       "x": 210.34,
       "z": -173.46
+    },
+    {
+      "id": "transit-edge",
+      "label": "Transit edge",
+      "x": 188.12,
+      "z": -137.83
     },
     {
       "id": "cambie-rise-continuation",
@@ -242,6 +236,72 @@
         ]
       },
       {
+        "id": "station-plaza-loop",
+        "label": "Station plaza loop",
+        "points": [
+          {
+            "x": -3.93,
+            "z": -1.13
+          },
+          {
+            "x": 0.54,
+            "z": -7.41
+          },
+          {
+            "x": 5.02,
+            "z": -4.71
+          },
+          {
+            "x": -0.04,
+            "z": 1.36
+          }
+        ]
+      },
+      {
+        "id": "storefront-pocket-loop",
+        "label": "Storefront pocket loop",
+        "points": [
+          {
+            "x": 126.94,
+            "z": -102.91
+          },
+          {
+            "x": 133.09,
+            "z": -111.05
+          },
+          {
+            "x": 130.19,
+            "z": -113.03
+          },
+          {
+            "x": 124.51,
+            "z": -105.16
+          }
+        ]
+      },
+      {
+        "id": "alley-threshold-loop",
+        "label": "Alley threshold loop",
+        "points": [
+          {
+            "x": 188.66,
+            "z": -141.24
+          },
+          {
+            "x": 192.8,
+            "z": -142.85
+          },
+          {
+            "x": 194.45,
+            "z": -139.43
+          },
+          {
+            "x": 190.49,
+            "z": -138.06
+          }
+        ]
+      },
+      {
         "id": "steam-clock-plaza-loop",
         "label": "Steam Clock plaza",
         "points": [
@@ -282,6 +342,28 @@
         ]
       },
       {
+        "id": "maple-square-loop",
+        "label": "Maple Tree Square loop",
+        "points": [
+          {
+            "x": 210.59,
+            "z": -171
+          },
+          {
+            "x": 213.29,
+            "z": -175.99
+          },
+          {
+            "x": 210.49,
+            "z": -178.9
+          },
+          {
+            "x": 206.78,
+            "z": -175.07
+          }
+        ]
+      },
+      {
         "id": "cambie-crossing",
         "label": "Cambie crossing",
         "points": [
@@ -296,6 +378,28 @@
           {
             "x": 179.48,
             "z": -129
+          }
+        ]
+      },
+      {
+        "id": "transit-edge-loop",
+        "label": "Transit edge loop",
+        "points": [
+          {
+            "x": 187.69,
+            "z": -134
+          },
+          {
+            "x": 185.18,
+            "z": -136.31
+          },
+          {
+            "x": 188.43,
+            "z": -141.01
+          },
+          {
+            "x": 191.46,
+            "z": -139.05
           }
         ]
       }
@@ -598,6 +702,84 @@
         ]
       },
       {
+        "id": "waterfront-station-plaza",
+        "side": "plaza",
+        "polygon": [
+          {
+            "x": -1.33,
+            "z": -9.74
+          },
+          {
+            "x": 7.22,
+            "z": -3.14
+          },
+          {
+            "x": 1.36,
+            "z": 4.46
+          },
+          {
+            "x": -7.19,
+            "z": -2.14
+          },
+          {
+            "x": -1.33,
+            "z": -9.74
+          }
+        ]
+      },
+      {
+        "id": "water-street-storefront-pocket",
+        "side": "storefront",
+        "polygon": [
+          {
+            "x": 121.96,
+            "z": -118.37
+          },
+          {
+            "x": 134.95,
+            "z": -108.35
+          },
+          {
+            "x": 130.31,
+            "z": -102.33
+          },
+          {
+            "x": 117.32,
+            "z": -112.35
+          },
+          {
+            "x": 121.96,
+            "z": -118.37
+          }
+        ]
+      },
+      {
+        "id": "water-street-alley-threshold",
+        "side": "alley",
+        "polygon": [
+          {
+            "x": 194.64,
+            "z": -144.84
+          },
+          {
+            "x": 200.34,
+            "z": -140.44
+          },
+          {
+            "x": 195.58,
+            "z": -134.26
+          },
+          {
+            "x": 189.88,
+            "z": -138.66
+          },
+          {
+            "x": 194.64,
+            "z": -144.84
+          }
+        ]
+      },
+      {
         "id": "cambie-west-sidewalk",
         "side": "west",
         "polygon": [
@@ -628,6 +810,32 @@
           {
             "x": 197.85,
             "z": -170.82
+          }
+        ]
+      },
+      {
+        "id": "cambie-transit-edge",
+        "side": "transit",
+        "polygon": [
+          {
+            "x": 182.26,
+            "z": -135.79
+          },
+          {
+            "x": 188.61,
+            "z": -144.03
+          },
+          {
+            "x": 193.99,
+            "z": -139.87
+          },
+          {
+            "x": 187.64,
+            "z": -131.64
+          },
+          {
+            "x": 182.26,
+            "z": -135.79
           }
         ]
       },
@@ -680,6 +888,58 @@
           {
             "x": 183.59,
             "z": -161.25
+          }
+        ]
+      },
+      {
+        "id": "steam-clock-landmark-corner",
+        "side": "corner",
+        "polygon": [
+          {
+            "x": 182.52,
+            "z": -162.58
+          },
+          {
+            "x": 189.96,
+            "z": -156.84
+          },
+          {
+            "x": 185.44,
+            "z": -150.98
+          },
+          {
+            "x": 178,
+            "z": -156.72
+          },
+          {
+            "x": 182.52,
+            "z": -162.58
+          }
+        ]
+      },
+      {
+        "id": "maple-tree-square-pocket",
+        "side": "plaza",
+        "polygon": [
+          {
+            "x": 209.03,
+            "z": -181.92
+          },
+          {
+            "x": 216.63,
+            "z": -176.06
+          },
+          {
+            "x": 211.63,
+            "z": -169.57
+          },
+          {
+            "x": 204.02,
+            "z": -175.43
+          },
+          {
+            "x": 209.03,
+            "z": -181.92
           }
         ]
       }
@@ -3852,12 +4112,7 @@
       "y": 0,
       "z": -19.21,
       "yaw": 0.7005,
-      "scale": 1.05,
-      "randomOffset": true,
-      "collectible": true,
-      "collectibleKey": "newspaper_box",
-      "collectibleLabel": "Newspaper box",
-      "minimapIcon": "collectible"
+      "scale": 1.05
     },
     {
       "id": "starter-prop-threshold-utility",
@@ -3902,8 +4157,46 @@
       "y": 0,
       "z": -157.61,
       "yaw": 0,
-      "scale": 0.98,
-      "randomOffset": true
+      "scale": 0.98
+    },
+    {
+      "id": "starter-prop-station-kiosk",
+      "kind": "newspaper_box",
+      "x": 0.67,
+      "y": 0,
+      "z": -5.29,
+      "yaw": 2.4849,
+      "scale": 1,
+      "collectible": true,
+      "collectibleKey": "newspaper_box",
+      "collectibleLabel": "Newspaper box",
+      "minimapIcon": "collectible"
+    },
+    {
+      "id": "starter-prop-maple-mural",
+      "kind": "planter",
+      "x": 209.59,
+      "y": 0,
+      "z": -177.57,
+      "yaw": 0.9141,
+      "scale": 1.08,
+      "collectible": true,
+      "collectibleKey": "mural",
+      "collectibleLabel": "Maple Tree mural",
+      "minimapIcon": "collectible"
+    },
+    {
+      "id": "starter-prop-alley-plaque",
+      "kind": "utility_box",
+      "x": 193.31,
+      "y": 0,
+      "z": -140.56,
+      "yaw": 0.9141,
+      "scale": 1,
+      "collectible": true,
+      "collectibleKey": "historic_plaque",
+      "collectibleLabel": "Historic plaque",
+      "minimapIcon": "collectible"
     },
     {
       "id": "starter-prop-postclock-utility",
@@ -3921,8 +4214,7 @@
       "y": 0,
       "z": -146.08,
       "yaw": -2.1112,
-      "scale": 0.96,
-      "randomOffset": true
+      "scale": 0.96
     },
     {
       "id": "starter-prop-postclock-bench",
@@ -3932,40 +4224,6 @@
       "z": -141.56,
       "yaw": -0.5404,
       "scale": 1
-    },
-    {
-      "id": "starter-prop-maple-mural",
-      "kind": "cardboard_box",
-      "x": 206.22,
-      "z": -170.84,
-      "yaw": 0.14,
-      "scale": 0.95,
-      "collectible": true,
-      "collectibleKey": "mural",
-      "collectibleLabel": "Maple Tree mural",
-      "minimapIcon": "mural",
-      "randomOffset": true
-    },
-    {
-      "id": "starter-prop-clock-plaque",
-      "kind": "utility_box",
-      "x": 188.62,
-      "z": -151.38,
-      "yaw": -0.22,
-      "scale": 0.65,
-      "collectible": true,
-      "collectibleKey": "historic_plaque",
-      "collectibleLabel": "Historic plaque",
-      "minimapIcon": "plaque"
-    },
-    {
-      "id": "starter-prop-vendor-crate",
-      "kind": "cardboard_box",
-      "x": 174.96,
-      "z": -143.72,
-      "yaw": 0.51,
-      "scale": 0.88,
-      "randomOffset": true
     }
   ],
   "npcs": [
@@ -4216,6 +4474,264 @@
           "x": 185.52,
           "z": -155.59
         }
+      ]
+    }
+  ],
+  "exploration": {
+    "publicGoal": "I’m exploring Gastown.",
+    "fallbackPrompt": "Wander the connected plazas, storefront edges, alley mouths, and landmark corners to build your own short loop."
+  },
+  "microAreas": [
+    {
+      "id": "station-plaza",
+      "label": "Station plaza",
+      "identity": "transit edge",
+      "nodeId": "station-plaza",
+      "polygon": [
+        {
+          "x": -1.33,
+          "z": -9.74
+        },
+        {
+          "x": 7.22,
+          "z": -3.14
+        },
+        {
+          "x": 1.36,
+          "z": 4.46
+        },
+        {
+          "x": -7.19,
+          "z": -2.14
+        },
+        {
+          "x": -1.33,
+          "z": -9.74
+        }
+      ],
+      "stopReasons": [
+        "Watch people spill out from Waterfront Station.",
+        "Reorient before committing to Water Street."
+      ],
+      "returnReasons": [
+        "It works as a reliable reset point.",
+        "The wider pad gives you a clear view back into Gastown."
+      ]
+    },
+    {
+      "id": "storefront-edge",
+      "label": "Storefront edge",
+      "identity": "storefront edge",
+      "nodeId": "storefront-edge",
+      "polygon": [
+        {
+          "x": 121.96,
+          "z": -118.37
+        },
+        {
+          "x": 134.95,
+          "z": -108.35
+        },
+        {
+          "x": 130.31,
+          "z": -102.33
+        },
+        {
+          "x": 117.32,
+          "z": -112.35
+        },
+        {
+          "x": 121.96,
+          "z": -118.37
+        }
+      ],
+      "stopReasons": [
+        "Window-shop the heritage frontage rhythm.",
+        "Use the pocket as a pause between the station and the clock."
+      ],
+      "returnReasons": [
+        "It makes a good midway meeting point.",
+        "The tighter edge reveals the street from a different angle on the way back."
+      ]
+    },
+    {
+      "id": "alley-threshold",
+      "label": "Alley threshold",
+      "identity": "alley threshold",
+      "nodeId": "alley-threshold",
+      "polygon": [
+        {
+          "x": 194.64,
+          "z": -144.84
+        },
+        {
+          "x": 200.34,
+          "z": -140.44
+        },
+        {
+          "x": 195.58,
+          "z": -134.26
+        },
+        {
+          "x": 189.88,
+          "z": -138.66
+        },
+        {
+          "x": 194.64,
+          "z": -144.84
+        }
+      ],
+      "stopReasons": [
+        "Peek into the service lane without leaving the public edge.",
+        "Listen for the quieter pocket off the main block."
+      ],
+      "returnReasons": [
+        "It turns the approach into a loop instead of a one-way run.",
+        "The threshold frames the Steam Clock corner from the side."
+      ]
+    },
+    {
+      "id": "steam-clock-plaza",
+      "label": "Steam Clock plaza",
+      "identity": "plaza",
+      "nodeId": "steam-clock",
+      "polygon": [
+        {
+          "x": 183.59,
+          "z": -161.25
+        },
+        {
+          "x": 190.4,
+          "z": -156
+        },
+        {
+          "x": 184.66,
+          "z": -148.55
+        },
+        {
+          "x": 177.85,
+          "z": -153.8
+        },
+        {
+          "x": 183.59,
+          "z": -161.25
+        }
+      ],
+      "stopReasons": [
+        "Pause for the clock, seating, and busker activity.",
+        "Use the open pad to decide where to head next."
+      ],
+      "returnReasons": [
+        "The plaza is the natural social hub.",
+        "It links back out to Water Street and Maple Tree Square."
+      ]
+    },
+    {
+      "id": "landmark-corner",
+      "label": "Landmark corner",
+      "identity": "landmark corner",
+      "nodeId": "landmark-corner",
+      "polygon": [
+        {
+          "x": 182.52,
+          "z": -162.58
+        },
+        {
+          "x": 189.96,
+          "z": -156.84
+        },
+        {
+          "x": 185.44,
+          "z": -150.98
+        },
+        {
+          "x": 178,
+          "z": -156.72
+        },
+        {
+          "x": 182.52,
+          "z": -162.58
+        }
+      ],
+      "stopReasons": [
+        "Take in the clock and corner facades together.",
+        "Catch the diagonal view into Maple Tree Square."
+      ],
+      "returnReasons": [
+        "It is the clearest landmark rendezvous point.",
+        "The corner keeps changing depending on approach direction."
+      ]
+    },
+    {
+      "id": "maple-tree-square-pocket",
+      "label": "Maple Tree Square pocket",
+      "identity": "plaza edge",
+      "nodeId": "maple-tree-square-edge",
+      "polygon": [
+        {
+          "x": 209.03,
+          "z": -181.92
+        },
+        {
+          "x": 216.63,
+          "z": -176.06
+        },
+        {
+          "x": 211.63,
+          "z": -169.57
+        },
+        {
+          "x": 204.02,
+          "z": -175.43
+        },
+        {
+          "x": 209.03,
+          "z": -181.92
+        }
+      ],
+      "stopReasons": [
+        "Step to the square edge for the crossroads feel.",
+        "Use the pocket as the eastern half of the loop."
+      ],
+      "returnReasons": [
+        "It rewards a second pass after circling the clock.",
+        "The square reads differently when you approach from Cambie."
+      ]
+    },
+    {
+      "id": "transit-edge",
+      "label": "Transit edge",
+      "identity": "transit edge",
+      "nodeId": "transit-edge",
+      "polygon": [
+        {
+          "x": 182.26,
+          "z": -135.79
+        },
+        {
+          "x": 188.61,
+          "z": -144.03
+        },
+        {
+          "x": 193.99,
+          "z": -139.87
+        },
+        {
+          "x": 187.64,
+          "z": -131.64
+        },
+        {
+          "x": 182.26,
+          "z": -135.79
+        }
+      ],
+      "stopReasons": [
+        "Look uphill toward the Cambie continuation.",
+        "Feel the district open toward the station/transit seam."
+      ],
+      "returnReasons": [
+        "It gives the loop a practical edge instead of a dead end.",
+        "The shift in grade changes your sense of the block."
       ]
     }
   ],
@@ -4848,6 +5364,32 @@
       }
     ]
   },
+  "audioZones": [
+    {
+      "id": "station-plaza-bed",
+      "label": "Station plaza ambience",
+      "bed": "station-plaza.mp3",
+      "x": 2.93,
+      "z": -3.8,
+      "radius": 16
+    },
+    {
+      "id": "steam-clock-bed",
+      "label": "Steam Clock plaza ambience",
+      "bed": "steam-clock-plaza.mp3",
+      "x": 184.31,
+      "z": -154.75,
+      "radius": 18
+    },
+    {
+      "id": "maple-square-bed",
+      "label": "Maple Tree Square ambience",
+      "bed": "maple-square.mp3",
+      "x": 210.34,
+      "z": -173.46,
+      "radius": 15
+    }
+  ],
   "spawn": {
     "x": 6.88,
     "y": 1.7,
@@ -4856,7 +5398,7 @@
   },
   "bounds": {
     "floorY": 0,
-    "edgeMessage": "Stayed within the Gastown working corridor.",
-    "resetMessage": "Returned to the Gastown working corridor."
+    "edgeMessage": "Stayed inside the explorable Gastown district.",
+    "resetMessage": "Returned to the explorable Gastown district."
   }
 }

--- a/assets/world/gastown-water-street.json
+++ b/assets/world/gastown-water-street.json
@@ -22,7 +22,15 @@
       "orthophotoImagery2015": false
     },
     "provenanceSummary": "Approximate fallback corridor retained because the offline civic/open-data pipeline did not have all required local inputs.",
-    "lastBuild": "2026-03-23T07:44:29.599Z"
+    "lastBuild": "2026-03-23T07:44:29.599Z",
+    "artDirection": {
+      "label": "stylized realism with cinematic Vancouver rain-lighting",
+      "pillars": [
+        "wet cobblestone reflections and low-angle dawn highlights",
+        "heritage masonry with richer brick-stone-glass contrast",
+        "dense civic clutter and postcard framing around the Steam Clock and Water Street bends"
+      ]
+    }
   },
   "route": {
     "name": "Explorable Gastown: Water Street loops",
@@ -4124,6 +4132,15 @@
       "scale": 1.1
     },
     {
+      "id": "starter-prop-threshold-bench",
+      "kind": "bench",
+      "x": 8.12,
+      "y": 0,
+      "z": -21.39,
+      "yaw": 2.2713,
+      "scale": 0.92
+    },
+    {
       "id": "starter-prop-planter-west",
       "kind": "planter",
       "x": 41.15,
@@ -4174,16 +4191,26 @@
     },
     {
       "id": "starter-prop-maple-mural",
-      "kind": "planter",
-      "x": 209.59,
+      "kind": "cardboard_box",
+      "x": 209.8,
       "y": 0,
-      "z": -177.57,
-      "yaw": 0.9141,
-      "scale": 1.08,
+      "z": -176.53,
+      "yaw": 2.4849,
+      "scale": 0.95,
       "collectible": true,
       "collectibleKey": "mural",
       "collectibleLabel": "Maple Tree mural",
-      "minimapIcon": "collectible"
+      "minimapIcon": "mural",
+      "randomOffset": true
+    },
+    {
+      "id": "starter-prop-clock-plaque",
+      "kind": "utility_box",
+      "x": 183.11,
+      "y": 0,
+      "z": -156.31,
+      "yaw": -2.2275,
+      "scale": 0.65
     },
     {
       "id": "starter-prop-alley-plaque",
@@ -4197,6 +4224,15 @@
       "collectibleKey": "historic_plaque",
       "collectibleLabel": "Historic plaque",
       "minimapIcon": "collectible"
+    },
+    {
+      "id": "starter-prop-east-newsbox",
+      "kind": "newspaper_box",
+      "x": 176.45,
+      "y": 0,
+      "z": -127.06,
+      "yaw": 0.654,
+      "scale": 1.02
     },
     {
       "id": "starter-prop-postclock-utility",
@@ -4224,6 +4260,15 @@
       "z": -141.56,
       "yaw": -0.5404,
       "scale": 1
+    },
+    {
+      "id": "starter-prop-postclock-planter",
+      "kind": "planter",
+      "x": 193.94,
+      "y": 0,
+      "z": -136.29,
+      "yaw": -2.1112,
+      "scale": 1.12
     }
   ],
   "npcs": [

--- a/assets/world/gastown-water-street.json
+++ b/assets/world/gastown-water-street.json
@@ -22,7 +22,7 @@
       "orthophotoImagery2015": false
     },
     "provenanceSummary": "Approximate fallback corridor retained because the offline civic/open-data pipeline did not have all required local inputs.",
-    "lastBuild": "2026-03-23T06:54:42.055Z"
+    "lastBuild": "2026-03-23T07:44:29.599Z"
   },
   "route": {
     "name": "Explorable Gastown: Water Street loops",
@@ -5364,32 +5364,6 @@
       }
     ]
   },
-  "audioZones": [
-    {
-      "id": "station-plaza-bed",
-      "label": "Station plaza ambience",
-      "bed": "station-plaza.mp3",
-      "x": 2.93,
-      "z": -3.8,
-      "radius": 16
-    },
-    {
-      "id": "steam-clock-bed",
-      "label": "Steam Clock plaza ambience",
-      "bed": "steam-clock-plaza.mp3",
-      "x": 184.31,
-      "z": -154.75,
-      "radius": 18
-    },
-    {
-      "id": "maple-square-bed",
-      "label": "Maple Tree Square ambience",
-      "bed": "maple-square.mp3",
-      "x": 210.34,
-      "z": -173.46,
-      "radius": 15
-    }
-  ],
   "spawn": {
     "x": 6.88,
     "y": 1.7,

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -136,6 +136,7 @@
     npcVoiceIndex: 0,
     clockTimer: null,
     boundaryNoticeTimer: null,
+    currentMicroAreaId: '',
     audioWarningIssued: false,
     worldBuildStatus: null,
     npcs: [],
@@ -287,11 +288,19 @@
     }
   }
 
+  function getPublicGoalText() {
+    return (state.world && state.world.exploration && state.world.exploration.publicGoal) || 'I’m exploring Gastown.';
+  }
+
+  function getStreetModeStatusText() {
+    return getPublicGoalText() + ' Mouse look and movement are live. Press V for overview.';
+  }
+
   function openTutorialOverlay() {
     if (!tutorialOverlayEl) return;
     tutorialOverlayEl.removeAttribute('hidden');
     tutorialOverlayEl.setAttribute('aria-hidden', 'false');
-    setStatus('Tutorial open. Review the controls, then start walking when ready.');
+    setStatus('Tutorial open. Review the controls, then start exploring when ready.');
   }
 
   function closeTutorialOverlay() {
@@ -332,7 +341,7 @@
     }
     state.boundaryNoticeTimer = setTimeout(() => {
       if (!state.isRunning || state.cameraMode !== 'street') return;
-      setStatus('Street mode active. Mouse look and movement are live. Press V for overview.');
+      setStatus(getStreetModeStatusText());
     }, 1900);
   }
 
@@ -376,14 +385,14 @@
       setStatus('Overview mode active. Mouse wheel zooms altitude; press V to return to street view.');
       setPointerStatus('Pointer unlocked. Overview camera detached above player.');
     } else if (state.isRunning) {
-      setStatus('Street mode active. Mouse look and movement are live. Press V for overview.');
+      setStatus(getStreetModeStatusText());
       if (state.cameraMode === 'street' && document.pointerLockElement === renderer.domElement) {
         setPointerStatus('Pointer locked. Mouse look active. Press Esc to release pointer.');
       } else {
         setPointerStatus('Pointer lock requested… press Esc any time to release.');
       }
     } else {
-      setStatus('Street mode ready. Click scene to enter look mode and begin moving, or press V for overview.');
+      setStatus(getPublicGoalText() + ' Click scene to enter look mode and begin moving, or press V for overview.');
       setPointerStatus('Pointer unlocked. Click scene to enter look mode. Press V for overview.');
     }
   }
@@ -2692,8 +2701,11 @@
     const heading = getHeadingVector();
     const facing = getFacingLabel(heading);
     const nearest = minimapState.nearestGuidance;
+    const area = state.world ? getMicroAreaForPoint(player.position, state.world) : null;
     if (minimapContextEl) {
-      minimapContextEl.innerHTML = '<strong>Now facing:</strong> ' + facing + (nearest ? '<br><strong>Nearest landmark:</strong> ' + nearest.text : '');
+      minimapContextEl.innerHTML = '<strong>Now facing:</strong> ' + facing
+        + (area ? '<br><strong>Exploring:</strong> ' + area.label + ' (' + area.identity + ')' : '')
+        + (nearest ? '<br><strong>Nearest landmark:</strong> ' + nearest.text : '');
     }
     if (minimapModeStatusEl) {
       const isHeadingUp = minimapState.mode === 'heading-up';
@@ -2701,6 +2713,31 @@
         ? '<strong>Map mode:</strong> Heading-up — the top of the map follows the way you are facing.<br><strong>Guidance:</strong> Landmark callouts stay player-relative (ahead/left/right) for first-person wayfinding.'
         : '<strong>Map mode:</strong> North-up — the top of the map is geographic north.<br><strong>Guidance:</strong> Landmark callouts stay player-relative (ahead/left/right) so the legend still reads like the street.';
     }
+  }
+
+  function getMicroAreaForPoint(point, world) {
+    if (!world || !Array.isArray(world.microAreas) || !world.microAreas.length) {
+      return null;
+    }
+    const containing = world.microAreas.find((area) => isPointInPolygon(point, area.polygon));
+    if (containing) {
+      return containing;
+    }
+    return world.microAreas.reduce((best, area) => {
+      const anchor = area.anchor || area.polygon[0];
+      if (!anchor) return best;
+      const nextDistance = Math.hypot(anchor.x - point.x, anchor.z - point.z);
+      if (!best || nextDistance < best.distance) {
+        return { area, distance: nextDistance };
+      }
+      return best;
+    }, null)?.area || null;
+  }
+
+  function describeMicroArea(area) {
+    if (!area) return '';
+    const stop = Array.isArray(area.stopReasons) && area.stopReasons.length ? area.stopReasons[0] : '';
+    return area.label + ' — ' + area.identity + (stop ? '. ' + stop : '');
   }
 
   function updateNearestNode() {
@@ -2727,20 +2764,26 @@
       }
       return best;
     }, null) || (nearest ? describeLandmarkGuidance(nearest, heading, state.world) : null);
+    const microArea = getMicroAreaForPoint(player.position, state.world);
 
     if (nearest) {
       minimapState.nearestNode = nearest;
       minimapState.nearestGuidance = nearestGuidance;
-      setLandmark('Nearest landmark: ' + (nearestGuidance ? nearestGuidance.text : nearest.label));
+      setLandmark((microArea ? 'Exploring ' + describeMicroArea(microArea) + ' | ' : 'Nearest landmark: ') + (nearestGuidance ? nearestGuidance.text : nearest.label));
       if (routeSegmentEl) {
-        const nearestIndex = Math.max(0, state.world.nodes.findIndex((node) => node.id === nearest.id));
-        const total = Math.max(1, state.world.nodes.length - 1);
-        const progress = Math.round((nearestIndex / total) * 100);
-        routeSegmentEl.textContent = 'Route segment: ' + nearest.label + ' (' + progress + '%)';
+        routeSegmentEl.textContent = microArea
+          ? 'Exploring: ' + microArea.label + ' — ' + microArea.identity
+          : 'Exploring: ' + nearest.label;
       }
       if (minimapLandmarkEl) {
-        minimapLandmarkEl.textContent = nearestGuidance ? 'Nearest landmark: ' + nearestGuidance.text : 'Nearest landmark: ' + nearest.label;
+        minimapLandmarkEl.textContent = microArea
+          ? 'Current area: ' + microArea.label + ' (' + microArea.identity + ')'
+          : (nearestGuidance ? 'Nearest landmark: ' + nearestGuidance.text : 'Nearest landmark: ' + nearest.label);
       }
+      if (microArea && state.currentMicroAreaId !== microArea.id && state.isRunning) {
+        flashBoundaryStatus('Now exploring ' + microArea.label + ' — ' + microArea.identity + '.');
+      }
+      state.currentMicroAreaId = microArea ? microArea.id : '';
       updateMinimapContext();
     }
   }
@@ -3252,6 +3295,9 @@
     (state.world.zones.street || []).forEach((zone) => {
       drawPolygon(zone.polygon, metrics, pad, '#1a2f41', 'rgba(86, 117, 149, 0.68)', 1.15, view, projectionOptions);
     });
+    (state.world.microAreas || []).forEach((area) => {
+      drawPolygon(area.polygon, metrics, pad, 'rgba(255, 210, 135, 0.72)', 'rgba(255, 210, 135, 0.08)', 0.85, view, projectionOptions);
+    });
 
     if (compassEl) {
       compassEl.textContent = 'Heading: ' + getFacingLabel(getHeadingVector());
@@ -3352,6 +3398,15 @@
       if (node.id === 'water-street-mid-block') {
         ctx.fillText('Water St', mini.x + 6, mini.y + 7);
       }
+    });
+
+    (state.world.microAreas || []).forEach((area) => {
+      if (!area.anchor) return;
+      const mini = projectWorldToMinimap(area.anchor, metrics, pad, view, projectionOptions);
+      ctx.fillStyle = area.id === state.currentMicroAreaId ? '#ffd98f' : 'rgba(255, 217, 143, 0.72)';
+      ctx.beginPath();
+      ctx.arc(mini.x, mini.y, area.id === state.currentMicroAreaId ? 3.4 : 2.4, 0, Math.PI * 2);
+      ctx.fill();
     });
 
     const dirLength = 13;
@@ -3694,7 +3749,7 @@
   function startSim() {
     unlockSteamClockAudio();
     state.isRunning = true;
-    setStatus('Street mode active. Mouse look and movement are live. Press V for overview.');
+    setStatus(getStreetModeStatusText());
     setPointerStatus('Pointer lock requested… press Esc any time to release.');
     lockPointer();
   }
@@ -3968,7 +4023,7 @@
       setupAudio(state.world);
       minimapState.worldMetrics = getWorldMetrics();
       try { if (window.localStorage.getItem('gastownLowGraphics') === '1') { setLowGraphicsMode(true); } } catch (error) {}
-      setQuestStatus('Scavenger hunt: talk to the guide to begin.');
+      setQuestStatus(getPublicGoalText() + ' Optional scavenger hunt: talk to the guide to begin.');
       restoreMinimapZoom();
       restoreMinimapMode();
       updateSize();
@@ -3984,7 +4039,7 @@
       scheduleSteamClock();
       setWorldModeStatus(state.world);
       if (!(state.world.meta && state.world.meta.fallbackMode === 'working-gastown-corridor')) {
-        setStatus('Street mode ready. Click scene to enter look mode and begin moving, or press V for overview.');
+        setStatus(getPublicGoalText() + ' Click scene to enter look mode and begin moving, or press V for overview.');
       }
       updateCameraModeUi();
       renderer.setAnimationLoop((time) => {

--- a/js/gastown-world-loader.js
+++ b/js/gastown-world-loader.js
@@ -85,6 +85,30 @@
     (npc.patrol || []).forEach((point, patrolIndex) => validatePointLike(point, 'npcs[' + index + '].patrol[' + patrolIndex + ']'));
   }
 
+  function validateMicroArea(area, index) {
+    if (!area || typeof area !== 'object') {
+      throw new Error('Gastown world data is malformed: microAreas[' + index + '] must be an object.');
+    }
+    if (typeof area.id !== 'string' || !area.id) {
+      throw new Error('Gastown world data is malformed: microAreas[' + index + '].id is required.');
+    }
+    if (typeof area.label !== 'string' || !area.label) {
+      throw new Error('Gastown world data is malformed: microAreas[' + index + '].label is required.');
+    }
+    if (typeof area.identity !== 'string' || !area.identity) {
+      throw new Error('Gastown world data is malformed: microAreas[' + index + '].identity is required.');
+    }
+    assertPolygon(area.polygon, 'microAreas[' + index + '].polygon');
+    if (area.anchor) {
+      validatePointLike(area.anchor, 'microAreas[' + index + '].anchor');
+    }
+    ['stopReasons', 'returnReasons'].forEach((field) => {
+      if (area[field] !== undefined && !Array.isArray(area[field])) {
+        throw new Error('Gastown world data is malformed: microAreas[' + index + '].' + field + ' must be an array when present.');
+      }
+    });
+  }
+
   function validateWorldData(data) {
     const hasRoute = data && data.route && Array.isArray(data.route.centerline);
     const hasNodes = data && Array.isArray(data.nodes);
@@ -114,6 +138,9 @@
     if (data.npcs && !Array.isArray(data.npcs)) {
       throw new Error('Gastown world data is malformed: npcs must be an array.');
     }
+    if (data.microAreas && !Array.isArray(data.microAreas)) {
+      throw new Error('Gastown world data is malformed: microAreas must be an array.');
+    }
 
     if (data.navigator) {
       if (data.navigator.focusCorridor && !Array.isArray(data.navigator.focusCorridor)) {
@@ -138,6 +165,7 @@
 
     (data.props || []).forEach(validateProp);
     (data.npcs || []).forEach(validateNpc);
+    (data.microAreas || []).forEach(validateMicroArea);
 
     data.buildings.forEach((building, index) => {
       const hasAbsoluteFootprint = Array.isArray(building.footprint);
@@ -199,6 +227,13 @@
     normalized.landmarks = Array.isArray(normalized.landmarks) ? normalized.landmarks : [];
     normalized.audioZones = Array.isArray(normalized.audioZones) ? normalized.audioZones : [];
     normalized.hero_landmarks = Array.isArray(normalized.hero_landmarks) ? normalized.hero_landmarks : [];
+    normalized.exploration = normalized.exploration && typeof normalized.exploration === 'object' ? normalized.exploration : {};
+    normalized.exploration.publicGoal = typeof normalized.exploration.publicGoal === 'string' && normalized.exploration.publicGoal
+      ? normalized.exploration.publicGoal
+      : 'I’m exploring Gastown.';
+    normalized.exploration.fallbackPrompt = typeof normalized.exploration.fallbackPrompt === 'string'
+      ? normalized.exploration.fallbackPrompt
+      : 'Find your own short loops through the district.';
     normalized.facade_profiles = normalized.facade_profiles && typeof normalized.facade_profiles === 'object' ? normalized.facade_profiles : {};
 
     normalized.navigator = normalized.navigator && typeof normalized.navigator === 'object' ? normalized.navigator : {};
@@ -238,6 +273,32 @@
         dialogId: typeof npc.dialogId === 'string' ? npc.dialogId : '',
         idleSpot: normalizePoint(npc.idleSpot || fallbackPoint, fallbackPoint.x, fallbackPoint.z),
         patrol: patrol,
+      };
+    });
+
+    normalized.microAreas = Array.isArray(normalized.microAreas) ? normalized.microAreas : [];
+    normalized.microAreas = normalized.microAreas.map((area, index) => {
+      const polygon = Array.isArray(area.polygon) ? area.polygon.map((point) => normalizePoint(point, 0, 0)) : [];
+      const anchor = area.anchor
+        ? normalizePoint(area.anchor, polygon[0] ? polygon[0].x : 0, polygon[0] ? polygon[0].z : 0)
+        : (polygon.length
+          ? polygon.reduce((acc, point) => ({ x: acc.x + point.x, z: acc.z + point.z }), { x: 0, z: 0 })
+          : { x: 0, z: 0 });
+      const derivedAnchor = area.anchor
+        ? anchor
+        : {
+          x: polygon.length ? anchor.x / polygon.length : 0,
+          z: polygon.length ? anchor.z / polygon.length : 0,
+        };
+      return {
+        id: typeof area.id === 'string' && area.id ? area.id : 'micro-area-' + index,
+        label: typeof area.label === 'string' && area.label ? area.label : 'Gastown pocket',
+        identity: typeof area.identity === 'string' && area.identity ? area.identity : 'micro-area',
+        nodeId: typeof area.nodeId === 'string' ? area.nodeId : '',
+        polygon,
+        anchor: derivedAnchor,
+        stopReasons: Array.isArray(area.stopReasons) ? area.stopReasons.filter((entry) => typeof entry === 'string' && entry) : [],
+        returnReasons: Array.isArray(area.returnReasons) ? area.returnReasons.filter((entry) => typeof entry === 'string' && entry) : [],
       };
     });
 

--- a/js/gastown-world-loader.js
+++ b/js/gastown-world-loader.js
@@ -62,6 +62,9 @@
       assertFiniteNumberIfPresent(prop[field], 'props[' + index + '].' + field);
     });
     assertFiniteNumberIfPresent(prop.y, 'props[' + index + '].y');
+    if (prop.collectible !== undefined && typeof prop.collectible !== 'boolean') {
+      throw new Error('Gastown world data is malformed: props[' + index + '].collectible must be boolean when present.');
+    }
   }
 
   function validateNpc(npc, index) {
@@ -254,6 +257,11 @@
       z: isFiniteNumber(prop.z) ? prop.z : 0,
       yaw: isFiniteNumber(prop.yaw) ? prop.yaw : 0,
       scale: isFiniteNumber(prop.scale) ? prop.scale : 1,
+      collectible: !!prop.collectible,
+      collectibleKey: typeof prop.collectibleKey === 'string' ? prop.collectibleKey : '',
+      collectibleLabel: typeof prop.collectibleLabel === 'string' ? prop.collectibleLabel : '',
+      minimapIcon: typeof prop.minimapIcon === 'string' ? prop.minimapIcon : '',
+      randomOffset: !!prop.randomOffset,
     }));
 
     normalized.npcs = Array.isArray(normalized.npcs) ? normalized.npcs : [];

--- a/scripts/build-gastown-world.js
+++ b/scripts/build-gastown-world.js
@@ -75,6 +75,14 @@ function runScaffold() {
   world.meta.provenanceSummary = world.meta.isRealCivicBuild === false
     ? 'Approximate fallback corridor retained because civic/open-data inputs were unavailable at build time.'
     : 'Offline civic/open-data build generated from local source exports.';
+  world.meta.artDirection = world.meta.artDirection || {
+    label: 'stylized realism with cinematic Vancouver rain-lighting',
+    pillars: [
+      'wet cobblestone reflections and low-angle dawn highlights',
+      'heritage masonry with richer brick-stone-glass contrast',
+      'dense civic clutter and postcard framing around the Steam Clock and Water Street bends',
+    ],
+  };
   world.meta.importManifest = world.meta.importManifest || importManifest;
 
   (world.buildings || []).forEach((building) => applyReferenceScaffold(building));

--- a/scripts/build-gastown-world.js
+++ b/scripts/build-gastown-world.js
@@ -69,6 +69,7 @@ function runScaffold() {
     'Prepared for offline City of Vancouver footprints/streets/ROW widths + optional OSM route alignment.',
     'Supports hero_landmarks + facade_profiles to prioritize recognizability over photoreal detail.',
     'Scaffold includes reference-driven world notes for segment style, silhouette, and storefront cadence.',
+    'Exploration scaffolding should preserve multiple micro-areas, short loops, and reasons to stop rather than collapsing Gastown into a single through-route.',
   ];
   world.meta.buildClassification = world.meta.isRealCivicBuild === false ? 'approximate-fallback' : 'offline-civic-build';
   world.meta.provenanceSummary = world.meta.isRealCivicBuild === false

--- a/scripts/build-gastown-world.js
+++ b/scripts/build-gastown-world.js
@@ -63,7 +63,7 @@ function runScaffold() {
 
   const world = JSON.parse(fs.readFileSync(worldPath, 'utf8'));
   world.meta = world.meta || {};
-  world.meta.lastBuild = new Date().toISOString();
+  world.meta.lastBuild = world.meta.lastBuild || new Date().toISOString();
   world.meta.buildNotes = [
     'Runtime geometry is compact and static; no live map APIs.',
     'Prepared for offline City of Vancouver footprints/streets/ROW widths + optional OSM route alignment.',

--- a/scripts/generate-gastown-world.js
+++ b/scripts/generate-gastown-world.js
@@ -1192,6 +1192,9 @@ function makeStarterWorld(outputPath, options = {}) {
     ...(reference.orthophotoImagery2015 && Array.isArray(reference.orthophotoImagery2015.features) ? ['orthophoto-imagery-2015.geojson'] : []),
   ];
 
+  const existingWorld = fs.existsSync(outputPath) ? readJson(outputPath) : {};
+  const existingMeta = existingWorld.meta || {};
+
   const lampFeatures = getFeatureCollectionByKind(reference.poiReference, 'heritage_lamp');
   const lamps = lampFeatures.length
     ? lampFeatures.map((feature, index) => {
@@ -1220,7 +1223,7 @@ function makeStarterWorld(outputPath, options = {}) {
         orthophotoImagery2015: !!(reference.orthophotoImagery2015 && Array.isArray(reference.orthophotoImagery2015.features) && reference.orthophotoImagery2015.features.length),
       },
       provenanceSummary: 'Approximate fallback corridor retained because the offline civic/open-data pipeline did not have all required local inputs.',
-      lastBuild: new Date().toISOString(),
+      lastBuild: existingMeta.lastBuild || new Date().toISOString(),
     },
     route: { name: 'Explorable Gastown: Water Street loops', centerline, walkBounds, streetWidth, sidewalkWidth, softBoundary, hardResetDistance: 12 },
     nodes: [
@@ -1613,7 +1616,7 @@ function buildWorld(options = {}) {
       units: 'meters',
       source: 'Offline City of Vancouver Open Data exports',
       buildClassification: 'offline-civic-build',
-      lastBuild: new Date().toISOString(),
+      lastBuild: existingMeta.lastBuild || new Date().toISOString(),
       importManifest: existingMeta.importManifest || {
         inputs: {
           cityOfVancouver: {

--- a/scripts/generate-gastown-world.js
+++ b/scripts/generate-gastown-world.js
@@ -4,6 +4,14 @@ const fs = require('fs');
 const path = require('path');
 
 const EARTH_RADIUS_METERS = 6371008.8;
+const DEFAULT_ART_DIRECTION = {
+  label: 'stylized realism with cinematic Vancouver rain-lighting',
+  pillars: [
+    'wet cobblestone reflections and low-angle dawn highlights',
+    'heritage masonry with richer brick-stone-glass contrast',
+    'dense civic clutter and postcard framing around the Steam Clock and Water Street bends',
+  ],
+};
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
@@ -1162,16 +1170,20 @@ function makeStarterWorld(outputPath, options = {}) {
   const props = [
     placeStarterProp(waterCenterline, 18, -(sidewalkOuter + 0.55), 'starter-prop-threshold-box', 'newspaper_box', { scale: 1.05 }),
     placeStarterProp(waterCenterline, 24, sidewalkOuter + 0.72, 'starter-prop-threshold-utility', 'utility_box', { scale: 1.1 }),
+    placeStarterProp(waterCenterline, 20, -(sidewalkOuter + 1.72), 'starter-prop-threshold-bench', 'bench', { scale: 0.92, yawOffset: Math.PI / 2 }),
     placeStarterProp(waterCenterline, 62, -(sidewalkOuter + 0.88), 'starter-prop-planter-west', 'planter', { scale: 1.15 }),
     placeStarterProp(waterCenterline, primaryLength * 0.72, sidewalkOuter + 0.95, 'starter-prop-planter-east', 'planter', { scale: 1.08 }),
     { id: 'starter-prop-bench-clock', kind: 'bench', x: Number((layout.clock.x - (layout.plaza.tangent.x * 1.8) + (layout.plaza.normal.x * 2.2)).toFixed(2)), y: 0, z: Number((layout.clock.z - (layout.plaza.tangent.z * 1.8) + (layout.plaza.normal.z * 2.2)).toFixed(2)), yaw: Number((Math.atan2(layout.plaza.tangent.x, layout.plaza.tangent.z) + (Math.PI / 2)).toFixed(4)), scale: 1.04 },
     { id: 'starter-prop-clock-box', kind: 'newspaper_box', x: Number((layout.clock.x + (layout.plaza.tangent.x * 1.6) + (layout.plaza.normal.x * 2.6)).toFixed(2)), y: 0, z: Number((layout.clock.z + (layout.plaza.tangent.z * 1.6) + (layout.plaza.normal.z * 2.6)).toFixed(2)), yaw: 0, scale: 0.98 },
     { id: 'starter-prop-station-kiosk', kind: 'newspaper_box', x: Number((layout.station.x + (intersectionFrame.tangent.x * 4.6) - (intersectionFrame.normal.x * 2.7)).toFixed(2)), y: 0, z: Number((layout.station.z + (intersectionFrame.tangent.z * 4.6) - (intersectionFrame.normal.z * 2.7)).toFixed(2)), yaw: Number(Math.atan2(intersectionFrame.tangent.x, intersectionFrame.tangent.z).toFixed(4)), scale: 1, collectible: true, collectibleKey: 'newspaper_box', collectibleLabel: 'Newspaper box', minimapIcon: 'collectible' },
-    { id: 'starter-prop-maple-mural', kind: 'planter', x: Number((layout.mapleEdge.x + (layout.plaza.tangent.x * 2.8) + (layout.plaza.normal.x * 3.1)).toFixed(2)), y: 0, z: Number((layout.mapleEdge.z + (layout.plaza.tangent.z * 2.8) + (layout.plaza.normal.z * 3.1)).toFixed(2)), yaw: Number((Math.atan2(layout.plaza.normal.x, layout.plaza.normal.z) + Math.PI).toFixed(4)), scale: 1.08, collectible: true, collectibleKey: 'mural', collectibleLabel: 'Maple Tree mural', minimapIcon: 'collectible' },
+    { id: 'starter-prop-maple-mural', kind: 'cardboard_box', x: Number((layout.mapleEdge.x + (layout.plaza.tangent.x * 2.1) + (layout.plaza.normal.x * 2.3)).toFixed(2)), y: 0, z: Number((layout.mapleEdge.z + (layout.plaza.tangent.z * 2.1) + (layout.plaza.normal.z * 2.3)).toFixed(2)), yaw: Number(Math.atan2(layout.plaza.tangent.x, layout.plaza.tangent.z).toFixed(4)), scale: 0.95, collectible: true, collectibleKey: 'mural', collectibleLabel: 'Maple Tree mural', minimapIcon: 'mural', randomOffset: true },
+    { id: 'starter-prop-clock-plaque', kind: 'utility_box', x: Number((layout.clock.x + (layout.plaza.normal.x * 1.9) + (layout.plaza.tangent.x * 0.5)).toFixed(2)), y: 0, z: Number((layout.clock.z + (layout.plaza.normal.z * 1.9) + (layout.plaza.tangent.z * 0.5)).toFixed(2)), yaw: Number(Math.atan2(layout.plaza.normal.x, layout.plaza.normal.z).toFixed(4)), scale: 0.65 },
     { id: 'starter-prop-alley-plaque', kind: 'utility_box', x: Number((intersectionPoint.x - (intersectionFrame.tangent.x * 9.1) + (intersectionFrame.normal.x * 6.6)).toFixed(2)), y: 0, z: Number((intersectionPoint.z - (intersectionFrame.tangent.z * 9.1) + (intersectionFrame.normal.z * 6.6)).toFixed(2)), yaw: Number(Math.atan2(intersectionFrame.normal.x, intersectionFrame.normal.z).toFixed(4)), scale: 1, collectible: true, collectibleKey: 'historic_plaque', collectibleLabel: 'Historic plaque', minimapIcon: 'collectible' },
+    placeStarterProp(waterEastLeg, Math.max(3, polylineLength(waterEastLeg) * 0.3), sidewalkOuter * 0.88, 'starter-prop-east-newsbox', 'newspaper_box', { scale: 1.02 }),
     placeStarterProp(cambieCorridor, 18, -(sidewalkOuter * 0.82), 'starter-prop-postclock-utility', 'utility_box', { scale: 1.06 }),
     placeStarterProp(cambieCorridor, 30, sidewalkOuter * 0.75, 'starter-prop-postclock-bags', 'trash_bag', { scale: 0.96 }),
     placeStarterProp(cambieCorridor, 36, sidewalkOuter * 0.88, 'starter-prop-postclock-bench', 'bench', { scale: 1, yawOffset: Math.PI / 2 }),
+    placeStarterProp(cambieCorridor, 32, -(sidewalkOuter * 0.92), 'starter-prop-postclock-planter', 'planter', { scale: 1.12 }),
   ];
 
   const landmarkBundle = buildStarterLandmarks(layout);
@@ -1224,6 +1236,7 @@ function makeStarterWorld(outputPath, options = {}) {
       },
       provenanceSummary: 'Approximate fallback corridor retained because the offline civic/open-data pipeline did not have all required local inputs.',
       lastBuild: existingMeta.lastBuild || new Date().toISOString(),
+      artDirection: existingMeta.artDirection || DEFAULT_ART_DIRECTION,
     },
     route: { name: 'Explorable Gastown: Water Street loops', centerline, walkBounds, streetWidth, sidewalkWidth, softBoundary, hardResetDistance: 12 },
     nodes: [
@@ -1653,6 +1666,7 @@ function buildWorld(options = {}) {
         orthophotoImagery2015: fs.existsSync(path.join(root, 'data', 'cov', 'orthophoto-imagery-2015.geojson')),
       },
       provenanceSummary: 'Offline civic-data build generated from local source exports and normalized for the runtime simulator.',
+      artDirection: existingMeta.artDirection || DEFAULT_ART_DIRECTION,
     },
     route: {
       ...(existingWorld.route || {}),

--- a/scripts/generate-gastown-world.js
+++ b/scripts/generate-gastown-world.js
@@ -1328,11 +1328,6 @@ function makeStarterWorld(outputPath, options = {}) {
       ],
       surfaceBands: buildStarterSurfaceBands(centerline, streetWidth, routeLength),
     },
-    audioZones: [
-      { id: 'station-plaza-bed', label: 'Station plaza ambience', bed: 'station-plaza.mp3', x: Number((layout.station.x + (intersectionFrame.tangent.x * 4.8)).toFixed(2)), z: Number((layout.station.z + (intersectionFrame.tangent.z * 4.8)).toFixed(2)), radius: 16 },
-      { id: 'steam-clock-bed', label: 'Steam Clock plaza ambience', bed: 'steam-clock-plaza.mp3', x: Number(layout.clock.x.toFixed(2)), z: Number(layout.clock.z.toFixed(2)), radius: 18 },
-      { id: 'maple-square-bed', label: 'Maple Tree Square ambience', bed: 'maple-square.mp3', x: Number(layout.mapleEdge.x.toFixed(2)), z: Number(layout.mapleEdge.z.toFixed(2)), radius: 15 },
-    ],
     spawn,
     bounds: { floorY: 0, edgeMessage: 'Stayed inside the explorable Gastown district.', resetMessage: 'Returned to the explorable Gastown district.' },
   };

--- a/scripts/generate-gastown-world.js
+++ b/scripts/generate-gastown-world.js
@@ -987,7 +987,71 @@ function makeStarterWorld(outputPath, options = {}) {
     8.6,
     9.4
   ));
-  const walkBounds = sanitizePolygon(ribbonPolygon(waterRoute, walkOuter).concat([]));
+  const stationPlaza = sanitizeZonePolygon(orientedRect(
+    {
+      x: layout.station.x + (intersectionFrame.tangent.x * 2.1) - (intersectionFrame.normal.x * 1.6),
+      z: layout.station.z + (intersectionFrame.tangent.z * 2.1) - (intersectionFrame.normal.z * 1.6),
+    },
+    intersectionFrame.tangent,
+    10.8,
+    9.6
+  ));
+  const storefrontEdge = sanitizeZonePolygon(orientedRect(
+    {
+      x: layout.midBlock.x - (intersectionFrame.normal.x * (streetHalf + (sidewalkWidth * 0.9))),
+      z: layout.midBlock.z - (intersectionFrame.normal.z * (streetHalf + (sidewalkWidth * 0.9))),
+    },
+    intersectionFrame.tangent,
+    16.4,
+    7.6
+  ));
+  const alleyThreshold = sanitizeZonePolygon(orientedRect(
+    {
+      x: intersectionPoint.x - (intersectionFrame.tangent.x * 8.8) + (intersectionFrame.normal.x * (streetHalf + (sidewalkWidth * 0.82))),
+      z: intersectionPoint.z - (intersectionFrame.tangent.z * 8.8) + (intersectionFrame.normal.z * (streetHalf + (sidewalkWidth * 0.82))),
+    },
+    intersectionFrame.tangent,
+    7.2,
+    7.8
+  ));
+  const transitEdge = sanitizeZonePolygon(orientedRect(
+    {
+      x: layout.cambie.x - (layout.plaza.normal.x * 2.2) - (layout.plaza.tangent.x * 1.8),
+      z: layout.cambie.z - (layout.plaza.normal.z * 2.2) - (layout.plaza.tangent.z * 1.8),
+    },
+    layout.plaza.normal,
+    10.4,
+    6.8
+  ));
+  const landmarkCorner = sanitizeZonePolygon(orientedRect(
+    {
+      x: layout.clock.x + (layout.plaza.tangent.x * 1.4) + (layout.plaza.normal.x * 1.5),
+      z: layout.clock.z + (layout.plaza.tangent.z * 1.4) + (layout.plaza.normal.z * 1.5),
+    },
+    layout.plaza.tangent,
+    9.4,
+    7.4
+  ));
+  const mapleTriangle = sanitizeZonePolygon(orientedRect(
+    {
+      x: layout.mapleEdge.x + (layout.plaza.tangent.x * 1.8) + (layout.plaza.normal.x * 1.4),
+      z: layout.mapleEdge.z + (layout.plaza.tangent.z * 1.8) + (layout.plaza.normal.z * 1.4),
+    },
+    layout.plaza.tangent,
+    9.6,
+    8.2
+  ));
+  const walkBounds = sanitizeZonePolygon([
+    { x: layout.station.x - 12, z: layout.station.z - 11 },
+    { x: layout.station.x + 28, z: layout.station.z - 36 },
+    { x: layout.midBlock.x + 6, z: layout.midBlock.z - 82 },
+    { x: layout.clock.x + 5, z: layout.clock.z - 24 },
+    { x: layout.mapleEdge.x + 22, z: layout.mapleEdge.z - 6 },
+    { x: layout.mapleEdge.x + 18, z: layout.mapleEdge.z + 15 },
+    { x: layout.cambie.x - 14, z: layout.cambie.z + 22 },
+    { x: layout.midBlock.x - 52, z: layout.midBlock.z + 42 },
+    { x: layout.station.x - 18, z: layout.station.z + 10 },
+  ]);
 
   const frontagePattern = [7.5, 9.5, 8, 12.5, 8.8, 10.4, 9.2, 14.5, 10.8, 8.4, 12.8, 9.6];
   const depthPattern = [15, 20, 14, 23, 17, 21, 18, 19, 22, 16, 24, 17];
@@ -1102,6 +1166,9 @@ function makeStarterWorld(outputPath, options = {}) {
     placeStarterProp(waterCenterline, primaryLength * 0.72, sidewalkOuter + 0.95, 'starter-prop-planter-east', 'planter', { scale: 1.08 }),
     { id: 'starter-prop-bench-clock', kind: 'bench', x: Number((layout.clock.x - (layout.plaza.tangent.x * 1.8) + (layout.plaza.normal.x * 2.2)).toFixed(2)), y: 0, z: Number((layout.clock.z - (layout.plaza.tangent.z * 1.8) + (layout.plaza.normal.z * 2.2)).toFixed(2)), yaw: Number((Math.atan2(layout.plaza.tangent.x, layout.plaza.tangent.z) + (Math.PI / 2)).toFixed(4)), scale: 1.04 },
     { id: 'starter-prop-clock-box', kind: 'newspaper_box', x: Number((layout.clock.x + (layout.plaza.tangent.x * 1.6) + (layout.plaza.normal.x * 2.6)).toFixed(2)), y: 0, z: Number((layout.clock.z + (layout.plaza.tangent.z * 1.6) + (layout.plaza.normal.z * 2.6)).toFixed(2)), yaw: 0, scale: 0.98 },
+    { id: 'starter-prop-station-kiosk', kind: 'newspaper_box', x: Number((layout.station.x + (intersectionFrame.tangent.x * 4.6) - (intersectionFrame.normal.x * 2.7)).toFixed(2)), y: 0, z: Number((layout.station.z + (intersectionFrame.tangent.z * 4.6) - (intersectionFrame.normal.z * 2.7)).toFixed(2)), yaw: Number(Math.atan2(intersectionFrame.tangent.x, intersectionFrame.tangent.z).toFixed(4)), scale: 1, collectible: true, collectibleKey: 'newspaper_box', collectibleLabel: 'Newspaper box', minimapIcon: 'collectible' },
+    { id: 'starter-prop-maple-mural', kind: 'planter', x: Number((layout.mapleEdge.x + (layout.plaza.tangent.x * 2.8) + (layout.plaza.normal.x * 3.1)).toFixed(2)), y: 0, z: Number((layout.mapleEdge.z + (layout.plaza.tangent.z * 2.8) + (layout.plaza.normal.z * 3.1)).toFixed(2)), yaw: Number((Math.atan2(layout.plaza.normal.x, layout.plaza.normal.z) + Math.PI).toFixed(4)), scale: 1.08, collectible: true, collectibleKey: 'mural', collectibleLabel: 'Maple Tree mural', minimapIcon: 'collectible' },
+    { id: 'starter-prop-alley-plaque', kind: 'utility_box', x: Number((intersectionPoint.x - (intersectionFrame.tangent.x * 9.1) + (intersectionFrame.normal.x * 6.6)).toFixed(2)), y: 0, z: Number((intersectionPoint.z - (intersectionFrame.tangent.z * 9.1) + (intersectionFrame.normal.z * 6.6)).toFixed(2)), yaw: Number(Math.atan2(intersectionFrame.normal.x, intersectionFrame.normal.z).toFixed(4)), scale: 1, collectible: true, collectibleKey: 'historic_plaque', collectibleLabel: 'Historic plaque', minimapIcon: 'collectible' },
     placeStarterProp(cambieCorridor, 18, -(sidewalkOuter * 0.82), 'starter-prop-postclock-utility', 'utility_box', { scale: 1.06 }),
     placeStarterProp(cambieCorridor, 30, sidewalkOuter * 0.75, 'starter-prop-postclock-bags', 'trash_bag', { scale: 0.96 }),
     placeStarterProp(cambieCorridor, 36, sidewalkOuter * 0.88, 'starter-prop-postclock-bench', 'bench', { scale: 1, yawOffset: Math.PI / 2 }),
@@ -1140,7 +1207,7 @@ function makeStarterWorld(outputPath, options = {}) {
       buildClassification: 'approximate-fallback',
       buildNotes: [
         'Working fallback corridor is active because required offline civic source files are missing.',
-        'This fallback now stages Water Street, a real Water/Cambie corner condition, and a Steam Clock plaza pad outside the carriageway instead of a single bent ribbon corridor.',
+        'This fallback now stages Water Street as a compact exploration district with plaza, storefront edge, alley threshold, transit edge, and landmark corner micro-areas instead of a single bent ribbon corridor.',
         referenceFeaturesUsed.length ? `Optional refreshed reference inputs were present: ${referenceFeaturesUsed.join(', ')}.` : 'No refreshed reference inputs were present; deterministic default route staging was used.',
       ],
       referenceInputsUsed: referenceFeaturesUsed,
@@ -1155,19 +1222,42 @@ function makeStarterWorld(outputPath, options = {}) {
       provenanceSummary: 'Approximate fallback corridor retained because the offline civic/open-data pipeline did not have all required local inputs.',
       lastBuild: new Date().toISOString(),
     },
-    route: { name: 'Waterfront Station → Water Street → Steam Clock working corridor', centerline, walkBounds, streetWidth, sidewalkWidth, softBoundary, hardResetDistance: 12 },
+    route: { name: 'Explorable Gastown: Water Street loops', centerline, walkBounds, streetWidth, sidewalkWidth, softBoundary, hardResetDistance: 12 },
     nodes: [
       { ...centerline[0], label: 'Waterfront Station threshold' },
+      { id: 'station-plaza', label: 'Station plaza', x: Number((layout.station.x + (intersectionFrame.tangent.x * 5.4) - (intersectionFrame.normal.x * 2.2)).toFixed(2)), z: Number((layout.station.z + (intersectionFrame.tangent.z * 5.4) - (intersectionFrame.normal.z * 2.2)).toFixed(2)) },
       { ...centerline[2], label: 'Water/Cordova seam' },
+      { id: 'storefront-edge', label: 'Storefront edge', x: Number((layout.midBlock.x - (intersectionFrame.normal.x * (streetHalf + (sidewalkWidth * 0.88)))).toFixed(2)), z: Number((layout.midBlock.z - (intersectionFrame.normal.z * (streetHalf + (sidewalkWidth * 0.88)))).toFixed(2)) },
       { ...centerline[4], label: 'Water Street mid block' },
+      { id: 'alley-threshold', label: 'Alley threshold', x: Number((intersectionPoint.x - (intersectionFrame.tangent.x * 8.8) + (intersectionFrame.normal.x * (streetHalf + (sidewalkWidth * 0.82)))).toFixed(2)), z: Number((intersectionPoint.z - (intersectionFrame.tangent.z * 8.8) + (intersectionFrame.normal.z * (streetHalf + (sidewalkWidth * 0.82)))).toFixed(2)) },
       { ...centerline[6], label: 'Steam Clock plaza' },
+      { id: 'landmark-corner', label: 'Landmark corner', x: Number((layout.clock.x + (layout.plaza.tangent.x * 1.4) + (layout.plaza.normal.x * 1.5)).toFixed(2)), z: Number((layout.clock.z + (layout.plaza.tangent.z * 1.4) + (layout.plaza.normal.z * 1.5)).toFixed(2)) },
       { ...centerline[7], label: 'Maple Tree Square edge' },
+      { id: 'transit-edge', label: 'Transit edge', x: Number((layout.cambie.x - (layout.plaza.normal.x * 2.2) - (layout.plaza.tangent.x * 1.8)).toFixed(2)), z: Number((layout.cambie.z - (layout.plaza.normal.z * 2.2) - (layout.plaza.tangent.z * 1.8)).toFixed(2)) },
       { ...centerline[8], label: 'Cambie rise continuation' },
       { id: 'water-cambie-intersection', label: 'Water/Cambie intersection', x: Number(intersectionPoint.x.toFixed(2)), z: Number(intersectionPoint.z.toFixed(2)) },
     ],
     navigator: {
       focusCorridor: [
         { id: 'water-street-west-leg', label: 'Water Street west leg', points: waterWestLeg.map((point) => ({ x: Number(point.x.toFixed(2)), z: Number(point.z.toFixed(2)) })) },
+        { id: 'station-plaza-loop', label: 'Station plaza loop', points: [
+          { x: Number((layout.station.x - (intersectionFrame.tangent.x * 1.5) - (intersectionFrame.normal.x * 3.8)).toFixed(2)), z: Number((layout.station.z - (intersectionFrame.tangent.z * 1.5) - (intersectionFrame.normal.z * 3.8)).toFixed(2)) },
+          { x: Number((layout.station.x + (intersectionFrame.tangent.x * 6.2) - (intersectionFrame.normal.x * 4.1)).toFixed(2)), z: Number((layout.station.z + (intersectionFrame.tangent.z * 6.2) - (intersectionFrame.normal.z * 4.1)).toFixed(2)) },
+          { x: Number((layout.station.x + (intersectionFrame.tangent.x * 6.8) + (intersectionFrame.normal.x * 1.1)).toFixed(2)), z: Number((layout.station.z + (intersectionFrame.tangent.z * 6.8) + (intersectionFrame.normal.z * 1.1)).toFixed(2)) },
+          { x: Number((layout.station.x - (intersectionFrame.tangent.x * 1.1) + (intersectionFrame.normal.x * 0.8)).toFixed(2)), z: Number((layout.station.z - (intersectionFrame.tangent.z * 1.1) + (intersectionFrame.normal.z * 0.8)).toFixed(2)) },
+        ] },
+        { id: 'storefront-pocket-loop', label: 'Storefront pocket loop', points: [
+          { x: Number((layout.midBlock.x - (intersectionFrame.tangent.x * 5.4) - (intersectionFrame.normal.x * 3.8)).toFixed(2)), z: Number((layout.midBlock.z - (intersectionFrame.tangent.z * 5.4) - (intersectionFrame.normal.z * 3.8)).toFixed(2)) },
+          { x: Number((layout.midBlock.x + (intersectionFrame.tangent.x * 4.8) - (intersectionFrame.normal.x * 3.9)).toFixed(2)), z: Number((layout.midBlock.z + (intersectionFrame.tangent.z * 4.8) - (intersectionFrame.normal.z * 3.9)).toFixed(2)) },
+          { x: Number((layout.midBlock.x + (intersectionFrame.tangent.x * 4.6) - (intersectionFrame.normal.x * 7.4)).toFixed(2)), z: Number((layout.midBlock.z + (intersectionFrame.tangent.z * 4.6) - (intersectionFrame.normal.z * 7.4)).toFixed(2)) },
+          { x: Number((layout.midBlock.x - (intersectionFrame.tangent.x * 5.1) - (intersectionFrame.normal.x * 7.1)).toFixed(2)), z: Number((layout.midBlock.z - (intersectionFrame.tangent.z * 5.1) - (intersectionFrame.normal.z * 7.1)).toFixed(2)) },
+        ] },
+        { id: 'alley-threshold-loop', label: 'Alley threshold loop', points: [
+          { x: Number((intersectionPoint.x - (intersectionFrame.tangent.x * 11.4) + (intersectionFrame.normal.x * 2.5)).toFixed(2)), z: Number((intersectionPoint.z - (intersectionFrame.tangent.z * 11.4) + (intersectionFrame.normal.z * 2.5)).toFixed(2)) },
+          { x: Number((intersectionPoint.x - (intersectionFrame.tangent.x * 7.6) + (intersectionFrame.normal.x * 4.8)).toFixed(2)), z: Number((intersectionPoint.z - (intersectionFrame.tangent.z * 7.6) + (intersectionFrame.normal.z * 4.8)).toFixed(2)) },
+          { x: Number((intersectionPoint.x - (intersectionFrame.tangent.x * 9.3) + (intersectionFrame.normal.x * 8.2)).toFixed(2)), z: Number((intersectionPoint.z - (intersectionFrame.tangent.z * 9.3) + (intersectionFrame.normal.z * 8.2)).toFixed(2)) },
+          { x: Number((intersectionPoint.x - (intersectionFrame.tangent.x * 12.8) + (intersectionFrame.normal.x * 5.9)).toFixed(2)), z: Number((intersectionPoint.z - (intersectionFrame.tangent.z * 12.8) + (intersectionFrame.normal.z * 5.9)).toFixed(2)) },
+        ] },
         { id: 'steam-clock-plaza-loop', label: 'Steam Clock plaza', points: [
           { x: Number((layout.clock.x + (layout.plaza.normal.x * -2.2)).toFixed(2)), z: Number((layout.clock.z + (layout.plaza.normal.z * -2.2)).toFixed(2)) },
           { x: Number((layout.clock.x + (layout.plaza.tangent.x * 2.5) + (layout.plaza.normal.x * -1.3)).toFixed(2)), z: Number((layout.clock.z + (layout.plaza.tangent.z * 2.5) + (layout.plaza.normal.z * -1.3)).toFixed(2)) },
@@ -1175,7 +1265,19 @@ function makeStarterWorld(outputPath, options = {}) {
           { x: Number((layout.clock.x + (layout.plaza.normal.x * 2.3)).toFixed(2)), z: Number((layout.clock.z + (layout.plaza.normal.z * 2.3)).toFixed(2)) },
         ] },
         { id: 'water-street-east-leg', label: 'Water Street east leg', points: waterEastLeg.map((point) => ({ x: Number(point.x.toFixed(2)), z: Number(point.z.toFixed(2)) })) },
+        { id: 'maple-square-loop', label: 'Maple Tree Square loop', points: [
+          { x: Number((layout.mapleEdge.x - (layout.plaza.tangent.x * 1.8) - (layout.plaza.normal.x * 1.7)).toFixed(2)), z: Number((layout.mapleEdge.z - (layout.plaza.tangent.z * 1.8) - (layout.plaza.normal.z * 1.7)).toFixed(2)) },
+          { x: Number((layout.mapleEdge.x + (layout.plaza.tangent.x * 3.8) - (layout.plaza.normal.x * 0.8)).toFixed(2)), z: Number((layout.mapleEdge.z + (layout.plaza.tangent.z * 3.8) - (layout.plaza.normal.z * 0.8)).toFixed(2)) },
+          { x: Number((layout.mapleEdge.x + (layout.plaza.tangent.x * 4.4) + (layout.plaza.normal.x * 3.2)).toFixed(2)), z: Number((layout.mapleEdge.z + (layout.plaza.tangent.z * 4.4) + (layout.plaza.normal.z * 3.2)).toFixed(2)) },
+          { x: Number((layout.mapleEdge.x - (layout.plaza.tangent.x * 0.9) + (layout.plaza.normal.x * 3.8)).toFixed(2)), z: Number((layout.mapleEdge.z - (layout.plaza.tangent.z * 0.9) + (layout.plaza.normal.z * 3.8)).toFixed(2)) },
+        ] },
         { id: 'cambie-crossing', label: 'Cambie crossing', points: cambieCorridor.map((point) => ({ x: Number(point.x.toFixed(2)), z: Number(point.z.toFixed(2)) })) },
+        { id: 'transit-edge-loop', label: 'Transit edge loop', points: [
+          { x: Number((layout.cambie.x - (layout.plaza.normal.x * 4.2) - (layout.plaza.tangent.x * 5.1)).toFixed(2)), z: Number((layout.cambie.z - (layout.plaza.normal.z * 4.2) - (layout.plaza.tangent.z * 5.1)).toFixed(2)) },
+          { x: Number((layout.cambie.x - (layout.plaza.normal.x * 0.8) - (layout.plaza.tangent.x * 4.8)).toFixed(2)), z: Number((layout.cambie.z - (layout.plaza.normal.z * 0.8) - (layout.plaza.tangent.z * 4.8)).toFixed(2)) },
+          { x: Number((layout.cambie.x - (layout.plaza.normal.x * 0.5) + (layout.plaza.tangent.x * 0.9)).toFixed(2)), z: Number((layout.cambie.z - (layout.plaza.normal.z * 0.5) + (layout.plaza.tangent.z * 0.9)).toFixed(2)) },
+          { x: Number((layout.cambie.x - (layout.plaza.normal.x * 4.1) + (layout.plaza.tangent.x * 1.2)).toFixed(2)), z: Number((layout.cambie.z - (layout.plaza.normal.z * 4.1) + (layout.plaza.tangent.z * 1.2)).toFixed(2)) },
+        ] },
       ],
     },
     zones: {
@@ -1188,9 +1290,15 @@ function makeStarterWorld(outputPath, options = {}) {
       sidewalk: [
         { id: 'water-street-south-sidewalk', side: 'south', polygon: southSidewalk },
         { id: 'water-street-north-sidewalk', side: 'north', polygon: northSidewalk },
+        { id: 'waterfront-station-plaza', side: 'plaza', polygon: stationPlaza },
+        { id: 'water-street-storefront-pocket', side: 'storefront', polygon: storefrontEdge },
+        { id: 'water-street-alley-threshold', side: 'alley', polygon: alleyThreshold },
         { id: 'cambie-west-sidewalk', side: 'west', polygon: cambieWestSidewalk },
+        { id: 'cambie-transit-edge', side: 'transit', polygon: transitEdge },
         { id: 'water-cambie-curb-return', side: 'corner', polygon: curbReturn },
         { id: 'steam-clock-plaza-sidewalk', side: 'plaza', polygon: plazaPad },
+        { id: 'steam-clock-landmark-corner', side: 'corner', polygon: landmarkCorner },
+        { id: 'maple-tree-square-pocket', side: 'plaza', polygon: mapleTriangle },
       ],
     },
     buildings,
@@ -1198,6 +1306,19 @@ function makeStarterWorld(outputPath, options = {}) {
     landmarks,
     props,
     npcs,
+    exploration: {
+      publicGoal: 'I’m exploring Gastown.',
+      fallbackPrompt: 'Wander the connected plazas, storefront edges, alley mouths, and landmark corners to build your own short loop.',
+    },
+    microAreas: [
+      { id: 'station-plaza', label: 'Station plaza', identity: 'transit edge', nodeId: 'station-plaza', polygon: stationPlaza, stopReasons: ['Watch people spill out from Waterfront Station.', 'Reorient before committing to Water Street.'], returnReasons: ['It works as a reliable reset point.', 'The wider pad gives you a clear view back into Gastown.'] },
+      { id: 'storefront-edge', label: 'Storefront edge', identity: 'storefront edge', nodeId: 'storefront-edge', polygon: storefrontEdge, stopReasons: ['Window-shop the heritage frontage rhythm.', 'Use the pocket as a pause between the station and the clock.'], returnReasons: ['It makes a good midway meeting point.', 'The tighter edge reveals the street from a different angle on the way back.'] },
+      { id: 'alley-threshold', label: 'Alley threshold', identity: 'alley threshold', nodeId: 'alley-threshold', polygon: alleyThreshold, stopReasons: ['Peek into the service lane without leaving the public edge.', 'Listen for the quieter pocket off the main block.'], returnReasons: ['It turns the approach into a loop instead of a one-way run.', 'The threshold frames the Steam Clock corner from the side.'] },
+      { id: 'steam-clock-plaza', label: 'Steam Clock plaza', identity: 'plaza', nodeId: 'steam-clock', polygon: plazaPad, stopReasons: ['Pause for the clock, seating, and busker activity.', 'Use the open pad to decide where to head next.'], returnReasons: ['The plaza is the natural social hub.', 'It links back out to Water Street and Maple Tree Square.'] },
+      { id: 'landmark-corner', label: 'Landmark corner', identity: 'landmark corner', nodeId: 'landmark-corner', polygon: landmarkCorner, stopReasons: ['Take in the clock and corner facades together.', 'Catch the diagonal view into Maple Tree Square.'], returnReasons: ['It is the clearest landmark rendezvous point.', 'The corner keeps changing depending on approach direction.'] },
+      { id: 'maple-tree-square-pocket', label: 'Maple Tree Square pocket', identity: 'plaza edge', nodeId: 'maple-tree-square-edge', polygon: mapleTriangle, stopReasons: ['Step to the square edge for the crossroads feel.', 'Use the pocket as the eastern half of the loop.'], returnReasons: ['It rewards a second pass after circling the clock.', 'The square reads differently when you approach from Cambie.'] },
+      { id: 'transit-edge', label: 'Transit edge', identity: 'transit edge', nodeId: 'transit-edge', polygon: transitEdge, stopReasons: ['Look uphill toward the Cambie continuation.', 'Feel the district open toward the station/transit seam.'], returnReasons: ['It gives the loop a practical edge instead of a dead end.', 'The shift in grade changes your sense of the block.'] },
+    ],
     streetscape: {
       lamps,
       trees: proceduralStreetscape(waterRoute, { idPrefix: 'starter-tree', strideMeters: 38, laneOffset: sidewalkOuter + 2.3, maxCount: 10, mapper: (point, id) => ({ id, x: Number(point.x.toFixed(2)), z: Number(point.z.toFixed(2)), radius: 1.4 }) }),
@@ -1207,8 +1328,13 @@ function makeStarterWorld(outputPath, options = {}) {
       ],
       surfaceBands: buildStarterSurfaceBands(centerline, streetWidth, routeLength),
     },
+    audioZones: [
+      { id: 'station-plaza-bed', label: 'Station plaza ambience', bed: 'station-plaza.mp3', x: Number((layout.station.x + (intersectionFrame.tangent.x * 4.8)).toFixed(2)), z: Number((layout.station.z + (intersectionFrame.tangent.z * 4.8)).toFixed(2)), radius: 16 },
+      { id: 'steam-clock-bed', label: 'Steam Clock plaza ambience', bed: 'steam-clock-plaza.mp3', x: Number(layout.clock.x.toFixed(2)), z: Number(layout.clock.z.toFixed(2)), radius: 18 },
+      { id: 'maple-square-bed', label: 'Maple Tree Square ambience', bed: 'maple-square.mp3', x: Number(layout.mapleEdge.x.toFixed(2)), z: Number(layout.mapleEdge.z.toFixed(2)), radius: 15 },
+    ],
     spawn,
-    bounds: { floorY: 0, edgeMessage: 'Stayed within the Gastown working corridor.', resetMessage: 'Returned to the Gastown working corridor.' },
+    bounds: { floorY: 0, edgeMessage: 'Stayed inside the explorable Gastown district.', resetMessage: 'Returned to the explorable Gastown district.' },
   };
 
   const plazaZone = world.zones.sidewalk.find((zone) => zone.id === 'steam-clock-plaza-sidewalk');
@@ -1541,6 +1667,11 @@ function buildWorld(options = {}) {
       hardResetDistance: 14,
     },
     nodes: routeNodes,
+    exploration: existingWorld.exploration || {
+      publicGoal: 'I’m exploring Gastown.',
+      fallbackPrompt: 'Use the connected sidewalks and corners as a small exploration district rather than a single route segment.',
+    },
+    microAreas: Array.isArray(existingWorld.microAreas) ? existingWorld.microAreas : [],
     zones: {
       street: [{ id: 'water-cordova-roadway', surface: 'road', polygon: streetPolygon }],
       sidewalk: [


### PR DESCRIPTION
### Motivation
- Turn the fallback Gastown build from a single linear corridor into a small explorable district so players can meaningfully inhabit Gastown rather than just traverse a route segment.
- Surface distinct micro-areas (plaza, storefront edge, alley threshold, transit edge, landmark corner, Maple Tree pocket) and provide reasons to stop/return to encourage short loops and pause behavior.

### Description
- World generation: `scripts/generate-gastown-world.js` now constructs additional zone geometry (station plaza, storefront edge, alley threshold, transit edge, landmark corner, maple pocket), expands `walkBounds`, adds short `navigator.focusCorridor` loops, and redistributes starter `props`/collectibles and `audioZones` accordingly.
- Runtime data: regenerated `assets/world/gastown-water-street.json` to include an `exploration` object, a `microAreas` array with identity/stop/return reasons and anchors, updated `nodes`, `zones`, `navigator` loops, collectible placement, and revised `bounds` messages describing an explorable district.
- Loader: `js/gastown-world-loader.js` now validates `microAreas` and `exploration` metadata and normalizes `microAreas` (derive anchors, sanitize polygons, preserve stop/return reasons) for runtime use.
- Simulator/UI: `js/gastown-sim.js` uses the exploration framing for status/quest text, detects the current micro-area (`getMicroAreaForPoint`), updates HUD/route label to describe the current area instead of a route percentage, overlays micro-area polygons and anchors on the minimap, and flashes area-enter messages when players move between pockets.
- Scaffold: `scripts/build-gastown-world.js` notes preservation of exploration scaffolding so future runs keep micro-area/loop priorities.

### Testing
- Ran `node scripts/build-gastown-world.js` and confirmed it regenerated `assets/world/gastown-water-street.json` successfully (deterministic starter fallback). — passed.
- Syntax/type checks: `node --check scripts/build-gastown-world.js && node --check scripts/generate-gastown-world.js && node --check js/gastown-world-loader.js && node --check js/gastown-sim.js`. — passed.
- VM smoke-loader: executed a small VM-based loader that calls `GastownWorldLoader.load` against `assets/world/gastown-water-street.json` to validate normalization; it loaded `microAreas` and `exploration.publicGoal`. — passed.
- Quick JSON assertions: inspected regenerated world (`microAreas` count, `zones.sidewalk` length, `navigator.focusCorridor` count, `exploration.publicGoal`) to verify expected additions. — passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0e218b530832eaffb282be7ac74fe)