### PR TITLE
Overhaul Gastown simulator UX: HUD, interaction, naming, and NPC TTS

### DIFF
--- a/assets/css/gastown-sim.css
+++ b/assets/css/gastown-sim.css
@@ -4,21 +4,21 @@
     radial-gradient(circle at 76% 18%, rgba(203, 146, 89, 0.15) 0, rgba(8, 11, 17, 0) 28%),
     linear-gradient(180deg, #111824 0%, #080a10 56%, #040507 100%);
   color: #d5dde8;
-  padding: 2rem 1rem 3rem;
+  padding: 1.2rem 1rem 2.4rem;
 }
 
 .gastown-sim-shell {
-  max-width: 1120px;
+  max-width: 1280px;
   margin: 0 auto;
+  display: grid;
+  gap: 0.8rem;
   background:
-    linear-gradient(180deg, rgba(10, 13, 20, 0.84), rgba(8, 10, 15, 0.9)),
+    linear-gradient(180deg, rgba(10, 13, 20, 0.88), rgba(8, 10, 15, 0.92)),
     rgba(8, 11, 18, 0.75);
   border: 1px solid rgba(173, 190, 215, 0.16);
   border-radius: 16px;
-  padding: 1.2rem;
-  box-shadow:
-    0 22px 60px rgba(0, 0, 0, 0.5),
-    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  padding: 1rem;
+  box-shadow: 0 22px 60px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.05);
   backdrop-filter: blur(10px);
 }
 
@@ -30,8 +30,18 @@
 .gastown-sim-kicker,
 .gastown-sim-intro,
 .gastown-status,
-.gastown-landmark {
-  margin: 0.4rem 0;
+.gastown-landmark,
+.gastown-route-segment,
+.gastown-world-status,
+.gastown-pointer-status,
+.gastown-quest-status {
+  margin: 0;
+}
+
+.gastown-sim-intro {
+  margin-top: 0.35rem;
+  max-width: 72ch;
+  line-height: 1.5;
 }
 
 .gastown-controls {
@@ -39,7 +49,6 @@
   flex-wrap: wrap;
   align-items: center;
   gap: 0.6rem;
-  margin: 1rem 0;
 }
 
 .gastown-controls label {
@@ -49,70 +58,21 @@
   font-size: 0.85rem;
 }
 
-.gastown-controls select {
+.gastown-controls select,
+.gastown-name-field input {
   min-width: 130px;
   border-radius: 6px;
   border: 1px solid rgba(200, 214, 236, 0.3);
   background: #0f131b;
   color: #dce5f3;
-  padding: 0.35rem;
+  padding: 0.45rem 0.55rem;
 }
-
-.gastown-sim-canvas {
-  position: relative;
-  width: 100%;
-  border-radius: 12px;
-  overflow: hidden;
-  border: 1px solid rgba(164, 182, 209, 0.22);
-  background:
-    radial-gradient(circle at 50% 0, rgba(120, 165, 215, 0.15), rgba(8, 10, 14, 0) 38%),
-    linear-gradient(180deg, #0b0d12 0%, #06080c 100%);
-  box-shadow:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.04),
-    0 18px 42px rgba(0, 0, 0, 0.42);
-}
-
-.gastown-sim-canvas::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background:
-    linear-gradient(180deg, rgba(197, 156, 112, 0.08), rgba(0, 0, 0, 0) 22%, rgba(0, 0, 0, 0.18) 100%),
-    radial-gradient(circle at 50% 15%, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0) 38%);
-  mix-blend-mode: screen;
-  opacity: 0.85;
-}
-
-.gastown-sim-canvas::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background: linear-gradient(180deg, rgba(4, 5, 8, 0.08), rgba(4, 5, 8, 0.24));
-  box-shadow: inset 0 0 100px rgba(0, 0, 0, 0.25);
-}
-
-.gastown-sim-canvas canvas {
-  display: block;
-  width: 100% !important;
-  height: auto !important;
-}
-
-.gastown-debug {
-  margin-top: 1rem;
-  border-top: 1px dashed rgba(162, 180, 201, 0.28);
-  padding-top: 0.8rem;
-}
-
 
 .gastown-help {
-  margin: 0.75rem 0 0.9rem;
   padding: 0.7rem 0.9rem;
   border: 1px solid rgba(193, 213, 238, 0.26);
   border-radius: 10px;
   background: linear-gradient(160deg, rgba(31, 39, 55, 0.8), rgba(10, 13, 19, 0.88));
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
 .gastown-help h2 {
@@ -127,67 +87,89 @@
   gap: 0.2rem;
 }
 
-.gastown-help li {
-  color: #e4ebf7;
+.gastown-hud {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.gastown-hud-top {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(340px, 1.8fr) minmax(210px, 0.9fr);
+  gap: 0.7rem;
+  align-items: start;
+}
+
+.gastown-hud-identity,
+.gastown-hud-statuses,
+.gastown-hud-route,
+.gastown-hud-card,
+.gastown-meta-strip > * {
+  padding: 0.7rem 0.8rem;
+  border-radius: 10px;
+  border: 1px solid rgba(170, 197, 226, 0.22);
+  background: linear-gradient(180deg, rgba(16, 22, 33, 0.8), rgba(8, 11, 18, 0.92));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.gastown-hud-kicker,
+.gastown-expedition-label {
+  margin: 0 0 0.28rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #8fc8ff;
+}
+
+.gastown-hud-name {
+  margin: 0;
+  font-size: clamp(1.15rem, 2.1vw, 1.6rem);
+  color: #f6fbff;
+}
+
+.gastown-hud-subline,
+.gastown-hud-disclosure {
+  margin: 0.3rem 0 0;
+  font-size: 0.82rem;
+  line-height: 1.4;
+  color: rgba(220, 236, 255, 0.85);
+}
+
+.gastown-hud-statuses {
+  display: grid;
+  gap: 0.45rem;
 }
 
 .gastown-status,
 .gastown-world-status,
 .gastown-pointer-status,
 .gastown-landmark,
-.gastown-route-segment {
-  padding: 0.2rem 0.55rem;
+.gastown-route-segment,
+.gastown-quest-status,
+.gastown-interact-prompt {
+  padding: 0.28rem 0.55rem;
   border-left: 2px solid rgba(192, 211, 237, 0.45);
-  background: linear-gradient(180deg, rgba(15, 20, 29, 0.5), rgba(10, 14, 22, 0.3));
+  background: linear-gradient(180deg, rgba(15, 20, 29, 0.7), rgba(10, 14, 22, 0.42));
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
 }
 
 .gastown-world-status {
-  margin-top: 0.35rem;
   border-left-color: rgba(255, 196, 120, 0.88);
   background: rgba(39, 24, 7, 0.42);
   color: #ffe2bf;
 }
 
-.gastown-world-status.is-approximate {
-  border-left-color: #ffbf7c;
-  box-shadow: inset 0 0 0 1px rgba(255, 191, 124, 0.14);
-}
+.gastown-pointer-status { color: #bdd8ff; }
+.gastown-quest-status { color: #d6f0c4; }
 
-.gastown-world-status.is-civic {
-  border-left-color: rgba(149, 234, 199, 0.88);
-  background: rgba(12, 35, 28, 0.38);
-  color: #dcfff2;
-}
-
-.gastown-pointer-status {
-  color: #bdd8ff;
-  font-size: 0.92rem;
-}
-
-.gastown-expedition-panel {
+.gastown-hud-support {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: minmax(260px, 1.1fr) minmax(220px, 0.9fr) minmax(220px, 0.9fr);
   gap: 0.7rem;
-  margin: 0.7rem 0 0.8rem;
 }
 
-.gastown-expedition-card {
-  padding: 0.7rem 0.8rem;
-  border: 1px solid rgba(170, 197, 226, 0.22);
-  border-radius: 10px;
-  background: linear-gradient(180deg, rgba(16, 22, 33, 0.8), rgba(8, 11, 18, 0.92));
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
-}
-
-.gastown-expedition-label {
-  margin: 0 0 0.35rem;
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: #8fc8ff;
-}
+.gastown-hud-card--prompt { min-height: 0; }
+.gastown-hud-next-step { margin-top: 0.5rem; color: #fff1c7; }
 
 .gastown-expedition-value {
   margin: 0;
@@ -204,6 +186,47 @@
   font-size: 0.9rem;
 }
 
+.gastown-sim-canvas {
+  position: relative;
+  width: 100%;
+  min-height: 540px;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid rgba(164, 182, 209, 0.22);
+  background: radial-gradient(circle at 50% 0, rgba(120, 165, 215, 0.15), rgba(8, 10, 14, 0) 38%), linear-gradient(180deg, #0b0d12 0%, #06080c 100%);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 18px 42px rgba(0, 0, 0, 0.42);
+}
+
+.gastown-sim-canvas::before,
+.gastown-sim-canvas::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.gastown-sim-canvas::before {
+  background: linear-gradient(180deg, rgba(197, 156, 112, 0.08), rgba(0, 0, 0, 0) 22%, rgba(0, 0, 0, 0.18) 100%), radial-gradient(circle at 50% 15%, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0) 38%);
+  mix-blend-mode: screen;
+  opacity: 0.85;
+}
+
+.gastown-sim-canvas::after {
+  background: linear-gradient(180deg, rgba(4, 5, 8, 0.08), rgba(4, 5, 8, 0.24));
+  box-shadow: inset 0 0 100px rgba(0, 0, 0, 0.25);
+}
+
+.gastown-sim-canvas canvas {
+  display: block;
+  width: 100% !important;
+  height: auto !important;
+}
+
+.gastown-meta-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.7rem;
+}
 
 .gastown-route-debug-overlay {
   position: absolute;
@@ -231,6 +254,8 @@
   left: 0.85rem;
   bottom: 0.85rem;
   width: 220px;
+  display: grid;
+  gap: 0.38rem;
   padding: 0.45rem;
   border-radius: 10px;
   background: linear-gradient(180deg, rgba(10, 15, 23, 0.92), rgba(7, 11, 18, 0.86));
@@ -247,186 +272,45 @@
   border: 1px solid rgba(172, 201, 230, 0.24);
 }
 
-.gastown-minimap-label {
-  margin: 0.38rem 0 0;
-  font-size: 0.75rem;
-  line-height: 1.2;
-  color: #dbe9ff;
-}
+.gastown-minimap-label { margin: 0.38rem 0 0; font-size: 0.75rem; line-height: 1.2; color: #dbe9ff; }
+.gastown-minimap-toolbar { display: flex; justify-content: flex-end; align-items: center; gap: 0.35rem; }
+.gastown-minimap-mode, .gastown-minimap-zoom { height: 1.7rem; font-size: 0.72rem; font-weight: 700; border-radius: 6px; border: 1px solid rgba(174, 207, 239, 0.5); background: rgba(18, 28, 41, 0.95); color: #e8f3ff; line-height: 1; cursor: pointer; }
+.gastown-minimap-mode { min-width: 5.6rem; padding: 0 0.55rem; }
+.gastown-minimap-mode[data-minimap-mode="north-up"] { border-color: rgba(137, 189, 245, 0.7); box-shadow: inset 0 0 0 1px rgba(137, 189, 245, 0.18); }
+.gastown-minimap-mode[data-minimap-mode="heading-up"] { border-color: rgba(255, 197, 126, 0.78); color: #fff3de; box-shadow: inset 0 0 0 1px rgba(255, 197, 126, 0.18); }
+.gastown-minimap-zoom { width: 1.7rem; padding: 0; font-size: 1rem; }
+.gastown-minimap-mode:hover, .gastown-minimap-mode:focus-visible, .gastown-minimap-zoom:hover, .gastown-minimap-zoom:focus-visible { background: rgba(36, 53, 74, 0.95); outline: none; }
+.gastown-minimap-context { margin: 0.28rem 0 0.18rem; font-size: 0.68rem; line-height: 1.45; color: rgba(220, 236, 255, 0.92); }
+.gastown-minimap-context strong, .gastown-minimap-mode-status strong { color: #f5fbff; }
+.gastown-minimap-mode-status { margin: 0; padding: 0.35rem 0.45rem; border-radius: 8px; background: rgba(18, 28, 41, 0.96); border: 1px solid rgba(126, 178, 226, 0.24); color: #ecf5ff; font-size: 0.71rem; line-height: 1.35; }
+.gastown-minimap-legend { list-style: none; margin: 0.12rem 0 0; padding: 0; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.18rem 0.5rem; font-size: 0.68rem; color: rgba(220, 236, 255, 0.9); }
+.gastown-minimap-legend li { display: inline-flex; align-items: center; gap: 0.3rem; white-space: nowrap; }
+.gastown-minimap-legend .dot { width: 0.48rem; height: 0.48rem; border-radius: 999px; display: inline-block; border: 1px solid rgba(235, 245, 255, 0.58); }
+.gastown-minimap-legend .dot.player { background: radial-gradient(circle at 35% 35%, #ffffff 0, #b7ecff 58%, #3f8fca 100%); }
+.gastown-minimap-legend .dot.route { background: #ffd28f; }
+.gastown-minimap-legend .dot.sidewalk { background: #6c7f95; }
+.gastown-minimap-legend .dot.street { background: #203344; }
+.gastown-minimap-legend .dot.station { background: #84b4d7; }
+.gastown-minimap-legend .dot.steam { background: #d8a968; }
+.gastown-minimap-legend .dot.nearest { background: #8af7cb; }
 
-.gastown-minimap-mode-status {
-  margin: 0;
-  padding: 0.35rem 0.45rem;
-  border-radius: 8px;
-  background: rgba(18, 28, 41, 0.96);
-  border: 1px solid rgba(126, 178, 226, 0.24);
-  color: #ecf5ff;
-  font-size: 0.71rem;
-  line-height: 1.35;
-}
+.gastown-attribution { margin-top: 0.2rem; font-size: 0.78rem; line-height: 1.35; color: rgba(209, 223, 242, 0.86); }
+.gastown-attribution p { margin: 0.1rem 0; }
 
-.gastown-minimap-mode-status strong {
-  color: #9ed6ff;
-}
-
-@media (max-width: 740px) {
-  .gastown-minimap {
-    width: 180px;
-  }
-}
-
-
-.gastown-minimap {
-  display: grid;
-  gap: 0.38rem;
-}
-
-.gastown-minimap-toolbar {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  gap: 0.35rem;
-}
-
-.gastown-minimap-mode,
-.gastown-minimap-zoom {
-  height: 1.7rem;
-  font-size: 0.72rem;
-  font-weight: 700;
-  border-radius: 6px;
-  border: 1px solid rgba(174, 207, 239, 0.5);
-  background: rgba(18, 28, 41, 0.95);
-  color: #e8f3ff;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.gastown-minimap-mode {
-  min-width: 5.6rem;
-  padding: 0 0.55rem;
-}
-
-.gastown-minimap-mode[data-minimap-mode="north-up"] {
-  border-color: rgba(137, 189, 245, 0.7);
-  box-shadow: inset 0 0 0 1px rgba(137, 189, 245, 0.18);
-}
-
-.gastown-minimap-mode[data-minimap-mode="heading-up"] {
-  border-color: rgba(255, 197, 126, 0.78);
-  color: #fff3de;
-  box-shadow: inset 0 0 0 1px rgba(255, 197, 126, 0.18);
-}
-
-.gastown-minimap-zoom {
-  width: 1.7rem;
-  padding: 0;
-  font-size: 1rem;
-}
-
-.gastown-minimap-mode:hover,
-.gastown-minimap-mode:focus-visible,
-.gastown-minimap-zoom:hover,
-.gastown-minimap-zoom:focus-visible {
-  background: rgba(36, 53, 74, 0.95);
-  outline: none;
-}
-
-.gastown-minimap-context {
-  margin: 0.28rem 0 0.18rem;
-  font-size: 0.68rem;
-  line-height: 1.45;
-  color: rgba(220, 236, 255, 0.92);
-}
-
-.gastown-minimap-context strong {
-  color: #f5fbff;
-}
-
-.gastown-minimap-legend {
-  list-style: none;
-  margin: 0.12rem 0 0;
-  padding: 0;
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.18rem 0.5rem;
-  font-size: 0.68rem;
-  color: rgba(220, 236, 255, 0.9);
-}
-
-.gastown-minimap-legend li {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  white-space: nowrap;
-}
-
-.gastown-minimap-legend .dot {
-  width: 0.48rem;
-  height: 0.48rem;
-  border-radius: 999px;
-  display: inline-block;
-  border: 1px solid rgba(235, 245, 255, 0.58);
-}
-
-.gastown-minimap-legend .dot.player {
-  background: radial-gradient(circle at 35% 35%, #ffffff 0, #b7ecff 58%, #3f8fca 100%);
-}
-
-.gastown-minimap-legend .dot.route {
-  background: #ffd28f;
-}
-
-.gastown-minimap-legend .dot.sidewalk {
-  background: #6c7f95;
-}
-
-.gastown-minimap-legend .dot.street {
-  background: #203344;
-}
-
-.gastown-minimap-legend .dot.station {
-  background: #84b4d7;
-}
-
-.gastown-minimap-legend .dot.steam {
-  background: #d8a968;
-}
-
-.gastown-minimap-legend .dot.nearest {
-  background: #8af7cb;
-}
-
-.gastown-attribution {
-  margin-top: 0.8rem;
-  font-size: 0.78rem;
-  line-height: 1.35;
-  color: rgba(209, 223, 242, 0.86);
-}
-
-.gastown-attribution p {
-  margin: 0.1rem 0;
-}
-
-.gastown-interact-prompt[hidden] {
+.gastown-interact-prompt[hidden],
+.gastown-dialog-modal[hidden],
+.gastown-name-overlay[hidden] {
   display: none !important;
 }
 
 .gastown-interact-prompt {
   display: inline-block;
-  margin: 0.45rem 0;
-  padding: 0.38rem 0.7rem;
-  border-radius: 999px;
-  border: 1px solid rgba(151, 200, 244, 0.4);
-  background: rgba(7, 13, 22, 0.72);
-  color: #eff7ff;
-  box-shadow: 0 0 0 1px rgba(51, 86, 126, 0.28) inset;
+  border-left-color: rgba(255, 205, 116, 0.92);
+  color: #fff5dd;
 }
 
-.gastown-dialog-modal[hidden] {
-  display: none !important;
-}
-
-.gastown-dialog-modal {
+.gastown-dialog-modal,
+.gastown-name-overlay {
   position: fixed;
   inset: 0;
   z-index: 30;
@@ -448,47 +332,35 @@
   box-shadow: 0 20px 70px rgba(0, 0, 0, 0.55);
 }
 
-.gastown-dialog-header,
-.gastown-dialog-actions {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
+.gastown-name-panel { width: min(100%, 420px); }
+.gastown-name-field { display: grid; gap: 0.35rem; }
+.gastown-name-field span { font-size: 0.82rem; color: #b9d6f7; }
+.gastown-dialog-header, .gastown-dialog-actions { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; }
+.gastown-dialog-header h2 { margin: 0; font-size: 1.2rem; }
+.gastown-dialog-body { margin-top: 0.85rem; color: #e7eef8; line-height: 1.55; }
+.gastown-dialog-body p { margin: 0 0 0.8rem; }
+.gastown-dialog-actions { margin-top: 1rem; justify-content: flex-end; flex-wrap: wrap; }
+.gastown-dialog-actions-dynamic { display: flex; flex-wrap: wrap; gap: 0.65rem; }
+.gastown-dialog-audio-status { margin-right: auto; font-size: 0.78rem; color: #c3d9f4; }
+.gastown-dialog-actions .pixel-button { text-decoration: none; }
+.gastown-dialog-actions .pixel-button:focus-visible, .gastown-sim-canvas:focus-visible { outline: 2px solid rgba(155, 212, 255, 0.92); outline-offset: 2px; }
+
+.gastown-debug {
+  border-top: 1px dashed rgba(162, 180, 201, 0.28);
+  padding-top: 0.8rem;
 }
 
-.gastown-dialog-header h2 {
-  margin: 0;
-  font-size: 1.2rem;
+@media (max-width: 980px) {
+  .gastown-hud-top,
+  .gastown-hud-support,
+  .gastown-meta-strip {
+    grid-template-columns: 1fr;
+  }
 }
 
-.gastown-dialog-body {
-  margin-top: 0.85rem;
-  color: #e7eef8;
-  line-height: 1.55;
-}
-
-.gastown-dialog-body p {
-  margin: 0 0 0.8rem;
-}
-
-.gastown-dialog-actions {
-  margin-top: 1rem;
-  justify-content: flex-end;
-}
-
-
-.gastown-dialog-actions-dynamic {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.65rem;
-}
-
-.gastown-dialog-actions .pixel-button {
-  text-decoration: none;
-}
-
-.gastown-dialog-actions .pixel-button:focus-visible,
-.gastown-sim-canvas:focus-visible {
-  outline: 2px solid rgba(155, 212, 255, 0.92);
-  outline-offset: 2px;
+@media (max-width: 740px) {
+  .gastown-minimap { width: 180px; }
+  .gastown-sim-page { padding-inline: 0.45rem; }
+  .gastown-sim-shell { padding: 0.7rem; }
+  .gastown-sim-canvas { min-height: 460px; }
 }

--- a/functions.php
+++ b/functions.php
@@ -271,6 +271,7 @@ function se_enqueue_gastown_sim_assets() {
                 'textureBaseUrl' => esc_url_raw( $uri . '/assets/textures' ),
                 'dialogDataUrl'  => esc_url_raw( $uri . '/assets/dialog/gastown.json' ),
                 'conversationEndpoint' => esc_url_raw( rest_url( 'se/v1/gastown-npc-chat' ) ),
+                'voiceEndpoint' => esc_url_raw( rest_url( 'se/v1/gastown-npc-voice' ) ),
                 'nonce' => wp_create_nonce( 'wp_rest' ),
                 'defaultWeather' => 'clear',
                 'defaultMood'    => 'calm',
@@ -821,6 +822,12 @@ add_action('rest_api_init', function() {
         'callback'            => 'se_handle_gastown_npc_chat',
         'permission_callback' => '__return_true',
     ]);
+
+    register_rest_route('se/v1', '/gastown-npc-voice', [
+        'methods'             => 'POST',
+        'callback'            => 'se_handle_gastown_npc_voice',
+        'permission_callback' => '__return_true',
+    ]);
 });
 
 // =========================================
@@ -842,6 +849,65 @@ function get_custom_canucks_betting( WP_REST_Request $request ) {
         $odds = get_transient('suzyeaston_canucks_betting');
     }
     return rest_ensure_response( $odds );
+}
+
+
+function se_handle_gastown_npc_voice( WP_REST_Request $request ) {
+    $role       = sanitize_key( (string) $request->get_param( 'role' ) );
+    $name       = sanitize_text_field( (string) $request->get_param( 'name' ) );
+    $text       = sanitize_textarea_field( (string) $request->get_param( 'text' ) );
+    $style_hint = sanitize_text_field( (string) $request->get_param( 'style_hint' ) );
+
+    if ( '' === trim( $text ) ) {
+        return rest_ensure_response(
+            array(
+                'ok'      => false,
+                'fallback'=> true,
+                'message' => 'No speech text provided.',
+            )
+        );
+    }
+
+    $instructions = 'Read this as a grounded Gastown local: dry, blunt, restrained, low-hype, and human. Do not impersonate any real person. Avoid celebrity mimicry. Keep the cadence terse, sharp, and unromantic.';
+    if ( '' !== $style_hint ) {
+        $instructions .= ' Style hint: ' . $style_hint;
+    }
+
+    $speech = se_openai_tts(
+        $text,
+        array(
+            'model'           => 'gpt-4o-mini-tts',
+            'voice'           => 'alloy',
+            'response_format' => 'mp3',
+            'instructions'    => $instructions,
+        ),
+        array( 'timeout' => 20 )
+    );
+
+    if ( is_wp_error( $speech ) ) {
+        return rest_ensure_response(
+            array(
+                'ok'       => false,
+                'fallback' => true,
+                'message'  => wp_strip_all_tags( $speech->get_error_message() ),
+                'role'     => $role,
+                'name'     => $name,
+            )
+        );
+    }
+
+    return rest_ensure_response(
+        array(
+            'ok'          => true,
+            'fallback'    => false,
+            'role'        => $role,
+            'name'        => $name,
+            'audioBase64' => base64_encode( $speech['audio'] ),
+            'mimeType'    => 'audio/mpeg',
+            'model'       => $speech['model'],
+            'voice'       => $speech['voice'],
+        )
+    );
 }
 
 function se_handle_gastown_npc_chat( WP_REST_Request $request ) {

--- a/inc/openai.php
+++ b/inc/openai.php
@@ -106,3 +106,74 @@ if ( ! function_exists( 'se_openai_chat' ) ) {
         return $data;
     }
 }
+
+if ( ! function_exists( 'se_openai_tts' ) ) {
+    /**
+     * Send a text-to-speech request to OpenAI.
+     *
+     * @param string $text Speech text.
+     * @param array  $options Request options.
+     * @param array  $http_options Optional transport options.
+     *
+     * @return array|WP_Error
+     */
+    function se_openai_tts( $text, $options = array(), $http_options = array() ) {
+        if ( ! defined( 'OPENAI_API_KEY' ) || ! OPENAI_API_KEY ) {
+            return new WP_Error( 'no_key', __( 'OpenAI API key is not configured.', 'suzys-music-theme' ) );
+        }
+
+        $text = trim( wp_strip_all_tags( (string) $text ) );
+        if ( '' === $text ) {
+            return new WP_Error( 'invalid_text', __( 'Speech text is empty.', 'suzys-music-theme' ) );
+        }
+
+        $http_timeout = 30;
+        if ( isset( $http_options['timeout'] ) ) {
+            $http_timeout = (int) $http_options['timeout'];
+            unset( $http_options['timeout'] );
+        }
+
+        $body = array(
+            'model'           => isset( $options['model'] ) ? sanitize_text_field( $options['model'] ) : 'gpt-4o-mini-tts',
+            'voice'           => isset( $options['voice'] ) ? sanitize_text_field( $options['voice'] ) : 'alloy',
+            'input'           => $text,
+            'response_format' => isset( $options['response_format'] ) ? sanitize_text_field( $options['response_format'] ) : 'mp3',
+        );
+
+        if ( ! empty( $options['instructions'] ) ) {
+            $body['instructions'] = wp_strip_all_tags( (string) $options['instructions'] );
+        }
+
+        $response = wp_remote_post(
+            'https://api.openai.com/v1/audio/speech',
+            array_merge(
+                array(
+                    'headers' => array(
+                        'Authorization' => 'Bearer ' . OPENAI_API_KEY,
+                        'Content-Type'  => 'application/json',
+                    ),
+                    'body'    => wp_json_encode( $body ),
+                    'timeout' => $http_timeout,
+                ),
+                $http_options
+            )
+        );
+
+        if ( is_wp_error( $response ) ) {
+            return new WP_Error( 'openai_tts_http_error', wp_strip_all_tags( $response->get_error_message() ) );
+        }
+
+        $code = wp_remote_retrieve_response_code( $response );
+        $audio = wp_remote_retrieve_body( $response );
+        if ( $code < 200 || $code >= 300 || '' === $audio ) {
+            return new WP_Error( 'openai_tts_http_error', sprintf( 'OpenAI TTS HTTP %s', $code ) );
+        }
+
+        return array(
+            'audio'  => $audio,
+            'format' => $body['response_format'],
+            'model'  => $body['model'],
+            'voice'  => $body['voice'],
+        );
+    }
+}

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -56,6 +56,12 @@
   const minimapModeBtn = app.querySelector('[data-action="minimap-mode-toggle"]');
   const osmAttributionEl = app.querySelector('[data-gastown-osm-attribution]');
   const interactPromptEl = app.querySelector('[data-sim-interact-prompt]');
+  const renameWalkerBtn = app.querySelector('[data-action="rename-walker"]');
+  const walkerNameDisplayEl = app.querySelector('[data-walker-name-display]');
+  const walkerNameOverlayEl = app.querySelector('[data-name-overlay]');
+  const walkerNameInputEl = app.querySelector('[data-walker-name-input]');
+  const walkerStartBtn = app.querySelector('[data-action="walker-start"]');
+  const walkerSkipBtn = app.querySelector('[data-action="walker-skip"]');
   const questStatusEl = app.querySelector('[data-sim-quest-status]');
   const objectiveEl = app.querySelector('[data-sim-objective]');
   const nextStepEl = app.querySelector('[data-sim-next-step]');
@@ -76,6 +82,7 @@
   const dialogTitleEl = app.querySelector('[data-dialog-title]');
   const dialogBodyEl = app.querySelector('[data-dialog-body]');
   const dialogActionsDynamicEl = app.querySelector('[data-dialog-actions-dynamic]');
+  const dialogAudioStatusEl = app.querySelector('[data-dialog-audio-status]');
   const dialogCloseEls = app.querySelectorAll('[data-dialog-close]');
   const dialogFallbackCloseEl = app.querySelector('[data-dialog-close-fallback]');
   const dialogUtils = window.GastownDialog || {};
@@ -142,6 +149,11 @@
     npcVoiceTimer: null,
     lastNpcVoiceAt: -Infinity,
     npcVoiceIndex: 0,
+    walkerName: 'Walker',
+    hasInteracted: false,
+    npcSpeechCache: {},
+    npcSpeechController: null,
+    npcSpeechAudio: null,
     clockTimer: null,
     boundaryNoticeTimer: null,
     currentMicroAreaId: '',
@@ -178,6 +190,8 @@
   };
 
   const DEFAULT_EYE_HEIGHT = 1.7;
+  const WALKER_NAME_STORAGE_KEY = 'gastownWalkerName';
+  const NPC_SPEECH_CACHE_LIMIT = 18;
   const ART_DIRECTION = {
     label: 'stylized realism with cinematic Vancouver rain-lighting',
     streetReflectionBoost: 0.22,
@@ -333,8 +347,52 @@
     }
   }
 
+  function normalizeWalkerName(value) {
+    const normalized = String(value || '').replace(/\s+/g, ' ').trim();
+    return normalized ? normalized.slice(0, 24) : 'Walker';
+  }
+
+  function setWalkerName(value, options) {
+    state.walkerName = normalizeWalkerName(value);
+    if (walkerNameDisplayEl) walkerNameDisplayEl.textContent = state.walkerName;
+    if (!(options && options.skipStore)) {
+      try { window.localStorage.setItem(WALKER_NAME_STORAGE_KEY, state.walkerName); } catch (error) {}
+    }
+    if (walkerNameInputEl && !(options && options.skipInputSync)) walkerNameInputEl.value = state.walkerName === 'Walker' ? '' : state.walkerName;
+  }
+
+  function restoreWalkerName() {
+    try {
+      const saved = window.localStorage.getItem(WALKER_NAME_STORAGE_KEY);
+      if (saved) {
+        setWalkerName(saved, { skipStore: true });
+        return true;
+      }
+    } catch (error) {}
+    setWalkerName('Walker', { skipStore: true });
+    return false;
+  }
+
+  function openWalkerNameOverlay(prefill) {
+    if (!walkerNameOverlayEl) return;
+    if (typeof prefill === 'string' && walkerNameInputEl) walkerNameInputEl.value = prefill === 'Walker' ? '' : prefill;
+    walkerNameOverlayEl.removeAttribute('hidden');
+    window.setTimeout(() => { if (walkerNameInputEl && typeof walkerNameInputEl.focus === 'function') walkerNameInputEl.focus(); }, 0);
+  }
+
+  function closeWalkerNameOverlay() {
+    if (walkerNameOverlayEl) walkerNameOverlayEl.setAttribute('hidden', 'hidden');
+  }
+
+  function confirmWalkerName(value) {
+    setWalkerName(value);
+    closeWalkerNameOverlay();
+    pushJournalEntry('On the street as ' + state.walkerName + '.');
+    setStatus('Walker ready: ' + state.walkerName + '. Click into the street when you want to move.');
+  }
+
   const QUEST_DEFINITIONS = {
-    orientation: { label: 'Drift', status: 'Choose your own lead through Gastown.' },
+    orientation: { label: 'Get bearings', status: 'Get your bearings and see what the street gives you.' },
     scavenger: { label: 'Street details log', status: 'Street details log active: note the newspaper box, historic plaque, and painted brick panel as observations.' },
     survey: { label: 'Route survey', status: 'Route survey active: trace how Water Street tightens, loosens, and rises as you move east.' },
     soundwalk: { label: 'Soundwalk', status: 'Soundwalk active: follow the station rumble, busker corner, and clock chime without rushing.' },
@@ -344,9 +402,9 @@
   const THREAD_DEFINITIONS = {
     drift: {
       label: 'Drift',
-      objective: 'Choose your own lead through Gastown.',
-      hint: 'Look around and follow what catches your attention.',
-      status: 'Drift active: roam, linger, and let the street set the pace.',
+      objective: 'Get your bearings and see what the street gives you.',
+      hint: 'Look around, move a little, and follow what feels alive.',
+      status: 'Free exploration active: roam, linger, and let the street set the pace.',
       autoTarget: { type: 'landmark', id: 'water-cordova-seam' },
     },
     scavenger: {
@@ -390,7 +448,7 @@
 
   function getPublicGoalText() {
     const thread = getActiveThreadDefinition();
-    return thread.objective || 'Choose your own lead through Gastown.';
+    return thread.objective || 'Get your bearings and see what the street gives you.';
   }
 
   function getStreetModeStatusText() {
@@ -408,15 +466,22 @@
 
   function renderProgressionUi() {
     if (routeScoreEl) {
-      routeScoreEl.textContent = Math.round(state.progression.routeCompletionScore) + '% of the corridor surveyed.';
+      routeScoreEl.textContent = Math.round(state.progression.routeCompletionScore) + '% of the corridor mapped by your feet.';
     }
     if (collectiblesLogEl) {
-      const items = getCollectibleProps();
-      collectiblesLogEl.innerHTML = items.map((prop) => '<li>' + (prop.collectibleLabel || prop.id) + ' — ' + (prop.collected ? 'logged' : 'not logged') + '</li>').join('');
+      const deduped = [];
+      const seenKeys = new Set();
+      getCollectibleProps().forEach((prop) => {
+        const key = prop.collectibleKey || prop.collectibleLabel || prop.id;
+        if (seenKeys.has(key)) return;
+        seenKeys.add(key);
+        deduped.push(prop);
+      });
+      collectiblesLogEl.innerHTML = deduped.map((prop) => '<li>' + (prop.collectibleLabel || prop.id) + ' — ' + (prop.collected ? 'logged' : 'not logged') + '</li>').join('');
     }
     if (journalEl) {
       const entries = state.progression.journalEntries.length ? state.progression.journalEntries : ['Arrive at the station threshold and get your bearings.'];
-      journalEl.innerHTML = entries.map((entry) => '<li>' + entry + '</li>').join('');
+      journalEl.innerHTML = entries.slice(0, 4).map((entry) => '<li>' + entry + '</li>').join('');
     }
   }
 
@@ -608,7 +673,7 @@
         hint = { text: activeThread.hint + ' Next landmark: ' + nextLandmark.label + '.', target: { type: 'landmark', id: nextLandmark.id } };
       }
     } else {
-      objective = 'You have a full set of route notes — keep wandering and compare the neighbourhood across threads.';
+      objective = 'You have a full set of route notes — keep wandering and compare the neighbourhood on your own terms.';
       hint = { text: 'Roam freely: the journal now updates from proximity, lingering, and what you decide to revisit.', target: null };
     }
 
@@ -1540,6 +1605,104 @@
     };
   }
 
+  function updateDialogAudioStatus(message) {
+    if (dialogAudioStatusEl) dialogAudioStatusEl.textContent = message || '';
+  }
+
+  function hashNpcSpeechKey(payload) {
+    const source = [payload.role || '', payload.name || '', payload.text || '', payload.style_hint || ''].join('|');
+    let hash = 0;
+    for (let i = 0; i < source.length; i += 1) {
+      hash = ((hash << 5) - hash) + source.charCodeAt(i);
+      hash |= 0;
+    }
+    return 'speech-' + Math.abs(hash);
+  }
+
+  function stopNpcSpeech() {
+    if (state.npcSpeechController) {
+      try { state.npcSpeechController.abort(); } catch (error) {}
+      state.npcSpeechController = null;
+    }
+    if (state.npcSpeechAudio) {
+      try { state.npcSpeechAudio.pause(); } catch (error) {}
+      state.npcSpeechAudio.src = '';
+      state.npcSpeechAudio = null;
+    }
+    updateDialogAudioStatus('');
+  }
+
+  async function requestNpcSpeech(npcState, textBlock) {
+    if (!config.voiceEndpoint || !window.fetch || !textBlock) return null;
+    const payload = {
+      role: npcState.role || 'pedestrian',
+      name: npcState.name || npcState.id || '',
+      text: textBlock,
+      style_hint: 'Dry, blunt, grounded local commentary. Terse, sharp, low-hype, never an impersonation.',
+    };
+    const cacheKey = hashNpcSpeechKey(payload);
+    if (state.npcSpeechCache[cacheKey]) return state.npcSpeechCache[cacheKey];
+    const headers = { 'Content-Type': 'application/json' };
+    if (config.nonce) headers['X-WP-Nonce'] = config.nonce;
+    const controller = new AbortController();
+    state.npcSpeechController = controller;
+    try {
+      const response = await fetch(config.voiceEndpoint, {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers,
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+      if (!response.ok) throw new Error('speech unavailable');
+      const data = await response.json();
+      if (!data || !data.ok || !data.audioBase64) throw new Error('speech empty');
+      const cached = { url: 'data:audio/mpeg;base64,' + data.audioBase64, fallback: !!data.fallback, cacheKey };
+      state.npcSpeechCache[cacheKey] = cached;
+      const keys = Object.keys(state.npcSpeechCache);
+      if (keys.length > NPC_SPEECH_CACHE_LIMIT) delete state.npcSpeechCache[keys[0]];
+      return cached;
+    } catch (error) {
+      return null;
+    } finally {
+      if (state.npcSpeechController === controller) state.npcSpeechController = null;
+    }
+  }
+
+  async function playNpcSpeech(npcState, lines) {
+    stopNpcSpeech();
+    if (!state.hasInteracted || !Array.isArray(lines) || !lines.length) {
+      updateDialogAudioStatus('');
+      return;
+    }
+    updateDialogAudioStatus('Voice loading…');
+    const speech = await requestNpcSpeech(npcState, lines.join(' '));
+    if (!speech || !state.activeDialogNpcId || state.activeDialogNpcId !== npcState.id) {
+      updateDialogAudioStatus('');
+      return;
+    }
+    try {
+      const audio = new window.Audio(speech.url);
+      audio.autoplay = true;
+      audio.preload = 'auto';
+      audio.addEventListener('ended', () => {
+        if (state.npcSpeechAudio === audio) state.npcSpeechAudio = null;
+        updateDialogAudioStatus('');
+      });
+      audio.addEventListener('error', () => {
+        if (state.npcSpeechAudio === audio) state.npcSpeechAudio = null;
+        updateDialogAudioStatus('Voice unavailable. Text stays live.');
+      });
+      state.npcSpeechAudio = audio;
+      await audio.play().catch(() => {
+        updateDialogAudioStatus('Voice blocked by browser. Text stays live.');
+      });
+      if (!audio.paused) updateDialogAudioStatus('AI voice playing.');
+    } catch (error) {
+      updateDialogAudioStatus('Voice unavailable. Text stays live.');
+    }
+  }
+
   function getNpcDialogActions(npcState) {
     if (!npcState) {
       return [{ type: 'close', label: 'Back to walk' }];
@@ -1587,6 +1750,7 @@
       renderDialogBody(cached.lines);
       renderDialogActions(cached);
       focusFirstDialogControl();
+      playNpcSpeech(npcState, cached.lines || []);
       return;
     }
 
@@ -1606,6 +1770,7 @@
     renderDialogActions(entry);
     setStatus(conversation.fallback ? 'NPC chat fallback active. Click scene to resume when ready.' : 'NPC conversation ready. Click scene to resume when ready.');
     focusFirstDialogControl();
+    playNpcSpeech(npcState, entry.lines || []);
   }
 
   function createDialogLineElement(line) {
@@ -1709,6 +1874,7 @@
   function closeDialog() {
     state.activeDialogNpcId = '';
     state.activeDialogEntry = null;
+    stopNpcSpeech();
     if (dialogActionsDynamicEl) {
       dialogActionsDynamicEl.innerHTML = '';
     }
@@ -1768,6 +1934,7 @@
       dialogModalEl.setAttribute('aria-hidden', 'false');
       state.activeDialogNpcId = npcState.id;
       state.activeDialogEntry = normalized;
+      updateDialogAudioStatus('');
       setStatus('Dialog open. Loading nearby conversation.');
       setPointerStatus('Pointer unlocked. Dialog controls are active.');
       focusFirstDialogControl();
@@ -2428,6 +2595,32 @@
     });
   }
 
+  function scoreNpcInteractionCandidate(npc, options) {
+    if (!npc || !npc.mesh) return null;
+    const radius = (npc.interactRadius || 2.8) + 1.6;
+    const dx = npc.mesh.position.x - player.position.x;
+    const dz = npc.mesh.position.z - player.position.z;
+    const distance = Math.hypot(dx, dz);
+    if (distance > radius) return null;
+    const heading = getHeadingVector();
+    const dirX = dx / Math.max(distance, 0.001);
+    const dirZ = dz / Math.max(distance, 0.001);
+    const facingDot = (heading.x * dirX) + (heading.z * dirZ);
+    if (facingDot < -0.25) return null;
+    const centerBonus = options && options.centered ? Math.max(0, facingDot - 0.75) * 1.6 : 0;
+    const rayBonus = options && options.rayHit ? 0.45 : 0;
+    const visibleScore = Math.max(0, facingDot + 0.25) * 1.8;
+    const distanceScore = Math.max(0, 1.5 - (distance / Math.max(1, radius)));
+    return {
+      npc,
+      distance,
+      facingDot,
+      score: visibleScore + distanceScore + centerBonus + rayBonus,
+      centered: !!(options && options.centered),
+      rayHit: !!(options && options.rayHit),
+    };
+  }
+
   function findLookedAtNpc() {
     if (!Array.isArray(state.npcs) || state.npcs.length === 0) return null;
     camera.getWorldDirection(lookTarget);
@@ -2436,20 +2629,15 @@
     let best = null;
     state.npcs.forEach((npc) => {
       if (!npc.mesh) return;
-      const distance = tempCameraWorldPosition.distanceTo(npc.mesh.position);
-      if (distance > (npc.interactRadius || 2.4) + 1.2) {
-        return;
-      }
       const hits = sharedRaycaster.intersectObject(npc.mesh, true);
-      if (!hits.length) {
-        return;
-      }
-      const hitDistance = hits[0].distance;
-      if (!best || hitDistance < best.hitDistance) {
-        best = { npc: npc, hitDistance: hitDistance, distance: distance };
-      }
+      const hitDistance = hits.length ? hits[0].distance : null;
+      const centered = hits.length || lookTarget.dot(new THREE.Vector3().subVectors(npc.mesh.position, tempCameraWorldPosition).normalize()) > 0.92;
+      const candidate = scoreNpcInteractionCandidate(npc, { rayHit: hits.length > 0, centered });
+      if (!candidate) return;
+      candidate.hitDistance = hitDistance;
+      if (!best || candidate.score > best.score || (candidate.score === best.score && candidate.distance < best.distance)) best = candidate;
     });
-    return best && best.distance <= (best.npc.interactRadius || 2.4) ? best.npc : null;
+    return best;
   }
 
   function updateInteractionTarget() {
@@ -2458,18 +2646,16 @@
       setInteractPrompt('');
       return;
     }
-    const npc = findLookedAtNpc();
+    const npcTarget = findLookedAtNpc();
     const collectible = findNearbyCollectible();
-    state.hoveredNpcId = npc ? npc.id : '';
-    const interactionPulse = (Math.sin((performance.now() / 1000) * 5.4) + 1) * 0.5;
-    state.motion.interactionPulse = interactionPulse;
-    if (npc) {
+    state.hoveredNpcId = npcTarget ? npcTarget.npc.id : '';
+    state.motion.interactionPulse = (Math.sin((performance.now() / 1000) * 5.4) + 1) * 0.5;
+    if (npcTarget) {
+      const npc = npcTarget.npc;
       const roleLabel = getNpcRoleLabel(npc);
-      const interactRadius = npc.interactRadius || 2.4;
-      const distance = Math.hypot(player.position.x - npc.mesh.position.x, player.position.z - npc.mesh.position.z);
-      const closeness = 1 - THREE.MathUtils.clamp(distance / Math.max(0.01, interactRadius + 1.1), 0, 1);
-      const promptStrength = closeness > 0.62 ? 'Talk now' : 'Step closer';
-      setInteractPrompt(promptStrength + ': ' + roleLabel + ' · ' + formatDistanceLabel(distance) + (closeness > 0.82 ? ' · press E' : ''));
+      const talkCue = npcTarget.centered || npcTarget.distance <= (npc.interactRadius || 2.8) ? 'Press E or click to talk' : 'Face them and step in';
+      const centeredCue = npcTarget.centered ? 'centered' : npcTarget.facingDot > 0.75 ? 'in view' : 'nearby';
+      setInteractPrompt(talkCue + ': ' + (npc.name || roleLabel) + ' · ' + roleLabel + ' · ' + centeredCue + ' · ' + formatDistanceLabel(npcTarget.distance));
       return;
     }
     if (collectible) {
@@ -2477,19 +2663,17 @@
       const range = 2.2;
       const closeEnough = collectible.distance <= range;
       const headingCue = collectible.alignment > 0.78 ? 'ahead' : collectible.alignment > 0.3 ? 'off-center' : 'nearby';
-      setInteractPrompt((closeEnough ? 'Collect now' : 'Collectible ' + headingCue) + ': ' + (prop.collectibleLabel || prop.id) + ' · ' + formatDistanceLabel(collectible.distance) + (closeEnough ? ' · press E' : ''));
+      setInteractPrompt((closeEnough ? 'Press E to log' : 'Street detail ' + headingCue) + ': ' + (prop.collectibleLabel || prop.id) + ' · ' + formatDistanceLabel(collectible.distance));
       return;
     }
-    const roleLabel = getNpcRoleLabel(npc);
-    const context = getPlayerRouteContext();
-    setInteractPrompt('Click or press E to talk to the ' + roleLabel + ' near ' + context.label + '.');
+    setInteractPrompt('');
   }
 
   function interactWithHoveredNpc() {
-    if (!state.hoveredNpcId) return false;
-    const npc = (state.npcs || []).find((candidate) => candidate.id === state.hoveredNpcId);
-    if (!npc) return false;
-    openDialogForNpc(npc);
+    const target = findLookedAtNpc();
+    if (!target || !target.npc) return false;
+    state.hoveredNpcId = target.npc.id;
+    openDialogForNpc(target.npc);
     return true;
   }
 
@@ -2696,8 +2880,8 @@
   function addGround(world) {
     visualState.roadMaterial = createGroundMaterial('street', 0x0a0f14, 0.94, 0.1);
     visualState.sidewalkMaterial = createGroundMaterial('sidewalk', 0x85796d, 0.98, 0.02);
-    visualState.curbMaterial = new THREE.LineBasicMaterial({ color: 0xc2c8cf, transparent: true, opacity: 0.5 });
-    visualState.laneMaterial = new THREE.MeshStandardMaterial({ color: 0x8fa0af, roughness: 0.92, metalness: 0.02, transparent: true, opacity: 0.02, depthWrite: false });
+    visualState.curbMaterial = new THREE.LineBasicMaterial({ color: 0xc2c8cf, transparent: true, opacity: 0.38 });
+    visualState.laneMaterial = new THREE.MeshStandardMaterial({ color: 0x8fa0af, roughness: 0.96, metalness: 0.01, transparent: true, opacity: 0.015, depthWrite: false, depthTest: true });
     visualState.routeGuideMaterials = [visualState.laneMaterial];
     visualState.reflectiveMaterials.push(visualState.roadMaterial, visualState.sidewalkMaterial, visualState.laneMaterial);
 
@@ -2727,9 +2911,9 @@
             wheel_track: { color: 0x0d1217, roughness: 0.62, metalness: 0.14, opacity: 0.2 },
             patch: { color: 0x2f353d, roughness: 0.76, metalness: 0.12, opacity: 0.2 },
             repair_patch_dark: { color: 0x252b32, roughness: 0.72, metalness: 0.14, opacity: 0.22 },
-            puddle: { color: 0x1a212a, roughness: 0.18, metalness: 0.42, opacity: 0.18 },
-            wet_streak: { color: 0x202731, roughness: 0.34, metalness: 0.26, opacity: 0.2 },
-            reflection_pool: { color: 0x233242, roughness: 0.12, metalness: 0.5, opacity: 0.16 },
+            puddle: { color: 0x1a212a, roughness: 0.74, metalness: 0.08, opacity: 0.1 },
+            wet_streak: { color: 0x202731, roughness: 0.82, metalness: 0.06, opacity: 0.08 },
+            reflection_pool: { color: 0x233242, roughness: 0.86, metalness: 0.04, opacity: 0.06 },
             edge_grime: { color: 0x1b1d20, roughness: 0.8, metalness: 0.08, opacity: 0.18 },
             curb_grime: { color: 0x181c20, roughness: 0.88, metalness: 0.04, opacity: 0.18 },
             cobble_break: { color: 0x55483d, roughness: 0.86, metalness: 0.04, opacity: 0.18 },
@@ -2742,7 +2926,7 @@
             color: style.color,
             roughness: style.roughness,
             metalness: style.metalness,
-            transparent: true,
+            transparent: style.opacity < 0.98,
             opacity: Math.min(style.opacity, band.opacity || style.opacity),
           });
           visualState.reflectiveMaterials.push(material);
@@ -2750,6 +2934,7 @@
         })()
       );
       paver.rotation.x = -Math.PI / 2;
+      paver.renderOrder = -1;
       paver.rotation.y = band.yaw || 0;
       paver.position.set(segment.x + (band.offset_x || 0), band.elevation || 0.02, segment.z + (band.offset_z || 0));
       worldGroup.add(paver);
@@ -3250,7 +3435,7 @@
         plazaApron.position.y = 0.031;
         clockRoot.add(plazaApron);
 
-        const steamMaterial = new THREE.MeshBasicMaterial({ color: 0xd8dfdf, transparent: true, opacity: 0.18, depthWrite: false });
+        const steamMaterial = new THREE.MeshBasicMaterial({ color: 0xd8dfdf, transparent: true, opacity: 0.12, depthWrite: false, depthTest: true });
         const steamPlume = new THREE.Mesh(new THREE.SphereGeometry(0.62, 10, 10), steamMaterial);
         steamPlume.position.set(0, 9.72, 0.08);
         clockRoot.add(steamPlume);
@@ -3291,8 +3476,9 @@
       }
 
       if (state.debugEnabled || !suppressGenericMarker) {
-        const reflectionMaterial = new THREE.MeshStandardMaterial({ color: col, emissive: 0x1b2533, emissiveIntensity: 0.45, transparent: true, opacity: 0.22, roughness: 0.55, metalness: 0.3 });
+        const reflectionMaterial = new THREE.MeshStandardMaterial({ color: col, emissive: 0x1b2533, emissiveIntensity: 0.18, transparent: true, opacity: 0.08, roughness: 0.92, metalness: 0.04, depthWrite: false });
         const reflection = new THREE.Mesh(new THREE.CircleGeometry(landmark.radius || 2.7, 24), reflectionMaterial);
+        reflection.renderOrder = -1;
         reflection.rotation.x = -Math.PI / 2;
         reflection.position.set(landmark.x, 0.11, landmark.z);
         worldGroup.add(reflection);
@@ -3535,7 +3721,7 @@
     for (let i = 0; i < streakCount; i += 1) {
       const streak = new THREE.Mesh(
         new THREE.PlaneGeometry(0.025, 0.7 + (intensity * 0.85)),
-        new THREE.MeshBasicMaterial({ color: 0xc7d9e6, transparent: true, opacity: 0.025 + (intensity * 0.025), depthWrite: false })
+        new THREE.MeshBasicMaterial({ color: 0xc7d9e6, transparent: true, opacity: 0.012 + (intensity * 0.012), depthWrite: false, depthTest: true })
       );
       streak.rotation.x = -0.22;
       streak.position.set((Math.random() - 0.5) * 55, 9 + (Math.random() * 14), -8 - (Math.random() * 26));
@@ -3746,8 +3932,8 @@
       const isHeadingUp = minimapState.mode === 'heading-up';
       const threadLabel = (THREAD_DEFINITIONS[state.currentThread] || THREAD_DEFINITIONS.drift).label;
       minimapModeStatusEl.innerHTML = isHeadingUp
-        ? '<strong>Map mode:</strong> Heading-up — the top of the map follows the way you are facing.<br><strong>Thread hint:</strong> ' + threadLabel + ' stays highlighted without forcing a route.'
-        : '<strong>Map mode:</strong> North-up — the top of the map is geographic north.<br><strong>Thread hint:</strong> ' + threadLabel + ' stays highlighted without forcing a route.';
+        ? '<strong>Map mode:</strong> Heading-up — the top of the map follows the way you are facing.<br><strong>Ambient hint:</strong> ' + threadLabel + ' cues stay in the background.'
+        : '<strong>Map mode:</strong> North-up — the top of the map is geographic north.<br><strong>Ambient hint:</strong> ' + threadLabel + ' cues stay in the background.';
     }
   }
 
@@ -4274,7 +4460,7 @@
     const npcCounts = getActiveNpcCounts();
     const collectibleCount = getCollectibleProps().filter((prop) => !prop.collected).length;
     const threadLabel = (THREAD_DEFINITIONS[state.currentThread] || THREAD_DEFINITIONS.drift).label;
-    const items = ['You', 'Route line', 'Sidewalk / plaza', 'Road', 'Landmark', 'Thread hint: ' + threadLabel, 'Observations left: ' + collectibleCount, 'Pedestrians: ' + (npcCounts.pedestrian || 0), 'Tourists: ' + ((npcCounts.tourist || 0) + (npcCounts.photographer || 0)), 'Cyclists: ' + (npcCounts.cyclist || 0)];
+    const items = ['You', 'Route line', 'Sidewalk / plaza', 'Road', 'Landmark', 'Ambient hint: ' + threadLabel, 'Observations left: ' + collectibleCount, 'Pedestrians: ' + (npcCounts.pedestrian || 0), 'Tourists: ' + ((npcCounts.tourist || 0) + (npcCounts.photographer || 0)), 'Cyclists: ' + (npcCounts.cyclist || 0)];
     minimapLegendEl.innerHTML = items.map((item) => '<li>' + item + '</li>').join('');
   }
 
@@ -4640,7 +4826,7 @@
     }
     if (visualState.laneMaterial) {
       visualState.laneMaterial.color.set(timeOfDay.laneColor || '#aab1b8');
-      visualState.laneMaterial.opacity = Math.min(0.14, 0.035 + ((timeOfDay.pathBrightness || 0.2) * 0.12));
+      visualState.laneMaterial.opacity = Math.min(0.06, 0.01 + ((timeOfDay.pathBrightness || 0.2) * 0.04));
     }
 
     if (worldStatusEl) {
@@ -4867,7 +5053,7 @@
   function attachEvents() {
     window.addEventListener('resize', updateSize);
     ['pointerdown', 'click', 'keydown'].forEach((eventName) => {
-      document.addEventListener(eventName, () => { unlockAudioFromGesture().finally(() => unlockSteamClockAudio()); }, { passive: true });
+      document.addEventListener(eventName, () => { state.hasInteracted = true; unlockAudioFromGesture().finally(() => unlockSteamClockAudio()); }, { passive: true });
     });
     renderer.domElement.addEventListener('click', () => {
       if (state.activeDialogNpcId) {
@@ -4937,19 +5123,6 @@
       minimapModeBtn.addEventListener('click', toggleMinimapMode);
     }
 
-    threadButtons.forEach((button) => {
-      button.addEventListener('click', () => {
-        const threadId = button.getAttribute('data-thread-mode') || 'drift';
-        if (threadId === 'drift') {
-          setActiveThread('drift');
-          unlockOrientationIfNeeded('Orientation complete: you set your own pace through the route.');
-          return;
-        }
-        startQuestById(threadId);
-        unlockOrientationIfNeeded('Orientation complete: you picked a thread to follow.');
-      });
-    });
-
     pauseBtn.addEventListener('click', pauseSim);
     resetBtn.addEventListener('click', resetToStart);
 
@@ -4988,6 +5161,10 @@
     if (tutorialOpenBtn) tutorialOpenBtn.addEventListener('click', openTutorialOverlay);
     tutorialCloseEls.forEach((button) => button.addEventListener('click', closeTutorialOverlay));
     if (tutorialStartBtn) tutorialStartBtn.addEventListener('click', () => { closeTutorialOverlay(); resetToStart(); setStatus('Tutorial started. Click into the scene, then wander toward whatever catches your attention first.'); });
+    if (renameWalkerBtn) renameWalkerBtn.addEventListener('click', () => openWalkerNameOverlay(state.walkerName));
+    if (walkerStartBtn) walkerStartBtn.addEventListener('click', () => confirmWalkerName(walkerNameInputEl ? walkerNameInputEl.value : state.walkerName));
+    if (walkerSkipBtn) walkerSkipBtn.addEventListener('click', () => confirmWalkerName('Walker'));
+    if (walkerNameInputEl) walkerNameInputEl.addEventListener('keydown', (event) => { if (event.key === 'Enter') { event.preventDefault(); confirmWalkerName(walkerNameInputEl.value); } });
     if (lowGraphicsToggle) lowGraphicsToggle.addEventListener('change', (event) => setLowGraphicsMode(event.target.checked));
     if (reopenTutorialToggle) reopenTutorialToggle.addEventListener('change', (event) => { try { window.localStorage.setItem('gastownTutorialReopen', event.target.checked ? '1' : '0'); } catch (error) {} });
     if (dialogModalEl) {
@@ -5133,8 +5310,9 @@
       });
       minimapState.worldMetrics = getWorldMetrics();
       try { if (window.localStorage.getItem('gastownLowGraphics') === '1') { setLowGraphicsMode(true); } } catch (error) {}
+      const hadWalkerName = restoreWalkerName();
       state.progression.openingObjectiveStartedAt = window.performance && typeof window.performance.now === 'function' ? window.performance.now() : Date.now();
-      setQuestStatus('Choose your own lead through Gastown.');
+      setQuestStatus('Get your bearings and see what the street gives you.');
       restoreMinimapZoom();
       restoreMinimapMode();
       updateSize();
@@ -5143,10 +5321,11 @@
       applyWeather(state.activeWeather);
       resetToStart();
       setActiveThread('drift', { silent: true });
-      pushJournalEntry('Arrived at the station threshold. Start anywhere: drift, survey, soundwalk, or memory walk.');
+      pushJournalEntry('Arrived at the station threshold. The walk is already underway; start where the block feels most alive.');
       renderProgressionUi();
       updateNextMeaningfulThing();
       attachEvents();
+      if (!hadWalkerName) { openWalkerNameOverlay(''); }
       setDebugState(state.debugEnabled);
       if (state.debugEnabled) {
         debugPanel.removeAttribute('hidden');

--- a/page-gastown-sim.php
+++ b/page-gastown-sim.php
@@ -10,13 +10,14 @@ get_header();
     <header class="gastown-sim-header">
       <p class="gastown-sim-kicker">Prototype route: Waterfront Station → Water Street → Steam Clock</p>
       <h1>Gastown First-Person Simulator</h1>
-      <p class="gastown-sim-intro">A stylized, geographically grounded Gastown walk through a focused Water Street slice shaped as self-directed exploration. Wander between street details, route survey, soundwalk, and memory walk at your own pace.</p>
+      <p class="gastown-sim-intro">A stylized, geographically grounded Gastown walk built for wandering, noticing, and letting the block answer back. Start loose, move with the street, and see what the corridor decides to reveal.</p>
     </header>
 
     <div class="gastown-controls" role="group" aria-label="Simulator controls">
       <button type="button" class="pixel-button secondary" data-action="pause">Pause</button>
       <button type="button" class="pixel-button secondary" data-action="reset" aria-label="Reset to the start of the route">Reset to route start</button>
       <button type="button" class="pixel-button secondary" data-action="tutorial-open" aria-label="Open the controls tutorial overlay">Tutorial</button>
+      <button type="button" class="pixel-button secondary" data-action="rename-walker" aria-label="Rename your walker">Rename walker</button>
       <label>
         Time of day
         <select name="time-of-day">
@@ -65,11 +66,10 @@ get_header();
         <li><strong>Arrow keys</strong> = move forward/back + turn left/right</li>
         <li><strong>Mouse wheel</strong> = look up/down (while focused/in play mode)</li>
         <li><strong>Ctrl + ↑ / Ctrl + ↓</strong> = precise look up/down steps</li>
+        <li><strong>E / click</strong> = talk or log something nearby</li>
         <li><strong>Esc</strong> = release pointer / pause</li>
       </ul>
     </section>
-
-
 
     <section class="gastown-tutorial-overlay" data-tutorial-overlay role="dialog" aria-modal="true" aria-labelledby="gastown-tutorial-title" aria-describedby="gastown-tutorial-copy" hidden>
       <div class="gastown-dialog-panel">
@@ -79,8 +79,9 @@ get_header();
         </div>
         <div class="gastown-dialog-body" id="gastown-tutorial-copy">
           <p>Click the scene to lock the pointer, use the mouse to look around, and move with W A S D or the arrow keys.</p>
-          <p>Press E or click on nearby characters to talk. Press M M quickly to toggle the minimap between north-up and heading-up orientation.</p>
-          <p>Screen reader note: status updates, landmark callouts, thread changes, and journal updates are announced below the simulator.</p>
+          <p>Press E or click when a nearby local or street detail is in reach. You do not need to pick a route style first; the walk learns from what you linger on.</p>
+          <p>NPC voices use AI-generated speech when available. If audio or speech fails, the conversation stays on screen and the sim keeps moving.</p>
+          <p>Screen reader note: status updates, landmark callouts, and journal updates are announced below the simulator.</p>
         </div>
         <div class="gastown-dialog-actions">
           <button type="button" class="pixel-button secondary" data-action="tutorial-start" aria-label="Start the simulator tutorial">Start tutorial</button>
@@ -88,50 +89,68 @@ get_header();
         </div>
       </div>
     </section>
-    <p class="gastown-status" data-sim-status aria-live="polite">Loading simulator...</p>
-    <p class="gastown-quest-status" data-sim-quest-status aria-live="polite">Street details log: inactive.</p>
-    <section class="gastown-expedition-panel" aria-label="Exploration journal and guidance">
-      <div class="gastown-expedition-card">
-        <p class="gastown-expedition-label">Choose a thread</p>
-        <div class="gastown-thread-buttons" role="group" aria-label="Exploration threads">
-          <button type="button" class="pixel-button secondary" data-thread-mode="drift" aria-pressed="true">Drift</button>
-          <button type="button" class="pixel-button secondary" data-thread-mode="survey" aria-pressed="false">Survey</button>
-          <button type="button" class="pixel-button secondary" data-thread-mode="soundwalk" aria-pressed="false">Soundwalk</button>
-          <button type="button" class="pixel-button secondary" data-thread-mode="stories" aria-pressed="false">Memory walk</button>
+
+    <section class="gastown-name-overlay" data-name-overlay role="dialog" aria-modal="true" aria-labelledby="gastown-name-title" hidden>
+      <div class="gastown-dialog-panel gastown-name-panel">
+        <div class="gastown-dialog-header">
+          <h2 id="gastown-name-title">Name your walker</h2>
+        </div>
+        <div class="gastown-dialog-body">
+          <p>Give your walker a street name, or skip and keep it simple.</p>
+          <label class="gastown-name-field">
+            <span>Walker name</span>
+            <input type="text" maxlength="24" autocomplete="nickname" data-walker-name-input placeholder="Walker">
+          </label>
+        </div>
+        <div class="gastown-dialog-actions">
+          <button type="button" class="pixel-button secondary" data-action="walker-start">Start</button>
+          <button type="button" class="pixel-button secondary" data-action="walker-skip">Skip</button>
         </div>
       </div>
-      <div class="gastown-expedition-card">
-        <p class="gastown-expedition-label">Opening objective</p>
-        <p class="gastown-expedition-value" data-sim-objective aria-live="polite">Choose your own lead through Gastown.</p>
+    </section>
+
+    <section class="gastown-hud" aria-label="Exploration HUD">
+      <div class="gastown-hud-top">
+        <div class="gastown-hud-identity">
+          <p class="gastown-hud-kicker">ON THE STREET</p>
+          <p class="gastown-hud-name" data-walker-name-display>Walker</p>
+          <p class="gastown-hud-subline">Get your bearings and see what the street gives you.</p>
+        </div>
+        <div class="gastown-hud-statuses">
+          <p class="gastown-status" data-sim-status aria-live="polite">Loading simulator...</p>
+          <p class="gastown-quest-status" data-sim-quest-status aria-live="polite">Street details log: inactive.</p>
+          <p class="gastown-pointer-status" data-sim-pointer-status aria-live="polite">Pointer unlocked.</p>
+          <p class="gastown-interact-prompt" data-sim-interact-prompt aria-live="polite" hidden></p>
+        </div>
+        <div class="gastown-hud-route">
+          <p class="gastown-expedition-label">Route completion</p>
+          <p class="gastown-expedition-value" data-sim-route-score aria-live="polite">0% of the corridor surveyed.</p>
+          <p class="gastown-hud-disclosure">AI voice talkback is optional and may stay silent if your browser or the API says no.</p>
+        </div>
       </div>
-      <div class="gastown-expedition-card">
-        <p class="gastown-expedition-label">Next meaningful step</p>
-        <p class="gastown-expedition-value" data-sim-next-step aria-live="polite">Look around and follow what catches your attention.</p>
-      </div>
-      <div class="gastown-expedition-card">
-        <p class="gastown-expedition-label">Route completion</p>
-        <p class="gastown-expedition-value" data-sim-route-score aria-live="polite">0% of the corridor surveyed.</p>
-      </div>
-      <div class="gastown-expedition-card">
-        <p class="gastown-expedition-label">Street details log</p>
-        <ul class="gastown-expedition-list" data-sim-collectibles-log aria-live="polite">
-          <li>Newspaper box — not logged</li>
-          <li>Historic plaque — not logged</li>
-          <li>Painted brick panel — not logged</li>
-        </ul>
-      </div>
-      <div class="gastown-expedition-card">
-        <p class="gastown-expedition-label">Journal</p>
-        <ul class="gastown-expedition-list" data-sim-journal aria-live="polite">
-          <li>Arrive at the station threshold and choose where to begin.</li>
-        </ul>
+
+      <div class="gastown-hud-support">
+        <div class="gastown-hud-card gastown-hud-card--prompt">
+          <p class="gastown-expedition-label">Current drift</p>
+          <p class="gastown-expedition-value" data-sim-objective aria-live="polite">Get your bearings and see what the street gives you.</p>
+          <p class="gastown-expedition-value gastown-hud-next-step" data-sim-next-step aria-live="polite">Look around, move a little, and follow what feels alive.</p>
+        </div>
+        <div class="gastown-hud-card gastown-hud-card--journal">
+          <p class="gastown-expedition-label">Journal</p>
+          <ul class="gastown-expedition-list" data-sim-journal aria-live="polite">
+            <li>Arrive at the station threshold and get your bearings.</li>
+          </ul>
+        </div>
+        <div class="gastown-hud-card gastown-hud-card--details">
+          <p class="gastown-expedition-label">Street details log</p>
+          <ul class="gastown-expedition-list" data-sim-collectibles-log aria-live="polite">
+            <li>Newspaper box — not logged</li>
+            <li>Historic plaque — not logged</li>
+            <li>Painted brick panel — not logged</li>
+          </ul>
+        </div>
       </div>
     </section>
-    <p class="gastown-world-status" data-sim-world-status aria-live="polite">World data status: checking build provenance…</p>
-    <p class="gastown-pointer-status" data-sim-pointer-status aria-live="polite">Pointer unlocked.</p>
-    <p class="gastown-landmark" data-sim-landmark aria-live="polite">Nearest landmark: Station threshold</p>
-    <p class="gastown-route-segment" data-sim-route-segment aria-live="polite">Route segment: Waterfront Station Threshold</p>
-    <p class="gastown-interact-prompt" data-sim-interact-prompt aria-live="polite" hidden></p>
 
     <div class="gastown-sim-canvas" data-sim-canvas tabindex="-1">
       <aside class="gastown-minimap" aria-label="Exploration minimap">
@@ -151,12 +170,18 @@ get_header();
           <li>Sidewalk / plaza</li>
           <li>Road</li>
           <li>Landmark</li>
-          <li>Thread hint</li>
+          <li>Ambient hint</li>
           <li>Observations</li>
         </ul>
         <p class="gastown-minimap-label" data-sim-minimap-landmark>Nearest landmark: Waterfront Station threshold — ahead</p>
       </aside>
       <pre class="gastown-route-debug-overlay" data-route-debug-overlay hidden></pre>
+    </div>
+
+    <div class="gastown-meta-strip">
+      <p class="gastown-world-status" data-sim-world-status aria-live="polite">World data status: checking build provenance…</p>
+      <p class="gastown-landmark" data-sim-landmark aria-live="polite">Nearest landmark: Station threshold</p>
+      <p class="gastown-route-segment" data-sim-route-segment aria-live="polite">Route segment: Waterfront Station Threshold</p>
     </div>
 
     <section class="gastown-debug" data-debug-panel hidden>
@@ -172,10 +197,6 @@ get_header();
       </ul>
     </section>
 
-    <!-- Template-ready teaser for homepage placement later.
-      In progress: Gastown first-person simulator.
-      Frequent updates are expected; hard refresh / clear cache may be needed after releases.
-    -->
     <p class="gastown-teaser-snippet" hidden>
       In progress: our Gastown first-person simulator is evolving quickly. We ship frequent updates, so if a change looks odd, please hard refresh and clear cache.
     </p>
@@ -193,6 +214,7 @@ get_header();
         </div>
         <div class="gastown-dialog-body" data-dialog-body></div>
         <div class="gastown-dialog-actions">
+          <div class="gastown-dialog-audio-status" data-dialog-audio-status aria-live="polite"></div>
           <div class="gastown-dialog-actions-dynamic" data-dialog-actions-dynamic aria-live="polite"></div>
           <button type="button" class="pixel-button secondary" data-dialog-close data-dialog-close-fallback>Back to walk</button>
         </div>


### PR DESCRIPTION
### Motivation
- Replace the modal “Choose a thread” flow with an implicit, free-exploration opening and language that encourages wandering and discovery. 
- Tighten the UI so the 3D scene is visually prioritized and the HUD feels game-like rather than a tall dashboard. 
- Make NPC conversation reliable and lively by fixing E/click interaction failures and adding optional OpenAI TTS while keeping the sim resilient to failures. 
- Reduce turn-around visual artifacts by simplifying/smoothing reflective and translucent ground/landmark layers.

### Description
- Removed the visible thread picker and reframed opening copy and ambient hinting; substituted free-explore wording and ambient hint language (changes in `page-gastown-sim.php` and `js/gastown-sim.js`).
- Rebuilt the HUD and tightened layout with a compact top identity/status area plus a slim support panel and compact journal/details list, and updated CSS accordingly (`page-gastown-sim.php`, `assets/css/gastown-sim.css`).
- Added avatar naming flow with lightweight overlay, localStorage persistence, rename control, and HUD display of the walker name (`page-gastown-sim.php`, `js/gastown-sim.js`).
- Reworked NPC interaction: replaced brittle ray-only detection with a scored candidate system (distance, facing cone, centered bonus, ray bonus), improved E / click behavior and prompt text, and kept pointer-lock friendly behavior (`js/gastown-sim.js`).
- Added OpenAI-powered NPC TTS support: new TTS helper `se_openai_tts()` (in `inc/openai.php`), added REST endpoint `POST /se/v1/gastown-npc-voice` and localized `voiceEndpoint` (in `functions.php`), and frontend request/caching/playback with graceful fallbacks and audio-status UI (`js/gastown-sim.js`, `page-gastown-sim.php`).
- Made visual stability fixes by reducing reflectivity/opacity on surface bands, adjusting render order and depth settings on plane/steam/reflection materials to reduce ghosting when turning around (`js/gastown-sim.js`).
- Deduplicated street details log in the UI by collectible identity so repeated scene props do not create duplicate journal/log entries (`js/gastown-sim.js`).
- Defensive behavior: TTS, audio, and conversation fetches fail silently to keep text dialog and gameplay live; audio only auto-plays after user interaction and cached by text-hash to avoid regen (`js/gastown-sim.js`, `inc/openai.php`, `functions.php`).

### Testing
- Ran PHP syntax checks: `php -l page-gastown-sim.php`, `php -l functions.php`, `php -l inc/openai.php` (all succeeded).
- Verified JS syntax with `node --check js/gastown-sim.js` (succeeded).
- Confirmed removal/rephrasing of thread UI via `rg` for player-facing "Choose a thread"/"thread" references (no player-facing thread chooser remains).
- Validated collectible dedupe against `assets/world/gastown-water-street.json` via a small Python check for unique collectible keys (unique set confirmed).
- Manual run-time safety measures added so TTS/REST/audio failures fall back to text and do not crash the sim (front-end logic includes fallbacks and audio status messaging).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c101196498832e9031191e80f3ed37)