### PR TITLE
Add guided exploration progression to Gastown sim

### DIFF
--- a/assets/css/gastown-sim.css
+++ b/assets/css/gastown-sim.css
@@ -129,6 +129,45 @@
   font-size: 0.92rem;
 }
 
+.gastown-expedition-panel {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.7rem;
+  margin: 0.7rem 0 0.8rem;
+}
+
+.gastown-expedition-card {
+  padding: 0.7rem 0.8rem;
+  border: 1px solid rgba(170, 197, 226, 0.22);
+  border-radius: 10px;
+  background: linear-gradient(180deg, rgba(16, 22, 33, 0.8), rgba(8, 11, 18, 0.92));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.gastown-expedition-label {
+  margin: 0 0 0.35rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #8fc8ff;
+}
+
+.gastown-expedition-value {
+  margin: 0;
+  color: #edf5ff;
+  line-height: 1.45;
+}
+
+.gastown-expedition-list {
+  margin: 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.28rem;
+  color: #d9e8ff;
+  font-size: 0.9rem;
+}
+
 
 .gastown-route-debug-overlay {
   position: absolute;

--- a/assets/dialog/gastown.json
+++ b/assets/dialog/gastown.json
@@ -2,9 +2,9 @@
   "guide_intro": {
     "title": "Gastown guide",
     "lines": [
-      "Welcome to Water Street. This block sits in the old warehouse district that grew up around Vancouver's working waterfront, so the brick fronts and loading-bay rhythm are part of Gastown's real story.",
-      "If you want a quick challenge, I can send you on a scavenger hunt for three street details that locals use to read the neighbourhood: a newspaper box, a historic plaque, and a mural.",
-      "Maple Tree Square is just ahead too \u2014 it marks the birthplace of Gastown, where Gassy Jack's saloon helped spark the original settlement."
+      "You are starting at the station threshold, and your first meaningful move is simple: step forward to me in the first few seconds so I can point you toward the right kind of details.",
+      "From there you can follow three different leads: log small street clues in a scavenger-style details hunt, survey how Water Street changes as you move east, or unlock local stories around the Steam Clock and Maple Tree Square.",
+      "Nothing here is a checklist tunnel \u2014 use the minimap and nearby people as nudges, then let the street rhythm pull you along."
     ],
     "actions": [
       {
@@ -16,9 +16,9 @@
   "busker_clock_corner": {
     "title": "Clock-corner busker",
     "lines": [
-      "That Steam Clock was built in 1977 by Raymond Saunders after the city covered an old steam vent here on Water Street.",
-      "Every quarter-hour the whistles kick out a version of the Westminster chimes, so this corner keeps its own little performance schedule.",
-      "Ask again and I'll trade you one more local favourite about the square beyond the clock."
+      "The Steam Clock was built in 1977 by Raymond Saunders after the city covered an old steam vent here on Water Street.",
+      "This corner becomes more interesting once you have actually stood in the plaza and then pushed through toward Maple Tree Square \u2014 the landmark stops being a photo stop and starts feeling like a hinge in the route.",
+      "Come back after a few discoveries and I will turn those observations into a fuller historical story."
     ],
     "actions": [
       {
@@ -86,9 +86,9 @@
   "skateboarder_corridor": {
     "title": "Gastown skateboarder",
     "lines": [
-      "The bricks look rough, but the long sightlines on Water Street make it easy to roll as long as you respect the tourist knots around the Steam Clock.",
-      "Older locals still talk about Gastown as a place where rail, port traffic, and nightlife kept colliding \u2014 that mixed energy is kind of why this block still feels alive.",
-      "Hit me with one more question and I'll tell you which stretch is best for a clean glide."
+      "The fun part of this block is that the feel changes in stages \u2014 threshold, storefront rhythm, clock crowd, then the looser edge near Maple Tree Square.",
+      "If you want a challenge, use me as your cue to survey the route: notice where Water Street starts reading like a real corridor instead of a simple starter strip.",
+      "Once you have read the mid-block and the eastern rise, the whole route makes more sense."
     ],
     "actions": [
       {
@@ -100,9 +100,9 @@
   "cyclist_water_street": {
     "title": "Gastown cyclist",
     "lines": [
-      "Fog or rain changes this ride fast \u2014 the paving gets slick, the sightlines shorten, and everyone near the clock starts moving more cautiously.",
-      "On a clear afternoon, though, the block fills with visitors because the Steam Clock, Maple Tree Square, and the heritage storefronts are all within a minute of each other.",
-      "Ask again and I'll tell you the commuter shortcut locals use to slip past the photo crowd."
+      "Riding this stretch teaches you the route structure fast: you can feel when the corridor tightens, when the plaza interrupts it, and when the east leg opens back up.",
+      "Treat the minimap like a soft cue, not a GPS arrow \u2014 it is best when it confirms something you already noticed in the street itself.",
+      "If you keep the survey going past the clock, the Cambie rise gives you the last big contrast point."
     ],
     "actions": [
       {

--- a/assets/world/gastown-water-street.json
+++ b/assets/world/gastown-water-street.json
@@ -3790,7 +3790,10 @@
       "y": 0,
       "z": 0,
       "scale": 1.35,
-      "cue": "Station canopies give way to brick-front Gastown blocks and the Water Street bend begins."
+      "cue": "Station canopies give way to brick-front Gastown blocks and the Water Street bend begins.",
+      "discoveryNote": "Orientation logged. The station threshold is where the route stops feeling like transit spillover and starts reading as Gastown.",
+      "storyUnlock": "orientation",
+      "discoveryRadius": 9.5
     },
     {
       "id": "water-cordova-seam",
@@ -3800,7 +3803,10 @@
       "y": 0,
       "z": -45.43,
       "scale": 1.16,
-      "cue": "The corridor bends into Water Street and starts reading like a heritage streetscape instead of a starter ribbon."
+      "cue": "The corridor bends into Water Street and starts reading like a heritage streetscape instead of a starter ribbon.",
+      "discoveryNote": "Discovery logged. The bend into Water Street is the first place the heritage corridor becomes legible.",
+      "storyUnlock": "water_street_shift",
+      "discoveryRadius": 9.5
     },
     {
       "id": "water-street-mid-block",
@@ -3810,7 +3816,10 @@
       "y": 0,
       "z": -104.87,
       "scale": 1.12,
-      "cue": "Longer brick storefront rhythm and darker carriageway paving make the street read more like Water Street."
+      "cue": "Longer brick storefront rhythm and darker carriageway paving make the street read more like Water Street.",
+      "discoveryNote": "Survey logged. This is the clearest storefront-rhythm moment on the route.",
+      "storyUnlock": "mid_block_story",
+      "discoveryRadius": 9.5
     },
     {
       "id": "steam-clock",
@@ -3821,7 +3830,10 @@
       "z": -154.75,
       "radius": 5.2,
       "scale": 1.28,
-      "cue": "A brick-and-stone plaza opens at the intersection and stages the Steam Clock at the corner landmark moment."
+      "cue": "A brick-and-stone plaza opens at the intersection and stages the Steam Clock at the corner landmark moment.",
+      "discoveryNote": "Story unlocked. The Steam Clock plaza turns the walk into a landmark encounter instead of a straight corridor.",
+      "storyUnlock": "clock_story",
+      "discoveryRadius": 5.2
     },
     {
       "id": "maple-tree-square-edge",
@@ -3831,7 +3843,10 @@
       "y": 0,
       "z": -173.46,
       "scale": 1.1,
-      "cue": "Beyond the Steam Clock the street broadens and loosens toward Maple Tree Square."
+      "cue": "Beyond the Steam Clock the street broadens and loosens toward Maple Tree Square.",
+      "discoveryNote": "Story unlocked. Maple Tree Square expands the route beyond the clock and reveals the older village geometry.",
+      "storyUnlock": "maple_story",
+      "discoveryRadius": 9.5
     },
     {
       "id": "cambie-rise-continuation",
@@ -3841,7 +3856,10 @@
       "y": 0,
       "z": -140.6,
       "scale": 1.18,
-      "cue": "The eastern leg of the route continues beyond the clock intersection toward the Cambie rise."
+      "cue": "The eastern leg of the route continues beyond the clock intersection toward the Cambie rise.",
+      "discoveryNote": "Survey logged. The eastern rise finishes the sense of progression through the corridor.",
+      "storyUnlock": "east_leg_story",
+      "discoveryRadius": 9.5
     }
   ],
   "props": [
@@ -3857,7 +3875,8 @@
       "collectible": true,
       "collectibleKey": "newspaper_box",
       "collectibleLabel": "Newspaper box",
-      "minimapIcon": "collectible"
+      "minimapIcon": "collectible",
+      "journalNote": "A utilitarian newspaper box shows how everyday objects carry the working-street texture."
     },
     {
       "id": "starter-prop-threshold-utility",
@@ -3944,7 +3963,8 @@
       "collectibleKey": "mural",
       "collectibleLabel": "Maple Tree mural",
       "minimapIcon": "mural",
-      "randomOffset": true
+      "randomOffset": true,
+      "journalNote": "The mural pushes the walk from preservation into interpretation."
     },
     {
       "id": "starter-prop-clock-plaque",
@@ -3956,7 +3976,8 @@
       "collectible": true,
       "collectibleKey": "historic_plaque",
       "collectibleLabel": "Historic plaque",
-      "minimapIcon": "plaque"
+      "minimapIcon": "plaque",
+      "journalNote": "The plaque turns sightseeing into explicit history-reading."
     },
     {
       "id": "starter-prop-vendor-crate",

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -57,6 +57,11 @@
   const osmAttributionEl = app.querySelector('[data-gastown-osm-attribution]');
   const interactPromptEl = app.querySelector('[data-sim-interact-prompt]');
   const questStatusEl = app.querySelector('[data-sim-quest-status]');
+  const objectiveEl = app.querySelector('[data-sim-objective]');
+  const nextStepEl = app.querySelector('[data-sim-next-step]');
+  const routeScoreEl = app.querySelector('[data-sim-route-score]');
+  const collectiblesLogEl = app.querySelector('[data-sim-collectibles-log]');
+  const journalEl = app.querySelector('[data-sim-journal]');
   const tutorialOverlayEl = app.querySelector('[data-tutorial-overlay]');
   const tutorialOpenBtn = app.querySelector('[data-action="tutorial-open"]');
   const tutorialCloseEls = app.querySelectorAll('[data-action="tutorial-close"]');
@@ -143,7 +148,16 @@
     guideQuestTriggered: false,
     tutorial: { seen: false, lastMKeyAt: 0 },
     lowGraphics: false,
-    quest: { active: false, completed: false, rewardPending: false, items: [] },
+    quest: { active: false, completed: false, rewardPending: false, items: [], chains: {}, activeChainId: 'orientation' },
+    progression: {
+      discoveredLandmarks: {},
+      talkedNpcIds: {},
+      journalEntries: [],
+      unlockedStories: {},
+      routeCompletionScore: 0,
+      nextHint: null,
+      openingObjectiveStartedAt: 0,
+    },
   };
 
   const DEFAULT_EYE_HEIGHT = 1.7;
@@ -286,6 +300,199 @@
       questStatusEl.textContent = text;
     }
   }
+
+  const QUEST_DEFINITIONS = {
+    orientation: { label: 'Orientation', status: 'Opening objective: meet the guide just ahead and get your bearings.' },
+    scavenger: { label: 'Street details log', status: 'Street details log active: recover the newspaper box, historic plaque, and Maple Tree mural.' },
+    survey: { label: 'Route survey', status: 'Route survey active: scout the mid-block storefront rhythm, then continue to the Cambie rise.' },
+    stories: { label: 'Historical stories', status: 'Historical stories active: unlock the Steam Clock and Maple Tree Square stories, then report back to the busker.' },
+  };
+
+  function setObjective(text) {
+    if (objectiveEl) objectiveEl.textContent = text;
+  }
+
+  function setNextStep(text) {
+    if (nextStepEl) nextStepEl.textContent = text;
+    if (minimapTooltipEl) minimapTooltipEl.textContent = text;
+  }
+
+  function pushJournalEntry(text) {
+    if (!text) return;
+    const entries = state.progression.journalEntries;
+    if (entries.includes(text)) return;
+    entries.unshift(text);
+    state.progression.journalEntries = entries.slice(0, 5);
+    renderProgressionUi();
+  }
+
+  function renderProgressionUi() {
+    if (routeScoreEl) {
+      routeScoreEl.textContent = Math.round(state.progression.routeCompletionScore) + '% of the corridor surveyed.';
+    }
+    if (collectiblesLogEl) {
+      const items = getCollectibleProps();
+      collectiblesLogEl.innerHTML = items.map((prop) => '<li>' + (prop.collectibleLabel || prop.id) + ' — ' + (prop.collected ? 'logged' : 'not logged') + '</li>').join('');
+    }
+    if (journalEl) {
+      const entries = state.progression.journalEntries.length ? state.progression.journalEntries : ['Arrive at the station threshold and get your bearings.'];
+      journalEl.innerHTML = entries.map((entry) => '<li>' + entry + '</li>').join('');
+    }
+  }
+
+  function getQuestChain(id) {
+    if (!state.quest.chains[id]) {
+      state.quest.chains[id] = { active: id === 'orientation', completed: false };
+    }
+    return state.quest.chains[id];
+  }
+
+  function getLandmarkByIdLocal(id) {
+    return (state.world && state.world.landmarks || []).find((landmark) => landmark.id === id) || null;
+  }
+
+  function getNpcByRole(role) {
+    return (state.npcs || []).find((npc) => npc.role === role) || null;
+  }
+
+  function getHintTargetPosition(target) {
+    if (!target) return null;
+    if (target.type === 'npc' && target.id) {
+      const npc = (state.npcs || []).find((entry) => entry.id === target.id);
+      return npc ? npc.position : null;
+    }
+    if (target.type === 'landmark' && target.id) return getLandmarkByIdLocal(target.id);
+    if (target.type === 'collectible' && target.id) {
+      const prop = (state.props || []).find((entry) => entry.id === target.id);
+      return prop ? prop._position : null;
+    }
+    return null;
+  }
+
+  function startQuestById(id) {
+    const chain = getQuestChain(id);
+    chain.active = true;
+    state.quest.activeChainId = id;
+    if (id === 'scavenger') {
+      const items = getCollectibleProps().map((prop) => ({ key: prop.collectibleKey || prop.id, label: prop.collectibleLabel || prop.id, found: !!prop.collected, propId: prop.id }));
+      state.quest.active = true;
+      state.quest.completed = items.length && items.every((item) => item.found);
+      state.quest.items = items;
+      setQuestStatus('Street details log: ' + items.filter((item) => item.found).length + '/' + items.length + ' collected.');
+      renderDialogBody(['Street details log started.', 'Log the newspaper box, the historic plaque, and the Maple Tree mural. The minimap will nudge you, but you still have to read the street.']);
+    } else {
+      setQuestStatus((QUEST_DEFINITIONS[id] || {}).status || 'Quest updated.');
+      renderDialogBody([((QUEST_DEFINITIONS[id] || {}).label || 'Quest') + ' started.']);
+    }
+    pushJournalEntry(((QUEST_DEFINITIONS[id] || {}).label || 'Quest') + ' added to your journal.');
+    updateNextMeaningfulThing();
+  }
+
+  function completeQuestById(id, message) {
+    const chain = getQuestChain(id);
+    if (chain.completed) return;
+    chain.completed = true;
+    chain.active = false;
+    if (id === 'scavenger') { state.quest.completed = true; state.quest.active = false; }
+    if (message) setQuestStatus(message);
+    pushJournalEntry(message || (((QUEST_DEFINITIONS[id] || {}).label || 'Quest') + ' completed.'));
+    updateNextMeaningfulThing();
+  }
+
+  function discoverLandmark(landmark) {
+    if (!landmark || state.progression.discoveredLandmarks[landmark.id]) return;
+    state.progression.discoveredLandmarks[landmark.id] = true;
+    setStatus('Discovery: ' + landmark.label + '.');
+    pushJournalEntry('Discovered ' + landmark.label + ': ' + (landmark.discoveryNote || landmark.cue || 'New route context logged.'));
+    if (landmark.storyUnlock) {
+      state.progression.unlockedStories[landmark.storyUnlock] = true;
+    }
+    updateNextMeaningfulThing();
+  }
+
+  function updateRouteCompletionScore() {
+    if (!state.world || !Array.isArray(state.world.landmarks)) return;
+    const total = state.world.landmarks.length || 1;
+    const seen = Object.keys(state.progression.discoveredLandmarks).length;
+    state.progression.routeCompletionScore = Math.min(100, (seen / total) * 100);
+  }
+
+  function updateLandmarkDiscoveries() {
+    if (!state.world || !Array.isArray(state.world.landmarks)) return;
+    state.world.landmarks.forEach((landmark) => {
+      const radius = landmark.discoveryRadius || landmark.radius || 10;
+      if (Math.hypot(landmark.x - player.position.x, landmark.z - player.position.z) <= radius) {
+        discoverLandmark(landmark);
+      }
+    });
+  }
+
+  function updateQuestChainsFromProgress() {
+    if (state.progression.talkedNpcIds[(getNpcByRole('guide') || {}).id]) {
+      completeQuestById('orientation', 'Orientation complete: you met the guide and opened your first leads.');
+    }
+    const survey = getQuestChain('survey');
+    if (survey.active && !survey.completed && state.progression.discoveredLandmarks['water-street-mid-block'] && state.progression.discoveredLandmarks['cambie-rise-continuation']) {
+      completeQuestById('survey', 'Route survey complete: you traced Water Street from storefront rhythm to the Cambie rise.');
+    }
+    const stories = getQuestChain('stories');
+    const busker = getNpcByRole('busker');
+    if (stories.active && !stories.completed && state.progression.discoveredLandmarks['steam-clock'] && state.progression.discoveredLandmarks['maple-tree-square-edge'] && busker && state.progression.talkedNpcIds[busker.id]) {
+      completeQuestById('stories', 'Historical stories complete: the busker shared the full Steam Clock and Maple Tree Square thread.');
+    }
+    if (state.quest.items.length && state.quest.items.every((item) => item.found)) {
+      completeQuestById('scavenger', 'Street details log complete: the busker has a bonus story waiting near the Steam Clock.');
+    }
+  }
+
+  function updateNextMeaningfulThing() {
+    const guide = getNpcByRole('guide');
+    const busker = getNpcByRole('busker');
+    const chainOrientation = getQuestChain('orientation');
+    const chainScavenger = getQuestChain('scavenger');
+    const chainSurvey = getQuestChain('survey');
+    const chainStories = getQuestChain('stories');
+    let objective = 'Explore Water Street and build out your Gastown journal.';
+    let hint = { text: 'Follow the route and investigate anything that feels historically distinct.', target: { type: 'landmark', id: 'water-cordova-seam' } };
+
+    if (!chainOrientation.completed && guide) {
+      objective = 'Within your first few seconds, find the guide near the station threshold.';
+      hint = { text: 'Walk a few steps forward to the guide and press E to hear your first leads.', target: { type: 'npc', id: guide.id } };
+    } else if (chainScavenger.active && !chainScavenger.completed) {
+      const nextProp = getCollectibleProps().find((prop) => !prop.collected);
+      objective = 'Complete the street details log by reading small clues in the environment.';
+      hint = nextProp
+        ? { text: 'The next collectible to log is the ' + (nextProp.collectibleLabel || nextProp.id) + '.', target: { type: 'collectible', id: nextProp.id } }
+        : hint;
+    } else if (chainSurvey.active && !chainSurvey.completed) {
+      objective = 'Survey the route like a local and mark how Water Street changes as you move east.';
+      hint = !state.progression.discoveredLandmarks['water-street-mid-block']
+        ? { text: 'Push toward Water Street mid block to read the storefront rhythm.', target: { type: 'landmark', id: 'water-street-mid-block' } }
+        : { text: 'Continue beyond the clock toward the Cambie rise to finish the survey.', target: { type: 'landmark', id: 'cambie-rise-continuation' } };
+    } else if (chainStories.active && !chainStories.completed) {
+      objective = 'Unlock the Steam Clock and Maple Tree Square stories, then return to the busker.';
+      if (!state.progression.discoveredLandmarks['steam-clock']) {
+        hint = { text: 'Head for the Steam Clock plaza to unlock the next conversation beat.', target: { type: 'landmark', id: 'steam-clock' } };
+      } else if (!state.progression.discoveredLandmarks['maple-tree-square-edge']) {
+        hint = { text: 'Keep exploring past the clock until Maple Tree Square opens up.', target: { type: 'landmark', id: 'maple-tree-square-edge' } };
+      } else if (busker) {
+        hint = { text: 'Return to the busker near the clock for the unlocked historical story.', target: { type: 'npc', id: busker.id } };
+      }
+    } else if ((state.progression.routeCompletionScore || 0) < 100) {
+      objective = 'Round out the route by discovering the remaining named landmarks.';
+      const nextLandmark = (state.world && state.world.landmarks || []).find((landmark) => !state.progression.discoveredLandmarks[landmark.id]);
+      if (nextLandmark) hint = { text: 'Follow the corridor toward ' + nextLandmark.label + '.', target: { type: 'landmark', id: nextLandmark.id } };
+    } else {
+      objective = 'You have the full route logged — revisit NPCs to compare unlocked stories.';
+      hint = { text: 'Roam freely: NPC dialog now reflects what you have already discovered.', target: null };
+    }
+
+    state.progression.nextHint = hint;
+    setObjective(objective);
+    setNextStep(hint.text);
+    renderProgressionUi();
+  }
+
 
   function openTutorialOverlay() {
     if (!tutorialOverlayEl) return;
@@ -894,9 +1101,43 @@
     return {
       title: result.title || getDialogFallbackTitle(npcState),
       lines: result.lines || getNpcConversationFallback(npcState).lines,
-      actions: [{ type: 'close', label: 'Back to walk' }],
+      actions: getNpcDialogActions(npcState),
       hasCustomActions: true,
     };
+  }
+
+  function getNpcDialogActions(npcState) {
+    if (!npcState) {
+      return [{ type: 'close', label: 'Back to walk' }];
+    }
+    if (npcState.role === 'guide') {
+      return [
+        { type: 'quest', questId: 'scavenger', label: getQuestChain('scavenger').completed ? 'Review street details log' : 'Start street details log' },
+        { type: 'quest', questId: 'survey', label: getQuestChain('survey').completed ? 'Review route survey' : 'Start route survey' },
+        { type: 'response', label: 'Tell me more about Maple Tree Square', responseLines: ['Maple Tree Square marks the early centre of Gastown, where Carrall, Powell, Alexander, and Water come together in a triangular knot.', 'That irregular geometry is part of why the district feels older than the rest of downtown — the street plan still hints at the port-town era.'], followupStatus: 'Guide shared extra Gastown history.' },
+        { type: 'close', label: 'Back to walk' }
+      ];
+    }
+    if (npcState.role === 'busker') {
+      return [
+        { type: 'quest', questId: 'stories', label: getQuestChain('stories').completed ? 'Review unlocked stories' : 'Start story trail' },
+        { type: 'response', label: 'What changed after I got here?', responseLines: [state.progression.discoveredLandmarks['steam-clock'] ? 'Now that you have actually stood in the plaza, the clock stops feeling like a prop and starts acting like a route anchor.' : 'Come back after you have stood in the plaza itself — it changes how the whole corner reads.', state.progression.discoveredLandmarks['maple-tree-square-edge'] ? 'And once Maple Tree Square opens up behind it, the clock starts reading like an introduction instead of the whole story.' : 'Push beyond the clock and you will feel the square loosen the corridor.'], followupStatus: 'Busker reacted to your discoveries.' },
+        { type: 'close', label: 'Back to walk' }
+      ];
+    }
+    if (npcState.role === 'skateboarder') {
+      return [
+        { type: 'quest', questId: 'survey', label: getQuestChain('survey').completed ? 'Review route survey' : 'Take the route survey challenge' },
+        { type: 'close', label: 'Back to walk' }
+      ];
+    }
+    if (npcState.role === 'cyclist') {
+      return [
+        { type: 'quest', questId: 'survey', label: getQuestChain('survey').completed ? 'Review route survey' : 'Keep the survey going' },
+        { type: 'close', label: 'Back to walk' }
+      ];
+    }
+    return [{ type: 'close', label: 'Back to walk' }];
   }
 
   async function hydrateNpcConversation(npcState) {
@@ -978,7 +1219,7 @@
         button.type = 'button';
         button.className = 'pixel-button secondary';
         button.textContent = action.label || 'Start scavenger hunt';
-        button.addEventListener('click', () => startGuideQuest());
+        button.addEventListener('click', () => startQuestById(action.questId || 'scavenger'));
         dialogActionsDynamicEl.appendChild(button);
         controls.push(button);
         return;
@@ -1078,13 +1319,7 @@
       defaultCloseLabel: 'Back to walk',
     });
 
-    if (npcState.role === 'guide') {
-      normalized.actions = [
-        { type: 'quest', label: state.quest.completed ? 'Review scavenger hunt' : 'Start scavenger hunt' },
-        { type: 'response', label: 'Tell me more about Maple Tree Square', responseLines: ['Maple Tree Square marks the early centre of Gastown, where Carrall, Powell, Alexander, and Water come together in a triangular knot.', 'That irregular geometry is part of why the district feels older than the rest of downtown — the street plan still hints at the port-town era.'], followupStatus: 'Guide shared extra Gastown history.' },
-        { type: 'close', label: 'Back to walk' }
-      ];
-    }
+    normalized.actions = getNpcDialogActions(npcState);
 
     dialogTitleEl.textContent = normalized.title;
     renderDialogBody(normalized.lines);
@@ -1099,6 +1334,10 @@
       setPointerStatus('Pointer unlocked. Dialog controls are active.');
       focusFirstDialogControl();
     };
+
+    state.progression.talkedNpcIds[npcState.id] = true;
+    updateQuestChainsFromProgress();
+    updateNextMeaningfulThing();
 
     if (document.pointerLockElement === renderer.domElement) {
       document.exitPointerLock();
@@ -1118,19 +1357,12 @@
   }
 
   function startGuideQuest() {
-    const items = getCollectibleProps().map((prop) => ({ key: prop.collectibleKey || prop.id, label: prop.collectibleLabel || prop.id, found: !!prop.collected, propId: prop.id }));
-    state.quest.active = true;
-    state.quest.completed = items.length && items.every((item) => item.found);
-    state.quest.items = items;
-    setQuestStatus('Scavenger hunt active: find ' + items.map((item) => item.label).join(', ') + '.');
-    renderDialogBody(['Scavenger hunt started.', 'Find the highlighted newspaper box, historic plaque, and mural. Watch the minimap for star markers.']);
+    startQuestById('scavenger');
     updateMinimapLegend();
   }
 
   function completeGuideQuest() {
-    state.quest.completed = true;
-    state.quest.active = false;
-    setQuestStatus('Scavenger hunt complete: the busker has a bonus Gastown story waiting near the Steam Clock.');
+    completeQuestById('scavenger', 'Street details log complete: the busker has a bonus Gastown story waiting near the Steam Clock.');
     const busker = (state.npcs || []).find((npc) => npc.role === 'busker');
     if (busker) {
       state.npcConversationCache[busker.id] = {
@@ -1159,7 +1391,10 @@
     if (!match) return false;
     match.collected = true;
     setStatus('Collected: ' + (match.collectibleLabel || match.id) + '.');
+    pushJournalEntry('Logged collectible: ' + (match.collectibleLabel || match.id) + '. ' + (match.journalNote || ''));
     updateQuestProgress();
+    renderProgressionUi();
+    updateNextMeaningfulThing();
     return true;
   }
 
@@ -2729,6 +2964,7 @@
     }, null) || (nearest ? describeLandmarkGuidance(nearest, heading, state.world) : null);
 
     if (nearest) {
+      updateRouteCompletionScore();
       minimapState.nearestNode = nearest;
       minimapState.nearestGuidance = nearestGuidance;
       setLandmark('Nearest landmark: ' + (nearestGuidance ? nearestGuidance.text : nearest.label));
@@ -3270,6 +3506,16 @@
       ctx.arc(pt.x, pt.y, 4, 0, Math.PI * 2);
       ctx.fill();
     });
+
+    const hintTarget = getHintTargetPosition(state.progression.nextHint && state.progression.nextHint.target);
+    if (hintTarget) {
+      const pt = projectWorldToMinimap(hintTarget, metrics, pad, view, projectionOptions);
+      ctx.strokeStyle = 'rgba(255, 220, 120, 0.95)';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.arc(pt.x, pt.y, 8, 0, Math.PI * 2);
+      ctx.stroke();
+    }
 
     if (state.world.navigator && Array.isArray(state.world.navigator.focusCorridor) && state.world.navigator.focusCorridor.length) {
       ctx.strokeStyle = 'rgba(255, 194, 112, 0.92)';
@@ -3968,7 +4214,8 @@
       setupAudio(state.world);
       minimapState.worldMetrics = getWorldMetrics();
       try { if (window.localStorage.getItem('gastownLowGraphics') === '1') { setLowGraphicsMode(true); } } catch (error) {}
-      setQuestStatus('Scavenger hunt: talk to the guide to begin.');
+      state.progression.openingObjectiveStartedAt = window.performance && typeof window.performance.now === 'function' ? window.performance.now() : Date.now();
+      setQuestStatus('Opening objective: talk to the guide, then choose which lead to follow first.');
       restoreMinimapZoom();
       restoreMinimapMode();
       updateSize();
@@ -3976,6 +4223,9 @@
       applyMood(state.activeMood);
       applyWeather(state.activeWeather);
       resetToStart();
+      pushJournalEntry('Arrived at the station threshold. The guide is the first anchor point.');
+      renderProgressionUi();
+      updateNextMeaningfulThing();
       attachEvents();
       setDebugState(state.debugEnabled);
       if (state.debugEnabled) {
@@ -4001,6 +4251,8 @@
         updateProgressiveVisibility();
         updateNpcs(delta);
         updateInteractionTarget();
+        updateLandmarkDiscoveries();
+        updateQuestChainsFromProgress();
         animateRain(delta);
         drawMinimap();
         refreshDebugRuntimeReadout();

--- a/page-gastown-sim.php
+++ b/page-gastown-sim.php
@@ -90,6 +90,34 @@ get_header();
     </section>
     <p class="gastown-status" data-sim-status aria-live="polite">Loading simulator...</p>
     <p class="gastown-quest-status" data-sim-quest-status aria-live="polite">Scavenger hunt: inactive.</p>
+    <section class="gastown-expedition-panel" aria-label="Exploration journal and guidance">
+      <div class="gastown-expedition-card">
+        <p class="gastown-expedition-label">Opening objective</p>
+        <p class="gastown-expedition-value" data-sim-objective aria-live="polite">Meet the guide just ahead of the station threshold.</p>
+      </div>
+      <div class="gastown-expedition-card">
+        <p class="gastown-expedition-label">Next meaningful step</p>
+        <p class="gastown-expedition-value" data-sim-next-step aria-live="polite">Walk forward to the guide, then press E to talk.</p>
+      </div>
+      <div class="gastown-expedition-card">
+        <p class="gastown-expedition-label">Route completion</p>
+        <p class="gastown-expedition-value" data-sim-route-score aria-live="polite">0% of the corridor surveyed.</p>
+      </div>
+      <div class="gastown-expedition-card">
+        <p class="gastown-expedition-label">Collectibles log</p>
+        <ul class="gastown-expedition-list" data-sim-collectibles-log aria-live="polite">
+          <li>Newspaper box — not logged</li>
+          <li>Historic plaque — not logged</li>
+          <li>Maple Tree mural — not logged</li>
+        </ul>
+      </div>
+      <div class="gastown-expedition-card">
+        <p class="gastown-expedition-label">Journal</p>
+        <ul class="gastown-expedition-list" data-sim-journal aria-live="polite">
+          <li>Arrive at the station threshold and get your bearings.</li>
+        </ul>
+      </div>
+    </section>
     <p class="gastown-world-status" data-sim-world-status aria-live="polite">World data status: checking build provenance…</p>
     <p class="gastown-pointer-status" data-sim-pointer-status aria-live="polite">Pointer unlocked.</p>
     <p class="gastown-landmark" data-sim-landmark aria-live="polite">Nearest landmark: Station threshold</p>


### PR DESCRIPTION
### Motivation
- Make the simulator give a clear, satisfying opening objective within the first seconds and guide exploration without railroading the player. 
- Reuse existing NPC, dialog, collectible, and minimap systems to support multiple parallel exploration goals and light progression (journal, collectibles log, route score).

### Description
- Add an in-game expedition HUD to the simulator page with an "Opening objective", "Next meaningful step", route completion score, collectibles log, and a short journal (`page-gastown-sim.php` + `assets/css/gastown-sim.css`).
- Implement a lightweight progression layer in `js/gastown-sim.js` including multi-chain quests (`orientation`, `scavenger`, `survey`, `stories`), a `progression` state object, journal push/render helpers, route-completion scoring, and landmark discovery logic that marks landmarks when the player comes within a discovery radius.
- Wire NPC dialog actions to the new progression: guide/busker/skateboarder/cyclist dialogs can start or review different quest chains via dialog action buttons, and conversations now update `progression.talkedNpcIds` and drive quest-chain completions.
- Surface a subtle minimap hint: the minimap draws a highlighted ring around the current `nextHint` target (collectible / landmark / NPC) computed from the progression state, and the HUD `Next meaningful step` text is synced to the minimap tooltip for accessible guidance.
- Update content/data to match the new systems: adjusted dialog copy (`assets/dialog/gastown.json`) to present multi-lead orientation and tuned landmark metadata (`assets/world/gastown-water-street.json`) to include `discoveryNote`, `storyUnlock`, `discoveryRadius`, and `journalNote` for collectibles so discoveries write meaningful journal entries.
- Keep existing scavenger hunt flow but route it through the shared `startQuestById` / `completeQuestById` helpers so multiple chains can coexist and interlock.

### Testing
- Ran `node --check js/gastown-sim.js` with no syntax errors reported.
- Ran `php -l page-gastown-sim.php` with no syntax errors reported.
- Validated JSON with `python -m json.tool` for `assets/dialog/gastown.json` and `assets/world/gastown-water-street.json` (both valid).
- Verified changes committed locally; commit message: `Add guided exploration progression to Gastown sim` (files: `js/gastown-sim.js`, `page-gastown-sim.php`, `assets/css/gastown-sim.css`, `assets/dialog/gastown.json`, `assets/world/gastown-water-street.json`).
- Note: visual QA (screenshots/playtest) was not performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0e224e8d0832ebe16da69a1dbf3e0)