### PR TITLE
Refine Gastown simulator HUD, cinematic prompts, and hide diagnostics

### DIFF
--- a/assets/css/gastown-sim.css
+++ b/assets/css/gastown-sim.css
@@ -1,62 +1,202 @@
 .gastown-sim-page {
-  background: radial-gradient(circle at 20% 10%, #18202d 0, #090b10 54%, #050609 100%);
-  color: #d5dde8;
-  padding: 2rem 1rem 3rem;
+  background:
+    radial-gradient(circle at top, rgba(150, 111, 67, 0.16), transparent 32%),
+    linear-gradient(180deg, #17131c 0%, #090b10 58%, #050609 100%);
+  color: #e8dfd2;
+  padding: clamp(1.25rem, 2vw, 2rem) 1rem 3rem;
 }
 
 .gastown-sim-shell {
-  max-width: 1120px;
+  max-width: 1180px;
   margin: 0 auto;
-  background: rgba(8, 11, 18, 0.75);
-  border: 1px solid rgba(173, 190, 215, 0.18);
-  border-radius: 14px;
-  padding: 1.2rem;
-  box-shadow: 0 14px 48px rgba(0, 0, 0, 0.45);
+  padding: clamp(1rem, 2vw, 1.6rem);
+  border: 1px solid rgba(210, 181, 145, 0.18);
+  border-radius: 22px;
+  background:
+    linear-gradient(180deg, rgba(20, 16, 23, 0.94), rgba(8, 10, 15, 0.92)),
+    rgba(8, 11, 18, 0.9);
+  box-shadow:
+    0 30px 90px rgba(0, 0, 0, 0.5),
+    inset 0 1px 0 rgba(255, 233, 206, 0.06);
+}
+
+.gastown-sim-header {
+  display: grid;
+  gap: 0.8rem;
+  margin-bottom: 1.15rem;
+  padding: clamp(1.1rem, 2.5vw, 1.8rem);
+  border: 1px solid rgba(196, 162, 123, 0.18);
+  border-radius: 18px;
+  background:
+    radial-gradient(circle at top left, rgba(179, 128, 79, 0.22), transparent 34%),
+    linear-gradient(145deg, rgba(34, 25, 33, 0.96), rgba(13, 15, 21, 0.92));
 }
 
 .gastown-sim-header h1 {
   margin: 0;
-  font-size: clamp(1.5rem, 3.5vw, 2.4rem);
+  max-width: 16ch;
+  font-size: clamp(2rem, 5vw, 3.6rem);
+  line-height: 0.95;
+  letter-spacing: -0.03em;
+  color: #fff4e7;
 }
 
-.gastown-sim-kicker,
-.gastown-sim-intro,
-.gastown-status,
-.gastown-landmark {
-  margin: 0.4rem 0;
+.gastown-sim-kicker {
+  margin: 0;
+  color: #d8b389;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.74rem;
 }
 
-.gastown-controls {
+.gastown-sim-intro {
+  margin: 0;
+  max-width: 64ch;
+  font-size: 1.02rem;
+  line-height: 1.7;
+  color: rgba(240, 232, 219, 0.85);
+}
+
+.gastown-stage-directions {
+  display: grid;
+  gap: 0.7rem;
+  margin-bottom: 1rem;
+  padding: 1rem 1.05rem;
+  border: 1px solid rgba(190, 160, 127, 0.14);
+  border-radius: 16px;
+  background: linear-gradient(180deg, rgba(18, 16, 23, 0.9), rgba(11, 13, 18, 0.72));
+}
+
+.gastown-stage-actions {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
-  gap: 0.6rem;
-  margin: 1rem 0;
+  gap: 0.65rem;
+}
+
+.gastown-stage-note {
+  margin: 0;
+  max-width: 72ch;
+  color: rgba(222, 213, 201, 0.82);
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+.gastown-world-menu {
+  margin: 0 0 1rem;
+  border: 1px solid rgba(177, 151, 120, 0.18);
+  border-radius: 16px;
+  background: rgba(12, 14, 19, 0.78);
+  overflow: hidden;
+}
+
+.gastown-world-menu summary {
+  cursor: pointer;
+  list-style: none;
+  padding: 0.95rem 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: #f1e4d5;
+}
+
+.gastown-world-menu summary::-webkit-details-marker {
+  display: none;
+}
+
+.gastown-world-menu summary::after {
+  content: '+';
+  float: right;
+  color: #cda87c;
+}
+
+.gastown-world-menu[open] summary::after {
+  content: '–';
+}
+
+.gastown-world-menu-grid {
+  display: grid;
+  gap: 1rem;
+  padding: 0 1.05rem 1.05rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.gastown-controls,
+.gastown-help,
+.gastown-debug-meta,
+.gastown-debug {
+  padding: 1rem;
+  border: 1px solid rgba(183, 156, 123, 0.14);
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(24, 21, 28, 0.92), rgba(12, 14, 19, 0.88));
+}
+
+.gastown-controls h2,
+.gastown-help h2,
+.gastown-debug-meta h2,
+.gastown-debug h2 {
+  margin: 0 0 0.7rem;
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #dfc2a4;
+}
+
+.gastown-controls-grid {
+  display: grid;
+  gap: 0.75rem;
 }
 
 .gastown-controls label {
-  display: inline-flex;
-  flex-direction: column;
-  gap: 0.24rem;
+  display: grid;
+  gap: 0.35rem;
   font-size: 0.85rem;
+  color: rgba(234, 226, 214, 0.8);
+}
+
+.gastown-checkbox-row {
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 0.55rem;
 }
 
 .gastown-controls select {
   min-width: 130px;
-  border-radius: 6px;
-  border: 1px solid rgba(200, 214, 236, 0.3);
-  background: #0f131b;
-  color: #dce5f3;
-  padding: 0.35rem;
+  padding: 0.5rem 0.65rem;
+  border-radius: 10px;
+  border: 1px solid rgba(208, 181, 146, 0.22);
+  background: rgba(15, 18, 25, 0.96);
+  color: #f6efe5;
+}
+
+.gastown-help ul,
+.gastown-debug ul {
+  margin: 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.35rem;
+  color: rgba(239, 231, 219, 0.84);
+}
+
+.gastown-debug {
+  margin-top: 1rem;
 }
 
 .gastown-sim-canvas {
   position: relative;
   width: 100%;
-  border-radius: 12px;
   overflow: hidden;
-  border: 1px solid rgba(164, 182, 209, 0.25);
+  border-radius: 22px;
+  border: 1px solid rgba(192, 160, 123, 0.18);
   background: #0b0d12;
+  box-shadow: inset 0 1px 0 rgba(255, 232, 205, 0.06);
+}
+
+.gastown-sim-canvas::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(7, 8, 11, 0.15), rgba(7, 8, 11, 0) 18%, rgba(7, 8, 11, 0) 72%, rgba(7, 8, 11, 0.24));
+  pointer-events: none;
+  z-index: 1;
 }
 
 .gastown-sim-canvas canvas {
@@ -65,75 +205,139 @@
   height: auto !important;
 }
 
-.gastown-debug {
-  margin-top: 1rem;
-  border-top: 1px dashed rgba(162, 180, 201, 0.28);
-  padding-top: 0.8rem;
+.gastown-hud {
+  position: absolute;
+  left: 1rem;
+  right: 1rem;
+  z-index: 2;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  pointer-events: none;
 }
 
-
-.gastown-help {
-  margin: 0.75rem 0 0.9rem;
-  padding: 0.7rem 0.9rem;
-  border: 1px solid rgba(193, 213, 238, 0.26);
-  border-radius: 10px;
-  background: linear-gradient(160deg, rgba(26, 33, 46, 0.75), rgba(10, 13, 19, 0.85));
+.gastown-hud--top {
+  top: 1rem;
+  align-items: flex-start;
 }
 
-.gastown-help h2 {
-  margin: 0 0 0.35rem;
-  font-size: 1rem;
+.gastown-hud--bottom {
+  bottom: 1.1rem;
+  justify-content: center;
 }
 
-.gastown-help ul {
-  margin: 0;
-  padding-left: 1rem;
-  display: grid;
-  gap: 0.2rem;
+.gastown-hud-card {
+  max-width: min(480px, 100%);
+  padding: 0.95rem 1rem;
+  border-radius: 18px;
+  border: 1px solid rgba(215, 186, 148, 0.18);
+  background: linear-gradient(180deg, rgba(12, 12, 16, 0.84), rgba(12, 12, 16, 0.54));
+  backdrop-filter: blur(10px);
+  box-shadow: 0 16px 34px rgba(0, 0, 0, 0.28);
 }
 
-.gastown-help li {
-  color: #e4ebf7;
+.gastown-hud-card--scene {
+  flex: 1 1 auto;
+}
+
+.gastown-hud-card--quest {
+  width: min(320px, 36vw);
+}
+
+.gastown-hud-eyebrow {
+  margin: 0 0 0.32rem;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: #d5b18d;
 }
 
 .gastown-status,
+.gastown-quest-status,
+.gastown-landmark,
+.gastown-route-segment,
+.gastown-world-status,
+.gastown-pointer-status {
+  margin: 0;
+}
+
+.gastown-status {
+  font-size: clamp(1rem, 1.6vw, 1.18rem);
+  line-height: 1.45;
+  color: #fff7ed;
+}
+
+.gastown-hud-subgrid {
+  display: grid;
+  gap: 0.32rem;
+  margin-top: 0.7rem;
+  padding-top: 0.7rem;
+  border-top: 1px solid rgba(224, 195, 157, 0.12);
+}
+
+.gastown-landmark,
+.gastown-route-segment,
+.gastown-quest-status,
 .gastown-world-status,
 .gastown-pointer-status,
-.gastown-landmark,
+.gastown-minimap-mode-status,
+.gastown-minimap-context,
+.gastown-minimap-tooltip,
+.gastown-minimap-label,
+.gastown-minimap-compass {
+  color: rgba(241, 231, 218, 0.82);
+  font-size: 0.84rem;
+  line-height: 1.45;
+}
+
+.gastown-landmark {
+  color: #f5ddbe;
+}
+
 .gastown-route-segment {
-  padding: 0.2rem 0.55rem;
-  border-left: 2px solid rgba(192, 211, 237, 0.45);
-  background: rgba(10, 14, 22, 0.35);
+  color: rgba(223, 229, 237, 0.76);
+}
+
+.gastown-quest-status {
+  font-size: 0.95rem;
+  color: #f4ecdf;
 }
 
 .gastown-world-status {
-  margin-top: 0.35rem;
-  border-left-color: rgba(255, 196, 120, 0.88);
-  background: rgba(39, 24, 7, 0.42);
   color: #ffe2bf;
 }
 
 .gastown-world-status.is-approximate {
-  border-left-color: #ffbf7c;
-  box-shadow: inset 0 0 0 1px rgba(255, 191, 124, 0.14);
+  color: #ffd39b;
 }
 
 .gastown-world-status.is-civic {
-  border-left-color: rgba(149, 234, 199, 0.88);
-  background: rgba(12, 35, 28, 0.38);
   color: #dcfff2;
 }
 
 .gastown-pointer-status {
-  color: #bdd8ff;
-  font-size: 0.92rem;
+  color: #c8dcff;
 }
 
+.gastown-interact-prompt {
+  margin: 0;
+  max-width: min(620px, calc(100% - 2rem));
+  padding: 0.85rem 1.2rem;
+  border: 1px solid rgba(243, 214, 177, 0.26);
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(22, 18, 20, 0.92), rgba(12, 12, 16, 0.8));
+  box-shadow: 0 18px 34px rgba(0, 0, 0, 0.34);
+  text-align: center;
+  color: #fff5ea;
+  font-size: 0.94rem;
+  letter-spacing: 0.04em;
+}
 
 .gastown-route-debug-overlay {
   position: absolute;
-  right: 0.75rem;
-  top: 0.75rem;
+  right: 0.9rem;
+  top: 0.9rem;
+  z-index: 4;
   margin: 0;
   max-width: min(360px, 45vw);
   max-height: 52%;
@@ -143,135 +347,111 @@
   font-size: 0.72rem;
   line-height: 1.35;
   color: #d4ecff;
-  background: rgba(7, 11, 18, 0.7);
+  background: rgba(7, 11, 18, 0.82);
   border: 1px solid rgba(143, 182, 214, 0.4);
-  border-radius: 8px;
-  padding: 0.5rem 0.6rem;
+  border-radius: 10px;
+  padding: 0.55rem 0.65rem;
   pointer-events: none;
 }
 
 .gastown-minimap {
   position: absolute;
-  left: 0.85rem;
-  bottom: 0.85rem;
-  width: 220px;
-  padding: 0.45rem;
-  border-radius: 10px;
-  background: rgba(7, 11, 18, 0.86);
-  border: 1px solid rgba(136, 170, 204, 0.42);
-  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.44);
+  left: 1rem;
+  bottom: 1rem;
+  z-index: 2;
+  display: grid;
+  gap: 0.45rem;
+  width: 244px;
+  padding: 0.8rem;
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(10, 12, 16, 0.9), rgba(10, 12, 16, 0.68));
+  border: 1px solid rgba(197, 165, 127, 0.22);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.38);
+}
+
+.gastown-minimap-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.35rem;
 }
 
 .gastown-minimap canvas {
   display: block;
   width: 100%;
   height: auto;
-  border-radius: 8px;
-  border: 1px solid rgba(172, 201, 230, 0.24);
-}
-
-.gastown-minimap-label {
-  margin: 0.38rem 0 0;
-  font-size: 0.75rem;
-  line-height: 1.2;
-  color: #dbe9ff;
-}
-
-.gastown-minimap-mode-status {
-  margin: 0;
-  padding: 0.35rem 0.45rem;
-  border-radius: 8px;
-  background: rgba(18, 28, 41, 0.96);
-  border: 1px solid rgba(126, 178, 226, 0.24);
-  color: #ecf5ff;
-  font-size: 0.71rem;
-  line-height: 1.35;
-}
-
-.gastown-minimap-mode-status strong {
-  color: #9ed6ff;
-}
-
-@media (max-width: 740px) {
-  .gastown-minimap {
-    width: 180px;
-  }
-}
-
-
-.gastown-minimap {
-  display: grid;
-  gap: 0.38rem;
-}
-
-.gastown-minimap-toolbar {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  gap: 0.35rem;
+  border-radius: 12px;
+  border: 1px solid rgba(217, 187, 150, 0.18);
 }
 
 .gastown-minimap-mode,
 .gastown-minimap-zoom {
-  height: 1.7rem;
-  font-size: 0.72rem;
-  font-weight: 700;
-  border-radius: 6px;
-  border: 1px solid rgba(174, 207, 239, 0.5);
-  background: rgba(18, 28, 41, 0.95);
-  color: #e8f3ff;
+  height: 1.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(215, 186, 150, 0.34);
+  background: rgba(25, 22, 28, 0.92);
+  color: #f8efe4;
   line-height: 1;
   cursor: pointer;
 }
 
 .gastown-minimap-mode {
-  min-width: 5.6rem;
-  padding: 0 0.55rem;
-}
-
-.gastown-minimap-mode[data-minimap-mode="north-up"] {
-  border-color: rgba(137, 189, 245, 0.7);
-  box-shadow: inset 0 0 0 1px rgba(137, 189, 245, 0.18);
-}
-
-.gastown-minimap-mode[data-minimap-mode="heading-up"] {
-  border-color: rgba(255, 197, 126, 0.78);
-  color: #fff3de;
-  box-shadow: inset 0 0 0 1px rgba(255, 197, 126, 0.18);
+  min-width: 7rem;
+  padding: 0 0.8rem;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .gastown-minimap-zoom {
-  width: 1.7rem;
+  width: 1.9rem;
   padding: 0;
   font-size: 1rem;
+}
+
+.gastown-minimap-mode[data-minimap-mode="north-up"] {
+  border-color: rgba(137, 189, 245, 0.6);
+}
+
+.gastown-minimap-mode[data-minimap-mode="heading-up"] {
+  border-color: rgba(255, 197, 126, 0.7);
+  color: #fff3de;
 }
 
 .gastown-minimap-mode:hover,
 .gastown-minimap-mode:focus-visible,
 .gastown-minimap-zoom:hover,
 .gastown-minimap-zoom:focus-visible {
-  background: rgba(36, 53, 74, 0.95);
+  background: rgba(45, 37, 41, 0.96);
   outline: none;
 }
 
-.gastown-minimap-context {
-  margin: 0.28rem 0 0.18rem;
-  font-size: 0.68rem;
-  line-height: 1.45;
-  color: rgba(220, 236, 255, 0.92);
+.gastown-minimap-mode-status,
+.gastown-minimap-context,
+.gastown-minimap-tooltip {
+  margin: 0;
 }
 
 .gastown-minimap-context strong {
-  color: #f5fbff;
+  color: #fdf4e8;
+  font-weight: 600;
+}
+
+.gastown-minimap-compass {
+  color: #d9bb95;
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
 }
 
 .gastown-minimap-legend {
   list-style: none;
-  margin: 0.12rem 0 0;
+  margin: 0.15rem 0 0;
   padding: 0;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.18rem 0.5rem;
+  gap: 0.22rem 0.5rem;
   font-size: 0.68rem;
   color: rgba(220, 236, 255, 0.9);
 }
@@ -319,32 +499,82 @@
   background: #8af7cb;
 }
 
+.gastown-minimap-label {
+  margin: 0.1rem 0 0;
+}
+
+@media (max-width: 980px) {
+  .gastown-world-menu-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .gastown-hud--top {
+    flex-direction: column;
+  }
+
+  .gastown-hud-card--quest {
+    width: auto;
+  }
+}
+
+@media (max-width: 740px) {
+  .gastown-sim-header h1 {
+    max-width: none;
+  }
+
+  .gastown-stage-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .gastown-hud {
+    left: 0.75rem;
+    right: 0.75rem;
+  }
+
+  .gastown-hud-card,
+  .gastown-interact-prompt,
+  .gastown-minimap {
+    max-width: none;
+  }
+
+  .gastown-minimap {
+    position: static;
+    width: auto;
+    margin: 0.75rem;
+  }
+
+  .gastown-hud--bottom {
+    position: static;
+    padding: 0 0.75rem 0.75rem;
+  }
+
+  .gastown-interact-prompt {
+    border-radius: 18px;
+  }
+
+  .gastown-route-debug-overlay {
+    right: 0.75rem;
+    left: 0.75rem;
+    top: auto;
+    bottom: 0.75rem;
+    max-width: none;
+    max-height: 32%;
+  }
+}
+
 .gastown-attribution {
   margin-top: 0.8rem;
   font-size: 0.78rem;
-  line-height: 1.35;
-  color: rgba(209, 223, 242, 0.86);
+  line-height: 1.5;
+  color: rgba(217, 207, 193, 0.72);
 }
 
 .gastown-attribution p {
   margin: 0.1rem 0;
 }
 
-.gastown-interact-prompt[hidden] {
-  display: none !important;
-}
-
-.gastown-interact-prompt {
-  display: inline-block;
-  margin: 0.45rem 0;
-  padding: 0.38rem 0.7rem;
-  border-radius: 999px;
-  border: 1px solid rgba(151, 200, 244, 0.4);
-  background: rgba(7, 13, 22, 0.72);
-  color: #eff7ff;
-  box-shadow: 0 0 0 1px rgba(51, 86, 126, 0.28) inset;
-}
-
+.gastown-interact-prompt[hidden],
 .gastown-dialog-modal[hidden] {
   display: none !important;
 }
@@ -399,7 +629,6 @@
   justify-content: flex-end;
 }
 
-
 .gastown-dialog-actions-dynamic {
   display: flex;
   flex-wrap: wrap;
@@ -411,7 +640,10 @@
 }
 
 .gastown-dialog-actions .pixel-button:focus-visible,
-.gastown-sim-canvas:focus-visible {
+.gastown-sim-canvas:focus-visible,
+.gastown-world-menu summary:focus-visible,
+.gastown-minimap-mode:focus-visible,
+.gastown-minimap-zoom:focus-visible {
   outline: 2px solid rgba(155, 212, 255, 0.92);
   outline-offset: 2px;
 }

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -278,7 +278,9 @@
   }
 
   function setStatus(text) {
-    statusEl.textContent = text;
+    if (statusEl) {
+      statusEl.textContent = text;
+    }
   }
 
   function setQuestStatus(text) {
@@ -291,7 +293,7 @@
     if (!tutorialOverlayEl) return;
     tutorialOverlayEl.removeAttribute('hidden');
     tutorialOverlayEl.setAttribute('aria-hidden', 'false');
-    setStatus('Tutorial open. Review the controls, then start walking when ready.');
+    setStatus('The travel notes are open. Review them, then step into Gastown when ready.');
   }
 
   function closeTutorialOverlay() {
@@ -332,7 +334,7 @@
     }
     state.boundaryNoticeTimer = setTimeout(() => {
       if (!state.isRunning || state.cameraMode !== 'street') return;
-      setStatus('Street mode active. Mouse look and movement are live. Press V for overview.');
+      setStatus('You are in the street now. Look, wander, and press V if you want the city from above.');
     }, 1900);
   }
 
@@ -373,18 +375,18 @@
 
   function updateCameraModeUi() {
     if (state.cameraMode === 'overview') {
-      setStatus('Overview mode active. Mouse wheel zooms altitude; press V to return to street view.');
-      setPointerStatus('Pointer unlocked. Overview camera detached above player.');
+      setStatus('Overview mode lifts you above the block. Use the wheel to change altitude, then press V to descend.');
+      setPointerStatus('Pointer free. The overview camera is drifting above the route.');
     } else if (state.isRunning) {
-      setStatus('Street mode active. Mouse look and movement are live. Press V for overview.');
+      setStatus('You are in the street now. Look, wander, and press V if you want the city from above.');
       if (state.cameraMode === 'street' && document.pointerLockElement === renderer.domElement) {
-        setPointerStatus('Pointer locked. Mouse look active. Press Esc to release pointer.');
+        setPointerStatus('Pointer locked. Your gaze is tied to the street. Press Esc to release it.');
       } else {
-        setPointerStatus('Pointer lock requested… press Esc any time to release.');
+        setPointerStatus('Pointer requested. Press Esc at any time to loosen your view from the street.');
       }
     } else {
-      setStatus('Street mode ready. Click scene to enter look mode and begin moving, or press V for overview.');
-      setPointerStatus('Pointer unlocked. Click scene to enter look mode. Press V for overview.');
+      setStatus('The block is ready. Click into the scene to begin your walk, or press V for an overview.');
+      setPointerStatus('Pointer free. Click the scene to join the walk, or press V for overview.');
     }
   }
 
@@ -424,7 +426,17 @@
   }
 
   function setLandmark(text) {
-    landmarkEl.textContent = text;
+    if (!landmarkEl) {
+      return;
+    }
+    landmarkEl.textContent = String(text || '').replace(/^Nearest landmark:/, 'Nearest beacon:');
+  }
+
+  function setDebugToggleLabel() {
+    if (!debugToggle) {
+      return;
+    }
+    debugToggle.textContent = state.debugEnabled ? 'Hide route diagnostics' : 'Show route diagnostics';
   }
 
   function isApproximateWorld(world) {
@@ -453,13 +465,13 @@
       : 'Offline civic-data build loaded with ' + coverage + '.';
 
     if (worldStatusEl) {
-      worldStatusEl.textContent = 'World data status: ' + state.worldBuildStatus;
+      worldStatusEl.textContent = 'World ledger: ' + state.worldBuildStatus;
       worldStatusEl.classList.toggle('is-approximate', approximate);
       worldStatusEl.classList.toggle('is-civic', !approximate);
     }
 
     if (approximate) {
-      setStatus('Approximate fallback world loaded. This playable corridor is believable, but not survey-precise.');
+      setStatus('The street arrives in a believable prototype form—atmospheric and walkable, though not survey-precise.');
     }
   }
 
@@ -696,7 +708,7 @@
   function setInteractPrompt(text) {
     if (!interactPromptEl) return;
     if (text) {
-      interactPromptEl.textContent = text;
+      interactPromptEl.textContent = text.replace(/^Click or press E to /, 'Press E or click to ').replace(/^Press E to /, 'Press E to ');
       interactPromptEl.removeAttribute('hidden');
     } else {
       interactPromptEl.setAttribute('hidden', 'hidden');
@@ -1044,8 +1056,8 @@
     }
     clearMovementInput();
     setInteractPrompt('');
-    setStatus('Dialog closed. Click scene to resume.');
-    setPointerStatus('Pointer unlocked. Click scene to enter look mode.');
+    setStatus('Dialogue closed. Click back into the street to continue the walk.');
+    setPointerStatus('Pointer free. Click the scene when you are ready to move again.');
     const focusTarget = renderer.domElement || canvasWrap;
     if (focusTarget && typeof focusTarget.focus === 'function') {
       window.setTimeout(() => focusTarget.focus(), 0);
@@ -1095,8 +1107,8 @@
       dialogModalEl.setAttribute('aria-hidden', 'false');
       state.activeDialogNpcId = npcState.id;
       state.activeDialogEntry = normalized;
-      setStatus('Dialog open. Loading nearby conversation.');
-      setPointerStatus('Pointer unlocked. Dialog controls are active.');
+      setStatus('A nearby voice is coming into focus. Loading conversation.');
+      setPointerStatus('Pointer free while dialogue controls are active.');
       focusFirstDialogControl();
     };
 
@@ -1122,15 +1134,15 @@
     state.quest.active = true;
     state.quest.completed = items.length && items.every((item) => item.found);
     state.quest.items = items;
-    setQuestStatus('Scavenger hunt active: find ' + items.map((item) => item.label).join(', ') + '.');
-    renderDialogBody(['Scavenger hunt started.', 'Find the highlighted newspaper box, historic plaque, and mural. Watch the minimap for star markers.']);
+    setQuestStatus('Scavenger thread: seek ' + items.map((item) => item.label).join(', ') + '.');
+    renderDialogBody(['Scavenger thread opened.', 'Find the highlighted newspaper box, historic plaque, and mural. Watch the minimap for star markers and follow the street cues.']);
     updateMinimapLegend();
   }
 
   function completeGuideQuest() {
     state.quest.completed = true;
     state.quest.active = false;
-    setQuestStatus('Scavenger hunt complete: the busker has a bonus Gastown story waiting near the Steam Clock.');
+    setQuestStatus('Scavenger thread complete: the busker now carries a bonus Gastown story near the Steam Clock.');
     const busker = (state.npcs || []).find((npc) => npc.role === 'busker');
     if (busker) {
       state.npcConversationCache[busker.id] = {
@@ -1148,7 +1160,7 @@
       item.found = !!(prop && prop.collected);
     });
     const foundCount = state.quest.items.filter((item) => item.found).length;
-    setQuestStatus('Scavenger hunt: ' + foundCount + '/' + state.quest.items.length + ' found.');
+    setQuestStatus('Scavenger thread: ' + foundCount + ' of ' + state.quest.items.length + ' keepsakes recovered.');
     if (foundCount === state.quest.items.length && state.quest.items.length) {
       completeGuideQuest();
     }
@@ -1158,7 +1170,7 @@
     const match = (state.props || []).find((prop) => prop.collectible && !prop.collected && Math.hypot(player.position.x - prop._position.x, player.position.z - prop._position.z) < 2.2);
     if (!match) return false;
     match.collected = true;
-    setStatus('Collected: ' + (match.collectibleLabel || match.id) + '.');
+    setStatus('Keepsake recovered: ' + (match.collectibleLabel || match.id) + '.');
     updateQuestProgress();
     return true;
   }
@@ -1580,7 +1592,7 @@
       return;
     }
     const roleLabel = getNpcRoleLabel(npc);
-    setInteractPrompt('Click or press E to talk to the ' + roleLabel + '.');
+    setInteractPrompt('Press E or click to speak with the ' + roleLabel + '.');
   }
 
   function interactWithHoveredNpc() {
@@ -2693,13 +2705,13 @@
     const facing = getFacingLabel(heading);
     const nearest = minimapState.nearestGuidance;
     if (minimapContextEl) {
-      minimapContextEl.innerHTML = '<strong>Now facing:</strong> ' + facing + (nearest ? '<br><strong>Nearest landmark:</strong> ' + nearest.text : '');
+      minimapContextEl.innerHTML = '<strong>Facing</strong> ' + facing + (nearest ? '<br><strong>Nearest beacon</strong> ' + nearest.text.replace(/^.+?:\s*/, '') : '');
     }
     if (minimapModeStatusEl) {
       const isHeadingUp = minimapState.mode === 'heading-up';
       minimapModeStatusEl.innerHTML = isHeadingUp
-        ? '<strong>Map mode:</strong> Heading-up — the top of the map follows the way you are facing.<br><strong>Guidance:</strong> Landmark callouts stay player-relative (ahead/left/right) for first-person wayfinding.'
-        : '<strong>Map mode:</strong> North-up — the top of the map is geographic north.<br><strong>Guidance:</strong> Landmark callouts stay player-relative (ahead/left/right) so the legend still reads like the street.';
+        ? 'Traveler orientation. The chart turns with your body so the street ahead stays at the top.'
+        : 'Cartographer orientation. The chart holds geographic north while guidance still reads from your point of view.';
     }
   }
 
@@ -2736,10 +2748,10 @@
         const nearestIndex = Math.max(0, state.world.nodes.findIndex((node) => node.id === nearest.id));
         const total = Math.max(1, state.world.nodes.length - 1);
         const progress = Math.round((nearestIndex / total) * 100);
-        routeSegmentEl.textContent = 'Route segment: ' + nearest.label + ' (' + progress + '%)';
+        routeSegmentEl.textContent = 'Route pulse: ' + nearest.label + ' · ' + progress + '% along the promenade';
       }
       if (minimapLandmarkEl) {
-        minimapLandmarkEl.textContent = nearestGuidance ? 'Nearest landmark: ' + nearestGuidance.text : 'Nearest landmark: ' + nearest.label;
+        minimapLandmarkEl.textContent = nearestGuidance ? 'Nearest beacon: ' + nearestGuidance.text : 'Nearest beacon: ' + nearest.label;
       }
       updateMinimapContext();
     }
@@ -3689,13 +3701,14 @@
     if (routeDebugOverlay) {
       routeDebugOverlay.hidden = !enabled;
     }
+    setDebugToggleLabel();
   }
 
   function startSim() {
     unlockSteamClockAudio();
     state.isRunning = true;
-    setStatus('Street mode active. Mouse look and movement are live. Press V for overview.');
-    setPointerStatus('Pointer lock requested… press Esc any time to release.');
+    setStatus('You are in the street now. Look, wander, and press V if you want the city from above.');
+    setPointerStatus('Pointer requested. Press Esc at any time to loosen your view from the street.');
     lockPointer();
   }
 
@@ -3715,8 +3728,8 @@
     if (document.pointerLockElement) {
       document.exitPointerLock();
     }
-    setStatus('Street mode paused. Click scene to resume look mode and movement, or press V for overview.');
-    setPointerStatus('Pointer released. Click scene to re-enter look mode.');
+    setStatus('The walk is paused. Click back into the scene to continue, or press V to lift into overview.');
+    setPointerStatus('Pointer released. Click the scene to settle back into the walk.');
   }
 
   function attachEvents() {
@@ -3743,7 +3756,7 @@
         const now = performance.now();
         if (now - state.tutorial.lastMKeyAt < 450) {
           toggleMinimapMode();
-          if (minimapTooltipEl) { minimapTooltipEl.textContent = 'Minimap switched to ' + minimapState.mode + '.'; }
+          if (minimapTooltipEl) { minimapTooltipEl.textContent = minimapState.mode === 'heading-up' ? 'Traveler orientation engaged. The map now turns with you.' : 'Cartographer orientation engaged. North is fixed at the top again.'; }
         }
         state.tutorial.lastMKeyAt = now;
       }
@@ -3801,18 +3814,20 @@
 
     document.addEventListener('pointerlockchange', () => {
       if (state.cameraMode === 'street' && document.pointerLockElement === renderer.domElement) {
-        setPointerStatus('Pointer locked. Mouse look active. Press Esc to release pointer.');
+        setPointerStatus('Pointer locked. Your gaze is tied to the street. Press Esc to release it.');
       } else if (state.cameraMode === 'overview') {
-        setPointerStatus('Pointer unlocked. Overview camera detached above player.');
+        setPointerStatus('Pointer free. The overview camera is drifting above the route.');
       } else if (state.isRunning) {
         clearMovementInput();
         state.isRunning = false;
-        setStatus('Street mode paused. Click scene to resume look mode and movement, or press V for overview.');
-        setPointerStatus('Pointer released. Click scene to re-enter look mode.');
+        setStatus('The walk is paused. Click back into the scene to continue, or press V to lift into overview.');
+        setPointerStatus('Pointer released. Click the scene to settle back into the walk.');
       } else {
-        setPointerStatus('Pointer unlocked.');
+        setPointerStatus('Pointer free.');
       }
     });
+
+    setDebugToggleLabel();
 
     debugToggle.addEventListener('click', () => {
       const open = debugPanel.hasAttribute('hidden');
@@ -3827,7 +3842,7 @@
     dialogCloseEls.forEach((button) => button.addEventListener('click', closeDialog));
     if (tutorialOpenBtn) tutorialOpenBtn.addEventListener('click', openTutorialOverlay);
     tutorialCloseEls.forEach((button) => button.addEventListener('click', closeTutorialOverlay));
-    if (tutorialStartBtn) tutorialStartBtn.addEventListener('click', () => { closeTutorialOverlay(); resetToStart(); setStatus('Tutorial started. Click into the scene, then follow the route toward the Steam Clock.'); });
+    if (tutorialStartBtn) tutorialStartBtn.addEventListener('click', () => { closeTutorialOverlay(); resetToStart(); setStatus('Tutorial begun. Step into the scene, then follow the route toward the Steam Clock glow.'); });
     if (lowGraphicsToggle) lowGraphicsToggle.addEventListener('change', (event) => setLowGraphicsMode(event.target.checked));
     if (reopenTutorialToggle) reopenTutorialToggle.addEventListener('change', (event) => { try { window.localStorage.setItem('gastownTutorialReopen', event.target.checked ? '1' : '0'); } catch (error) {} });
     if (dialogModalEl) {
@@ -3968,7 +3983,7 @@
       setupAudio(state.world);
       minimapState.worldMetrics = getWorldMetrics();
       try { if (window.localStorage.getItem('gastownLowGraphics') === '1') { setLowGraphicsMode(true); } } catch (error) {}
-      setQuestStatus('Scavenger hunt: talk to the guide to begin.');
+      setQuestStatus('Scavenger thread: speak with the guide to begin.');
       restoreMinimapZoom();
       restoreMinimapMode();
       updateSize();
@@ -3984,7 +3999,7 @@
       scheduleSteamClock();
       setWorldModeStatus(state.world);
       if (!(state.world.meta && state.world.meta.fallbackMode === 'working-gastown-corridor')) {
-        setStatus('Street mode ready. Click scene to enter look mode and begin moving, or press V for overview.');
+        setStatus('The block is ready. Click into the scene to begin your walk, or press V for an overview.');
       }
       updateCameraModeUi();
       renderer.setAnimationLoop((time) => {
@@ -4007,7 +4022,7 @@
         renderer.render(scene, camera);
       });
     } catch (error) {
-      setStatus('Unable to start simulator: ' + error.message);
+      setStatus('Gastown could not finish loading: ' + error.message);
     }
   }
 

--- a/page-gastown-sim.php
+++ b/page-gastown-sim.php
@@ -8,68 +8,86 @@ get_header();
 <main id="primary" class="content-area gastown-sim-page">
   <section id="gastown-sim-app" class="gastown-sim-shell">
     <header class="gastown-sim-header">
-      <p class="gastown-sim-kicker">Prototype route: Waterfront Station → Water Street → Steam Clock</p>
-      <h1>Gastown First-Person Simulator</h1>
-      <p class="gastown-sim-intro">A stylized, geographically grounded Gastown walk through a focused Water Street slice with the Steam Clock staged at an intersection plaza. Click into the scene, look around, and walk the route.</p>
+      <p class="gastown-sim-kicker">Lantern route: Waterfront Station → Water Street → Steam Clock</p>
+      <h1>Walk into Gastown after the station doors fall quiet.</h1>
+      <p class="gastown-sim-intro">A first-person heritage promenade through brick facades, paving glimmer, and the Steam Clock plaza. Step into the street, follow the landmarks, and let the neighborhood reveal itself before the controls do.</p>
     </header>
 
-    <div class="gastown-controls" role="group" aria-label="Simulator controls">
-      <button type="button" class="pixel-button secondary" data-action="pause">Pause</button>
-      <button type="button" class="pixel-button secondary" data-action="reset" aria-label="Reset to the start of the route">Reset to route start</button>
-      <button type="button" class="pixel-button secondary" data-action="tutorial-open" aria-label="Open the controls tutorial overlay">Tutorial</button>
-      <label>
-        Time of day
-        <select name="time-of-day">
-          <option value="morning" selected>Morning</option>
-          <option value="afternoon">Afternoon</option>
-          <option value="dusk">Dusk</option>
-          <option value="night">Night</option>
-        </select>
-      </label>
-      <label>
-        Weather
-        <select name="weather">
-          <option value="clear" selected>Clear</option>
-          <option value="drizzle">Drizzle</option>
-          <option value="rain">Rain</option>
-          <option value="thunderstorm">Thunderstorm</option>
-          <option value="fog">Fog</option>
-        </select>
-      </label>
-      <label>
-        Mood
-        <select name="mood">
-          <option value="calm" selected>Calm</option>
-          <option value="commuter">Commuter</option>
-          <option value="lively">Lively</option>
-          <option value="eerie">Eerie</option>
-        </select>
-      </label>
-      <label>
-        <input type="checkbox" name="low-graphics" data-setting="low-graphics" aria-label="Enable low graphics mode">
-        Low graphics mode
-      </label>
-      <label>
-        <input type="checkbox" name="reopen-tutorial" data-setting="reopen-tutorial" aria-label="Show the tutorial overlay again">
-        Show tutorial on next load
-      </label>
-      <button type="button" class="pixel-button tiny secondary" data-action="debug-toggle" aria-label="Toggle the debug notes panel">Toggle debug</button>
+    <div class="gastown-stage-directions" role="group" aria-label="Primary simulator controls">
+      <div class="gastown-stage-actions">
+        <button type="button" class="pixel-button secondary" data-action="pause">Pause walk</button>
+        <button type="button" class="pixel-button secondary" data-action="reset" aria-label="Reset to the start of the route">Return to station</button>
+        <button type="button" class="pixel-button secondary" data-action="tutorial-open" aria-label="Open the controls tutorial overlay">How to roam</button>
+      </div>
+      <p class="gastown-stage-note">Click into the scene to enter look mode. The route, quest beats, and nearby encounters will surface in the heads-up display as you explore.</p>
     </div>
 
-    <section class="gastown-help" aria-label="Simulator controls guide">
-      <h2>Quick controls</h2>
-      <ul>
-        <li><strong>Click scene</strong> to enter look mode</li>
-        <li><strong>Mouse</strong> = look around</li>
-        <li><strong>W A S D</strong> = move / strafe</li>
-        <li><strong>Arrow keys</strong> = move forward/back + turn left/right</li>
-        <li><strong>Mouse wheel</strong> = look up/down (while focused/in play mode)</li>
-        <li><strong>Ctrl + ↑ / Ctrl + ↓</strong> = precise look up/down steps</li>
-        <li><strong>Esc</strong> = release pointer / pause</li>
-      </ul>
-    </section>
+    <details class="gastown-world-menu">
+      <summary>World settings &amp; diagnostics</summary>
+      <div class="gastown-world-menu-grid">
+        <section class="gastown-controls" aria-label="Simulator world settings">
+          <h2>Scene direction</h2>
+          <div class="gastown-controls-grid">
+            <label>
+              Time of day
+              <select name="time-of-day">
+                <option value="morning" selected>Morning</option>
+                <option value="afternoon">Afternoon</option>
+                <option value="dusk">Dusk</option>
+                <option value="night">Night</option>
+              </select>
+            </label>
+            <label>
+              Weather
+              <select name="weather">
+                <option value="clear" selected>Clear</option>
+                <option value="drizzle">Drizzle</option>
+                <option value="rain">Rain</option>
+                <option value="thunderstorm">Thunderstorm</option>
+                <option value="fog">Fog</option>
+              </select>
+            </label>
+            <label>
+              Mood
+              <select name="mood">
+                <option value="calm" selected>Calm</option>
+                <option value="commuter">Commuter</option>
+                <option value="lively">Lively</option>
+                <option value="eerie">Eerie</option>
+              </select>
+            </label>
+            <label class="gastown-checkbox-row">
+              <input type="checkbox" name="low-graphics" data-setting="low-graphics" aria-label="Enable low graphics mode">
+              Low graphics mode
+            </label>
+            <label class="gastown-checkbox-row">
+              <input type="checkbox" name="reopen-tutorial" data-setting="reopen-tutorial" aria-label="Show the tutorial overlay again">
+              Show tutorial on next load
+            </label>
+          </div>
+        </section>
 
+        <section class="gastown-help" aria-label="Simulator controls guide">
+          <h2>Traveler's notes</h2>
+          <ul>
+            <li><strong>Click scene</strong> to enter look mode</li>
+            <li><strong>Mouse</strong> to look around the block</li>
+            <li><strong>W A S D</strong> to move and strafe</li>
+            <li><strong>Arrow keys</strong> for walk/turn fallback controls</li>
+            <li><strong>Mouse wheel</strong> or <strong>Ctrl + ↑ / Ctrl + ↓</strong> for pitch adjustments</li>
+            <li><strong>Esc</strong> to release pointer and pause</li>
+            <li><strong>M, M</strong> quickly to shift minimap orientation</li>
+          </ul>
+        </section>
 
+        <section class="gastown-debug-meta" aria-label="Simulator diagnostic information">
+          <h2>Diagnostics</h2>
+          <p class="gastown-world-status" data-sim-world-status aria-live="polite">World data status: checking build provenance…</p>
+          <p class="gastown-pointer-status" data-sim-pointer-status aria-live="polite">Pointer unlocked.</p>
+          <button type="button" class="pixel-button tiny secondary" data-action="debug-toggle" aria-label="Toggle the debug notes panel">Toggle route diagnostics</button>
+        </section>
+      </div>
+    </details>
 
     <section class="gastown-tutorial-overlay" data-tutorial-overlay role="dialog" aria-modal="true" aria-labelledby="gastown-tutorial-title" aria-describedby="gastown-tutorial-copy" hidden>
       <div class="gastown-dialog-panel">
@@ -88,24 +106,30 @@ get_header();
         </div>
       </div>
     </section>
-    <p class="gastown-status" data-sim-status aria-live="polite">Loading simulator...</p>
-    <p class="gastown-quest-status" data-sim-quest-status aria-live="polite">Scavenger hunt: inactive.</p>
-    <p class="gastown-world-status" data-sim-world-status aria-live="polite">World data status: checking build provenance…</p>
-    <p class="gastown-pointer-status" data-sim-pointer-status aria-live="polite">Pointer unlocked.</p>
-    <p class="gastown-landmark" data-sim-landmark aria-live="polite">Nearest landmark: Station threshold</p>
-    <p class="gastown-route-segment" data-sim-route-segment aria-live="polite">Route segment: Waterfront Station Threshold</p>
-    <p class="gastown-interact-prompt" data-sim-interact-prompt aria-live="polite" hidden></p>
-
     <div class="gastown-sim-canvas" data-sim-canvas tabindex="-1">
+      <div class="gastown-hud gastown-hud--top">
+        <section class="gastown-hud-card gastown-hud-card--scene" aria-label="Current scene status">
+          <p class="gastown-status" data-sim-status aria-live="polite">Loading simulator...</p>
+          <div class="gastown-hud-subgrid">
+            <p class="gastown-landmark" data-sim-landmark aria-live="polite">Nearest landmark: Station threshold</p>
+            <p class="gastown-route-segment" data-sim-route-segment aria-live="polite">Route segment: Waterfront Station Threshold</p>
+          </div>
+        </section>
+        <section class="gastown-hud-card gastown-hud-card--quest" aria-label="Quest status">
+          <p class="gastown-hud-eyebrow">Current thread</p>
+          <p class="gastown-quest-status" data-sim-quest-status aria-live="polite">Scavenger hunt: inactive.</p>
+        </section>
+      </div>
+
       <aside class="gastown-minimap" aria-label="Route navigator minimap">
         <div class="gastown-minimap-toolbar" role="group" aria-label="Minimap controls">
           <button type="button" class="gastown-minimap-mode" data-action="minimap-mode-toggle" aria-pressed="false" aria-label="Switch minimap to heading-up mode">North up</button>
           <button type="button" class="gastown-minimap-zoom" data-action="minimap-zoom-in" aria-label="Zoom in minimap">+</button>
           <button type="button" class="gastown-minimap-zoom" data-action="minimap-zoom-out" aria-label="Zoom out minimap">−</button>
         </div>
-        <p class="gastown-minimap-mode-status" data-sim-minimap-mode-status aria-live="polite">Map mode: North-up — the top of the map is geographic north. Guidance: landmark callouts stay player-relative.</p>
-        <p class="gastown-minimap-tooltip" data-sim-minimap-tooltip aria-live="polite">Tip: press M twice quickly to switch between north-up and heading-up map modes.</p>
-        <p class="gastown-minimap-context" data-sim-minimap-context aria-live="polite"><strong>Now facing:</strong> north<br><strong>Nearest landmark:</strong> Waterfront Station threshold — ahead</p>
+        <p class="gastown-minimap-mode-status" data-sim-minimap-mode-status aria-live="polite">North-up charting. The avenue is drawn to geographic north while guidance remains relative to your body.</p>
+        <p class="gastown-minimap-tooltip" data-sim-minimap-tooltip aria-live="polite">Minimap cue: press M twice quickly to switch between cartographer and traveler orientation.</p>
+        <p class="gastown-minimap-context" data-sim-minimap-context aria-live="polite"><strong>Facing</strong> north<br><strong>Nearest beacon</strong> Waterfront Station threshold — ahead</p>
         <canvas data-sim-minimap width="220" height="220"></canvas>
         <div class="gastown-minimap-compass" data-sim-compass aria-live="polite">Heading: north</div>
         <ul class="gastown-minimap-legend" data-sim-minimap-legend aria-label="Minimap legend">
@@ -119,6 +143,11 @@ get_header();
         </ul>
         <p class="gastown-minimap-label" data-sim-minimap-landmark>Nearest landmark: Waterfront Station threshold — ahead</p>
       </aside>
+
+      <div class="gastown-hud gastown-hud--bottom">
+        <p class="gastown-interact-prompt" data-sim-interact-prompt aria-live="polite" hidden></p>
+      </div>
+
       <pre class="gastown-route-debug-overlay" data-route-debug-overlay hidden></pre>
     </div>
 


### PR DESCRIPTION
### Motivation
- Reduce always-visible configuration clutter so the initial screen communicates fantasy of place rather than a demo UI. 
- Make status, quests, interaction prompts, and minimap guidance read like a world-building walk rather than developer diagnostics. 
- Keep non-essential debug and configuration behind an opt-in menu so explorers see atmosphere first. 

### Description
- Template: rewrote the simulator hero and primary controls in `page-gastown-sim.php` to foreground atmosphere and primary walk actions, moved scene settings and debug controls into a collapsed `details` panel (`gastown-world-menu`), and added a layered HUD (`gastown-hud`) for scene/quest/interaction messages. 
- Stylesheet: replaced and extended `assets/css/gastown-sim.css` to introduce cinematic typography, translucent HUD cards, warmer gradients, refined spacing, integrated minimap visuals, and responsive adjustments for the new HUD and menu. 
- Script: updated `js/gastown-sim.js` status/UX wiring to match the new hierarchy by adding guards to `setStatus`/`setLandmark`, introducing `setDebugToggleLabel`, rewording many status messages (street/overview/pause), converting guidance language to "beacon"/"route pulse"/"thread", cleaning up minimap copy, changing quest copy to "Scavenger thread", and making the interact prompt and debug toggle labels reflect the optional diagnostics flow. 

### Testing
- Ran PHP syntax check: `php -l page-gastown-sim.php` (passed). 
- Ran JS syntax check: `node --check js/gastown-sim.js` (passed). 
- Basic runtime wiring validated by static checks and in-code guards for missing elements; no runtime screenshot was captured in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0e24ae124832ebaa51837ba26a4a3)