### PR TITLE
Gameplay-feel pass: compact HUD, dialog fixes, busker riff endpoint, and street polish

### DIFF
--- a/assets/css/gastown-sim.css
+++ b/assets/css/gastown-sim.css
@@ -4,27 +4,31 @@
     radial-gradient(circle at 76% 18%, rgba(203, 146, 89, 0.15) 0, rgba(8, 11, 17, 0) 28%),
     linear-gradient(180deg, #111824 0%, #080a10 56%, #040507 100%);
   color: #d5dde8;
-  padding: 1.2rem 1rem 2.4rem;
+  padding: 1rem 0.9rem 2.2rem;
 }
 
 .gastown-sim-shell {
   max-width: 1280px;
   margin: 0 auto;
   display: grid;
-  gap: 0.8rem;
-  background:
-    linear-gradient(180deg, rgba(10, 13, 20, 0.88), rgba(8, 10, 15, 0.92)),
-    rgba(8, 11, 18, 0.75);
+  gap: 0.75rem;
+  background: linear-gradient(180deg, rgba(10, 13, 20, 0.9), rgba(8, 10, 15, 0.94));
   border: 1px solid rgba(173, 190, 215, 0.16);
   border-radius: 16px;
-  padding: 1rem;
+  padding: 0.9rem;
   box-shadow: 0 22px 60px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.05);
   backdrop-filter: blur(10px);
 }
 
-.gastown-sim-header h1 {
+.gastown-sim-header h1,
+.gastown-help h2,
+.gastown-debug h2 {
   margin: 0;
-  font-size: clamp(1.5rem, 3.5vw, 2.4rem);
+}
+
+.gastown-sim-header {
+  display: grid;
+  gap: 0.2rem;
 }
 
 .gastown-sim-kicker,
@@ -34,162 +38,169 @@
 .gastown-route-segment,
 .gastown-world-status,
 .gastown-pointer-status,
-.gastown-quest-status {
+.gastown-quest-status,
+.gastown-hud-detail-count {
   margin: 0;
 }
 
 .gastown-sim-intro {
-  margin-top: 0.35rem;
-  max-width: 72ch;
-  line-height: 1.5;
+  color: rgba(224, 236, 249, 0.88);
+  font-size: 0.95rem;
+}
+
+.gastown-controls-drawer,
+.gastown-log-drawer {
+  border: 1px solid rgba(170, 197, 226, 0.18);
+  border-radius: 10px;
+  background: linear-gradient(180deg, rgba(16, 22, 33, 0.78), rgba(8, 11, 18, 0.9));
+}
+
+.gastown-controls-drawer summary,
+.gastown-log-drawer summary {
+  cursor: pointer;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8fc8ff;
 }
 
 .gastown-controls {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.6rem;
+  gap: 0.55rem;
+  padding: 0 0.75rem 0.75rem;
 }
 
 .gastown-controls label {
   display: inline-flex;
   flex-direction: column;
-  gap: 0.24rem;
-  font-size: 0.85rem;
+  gap: 0.2rem;
+  font-size: 0.78rem;
 }
 
 .gastown-controls select,
 .gastown-name-field input {
-  min-width: 130px;
+  min-width: 118px;
   border-radius: 6px;
   border: 1px solid rgba(200, 214, 236, 0.3);
   background: #0f131b;
   color: #dce5f3;
-  padding: 0.45rem 0.55rem;
+  padding: 0.42rem 0.52rem;
 }
 
 .gastown-help {
-  padding: 0.7rem 0.9rem;
-  border: 1px solid rgba(193, 213, 238, 0.26);
-  border-radius: 10px;
-  background: linear-gradient(160deg, rgba(31, 39, 55, 0.8), rgba(10, 13, 19, 0.88));
-}
-
-.gastown-help h2 {
-  margin: 0 0 0.35rem;
-  font-size: 1rem;
+  padding: 0 0.75rem 0.75rem;
+  color: rgba(219, 232, 248, 0.92);
 }
 
 .gastown-help ul {
-  margin: 0;
+  margin: 0.4rem 0 0;
   padding-left: 1rem;
   display: grid;
-  gap: 0.2rem;
+  gap: 0.18rem;
+}
+
+.gastown-help-note {
+  margin: 0.5rem 0 0;
+  color: #b8d7f4;
+  font-size: 0.8rem;
 }
 
 .gastown-hud {
   display: grid;
-  gap: 0.7rem;
-}
-
-.gastown-hud-top {
-  display: grid;
-  grid-template-columns: minmax(220px, 1fr) minmax(340px, 1.8fr) minmax(210px, 0.9fr);
-  gap: 0.7rem;
-  align-items: start;
+  grid-template-columns: minmax(220px, 1fr) auto;
+  gap: 0.6rem 0.75rem;
+  align-items: end;
 }
 
 .gastown-hud-identity,
-.gastown-hud-statuses,
 .gastown-hud-route,
 .gastown-hud-card,
 .gastown-meta-strip > * {
-  padding: 0.7rem 0.8rem;
+  padding: 0.65rem 0.75rem;
   border-radius: 10px;
   border: 1px solid rgba(170, 197, 226, 0.22);
   background: linear-gradient(180deg, rgba(16, 22, 33, 0.8), rgba(8, 11, 18, 0.92));
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
 }
 
 .gastown-hud-kicker,
 .gastown-expedition-label {
-  margin: 0 0 0.28rem;
-  font-size: 0.72rem;
+  margin: 0 0 0.24rem;
+  font-size: 0.68rem;
   font-weight: 700;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
   color: #8fc8ff;
 }
 
 .gastown-hud-name {
   margin: 0;
-  font-size: clamp(1.15rem, 2.1vw, 1.6rem);
+  font-size: clamp(1.1rem, 2.2vw, 1.55rem);
+  line-height: 1;
   color: #f6fbff;
+  text-transform: uppercase;
 }
 
 .gastown-hud-subline,
-.gastown-hud-disclosure {
-  margin: 0.3rem 0 0;
+.gastown-expedition-value,
+.gastown-hud-detail-count,
+.gastown-minimap-mode-status,
+.gastown-minimap-context,
+.gastown-minimap-label,
+.gastown-attribution {
   font-size: 0.82rem;
-  line-height: 1.4;
-  color: rgba(220, 236, 255, 0.85);
+  line-height: 1.3;
 }
 
-.gastown-hud-statuses {
+.gastown-hud-subline {
+  margin: 0.25rem 0 0;
+  color: #ffe9b8;
+}
+
+.gastown-hud-route {
   display: grid;
-  gap: 0.45rem;
+  justify-items: end;
+  gap: 0.16rem;
+  min-width: 140px;
 }
 
-.gastown-status,
-.gastown-world-status,
-.gastown-pointer-status,
-.gastown-landmark,
-.gastown-route-segment,
-.gastown-quest-status,
+.gastown-hud-route .gastown-expedition-value {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #f7fbff;
+}
+
+.gastown-hud-detail-count {
+  color: #bdd8ff;
+}
+
+.gastown-interact-prompt[hidden],
+.gastown-dialog-modal[hidden],
+.gastown-name-overlay[hidden],
+.gastown-tutorial-overlay[hidden] {
+  display: none !important;
+}
+
 .gastown-interact-prompt {
-  padding: 0.28rem 0.55rem;
-  border-left: 2px solid rgba(192, 211, 237, 0.45);
-  background: linear-gradient(180deg, rgba(15, 20, 29, 0.7), rgba(10, 14, 22, 0.42));
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
-}
-
-.gastown-world-status {
-  border-left-color: rgba(255, 196, 120, 0.88);
-  background: rgba(39, 24, 7, 0.42);
-  color: #ffe2bf;
-}
-
-.gastown-pointer-status { color: #bdd8ff; }
-.gastown-quest-status { color: #d6f0c4; }
-
-.gastown-hud-support {
-  display: grid;
-  grid-template-columns: minmax(260px, 1.1fr) minmax(220px, 0.9fr) minmax(220px, 0.9fr);
-  gap: 0.7rem;
-}
-
-.gastown-hud-card--prompt { min-height: 0; }
-.gastown-hud-next-step { margin-top: 0.5rem; color: #fff1c7; }
-
-.gastown-expedition-value {
+  grid-column: 1 / -1;
   margin: 0;
-  color: #edf5ff;
-  line-height: 1.45;
-}
-
-.gastown-expedition-list {
-  margin: 0;
-  padding-left: 1rem;
-  display: grid;
-  gap: 0.28rem;
-  color: #d9e8ff;
-  font-size: 0.9rem;
+  justify-self: start;
+  padding: 0.32rem 0.58rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 205, 116, 0.88);
+  background: rgba(30, 21, 10, 0.9);
+  color: #fff5dd;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.03) inset;
 }
 
 .gastown-sim-canvas {
   position: relative;
   width: 100%;
-  min-height: 540px;
+  min-height: 560px;
   border-radius: 12px;
   overflow: hidden;
   border: 1px solid rgba(164, 182, 209, 0.22);
@@ -212,7 +223,7 @@
 }
 
 .gastown-sim-canvas::after {
-  background: linear-gradient(180deg, rgba(4, 5, 8, 0.08), rgba(4, 5, 8, 0.24));
+  background: linear-gradient(180deg, rgba(4, 5, 8, 0.06), rgba(4, 5, 8, 0.22));
   box-shadow: inset 0 0 100px rgba(0, 0, 0, 0.25);
 }
 
@@ -222,16 +233,29 @@
   height: auto !important;
 }
 
-.gastown-meta-strip {
+.gastown-live-strip {
+  position: absolute;
+  right: 0.8rem;
+  top: 0.8rem;
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.7rem;
+  gap: 0.35rem;
+  max-width: min(260px, 36vw);
+}
+
+.gastown-pointer-status,
+.gastown-landmark,
+.gastown-route-segment,
+.gastown-world-status {
+  padding: 0.28rem 0.5rem;
+  border-radius: 7px;
+  background: rgba(10, 16, 25, 0.82);
+  border: 1px solid rgba(164, 190, 218, 0.18);
 }
 
 .gastown-route-debug-overlay {
   position: absolute;
   right: 0.75rem;
-  top: 0.75rem;
+  top: 4.75rem;
   margin: 0;
   max-width: min(360px, 45vw);
   max-height: 52%;
@@ -255,10 +279,10 @@
   bottom: 0.85rem;
   width: 220px;
   display: grid;
-  gap: 0.38rem;
+  gap: 0.34rem;
   padding: 0.45rem;
   border-radius: 10px;
-  background: linear-gradient(180deg, rgba(10, 15, 23, 0.92), rgba(7, 11, 18, 0.86));
+  background: linear-gradient(180deg, rgba(10, 15, 23, 0.92), rgba(7, 11, 18, 0.88));
   border: 1px solid rgba(136, 170, 204, 0.42);
   box-shadow: 0 8px 22px rgba(0, 0, 0, 0.44);
   backdrop-filter: blur(8px);
@@ -272,7 +296,6 @@
   border: 1px solid rgba(172, 201, 230, 0.24);
 }
 
-.gastown-minimap-label { margin: 0.38rem 0 0; font-size: 0.75rem; line-height: 1.2; color: #dbe9ff; }
 .gastown-minimap-toolbar { display: flex; justify-content: flex-end; align-items: center; gap: 0.35rem; }
 .gastown-minimap-mode, .gastown-minimap-zoom { height: 1.7rem; font-size: 0.72rem; font-weight: 700; border-radius: 6px; border: 1px solid rgba(174, 207, 239, 0.5); background: rgba(18, 28, 41, 0.95); color: #e8f3ff; line-height: 1; cursor: pointer; }
 .gastown-minimap-mode { min-width: 5.6rem; padding: 0 0.55rem; }
@@ -280,10 +303,10 @@
 .gastown-minimap-mode[data-minimap-mode="heading-up"] { border-color: rgba(255, 197, 126, 0.78); color: #fff3de; box-shadow: inset 0 0 0 1px rgba(255, 197, 126, 0.18); }
 .gastown-minimap-zoom { width: 1.7rem; padding: 0; font-size: 1rem; }
 .gastown-minimap-mode:hover, .gastown-minimap-mode:focus-visible, .gastown-minimap-zoom:hover, .gastown-minimap-zoom:focus-visible { background: rgba(36, 53, 74, 0.95); outline: none; }
-.gastown-minimap-context { margin: 0.28rem 0 0.18rem; font-size: 0.68rem; line-height: 1.45; color: rgba(220, 236, 255, 0.92); }
 .gastown-minimap-context strong, .gastown-minimap-mode-status strong { color: #f5fbff; }
-.gastown-minimap-mode-status { margin: 0; padding: 0.35rem 0.45rem; border-radius: 8px; background: rgba(18, 28, 41, 0.96); border: 1px solid rgba(126, 178, 226, 0.24); color: #ecf5ff; font-size: 0.71rem; line-height: 1.35; }
-.gastown-minimap-legend { list-style: none; margin: 0.12rem 0 0; padding: 0; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.18rem 0.5rem; font-size: 0.68rem; color: rgba(220, 236, 255, 0.9); }
+.gastown-minimap-mode-status { margin: 0; color: #ecf5ff; }
+.gastown-minimap-context { margin: 0.22rem 0 0.14rem; color: rgba(220, 236, 255, 0.92); }
+.gastown-minimap-legend { list-style: none; margin: 0.08rem 0 0; padding: 0; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.18rem 0.5rem; font-size: 0.68rem; color: rgba(220, 236, 255, 0.9); }
 .gastown-minimap-legend li { display: inline-flex; align-items: center; gap: 0.3rem; white-space: nowrap; }
 .gastown-minimap-legend .dot { width: 0.48rem; height: 0.48rem; border-radius: 999px; display: inline-block; border: 1px solid rgba(235, 245, 255, 0.58); }
 .gastown-minimap-legend .dot.player { background: radial-gradient(circle at 35% 35%, #ffffff 0, #b7ecff 58%, #3f8fca 100%); }
@@ -294,23 +317,40 @@
 .gastown-minimap-legend .dot.steam { background: #d8a968; }
 .gastown-minimap-legend .dot.nearest { background: #8af7cb; }
 
-.gastown-attribution { margin-top: 0.2rem; font-size: 0.78rem; line-height: 1.35; color: rgba(209, 223, 242, 0.86); }
-.gastown-attribution p { margin: 0.1rem 0; }
-
-.gastown-interact-prompt[hidden],
-.gastown-dialog-modal[hidden],
-.gastown-name-overlay[hidden] {
-  display: none !important;
+.gastown-meta-strip,
+.gastown-hud-support {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
+  padding: 0 0.75rem 0.75rem;
 }
 
-.gastown-interact-prompt {
-  display: inline-block;
-  border-left-color: rgba(255, 205, 116, 0.92);
-  color: #fff5dd;
+.gastown-hud-support {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  padding-top: 0;
+}
+
+.gastown-expedition-list {
+  margin: 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.2rem;
+  color: #d9e8ff;
+  font-size: 0.86rem;
+}
+
+.gastown-hud-next-step {
+  color: #fff1c7;
+}
+
+.gastown-attribution {
+  margin-top: 0.1rem;
+  color: rgba(209, 223, 242, 0.86);
 }
 
 .gastown-dialog-modal,
-.gastown-name-overlay {
+.gastown-name-overlay,
+.gastown-tutorial-overlay {
   position: fixed;
   inset: 0;
   z-index: 30;
@@ -337,8 +377,8 @@
 .gastown-name-field span { font-size: 0.82rem; color: #b9d6f7; }
 .gastown-dialog-header, .gastown-dialog-actions { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; }
 .gastown-dialog-header h2 { margin: 0; font-size: 1.2rem; }
-.gastown-dialog-body { margin-top: 0.85rem; color: #e7eef8; line-height: 1.55; }
-.gastown-dialog-body p { margin: 0 0 0.8rem; }
+.gastown-dialog-body { margin-top: 0.85rem; color: #e7eef8; line-height: 1.5; }
+.gastown-dialog-body p { margin: 0 0 0.7rem; }
 .gastown-dialog-actions { margin-top: 1rem; justify-content: flex-end; flex-wrap: wrap; }
 .gastown-dialog-actions-dynamic { display: flex; flex-wrap: wrap; gap: 0.65rem; }
 .gastown-dialog-audio-status { margin-right: auto; font-size: 0.78rem; color: #c3d9f4; }
@@ -351,9 +391,9 @@
 }
 
 @media (max-width: 980px) {
-  .gastown-hud-top,
-  .gastown-hud-support,
-  .gastown-meta-strip {
+  .gastown-hud,
+  .gastown-meta-strip,
+  .gastown-hud-support {
     grid-template-columns: 1fr;
   }
 }
@@ -363,4 +403,5 @@
   .gastown-sim-page { padding-inline: 0.45rem; }
   .gastown-sim-shell { padding: 0.7rem; }
   .gastown-sim-canvas { min-height: 460px; }
+  .gastown-live-strip { max-width: 46vw; }
 }

--- a/assets/dialog/gastown.json
+++ b/assets/dialog/gastown.json
@@ -2,9 +2,9 @@
   "guide_intro": {
     "title": "Gastown local",
     "lines": [
-      "You can begin anywhere from the station threshold: drift toward a detail, survey the route, follow the soundscape, or treat the walk like a memory map.",
-      "This area is on the unceded territories of the Musqueam, Squamish, and Tsleil-Waututh Nations, so the simulator keeps its public-history framing place-based and lightweight.",
-      "Use the minimap and nearby people as optional cues, then let the street rhythm pull you where it will."
+      "Start walking. The street will tell you what matters first.",
+      "Look for the sax, the storefront glow, and the pull toward the clock.",
+      "This place sits on the unceded territories of the Musqueam, Squamish, and Tsleil-Waututh Nations."
     ],
     "actions": [
       {
@@ -19,7 +19,7 @@
           "location": "waterfront_station"
         },
         "lines": [
-          "In the morning this end of the route still feels half commuter corridor, half heritage reveal — you can watch office workers peel away while visitors are only just orienting themselves."
+          "In the morning this end of the route still feels half commuter corridor, half heritage reveal \u2014 you can watch office workers peel away while visitors are only just orienting themselves."
         ]
       },
       {
@@ -41,11 +41,11 @@
     ]
   },
   "busker_clock_corner": {
-    "title": "Clock-corner busker",
+    "title": "Sax busker",
     "lines": [
-      "The Steam Clock was built in 1977 by Raymond Saunders after the city covered an old steam vent here on Water Street.",
-      "This corner becomes more interesting once you have actually stood in the plaza and then pushed through toward Maple Tree Square — the landmark stops being a photo stop and starts feeling like a hinge in the route.",
-      "Come back after a few discoveries and I will help you compare the soundwalk with the memory walk."
+      "You hear me before you see the clock. That is the point.",
+      "This stretch wakes up once the tourists, food spots, and station spill start mixing.",
+      "Keep moving east when you are ready."
     ],
     "actions": [
       {
@@ -60,7 +60,7 @@
           "location": "steam_clock"
         },
         "lines": [
-          "Rain changes my set here — people bunch under the awnings, listen for a minute, then dart back out when the whistle blows."
+          "Rain changes my set here \u2014 people bunch under the awnings, listen for a minute, then dart back out when the whistle blows."
         ]
       },
       {
@@ -85,8 +85,8 @@
   "pedestrian_route_tip": {
     "title": "Water Street walker",
     "lines": [
-      "Water Street still feels like old Gastown because the narrow lots and warehouse façades keep the block tight and walkable.",
-      "Before tourists filled the sidewalks, this corridor served the port economy — teamsters, merchants, and dock traffic all funneled through here.",
+      "Water Street still feels like old Gastown because the narrow lots and warehouse fa\u00e7ades keep the block tight and walkable.",
+      "Before tourists filled the sidewalks, this corridor served the port economy \u2014 teamsters, merchants, and dock traffic all funneled through here.",
       "If you ask me for a second tip, I'll tell you where the neighbourhood really started."
     ],
     "actions": [
@@ -136,7 +136,7 @@
           "location": "steam_clock"
         },
         "lines": [
-          "Closer to the Steam Clock, the flow changes every few seconds — somebody stops for a photo, somebody slips around them, and the whole street recomposes itself."
+          "Closer to the Steam Clock, the flow changes every few seconds \u2014 somebody stops for a photo, somebody slips around them, and the whole street recomposes itself."
         ]
       },
       {
@@ -150,11 +150,10 @@
     ]
   },
   "tourist_clock_stop": {
-    "title": "Steam Clock visitor",
+    "title": "Tourist",
     "lines": [
-      "We came for the Steam Clock, but the surprise is how much story is packed into one intersection — steam pipes below, brick warehouses above, and Maple Tree Square only steps away.",
-      "People love that it looks Victorian even though it is a 1977 creation; it is basically a heritage stage prop that became a real city icon.",
-      "Ask a second question and I'll tell you the best moment to stand here for the chime."
+      "We stopped for the street first, not just the clock.",
+      "The fun bit is how fast the block turns from station edge to old brick postcard."
     ],
     "actions": [
       {
@@ -187,7 +186,7 @@
           "location": "maple_tree_square"
         },
         "lines": [
-          "Near Maple Tree Square people slow down and point more — it feels less like passing through and more like arriving at the part everyone wants to remember."
+          "Near Maple Tree Square people slow down and point more \u2014 it feels less like passing through and more like arriving at the part everyone wants to remember."
         ]
       }
     ]
@@ -195,9 +194,8 @@
   "tourist_clock_photo": {
     "title": "Street photographer",
     "lines": [
-      "From this angle you can frame the Steam Clock with the old warehouse cornices, which is why photographers keep drifting back to this exact patch of sidewalk.",
-      "Maple Tree Square condenses a lot of urban history into one frame, which is why the image reads as more than a single attraction.",
-      "Give me a second prompt and I'll share the trick for timing the whistle plume."
+      "This angle catches the paving, the people, and the old facades in one frame.",
+      "It works better once the street has a bit of motion in it."
     ],
     "actions": [
       {
@@ -229,7 +227,7 @@
           "foundProp": "foundHistoricPlaque"
         },
         "lines": [
-          "If you already read the plaque, the image lands differently — you are not just photographing an icon, you are catching a block that knows its own backstory."
+          "If you already read the plaque, the image lands differently \u2014 you are not just photographing an icon, you are catching a block that knows its own backstory."
         ]
       }
     ]
@@ -237,7 +235,7 @@
   "skateboarder_corridor": {
     "title": "Gastown skateboarder",
     "lines": [
-      "The fun part of this block is that the feel changes in stages — threshold, storefront rhythm, clock crowd, then the looser edge near Maple Tree Square.",
+      "The fun part of this block is that the feel changes in stages \u2014 threshold, storefront rhythm, clock crowd, then the looser edge near Maple Tree Square.",
       "If you want a challenge, use me as your cue to survey the route: notice where Water Street starts reading like a real corridor instead of a simple starter strip.",
       "Once you have read the mid-block and the eastern rise, the whole route makes more sense."
     ],
@@ -271,7 +269,7 @@
     "title": "Gastown cyclist",
     "lines": [
       "Riding this stretch teaches you the route structure fast: you can feel when the corridor tightens, when the plaza interrupts it, and when the east leg opens back up.",
-      "Treat the minimap like a soft cue, not a GPS arrow — it is best when it confirms something you already noticed in the street itself.",
+      "Treat the minimap like a soft cue, not a GPS arrow \u2014 it is best when it confirms something you already noticed in the street itself.",
       "If you keep the survey going past the clock, the Cambie rise gives you the last big contrast point."
     ],
     "actions": [
@@ -287,7 +285,7 @@
           "location": "water_street"
         },
         "lines": [
-          "Morning makes this stretch feel more utilitarian — delivery workers, commuters, and early walkers all negotiate the same narrow line."
+          "Morning makes this stretch feel more utilitarian \u2014 delivery workers, commuters, and early walkers all negotiate the same narrow line."
         ]
       },
       {

--- a/assets/world/gastown-water-street.json
+++ b/assets/world/gastown-water-street.json
@@ -5049,6 +5049,33 @@
       "yaw": 0.51,
       "scale": 0.88,
       "randomOffset": true
+    },
+    {
+      "id": "starter-prop-busker-case",
+      "kind": "cardboard_box",
+      "x": 32.0,
+      "y": 0,
+      "z": -33.2,
+      "yaw": -0.82,
+      "scale": 0.86
+    },
+    {
+      "id": "starter-prop-brewery-crate",
+      "kind": "cardboard_box",
+      "x": 43.5,
+      "y": 0,
+      "z": -35.1,
+      "yaw": -0.72,
+      "scale": 0.94
+    },
+    {
+      "id": "starter-prop-sushi-box",
+      "kind": "newspaper_box",
+      "x": 29.0,
+      "y": 0,
+      "z": -24.4,
+      "yaw": -0.72,
+      "scale": 0.8
     }
   ],
   "npcs": [
@@ -5086,11 +5113,22 @@
       "dialogId": "busker_clock_corner",
       "interactRadius": 3,
       "idleSpot": {
-        "x": 183.98,
-        "z": -150.72
+        "x": 32.8,
+        "z": -34.4
       },
       "silhouetteScale": 1.06,
-      "yaw": 1.22
+      "yaw": -0.82,
+      "name": "sax busker",
+      "patrol": [
+        {
+          "x": 31.9,
+          "z": -33.8
+        },
+        {
+          "x": 33.6,
+          "z": -35.1
+        }
+      ]
     },
     {
       "id": "starter-pedestrian-west",
@@ -5145,13 +5183,13 @@
       "dialogId": "skateboarder_corridor",
       "interactRadius": 2.5,
       "idleSpot": {
-        "x": 53.94,
-        "z": -57.27
+        "x": 24.3,
+        "z": -22.1
       },
       "patrol": [
         {
-          "x": 38.41,
-          "z": -44.67
+          "x": 22.6,
+          "z": -20.7
         },
         {
           "x": 74.8,
@@ -5169,17 +5207,17 @@
       "dialogId": "cyclist_water_street",
       "interactRadius": 2.8,
       "idleSpot": {
-        "x": 96.3,
-        "z": -64.82
+        "x": 12.4,
+        "z": -13.1
       },
       "patrol": [
         {
-          "x": 60.12,
-          "z": -37.03
+          "x": 10.2,
+          "z": -11.4
         },
         {
-          "x": 179.4,
-          "z": -131.01
+          "x": 116.2,
+          "z": -96.6
         }
       ],
       "silhouetteScale": 0.99
@@ -5189,22 +5227,22 @@
       "role": "tourist",
       "behavior": "tourist_pause",
       "pose": "group_gather",
-      "companionGroup": "clock-family-a",
+      "companionGroup": "station-tourists-a",
       "voiceCue": "tourist-cluster",
       "dialogId": "tourist_clock_stop",
       "interactRadius": 2.2,
       "idleSpot": {
-        "x": 185.52,
-        "z": -154.27
+        "x": 17.8,
+        "z": -22.4
       },
       "patrol": [
         {
-          "x": 184.55,
-          "z": -153.5
+          "x": 17.1,
+          "z": -21.8
         },
         {
-          "x": 186.25,
-          "z": -154.72
+          "x": 18.4,
+          "z": -22.9
         }
       ]
     },
@@ -5213,22 +5251,22 @@
       "role": "tourist",
       "behavior": "tourist_pause",
       "pose": "being_photographed",
-      "companionGroup": "clock-family-a",
+      "companionGroup": "station-tourists-a",
       "voiceCue": "tourist-cluster",
       "dialogId": "tourist_clock_stop",
       "interactRadius": 2.2,
       "idleSpot": {
-        "x": 184.59,
-        "z": -155.36
+        "x": 19.5,
+        "z": -24.0
       },
       "patrol": [
         {
-          "x": 183.89,
-          "z": -154.77
+          "x": 18.9,
+          "z": -23.5
         },
         {
-          "x": 185.22,
-          "z": -155.76
+          "x": 20.1,
+          "z": -24.4
         }
       ]
     },
@@ -5239,36 +5277,37 @@
       "pose": "taking_photo",
       "heldProp": "camera",
       "voiceCue": "photo-direction",
-      "companionGroup": "clock-family-a",
+      "companionGroup": "station-tourists-b",
       "dialogId": "tourist_clock_photo",
       "interactRadius": 2.4,
       "idleSpot": {
-        "x": 182.4,
-        "z": -155.22
+        "x": 27.4,
+        "z": -28.6
       },
-      "silhouetteScale": 1.02
+      "silhouetteScale": 1.02,
+      "yaw": -0.78
     },
     {
       "id": "starter-tourist-clock-stroller",
       "role": "tourist",
       "behavior": "tourist_wander",
       "pose": "group_gather",
-      "companionGroup": "clock-family-b",
+      "companionGroup": "station-tourists-c",
       "voiceCue": "tourist-cluster",
       "dialogId": "tourist_clock_stop",
       "interactRadius": 2.2,
       "idleSpot": {
-        "x": 183.47,
-        "z": -157.99
+        "x": 35.2,
+        "z": -38.2
       },
       "patrol": [
         {
-          "x": 183.28,
-          "z": -157.26
+          "x": 34.4,
+          "z": -37.6
         },
         {
-          "x": 183.78,
-          "z": -158.89
+          "x": 36.3,
+          "z": -39.1
         }
       ],
       "silhouetteScale": 1.04
@@ -5278,15 +5317,16 @@
       "role": "tourist",
       "behavior": "photo_idle",
       "pose": "gathered",
-      "companionGroup": "clock-family-b",
+      "companionGroup": "station-tourists-b",
       "voiceCue": "tourist-cluster",
       "dialogId": "tourist_clock_stop",
       "interactRadius": 2.2,
       "idleSpot": {
-        "x": 183.74,
-        "z": -152.54
+        "x": 23.6,
+        "z": -26.5
       },
-      "silhouetteScale": 0.94
+      "silhouetteScale": 0.94,
+      "yaw": -0.74
     },
     {
       "id": "starter-tourist-clock-child",
@@ -5294,28 +5334,28 @@
       "behavior": "tourist_pause",
       "pose": "group_gather",
       "silhouetteScale": 0.82,
-      "companionGroup": "clock-family-b",
+      "companionGroup": "station-tourists-a",
       "voiceCue": "tourist-cluster",
       "dialogId": "tourist_clock_stop",
       "interactRadius": 2,
       "idleSpot": {
-        "x": 182.67,
-        "z": -155.32
+        "x": 18.6,
+        "z": -23.1
       },
       "patrol": [
         {
-          "x": 182.23,
-          "z": -154.91
+          "x": 18.1,
+          "z": -22.6
         },
         {
-          "x": 183.18,
-          "z": -155.57
+          "x": 19.2,
+          "z": -23.6
         }
       ]
     }
   ],
   "exploration": {
-    "publicGoal": "I’m exploring Gastown.",
+    "publicGoal": "I\u2019m exploring Gastown.",
     "fallbackPrompt": "Wander the connected plazas, storefront edges, alley mouths, and landmark corners to build your own short loop."
   },
   "microAreas": [
@@ -6344,6 +6384,30 @@
         "yaw": -0.92,
         "faceColor": "#e4d5af",
         "emissive": "#291f09"
+      },
+      {
+        "id": "water-sushi-sign",
+        "x": 31.6,
+        "z": -25.8,
+        "height": 2.5,
+        "width": 1.4,
+        "panelHeight": 0.46,
+        "yaw": -0.7,
+        "faceColor": "#d1b7a0",
+        "emissive": "#25140f",
+        "glow": true
+      },
+      {
+        "id": "water-pub-sign",
+        "x": 42.8,
+        "z": -36.5,
+        "height": 2.7,
+        "width": 1.6,
+        "panelHeight": 0.5,
+        "yaw": -0.7,
+        "faceColor": "#b8803f",
+        "emissive": "#2a1907",
+        "glow": true
       }
     ],
     "streetFurniture": [
@@ -6395,6 +6459,34 @@
         "x": 204.7,
         "z": -168.5,
         "yaw": -0.92
+      },
+      {
+        "id": "furn-start-bench-east",
+        "kind": "bench",
+        "x": 20.9,
+        "z": -20.8,
+        "yaw": -0.72
+      },
+      {
+        "id": "furn-start-planter-east",
+        "kind": "planter",
+        "x": 28.7,
+        "z": -27.3,
+        "yaw": -0.72
+      },
+      {
+        "id": "furn-start-bin",
+        "kind": "bin",
+        "x": 34.6,
+        "z": -31.8,
+        "yaw": -0.72
+      },
+      {
+        "id": "furn-start-planter-pub",
+        "kind": "planter",
+        "x": 41.7,
+        "z": -37.9,
+        "yaw": -0.72
       }
     ]
   },

--- a/functions.php
+++ b/functions.php
@@ -272,6 +272,7 @@ function se_enqueue_gastown_sim_assets() {
                 'dialogDataUrl'  => esc_url_raw( $uri . '/assets/dialog/gastown.json' ),
                 'conversationEndpoint' => esc_url_raw( rest_url( 'se/v1/gastown-npc-chat' ) ),
                 'voiceEndpoint' => esc_url_raw( rest_url( 'se/v1/gastown-npc-voice' ) ),
+                'buskerRiffEndpoint' => esc_url_raw( rest_url( 'se/v1/gastown-busker-riff' ) ),
                 'nonce' => wp_create_nonce( 'wp_rest' ),
                 'defaultWeather' => 'clear',
                 'defaultMood'    => 'calm',
@@ -828,6 +829,12 @@ add_action('rest_api_init', function() {
         'callback'            => 'se_handle_gastown_npc_voice',
         'permission_callback' => '__return_true',
     ]);
+
+    register_rest_route('se/v1', '/gastown-busker-riff', [
+        'methods'             => 'GET',
+        'callback'            => 'se_handle_gastown_busker_riff',
+        'permission_callback' => '__return_true',
+    ]);
 });
 
 // =========================================
@@ -851,6 +858,145 @@ function get_custom_canucks_betting( WP_REST_Request $request ) {
     return rest_ensure_response( $odds );
 }
 
+
+
+function se_get_gastown_busker_riff_fallback( $mood = 'lively', $weather = 'clear', $time_of_day = 'morning' ) {
+    $tempo = 'night' === $time_of_day ? 90 : ( 'lively' === $mood ? 108 : 96 );
+    $root = 'night' === $time_of_day ? 'D4' : ( 'eerie' === $mood ? 'E4' : 'G4' );
+    $motifs = array(
+        'lively' => array(
+            array( 'note' => $root, 'beats' => 0.5, 'velocity' => 0.96, 'accent' => true, 'articulation' => 'growl' ),
+            array( 'note' => 'Bb4', 'beats' => 0.5, 'velocity' => 0.84, 'accent' => false, 'articulation' => 'stab' ),
+            array( 'note' => 'D5', 'beats' => 1, 'velocity' => 0.92, 'accent' => true, 'articulation' => 'rasp' ),
+            array( 'note' => 'C5', 'beats' => 0.5, 'velocity' => 0.8, 'accent' => false, 'articulation' => 'fall' ),
+            array( 'note' => 'G4', 'beats' => 1, 'velocity' => 0.88, 'accent' => true, 'articulation' => 'hold' ),
+            array( 'note' => 'rest', 'beats' => 0.5 ),
+            array( 'note' => 'F4', 'beats' => 0.5, 'velocity' => 0.78, 'accent' => false, 'articulation' => 'bend' ),
+            array( 'note' => 'G4', 'beats' => 1, 'velocity' => 0.9, 'accent' => true, 'articulation' => 'growl' ),
+        ),
+        'calm' => array(
+            array( 'note' => 'G4', 'beats' => 1, 'velocity' => 0.76, 'accent' => false, 'articulation' => 'smear' ),
+            array( 'note' => 'A4', 'beats' => 0.5, 'velocity' => 0.68, 'accent' => false, 'articulation' => 'slide' ),
+            array( 'note' => 'Bb4', 'beats' => 1, 'velocity' => 0.74, 'accent' => true, 'articulation' => 'hold' ),
+            array( 'note' => 'D5', 'beats' => 0.5, 'velocity' => 0.82, 'accent' => true, 'articulation' => 'rasp' ),
+            array( 'note' => 'C5', 'beats' => 1, 'velocity' => 0.72, 'accent' => false, 'articulation' => 'fall' ),
+            array( 'note' => 'G4', 'beats' => 1, 'velocity' => 0.8, 'accent' => true, 'articulation' => 'hold' ),
+        ),
+        'commuter' => array(
+            array( 'note' => 'E4', 'beats' => 0.5, 'velocity' => 0.84, 'accent' => true, 'articulation' => 'stab' ),
+            array( 'note' => 'G4', 'beats' => 0.5, 'velocity' => 0.78, 'accent' => false, 'articulation' => 'growl' ),
+            array( 'note' => 'B4', 'beats' => 1, 'velocity' => 0.86, 'accent' => true, 'articulation' => 'rasp' ),
+            array( 'note' => 'A4', 'beats' => 0.5, 'velocity' => 0.76, 'accent' => false, 'articulation' => 'fall' ),
+            array( 'note' => 'G4', 'beats' => 1, 'velocity' => 0.8, 'accent' => true, 'articulation' => 'hold' ),
+            array( 'note' => 'rest', 'beats' => 0.5 ),
+            array( 'note' => 'E4', 'beats' => 0.5, 'velocity' => 0.88, 'accent' => true, 'articulation' => 'stab' ),
+            array( 'note' => 'G4', 'beats' => 1, 'velocity' => 0.8, 'accent' => false, 'articulation' => 'growl' ),
+        ),
+        'eerie' => array(
+            array( 'note' => 'D4', 'beats' => 1, 'velocity' => 0.72, 'accent' => false, 'articulation' => 'breathy' ),
+            array( 'note' => 'F4', 'beats' => 0.5, 'velocity' => 0.74, 'accent' => false, 'articulation' => 'slide' ),
+            array( 'note' => 'A4', 'beats' => 1, 'velocity' => 0.8, 'accent' => true, 'articulation' => 'rasp' ),
+            array( 'note' => 'C5', 'beats' => 0.5, 'velocity' => 0.76, 'accent' => false, 'articulation' => 'fall' ),
+            array( 'note' => 'A4', 'beats' => 1, 'velocity' => 0.78, 'accent' => true, 'articulation' => 'hold' ),
+            array( 'note' => 'F4', 'beats' => 1, 'velocity' => 0.7, 'accent' => false, 'articulation' => 'breathy' ),
+        ),
+    );
+
+    $sequence = $motifs[ $mood ] ?? $motifs['lively'];
+    if ( 'rain' === $weather || 'drizzle' === $weather ) {
+        $tempo -= 6;
+    }
+
+    return array(
+        'ok' => true,
+        'fallback' => true,
+        'spec' => array(
+            'mood' => $mood,
+            'weather' => $weather,
+            'timeOfDay' => $time_of_day,
+            'tempo' => max( 76, min( 118, $tempo ) ),
+            'key' => 'G minor pentatonic',
+            'loopBeats' => 8,
+            'phraseLengths' => array( 2, 2, 4 ),
+            'articulationHints' => array( 'gritty', 'street-corner', 'rock-adjacent', 'short breaths', 'raw edge' ),
+            'sequence' => $sequence,
+        ),
+    );
+}
+
+function se_handle_gastown_busker_riff( WP_REST_Request $request ) {
+    $mood = sanitize_key( (string) $request->get_param( 'mood' ) ) ?: 'lively';
+    $weather = sanitize_key( (string) $request->get_param( 'weather' ) ) ?: 'clear';
+    $time_of_day = sanitize_key( (string) $request->get_param( 'timeOfDay' ) ) ?: 'morning';
+
+    $fallback = se_get_gastown_busker_riff_fallback( $mood, $weather, $time_of_day );
+
+    $messages = array(
+        array(
+            'role' => 'system',
+            'content' => 'Return strict JSON only. You are designing a short loopable street-busker sax riff spec for a stylized Gastown simulator. Keep it 5-12 seconds, gritty, melodic, rock-adjacent, terse, and suitable for realtime synthesis. No prose outside JSON.',
+        ),
+        array(
+            'role' => 'user',
+            'content' => sprintf( 'Mood: %s. Weather: %s. Time of day: %s. Return JSON with keys mood, tempo, key, loopBeats, phraseLengths, articulationHints, and sequence. sequence must be 6-12 items of note events with note, beats, velocity, accent, articulation. Use note names like G4 or rest.', $mood, $weather, $time_of_day ),
+        ),
+    );
+
+    $response = se_openai_chat( $messages, array(
+        'model' => 'gpt-4o-mini',
+        'temperature' => 0.8,
+        'max_tokens' => 320,
+    ), array( 'timeout' => 8 ) );
+
+    if ( is_wp_error( $response ) ) {
+        return rest_ensure_response( $fallback );
+    }
+
+    $text = trim( (string) ( $response['choices'][0]['message']['content'] ?? '' ) );
+    if ( preg_match( '/```(?:json)?\s*(.*?)```/is', $text, $matches ) ) {
+        $text = trim( $matches[1] );
+    }
+    $decoded = json_decode( $text, true );
+    if ( ! is_array( $decoded ) || empty( $decoded['sequence'] ) || ! is_array( $decoded['sequence'] ) ) {
+        return rest_ensure_response( $fallback );
+    }
+
+    $spec = $fallback['spec'];
+    $spec['mood'] = sanitize_text_field( (string) ( $decoded['mood'] ?? $spec['mood'] ) );
+    $spec['tempo'] = max( 76, min( 118, intval( $decoded['tempo'] ?? $spec['tempo'] ) ) );
+    $spec['key'] = sanitize_text_field( (string) ( $decoded['key'] ?? $spec['key'] ) );
+    $spec['loopBeats'] = max( 6, min( 16, intval( $decoded['loopBeats'] ?? $spec['loopBeats'] ) ) );
+    $spec['phraseLengths'] = array_values( array_slice( array_map( 'intval', (array) ( $decoded['phraseLengths'] ?? $spec['phraseLengths'] ) ), 0, 4 ) );
+    $spec['articulationHints'] = array_values( array_slice( array_map( 'sanitize_text_field', (array) ( $decoded['articulationHints'] ?? $spec['articulationHints'] ) ), 0, 6 ) );
+    $spec['sequence'] = array();
+    foreach ( array_slice( $decoded['sequence'], 0, 12 ) as $event ) {
+        if ( ! is_array( $event ) ) {
+            continue;
+        }
+        $note = sanitize_text_field( (string) ( $event['note'] ?? 'rest' ) );
+        $beats = floatval( $event['beats'] ?? 0.5 );
+        if ( $beats <= 0 ) {
+            $beats = 0.5;
+        }
+        $spec['sequence'][] = array(
+            'note' => $note,
+            'beats' => min( 2.5, max( 0.25, $beats ) ),
+            'velocity' => min( 1, max( 0.3, floatval( $event['velocity'] ?? 0.8 ) ) ),
+            'accent' => ! empty( $event['accent'] ),
+            'articulation' => sanitize_text_field( (string) ( $event['articulation'] ?? 'growl' ) ),
+        );
+    }
+
+    if ( empty( $spec['sequence'] ) ) {
+        return rest_ensure_response( $fallback );
+    }
+
+    return rest_ensure_response( array(
+        'ok' => true,
+        'fallback' => false,
+        'spec' => $spec,
+    ) );
+}
 
 function se_handle_gastown_npc_voice( WP_REST_Request $request ) {
     $role       = sanitize_key( (string) $request->get_param( 'role' ) );

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -154,6 +154,7 @@
     npcSpeechCache: {},
     npcSpeechController: null,
     npcSpeechAudio: null,
+    resumePointerAfterDialogClose: false,
     clockTimer: null,
     boundaryNoticeTimer: null,
     currentMicroAreaId: '',
@@ -192,6 +193,7 @@
   const DEFAULT_EYE_HEIGHT = 1.7;
   const WALKER_NAME_STORAGE_KEY = 'gastownWalkerName';
   const NPC_SPEECH_CACHE_LIMIT = 18;
+  const BUSKER_RIFF_CACHE_PREFIX = 'gastownBuskerRiff:';
   const ART_DIRECTION = {
     label: 'stylized realism with cinematic Vancouver rain-lighting',
     streetReflectionBoost: 0.22,
@@ -388,48 +390,48 @@
     setWalkerName(value);
     closeWalkerNameOverlay();
     pushJournalEntry('On the street as ' + state.walkerName + '.');
-    setStatus('Walker ready: ' + state.walkerName + '. Click into the street when you want to move.');
+    setStatus(state.walkerName.toUpperCase() + ' ready. Click in.');
   }
 
   const QUEST_DEFINITIONS = {
-    orientation: { label: 'Get bearings', status: 'Get your bearings and see what the street gives you.' },
-    scavenger: { label: 'Street details log', status: 'Street details log active: note the newspaper box, historic plaque, and painted brick panel as observations.' },
-    survey: { label: 'Route survey', status: 'Route survey active: trace how Water Street tightens, loosens, and rises as you move east.' },
-    soundwalk: { label: 'Soundwalk', status: 'Soundwalk active: follow the station rumble, busker corner, and clock chime without rushing.' },
-    stories: { label: 'Memory walk', status: 'Memory walk active: gather place-based notes about shoreline change, public space, and layered civic memory.' },
+    orientation: { label: 'Get moving', status: 'Get moving.' },
+    scavenger: { label: 'Street details', status: 'Street details ready.' },
+    survey: { label: 'Route survey', status: 'Route opens east.' },
+    soundwalk: { label: 'Sound cues', status: 'Listen for the sax and the clock.' },
+    stories: { label: 'Layered places', status: 'Keep walking past the obvious photo stop.' },
   };
 
   const THREAD_DEFINITIONS = {
     drift: {
       label: 'Drift',
-      objective: 'Get your bearings and see what the street gives you.',
-      hint: 'Look around, move a little, and follow what feels alive.',
-      status: 'Free exploration active: roam, linger, and let the street set the pace.',
+      objective: 'Steam Clock ahead.',
+      hint: 'Follow the first bit of street energy.',
+      status: 'Free roam.',
       autoTarget: { type: 'landmark', id: 'water-cordova-seam' },
     },
     scavenger: {
       label: 'Street details',
-      objective: 'Use the street details log to notice small clues in storefronts, paving, and public surfaces.',
-      hint: 'Follow the smallest detail that feels worth logging next.',
-      status: 'Street details log active: note the newspaper box, historic plaque, and painted brick panel as observations.',
+      objective: 'Notice the small things.',
+      hint: 'Log the next detail that catches your eye.',
+      status: 'Street details ready.',
     },
     survey: {
       label: 'Survey',
-      objective: 'Survey the route and note how Water Street changes from threshold to plaza to eastward rise.',
-      hint: 'Use the minimap as a soft cue while you compare each block face.',
-      status: 'Route survey active: trace how Water Street tightens, loosens, and rises as you move east.',
+      objective: 'Read the block as it opens up.',
+      hint: 'Compare the station edge, storefronts, and the Steam Clock pull.',
+      status: 'Route opens east.',
     },
     soundwalk: {
-      label: 'Soundwalk',
-      objective: 'Listen for station rumble, busker phrases, weather, and clock cues as the corridor shifts around you.',
-      hint: 'Pause near the station edge, the clock corner, or any busker to hear the route differently.',
-      status: 'Soundwalk active: follow the station rumble, busker corner, and clock chime without rushing.',
+      label: 'Sound cues',
+      objective: 'Follow the sax, crowd, and clock.',
+      hint: 'Pause where the street sounds thickest.',
+      status: 'Listen for the sax and the clock.',
     },
     stories: {
-      label: 'Memory walk',
-      objective: 'Treat Maple Tree Square and the Steam Clock corner as layered places shaped by route, shoreline, labour, and public memory.',
-      hint: 'Move between the clock and Maple Tree Square, then compare what each place emphasizes.',
-      status: 'Memory walk active: gather place-based notes about shoreline change, public space, and layered civic memory.',
+      label: 'Layered places',
+      objective: 'Push past the obvious landmark.',
+      hint: 'Look for the block behind the postcard shot.',
+      status: 'Keep walking past the obvious photo stop.',
     },
   };
 
@@ -452,7 +454,7 @@
   }
 
   function getStreetModeStatusText() {
-    return getPublicGoalText() + ' Mouse look and movement are live. Press V for overview.';
+    return getPublicGoalText();
   }
 
   function pushJournalEntry(text) {
@@ -466,7 +468,7 @@
 
   function renderProgressionUi() {
     if (routeScoreEl) {
-      routeScoreEl.textContent = Math.round(state.progression.routeCompletionScore) + '% of the corridor mapped by your feet.';
+      routeScoreEl.textContent = Math.round(state.progression.routeCompletionScore) + '% mapped';
     }
     if (collectiblesLogEl) {
       const deduped = [];
@@ -477,10 +479,11 @@
         seenKeys.add(key);
         deduped.push(prop);
       });
-      collectiblesLogEl.innerHTML = deduped.map((prop) => '<li>' + (prop.collectibleLabel || prop.id) + ' — ' + (prop.collected ? 'logged' : 'not logged') + '</li>').join('');
+      collectiblesLogEl.innerHTML = deduped.map((prop) => '<li>' + (prop.collectibleLabel || prop.id) + ' — ' + (prop.collected ? 'logged' : 'not yet') + '</li>').join('');
+      if (questStatusEl) questStatusEl.textContent = deduped.filter((prop) => prop.collected).length + ' details';
     }
     if (journalEl) {
-      const entries = state.progression.journalEntries.length ? state.progression.journalEntries : ['Arrive at the station threshold and get your bearings.'];
+      const entries = state.progression.journalEntries.length ? state.progression.journalEntries : ['Station threshold.'];
       journalEl.innerHTML = entries.slice(0, 4).map((entry) => '<li>' + entry + '</li>').join('');
     }
   }
@@ -521,7 +524,6 @@
     state.currentThread = nextId;
     if (!silent) {
       setQuestStatus(THREAD_DEFINITIONS[nextId].status);
-      pushJournalEntry(THREAD_DEFINITIONS[nextId].label + ' selected.');
     }
     updateThreadButtonsUi();
     updateNextMeaningfulThing();
@@ -568,13 +570,12 @@
       state.quest.active = true;
       state.quest.completed = items.length && items.every((item) => item.found);
       state.quest.items = items;
-      setQuestStatus('Street details log: ' + items.filter((item) => item.found).length + '/' + items.length + ' logged.');
-      renderDialogBody(['Street details log started.', 'Note the newspaper box, the historic plaque, and the painted brick panel as observations. The minimap will hint, but wandering still matters.']);
+      setQuestStatus(items.filter((item) => item.found).length + ' details');
+      renderDialogBody(['Street details ready.', 'Log the newspaper box, plaque, and painted brick.']);
     } else {
-      setQuestStatus((QUEST_DEFINITIONS[id] || {}).status || 'Thread updated.');
-      renderDialogBody([((QUEST_DEFINITIONS[id] || {}).label || 'Quest') + ' started.']);
+      setQuestStatus((QUEST_DEFINITIONS[id] || {}).status || 'Updated.');
+      renderDialogBody([((QUEST_DEFINITIONS[id] || {}).label || 'Note') + '.']);
     }
-    pushJournalEntry(((QUEST_DEFINITIONS[id] || {}).label || 'Quest') + ' added to your journal.');
     updateNextMeaningfulThing();
   }
 
@@ -592,7 +593,7 @@
   function discoverLandmark(landmark) {
     if (!landmark || state.progression.discoveredLandmarks[landmark.id]) return;
     state.progression.discoveredLandmarks[landmark.id] = true;
-    setStatus('Discovery: ' + landmark.label + '.');
+    setStatus('Logged: ' + landmark.label + '.');
     pushJournalEntry('Discovered ' + landmark.label + ': ' + (landmark.discoveryNote || landmark.cue || 'New route context logged.'));
     if (landmark.storyUnlock) {
       state.progression.unlockedStories[landmark.storyUnlock] = true;
@@ -624,15 +625,15 @@
     }
     const survey = getQuestChain('survey');
     if (survey.active && !survey.completed && state.progression.discoveredLandmarks['water-street-mid-block'] && state.progression.discoveredLandmarks['cambie-rise-continuation']) {
-      completeQuestById('survey', 'Route survey complete: you traced Water Street from storefront rhythm to the Cambie rise.');
+      completeQuestById('survey', 'Route read complete.');
     }
     const stories = getQuestChain('stories');
     const busker = getNpcByRole('busker');
     if (stories.active && !stories.completed && state.progression.discoveredLandmarks['steam-clock'] && state.progression.discoveredLandmarks['maple-tree-square-edge'] && busker && state.progression.talkedNpcIds[busker.id]) {
-      completeQuestById('stories', "Memory walk complete: you linked the Steam Clock corner with Maple Tree Square's layered public history.");
+      completeQuestById('stories', 'You read past the postcard version.');
     }
     if (state.quest.items.length && state.quest.items.every((item) => item.found)) {
-      completeQuestById('scavenger', 'Street details log complete: the busker has a bonus story waiting near the Steam Clock.');
+      completeQuestById('scavenger', 'All details logged.');
     }
   }
 
@@ -657,24 +658,24 @@
         : { text: 'Continue east and notice how the corridor opens toward the Cambie rise.', target: { type: 'landmark', id: 'cambie-rise-continuation' } };
     } else if (state.currentThread === 'soundwalk' && chainSoundwalk.active && !chainSoundwalk.completed) {
       if (!state.progression.discoveredLandmarks['steam-clock']) {
-        hint = { text: 'Follow the sound cues toward the Steam Clock corner.', target: { type: 'landmark', id: 'steam-clock' } };
+        hint = { text: 'Steam Clock ahead.', target: { type: 'landmark', id: 'steam-clock' } };
       } else if (busker) {
-        hint = { text: 'Pause near the busker or clock corner and listen for how the space changes.', target: { type: 'npc', id: busker.id } };
+        hint = { text: 'Busker nearby.', target: { type: 'npc', id: busker.id } };
       }
     } else if (state.currentThread === 'stories' && chainStories.active && !chainStories.completed) {
       if (!state.progression.discoveredLandmarks['maple-tree-square-edge']) {
-        hint = { text: 'Walk past the clock until Maple Tree Square opens up as a layered public space.', target: { type: 'landmark', id: 'maple-tree-square-edge' } };
+        hint = { text: 'Keep walking past the clock.', target: { type: 'landmark', id: 'maple-tree-square-edge' } };
       } else if (busker) {
-        hint = { text: 'Return to the busker or another local voice to compare memory-walk notes.', target: { type: 'npc', id: busker.id } };
+        hint = { text: 'Talk to the busker again.', target: { type: 'npc', id: busker.id } };
       }
     } else if ((state.progression.routeCompletionScore || 0) < 100) {
       const nextLandmark = (state.world && state.world.landmarks || []).find((landmark) => !state.progression.discoveredLandmarks[landmark.id]);
       if (nextLandmark) {
-        hint = { text: activeThread.hint + ' Next landmark: ' + nextLandmark.label + '.', target: { type: 'landmark', id: nextLandmark.id } };
+        hint = { text: nextLandmark.label + ' ahead.', target: { type: 'landmark', id: nextLandmark.id } };
       }
     } else {
-      objective = 'You have a full set of route notes — keep wandering and compare the neighbourhood on your own terms.';
-      hint = { text: 'Roam freely: the journal now updates from proximity, lingering, and what you decide to revisit.', target: null };
+      objective = 'Keep roaming.';
+      hint = { text: 'Keep roaming.', target: null };
     }
 
     state.progression.nextHint = hint;
@@ -688,7 +689,7 @@
     if (!tutorialOverlayEl) return;
     tutorialOverlayEl.removeAttribute('hidden');
     tutorialOverlayEl.setAttribute('aria-hidden', 'false');
-    setStatus('Tutorial open. Review the controls, then start exploring when ready.');
+    setStatus('Help open.');
   }
 
   function closeTutorialOverlay() {
@@ -729,8 +730,7 @@
     }
     state.boundaryNoticeTimer = setTimeout(() => {
       if (!state.isRunning || state.cameraMode !== 'street') return;
-      setStatus('Street mode active. Mouse look and movement are live. Hold Alt for precise exploration, Shift for a brisk walk, or press V for overview.');
-      setStatus(getStreetModeStatusText());
+      setStatus(getPublicGoalText());
     }, 1900);
   }
 
@@ -740,7 +740,7 @@
 
   function setPointerStatus(text) {
     if (pointerStatusEl) {
-      pointerStatusEl.textContent = '[' + getCameraModeLabel() + ' view] ' + text;
+      pointerStatusEl.textContent = text;
     }
   }
 
@@ -771,18 +771,18 @@
 
   function updateCameraModeUi() {
     if (state.cameraMode === 'overview') {
-      setStatus('Overview mode active. Mouse wheel zooms altitude; WASD glides fast across the route; press V to return to street view.');
+      setStatus('Overview active.');
       setPointerStatus('Pointer unlocked. Overview camera detached above player.');
     } else if (state.isRunning) {
-      setStatus(getStreetModeStatusText());
+      setStatus(getPublicGoalText());
       if (state.cameraMode === 'street' && document.pointerLockElement === renderer.domElement) {
-        setPointerStatus('Pointer locked. Mouse look active. Press Esc to release pointer.');
+        setPointerStatus('Pointer live. Esc releases.');
       } else {
-        setPointerStatus('Pointer lock requested… press Esc any time to release.');
+        setPointerStatus('Pointer live. Esc releases.');
       }
     } else {
-      setStatus(getPublicGoalText() + ' Click scene to enter look mode and begin moving, or press V for overview.');
-      setPointerStatus('Pointer unlocked. Click scene to enter look mode. Press V for overview.');
+      setStatus(getPublicGoalText());
+      setPointerStatus('Pointer free. Click in.');
     }
   }
 
@@ -857,7 +857,7 @@
     }
 
     if (approximate) {
-      setStatus('Approximate fallback world loaded. This playable corridor is believable, but not survey-precise.');
+      setStatus('Street loaded.');
     }
   }
 
@@ -1709,30 +1709,13 @@
     }
     if (npcState.role === 'guide') {
       return [
-        { type: 'quest', questId: 'scavenger', label: getQuestChain('scavenger').completed ? 'Review street details log' : 'Start street details log' },
-        { type: 'quest', questId: 'survey', label: getQuestChain('survey').completed ? 'Review route survey' : 'Start route survey' },
-        { type: 'quest', questId: 'soundwalk', label: getQuestChain('soundwalk').completed ? 'Review soundwalk' : 'Start soundwalk' },
-        { type: 'response', label: 'Tell me more about Maple Tree Square', responseLines: ['Maple Tree Square is best read as a layered public space where routes, shoreline change, and later heritage framing overlap.', 'The area is on the unceded territories of the Musqueam, Squamish, and Tsleil-Waututh Nations, so this walk keeps the history lightweight and place-based rather than centering a founder myth.'], followupStatus: 'Shared extra place history.' },
+        { type: 'response', label: 'What should I notice?', responseLines: ['The paving changes first.', 'Then the storefront rhythm takes over.'], followupStatus: 'Guide pointed out a route cue.' },
         { type: 'close', label: 'Back to walk' }
       ];
     }
     if (npcState.role === 'busker') {
       return [
-        { type: 'quest', questId: 'stories', label: getQuestChain('stories').completed ? 'Review memory walk' : 'Start memory walk' },
-        { type: 'quest', questId: 'soundwalk', label: getQuestChain('soundwalk').completed ? 'Review soundwalk' : 'Start soundwalk' },
-        { type: 'response', label: 'What changes after I stand here awhile?', responseLines: [state.progression.discoveredLandmarks['steam-clock'] ? 'Once you have actually stood in the plaza, the clock reads less like a prop and more like one cue inside a larger street rhythm.' : 'Come back after you have stood in the plaza itself — it changes how the whole corner reads.', state.progression.discoveredLandmarks['maple-tree-square-edge'] ? 'And once Maple Tree Square opens up behind it, the corner shifts from single landmark to layered meeting point.' : 'Push beyond the clock and you will feel the square loosen the corridor.'], followupStatus: 'Busker reacted to your discoveries.' },
-        { type: 'close', label: 'Back to walk' }
-      ];
-    }
-    if (npcState.role === 'skateboarder') {
-      return [
-        { type: 'quest', questId: 'survey', label: getQuestChain('survey').completed ? 'Review route survey' : 'Start route survey' },
-        { type: 'close', label: 'Back to walk' }
-      ];
-    }
-    if (npcState.role === 'cyclist') {
-      return [
-        { type: 'quest', questId: 'survey', label: getQuestChain('survey').completed ? 'Review route survey' : 'Continue route survey' },
+        { type: 'response', label: 'What changes if I stay?', responseLines: ['The crowd starts moving around the sound instead of through it.', 'That is when the block feels alive.'], followupStatus: 'Busker reacted to the street energy.' },
         { type: 'close', label: 'Back to walk' }
       ];
     }
@@ -1871,10 +1854,11 @@
     }
   }
 
-  function closeDialog() {
+  function closeDialog(options) {
+    stopNpcSpeech();
+    state.npcConversationPending = false;
     state.activeDialogNpcId = '';
     state.activeDialogEntry = null;
-    stopNpcSpeech();
     if (dialogActionsDynamicEl) {
       dialogActionsDynamicEl.innerHTML = '';
     }
@@ -1885,13 +1869,17 @@
       dialogModalEl.setAttribute('hidden', 'hidden');
       dialogModalEl.setAttribute('aria-hidden', 'true');
     }
-    clearMovementInput();
     setInteractPrompt('');
-    setStatus('Dialog closed. Click scene to resume.');
-    setPointerStatus('Pointer unlocked. Click scene to enter look mode.');
-    const focusTarget = renderer.domElement || canvasWrap;
-    if (focusTarget && typeof focusTarget.focus === 'function') {
-      window.setTimeout(() => focusTarget.focus(), 0);
+    state.hoveredNpcId = '';
+    state.isRunning = false;
+    setPointerStatus('Pointer free. Click in.');
+    const shouldResume = !!(options && options.resumePointer) || state.resumePointerAfterDialogClose;
+    state.resumePointerAfterDialogClose = false;
+    if (shouldResume && state.cameraMode === 'street') {
+      window.setTimeout(() => enterPlayMode(), 30);
+    }
+    if (state.dialogLastFocusEl && typeof state.dialogLastFocusEl.focus === 'function') {
+      state.dialogLastFocusEl.focus();
     }
   }
 
@@ -1900,6 +1888,7 @@
     clearMovementInput();
     state.isRunning = false;
     state.dialogLastFocusEl = document.activeElement;
+    state.resumePointerAfterDialogClose = document.pointerLockElement === renderer.domElement;
 
     const rawEntry = Object.prototype.hasOwnProperty.call(state.dialogData, npcState.dialogId)
       ? state.dialogData[npcState.dialogId]
@@ -2311,6 +2300,106 @@
     return state.audioUnlocked;
   }
 
+  function getBuskerRiffCacheKey() {
+    return BUSKER_RIFF_CACHE_PREFIX + [state.activeMood || 'calm', state.activeWeather || 'clear', state.activeTimeOfDay || 'morning'].join(':');
+  }
+
+  function getFallbackBuskerRiffSpec() {
+    return {
+      mood: state.activeMood || 'lively',
+      weather: state.activeWeather || 'clear',
+      timeOfDay: state.activeTimeOfDay || 'morning',
+      tempo: state.activeTimeOfDay === 'night' ? 90 : (state.activeMood === 'lively' ? 108 : 96),
+      key: 'G minor pentatonic',
+      loopBeats: 8,
+      phraseLengths: [2, 2, 4],
+      articulationHints: ['gritty', 'street-corner', 'rock-adjacent'],
+      sequence: [
+        { note: 'G4', beats: 0.5, velocity: 0.94, accent: true, articulation: 'growl' },
+        { note: 'Bb4', beats: 0.5, velocity: 0.82, accent: false, articulation: 'stab' },
+        { note: 'D5', beats: 1, velocity: 0.9, accent: true, articulation: 'rasp' },
+        { note: 'C5', beats: 0.5, velocity: 0.76, accent: false, articulation: 'fall' },
+        { note: 'G4', beats: 1, velocity: 0.88, accent: true, articulation: 'hold' },
+        { note: 'rest', beats: 0.5, velocity: 0.2, accent: false, articulation: 'rest' },
+        { note: 'F4', beats: 0.5, velocity: 0.78, accent: false, articulation: 'bend' },
+        { note: 'G4', beats: 1, velocity: 0.9, accent: true, articulation: 'growl' }
+      ]
+    };
+  }
+
+  function saveBuskerRiffSpec(spec) {
+    try { window.localStorage.setItem(getBuskerRiffCacheKey(), JSON.stringify(spec)); } catch (error) {}
+  }
+
+  function loadCachedBuskerRiffSpec() {
+    try {
+      const raw = window.localStorage.getItem(getBuskerRiffCacheKey());
+      return raw ? JSON.parse(raw) : null;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  async function fetchBuskerRiffSpec() {
+    const cached = loadCachedBuskerRiffSpec();
+    if (cached && Array.isArray(cached.sequence) && cached.sequence.length) return cached;
+    if (!config.buskerRiffEndpoint || !window.fetch) {
+      const fallback = getFallbackBuskerRiffSpec();
+      saveBuskerRiffSpec(fallback);
+      return fallback;
+    }
+    try {
+      const response = await fetch(config.buskerRiffEndpoint + '?mood=' + encodeURIComponent(state.activeMood || 'calm') + '&weather=' + encodeURIComponent(state.activeWeather || 'clear') + '&timeOfDay=' + encodeURIComponent(state.activeTimeOfDay || 'morning'), { credentials: 'same-origin' });
+      if (!response.ok) throw new Error('riff unavailable');
+      const data = await response.json();
+      const spec = data && data.spec ? data.spec : null;
+      if (!spec || !Array.isArray(spec.sequence) || !spec.sequence.length) throw new Error('invalid riff');
+      saveBuskerRiffSpec(spec);
+      return spec;
+    } catch (error) {
+      const fallback = getFallbackBuskerRiffSpec();
+      saveBuskerRiffSpec(fallback);
+      return fallback;
+    }
+  }
+
+  function createBuskerSaxSynth(Tone) {
+    const bus = new Tone.Gain(0.72).toDestination();
+    const grit = new Tone.Distortion(0.18).connect(bus);
+    const filter = new Tone.Filter(1050, 'bandpass').connect(grit);
+    const breath = new Tone.NoiseSynth({
+      noise: { type: 'pink' },
+      envelope: { attack: 0.005, decay: 0.12, sustain: 0.02, release: 0.08 },
+      volume: -26
+    }).connect(filter);
+    const synth = new Tone.MonoSynth({
+      oscillator: { type: 'sawtooth3' },
+      filter: { Q: 4.8, type: 'bandpass', rolloff: -24 },
+      envelope: { attack: 0.012, decay: 0.18, sustain: 0.28, release: 0.2 },
+      filterEnvelope: { attack: 0.01, decay: 0.16, sustain: 0.14, release: 0.16, baseFrequency: 360, octaves: 3.1 },
+      volume: -13
+    }).connect(filter);
+    const slap = new Tone.MembraneSynth({
+      pitchDecay: 0.02,
+      octaves: 1.4,
+      envelope: { attack: 0.001, decay: 0.12, sustain: 0, release: 0.05 },
+      volume: -30
+    }).connect(bus);
+    return { synth, breath, slap, bus, filter, grit };
+  }
+
+  function scheduleBuskerNote(loop, event, when, nearFactor) {
+    if (!loop || !event || event.note === 'rest') return;
+    const seconds = (60 / Math.max(76, loop.spec.tempo || 96)) * Math.max(0.25, event.beats || 0.5);
+    const accentBoost = event.accent ? 0.1 : 0;
+    const velocity = Math.min(1, Math.max(0.25, (event.velocity || 0.78) + accentBoost + (nearFactor * 0.08)));
+    loop.synth.synth.triggerAttackRelease(event.note, seconds, when, velocity);
+    loop.synth.breath.triggerAttackRelease(seconds * 0.82, when, 0.4 + nearFactor * 0.18);
+    if (event.accent) {
+      loop.synth.slap.triggerAttackRelease('C2', '32n', when, 0.08 + nearFactor * 0.08);
+    }
+  }
+
   function ensureNpcLoop(npcState) {
     if (npcState.role !== 'busker' || state.sounds.npcAudio[npcState.id]) {
       return;
@@ -2320,32 +2409,20 @@
       state.sounds.npcAudio[npcState.id] = { muted: true, mode: 'silent_busker' };
       return;
     }
+    const fallbackSpec = getFallbackBuskerRiffSpec();
     try {
       state.sounds.npcAudio[npcState.id] = {
-        mode: 'busker_soft_duet',
-        radius: 11.5,
-        lastGestureAt: -Infinity,
+        mode: 'busker_sax_loop',
+        radius: 15,
         nextGestureAt: 0,
-        intervalSeconds: 5.6,
-        chordIndex: 0,
-        synth: new Tone.PolySynth(Tone.Synth, {
-          oscillator: { type: 'triangle6' },
-          envelope: { attack: 0.02, decay: 0.3, sustain: 0.18, release: 1.6 },
-          volume: -24,
-        }).toDestination(),
-        accent: new Tone.MembraneSynth({
-          pitchDecay: 0.05,
-          octaves: 2,
-          envelope: { attack: 0.001, decay: 0.22, sustain: 0, release: 0.08 },
-          volume: -34,
-        }).toDestination(),
-        motif: [
-          ['G3', 'D4', 'B4'],
-          ['E3', 'B3', 'G4'],
-          ['C4', 'G4', 'E4'],
-          ['D3', 'A3', 'F#4'],
-        ],
+        stepIndex: 0,
+        spec: fallbackSpec,
+        synth: createBuskerSaxSynth(Tone)
       };
+      fetchBuskerRiffSpec().then((spec) => {
+        const loop = state.sounds.npcAudio[npcState.id];
+        if (loop && spec) loop.spec = spec;
+      }).catch(() => {});
     } catch (error) {
       state.sounds.npcAudio[npcState.id] = { muted: true, mode: 'silent_busker' };
       warnAudioUnavailable('Busker motif setup failed; simulator continuing without busker audio.', error);
@@ -2573,19 +2650,15 @@
       npc.mesh.rotation.y = npc.currentYaw;
 
       const loop = state.sounds.npcAudio[npc.id];
-      if (loop && loop.mode === 'busker_soft_duet' && loop.synth && state.steamClockState.enabled) {
+      if (loop && loop.mode === 'busker_sax_loop' && loop.synth && loop.spec && Array.isArray(loop.spec.sequence)) {
         const distance = Math.hypot(player.position.x - npc.mesh.position.x, player.position.z - npc.mesh.position.z);
-        const nearFactor = Math.max(0, 1 - (distance / (loop.radius || 11.5)));
-        if (nearFactor > 0.24 && nowSeconds >= (loop.nextGestureAt || 0)) {
-          const chord = loop.motif[loop.chordIndex % loop.motif.length];
+        const nearFactor = Math.max(0, 1 - (distance / (loop.radius || 15)));
+        if (nearFactor > 0.14 && nowSeconds >= (loop.nextGestureAt || 0)) {
+          const event = loop.spec.sequence[loop.stepIndex % loop.spec.sequence.length];
           try {
-            loop.synth.triggerAttackRelease(chord, '2n', getTone().now(), 0.28 + (nearFactor * 0.16));
-            if (loop.accent) {
-              loop.accent.triggerAttackRelease('G2', '16n', getTone().now() + 0.02, 0.08 + (nearFactor * 0.08));
-            }
-            loop.lastGestureAt = nowSeconds;
-            loop.chordIndex = (loop.chordIndex + 1) % loop.motif.length;
-            loop.nextGestureAt = nowSeconds + loop.intervalSeconds + (deterministicUnit(npc.id + '-gesture-' + Math.floor(nowSeconds)) * 0.9);
+            scheduleBuskerNote(loop, event, getTone().now(), nearFactor);
+            loop.stepIndex = (loop.stepIndex + 1) % loop.spec.sequence.length;
+            loop.nextGestureAt = nowSeconds + ((60 / Math.max(76, loop.spec.tempo || 96)) * Math.max(0.25, event.beats || 0.5));
           } catch (error) {
             warnAudioUnavailable('Busker motif playback failed; simulator continuing without busker audio.', error);
             loop.mode = 'silent_busker';
@@ -2653,17 +2726,15 @@
     if (npcTarget) {
       const npc = npcTarget.npc;
       const roleLabel = getNpcRoleLabel(npc);
-      const talkCue = npcTarget.centered || npcTarget.distance <= (npc.interactRadius || 2.8) ? 'Press E or click to talk' : 'Face them and step in';
-      const centeredCue = npcTarget.centered ? 'centered' : npcTarget.facingDot > 0.75 ? 'in view' : 'nearby';
-      setInteractPrompt(talkCue + ': ' + (npc.name || roleLabel) + ' · ' + roleLabel + ' · ' + centeredCue + ' · ' + formatDistanceLabel(npcTarget.distance));
+      const verb = npc.role === 'busker' ? 'listen' : 'talk';
+      setInteractPrompt('E: ' + verb + ' to ' + (npc.name || roleLabel).toLowerCase());
       return;
     }
     if (collectible) {
       const prop = collectible.prop;
       const range = 2.2;
       const closeEnough = collectible.distance <= range;
-      const headingCue = collectible.alignment > 0.78 ? 'ahead' : collectible.alignment > 0.3 ? 'off-center' : 'nearby';
-      setInteractPrompt((closeEnough ? 'Press E to log' : 'Street detail ' + headingCue) + ': ' + (prop.collectibleLabel || prop.id) + ' · ' + formatDistanceLabel(collectible.distance));
+      setInteractPrompt(closeEnough ? 'E: log ' + (prop.collectibleLabel || prop.id).toLowerCase() : 'Street detail nearby');
       return;
     }
     setInteractPrompt('');
@@ -2878,10 +2949,10 @@
   }
 
   function addGround(world) {
-    visualState.roadMaterial = createGroundMaterial('street', 0x0a0f14, 0.94, 0.1);
-    visualState.sidewalkMaterial = createGroundMaterial('sidewalk', 0x85796d, 0.98, 0.02);
-    visualState.curbMaterial = new THREE.LineBasicMaterial({ color: 0xc2c8cf, transparent: true, opacity: 0.38 });
-    visualState.laneMaterial = new THREE.MeshStandardMaterial({ color: 0x8fa0af, roughness: 0.96, metalness: 0.01, transparent: true, opacity: 0.015, depthWrite: false, depthTest: true });
+    visualState.roadMaterial = createGroundMaterial('street', 0x161311, 0.98, 0.03);
+    visualState.sidewalkMaterial = createGroundMaterial('sidewalk', 0x6f6255, 0.99, 0.015);
+    visualState.curbMaterial = new THREE.LineBasicMaterial({ color: 0xb7a792, transparent: true, opacity: 0.28 });
+    visualState.laneMaterial = new THREE.MeshStandardMaterial({ color: 0x54473f, roughness: 1, metalness: 0, transparent: false, opacity: 1, depthWrite: true, depthTest: true });
     visualState.routeGuideMaterials = [visualState.laneMaterial];
     visualState.reflectiveMaterials.push(visualState.roadMaterial, visualState.sidewalkMaterial, visualState.laneMaterial);
 
@@ -2907,26 +2978,26 @@
         (() => {
           const toneStyles = {
             brick: { color: 0x5c4033, roughness: 0.82, metalness: 0.06, opacity: 0.72 },
-            road_base_dark: { color: 0x1c232a, roughness: 0.95, metalness: 0.03, opacity: 0.24 },
-            wheel_track: { color: 0x0d1217, roughness: 0.62, metalness: 0.14, opacity: 0.2 },
-            patch: { color: 0x2f353d, roughness: 0.76, metalness: 0.12, opacity: 0.2 },
-            repair_patch_dark: { color: 0x252b32, roughness: 0.72, metalness: 0.14, opacity: 0.22 },
-            puddle: { color: 0x1a212a, roughness: 0.74, metalness: 0.08, opacity: 0.1 },
-            wet_streak: { color: 0x202731, roughness: 0.82, metalness: 0.06, opacity: 0.08 },
-            reflection_pool: { color: 0x233242, roughness: 0.86, metalness: 0.04, opacity: 0.06 },
-            edge_grime: { color: 0x1b1d20, roughness: 0.8, metalness: 0.08, opacity: 0.18 },
-            curb_grime: { color: 0x181c20, roughness: 0.88, metalness: 0.04, opacity: 0.18 },
-            cobble_break: { color: 0x55483d, roughness: 0.86, metalness: 0.04, opacity: 0.18 },
-            paver_break: { color: 0x5d5144, roughness: 0.84, metalness: 0.05, opacity: 0.18 },
-            intersection_pavers: { color: 0x5c5044, roughness: 0.9, metalness: 0.04, opacity: 0.26 },
-            default: { color: 0x3a4048, roughness: 0.8, metalness: 0.08, opacity: 0.78 },
+            road_base_dark: { color: 0x2f2822, roughness: 0.98, metalness: 0.01, opacity: 0.96 },
+            wheel_track: { color: 0x221c18, roughness: 0.9, metalness: 0.02, opacity: 0.78 },
+            patch: { color: 0x453930, roughness: 0.9, metalness: 0.02, opacity: 0.7 },
+            repair_patch_dark: { color: 0x372f2a, roughness: 0.92, metalness: 0.02, opacity: 0.74 },
+            puddle: { color: 0x2a2724, roughness: 0.92, metalness: 0.02, opacity: 0.02 },
+            wet_streak: { color: 0x3a312b, roughness: 0.9, metalness: 0.02, opacity: 0.05 },
+            reflection_pool: { color: 0x352d29, roughness: 0.94, metalness: 0.01, opacity: 0.01 },
+            edge_grime: { color: 0x29231f, roughness: 0.94, metalness: 0.02, opacity: 0.62 },
+            curb_grime: { color: 0x2c2521, roughness: 0.95, metalness: 0.02, opacity: 0.58 },
+            cobble_break: { color: 0x6a5848, roughness: 0.92, metalness: 0.02, opacity: 0.88 },
+            paver_break: { color: 0x705d4b, roughness: 0.92, metalness: 0.02, opacity: 0.84 },
+            intersection_pavers: { color: 0x786553, roughness: 0.95, metalness: 0.02, opacity: 0.96 },
+            default: { color: 0x4a4038, roughness: 0.92, metalness: 0.02, opacity: 0.9 },
           };
           const style = toneStyles[band.tone] || toneStyles.default;
           const material = new THREE.MeshStandardMaterial({
             color: style.color,
             roughness: style.roughness,
             metalness: style.metalness,
-            transparent: style.opacity < 0.98,
+            transparent: style.opacity < 0.2,
             opacity: Math.min(style.opacity, band.opacity || style.opacity),
           });
           visualState.reflectiveMaterials.push(material);
@@ -2934,7 +3005,7 @@
         })()
       );
       paver.rotation.x = -Math.PI / 2;
-      paver.renderOrder = -1;
+      paver.renderOrder = 0;
       paver.rotation.y = band.yaw || 0;
       paver.position.set(segment.x + (band.offset_x || 0), band.elevation || 0.02, segment.z + (band.offset_z || 0));
       worldGroup.add(paver);
@@ -3476,7 +3547,7 @@
       }
 
       if (state.debugEnabled || !suppressGenericMarker) {
-        const reflectionMaterial = new THREE.MeshStandardMaterial({ color: col, emissive: 0x1b2533, emissiveIntensity: 0.18, transparent: true, opacity: 0.08, roughness: 0.92, metalness: 0.04, depthWrite: false });
+        const reflectionMaterial = new THREE.MeshStandardMaterial({ color: col, emissive: 0x1b2533, emissiveIntensity: 0.08, transparent: true, opacity: 0.015, roughness: 0.96, metalness: 0.02, depthWrite: false });
         const reflection = new THREE.Mesh(new THREE.CircleGeometry(landmark.radius || 2.7, 24), reflectionMaterial);
         reflection.renderOrder = -1;
         reflection.rotation.x = -Math.PI / 2;
@@ -3925,15 +3996,13 @@
     if (minimapContextEl) {
       minimapContextEl.innerHTML = '<strong>Now facing:</strong> ' + facing
         + (area ? '<br><strong>Exploring:</strong> ' + area.label + ' (' + area.identity + ')' : '')
-        + '<br><strong>Thread:</strong> ' + ((THREAD_DEFINITIONS[state.currentThread] || THREAD_DEFINITIONS.drift).label)
         + (nearest ? '<br><strong>Nearest landmark:</strong> ' + nearest.text : '');
     }
     if (minimapModeStatusEl) {
       const isHeadingUp = minimapState.mode === 'heading-up';
-      const threadLabel = (THREAD_DEFINITIONS[state.currentThread] || THREAD_DEFINITIONS.drift).label;
       minimapModeStatusEl.innerHTML = isHeadingUp
-        ? '<strong>Map mode:</strong> Heading-up — the top of the map follows the way you are facing.<br><strong>Ambient hint:</strong> ' + threadLabel + ' cues stay in the background.'
-        : '<strong>Map mode:</strong> North-up — the top of the map is geographic north.<br><strong>Ambient hint:</strong> ' + threadLabel + ' cues stay in the background.';
+        ? 'Heading-up map.'
+        : 'North-up map.';
     }
   }
 
@@ -4459,8 +4528,7 @@
     if (!minimapLegendEl) return;
     const npcCounts = getActiveNpcCounts();
     const collectibleCount = getCollectibleProps().filter((prop) => !prop.collected).length;
-    const threadLabel = (THREAD_DEFINITIONS[state.currentThread] || THREAD_DEFINITIONS.drift).label;
-    const items = ['You', 'Route line', 'Sidewalk / plaza', 'Road', 'Landmark', 'Ambient hint: ' + threadLabel, 'Observations left: ' + collectibleCount, 'Pedestrians: ' + (npcCounts.pedestrian || 0), 'Tourists: ' + ((npcCounts.tourist || 0) + (npcCounts.photographer || 0)), 'Cyclists: ' + (npcCounts.cyclist || 0)];
+    const items = ['You', 'Route', 'Sidewalk', 'Street', 'Landmark', 'Details left: ' + collectibleCount, 'Locals: ' + (npcCounts.pedestrian || 0), 'Visitors: ' + ((npcCounts.tourist || 0) + (npcCounts.photographer || 0)), 'Riders: ' + ((npcCounts.cyclist || 0) + (npcCounts.skateboarder || 0))];
     minimapLegendEl.innerHTML = items.map((item) => '<li>' + item + '</li>').join('');
   }
 
@@ -4809,14 +4877,14 @@
 
     if (visualState.roadMaterial) {
       visualState.roadMaterial.color.set(timeOfDay.roadColor || '#2b3138');
-      setSurfaceWetness(visualState.roadMaterial, 0.86, 0.16, weather.rainIntensity || 0);
+      setSurfaceWetness(visualState.roadMaterial, 0.95, 0.03, (weather.rainIntensity || 0) * 0.4);
       if (visualState.roadMaterial.normalScale) {
         visualState.roadMaterial.normalScale.set(1.35 + ((weather.rainIntensity || 0) * 0.24), 1.1 + ((weather.rainIntensity || 0) * 0.2));
       }
     }
     if (visualState.sidewalkMaterial) {
       visualState.sidewalkMaterial.color.set(timeOfDay.sidewalkColor || '#8f8780');
-      setSurfaceWetness(visualState.sidewalkMaterial, 0.92, 0.02, (weather.rainIntensity || 0) * 0.45);
+      setSurfaceWetness(visualState.sidewalkMaterial, 0.97, 0.015, (weather.rainIntensity || 0) * 0.2);
       if (visualState.sidewalkMaterial.normalScale) {
         visualState.sidewalkMaterial.normalScale.set(0.7 + ((weather.rainIntensity || 0) * 0.12), 0.7 + ((weather.rainIntensity || 0) * 0.12));
       }
@@ -4826,7 +4894,7 @@
     }
     if (visualState.laneMaterial) {
       visualState.laneMaterial.color.set(timeOfDay.laneColor || '#aab1b8');
-      visualState.laneMaterial.opacity = Math.min(0.06, 0.01 + ((timeOfDay.pathBrightness || 0.2) * 0.04));
+      visualState.laneMaterial.opacity = 1;
     }
 
     if (worldStatusEl) {
@@ -5025,8 +5093,8 @@
   function startSim() {
     unlockAudioFromGesture().finally(() => unlockSteamClockAudio());
     state.isRunning = true;
-    setStatus(getStreetModeStatusText());
-    setPointerStatus('Pointer lock requested… press Esc any time to release.');
+    setStatus(getPublicGoalText());
+    setPointerStatus('Pointer live. Esc releases.');
     lockPointer();
   }
 
@@ -5046,8 +5114,8 @@
     if (document.pointerLockElement) {
       document.exitPointerLock();
     }
-    setStatus('Street mode paused. Click scene to resume look mode and movement, or press V for overview.');
-    setPointerStatus('Pointer released. Click scene to re-enter look mode.');
+    setStatus('Paused. Click in to resume.');
+    setPointerStatus('Pointer free. Click in.');
   }
 
   function attachEvents() {
@@ -5057,6 +5125,7 @@
     });
     renderer.domElement.addEventListener('click', () => {
       if (state.activeDialogNpcId) {
+        closeDialog({ resumePointer: true });
         return;
       }
       if (state.cameraMode !== 'street') {
@@ -5134,16 +5203,16 @@
 
     document.addEventListener('pointerlockchange', () => {
       if (state.cameraMode === 'street' && document.pointerLockElement === renderer.domElement) {
-        setPointerStatus('Pointer locked. Mouse look active. Press Esc to release pointer.');
+        setPointerStatus('Pointer live. Esc releases.');
       } else if (state.cameraMode === 'overview') {
-        setPointerStatus('Pointer unlocked. Overview camera detached above player.');
+        setPointerStatus('Overview camera.');
       } else if (state.isRunning) {
         clearMovementInput();
         state.isRunning = false;
-        setStatus('Street mode paused. Click scene to resume look mode and movement, or press V for overview.');
-        setPointerStatus('Pointer released. Click scene to re-enter look mode.');
+        setStatus('Paused. Click in to resume.');
+        setPointerStatus('Pointer free. Click in.');
       } else {
-        setPointerStatus('Pointer unlocked.');
+        setPointerStatus('Pointer free.');
       }
     });
 
@@ -5160,7 +5229,7 @@
     dialogCloseEls.forEach((button) => button.addEventListener('click', closeDialog));
     if (tutorialOpenBtn) tutorialOpenBtn.addEventListener('click', openTutorialOverlay);
     tutorialCloseEls.forEach((button) => button.addEventListener('click', closeTutorialOverlay));
-    if (tutorialStartBtn) tutorialStartBtn.addEventListener('click', () => { closeTutorialOverlay(); resetToStart(); setStatus('Tutorial started. Click into the scene, then wander toward whatever catches your attention first.'); });
+    if (tutorialStartBtn) tutorialStartBtn.addEventListener('click', () => { closeTutorialOverlay(); resetToStart(); setStatus('Click in and move.'); });
     if (renameWalkerBtn) renameWalkerBtn.addEventListener('click', () => openWalkerNameOverlay(state.walkerName));
     if (walkerStartBtn) walkerStartBtn.addEventListener('click', () => confirmWalkerName(walkerNameInputEl ? walkerNameInputEl.value : state.walkerName));
     if (walkerSkipBtn) walkerSkipBtn.addEventListener('click', () => confirmWalkerName('Walker'));
@@ -5333,7 +5402,7 @@
       scheduleSteamClock();
       setWorldModeStatus(state.world);
       if (!(state.world.meta && state.world.meta.fallbackMode === 'working-gastown-corridor')) {
-        setStatus(getPublicGoalText() + ' Click scene to enter look mode and begin moving, or press V for overview.');
+        setStatus(getPublicGoalText());
       }
       updateCameraModeUi();
       renderer.setAnimationLoop((time) => {

--- a/page-gastown-sim.php
+++ b/page-gastown-sim.php
@@ -8,84 +8,85 @@ get_header();
 <main id="primary" class="content-area gastown-sim-page">
   <section id="gastown-sim-app" class="gastown-sim-shell">
     <header class="gastown-sim-header">
-      <p class="gastown-sim-kicker">Prototype route: Waterfront Station → Water Street → Steam Clock</p>
-      <h1>Gastown First-Person Simulator</h1>
-      <p class="gastown-sim-intro">A stylized, geographically grounded Gastown walk built for wandering, noticing, and letting the block answer back. Start loose, move with the street, and see what the corridor decides to reveal.</p>
+      <p class="gastown-sim-kicker">Waterfront Station → Water Street → Steam Clock</p>
+      <h1>Gastown Simulator</h1>
+      <p class="gastown-sim-intro">Name your walker, click in, and follow whatever feels alive first.</p>
     </header>
 
-    <div class="gastown-controls" role="group" aria-label="Simulator controls">
-      <button type="button" class="pixel-button secondary" data-action="pause">Pause</button>
-      <button type="button" class="pixel-button secondary" data-action="reset" aria-label="Reset to the start of the route">Reset to route start</button>
-      <button type="button" class="pixel-button secondary" data-action="tutorial-open" aria-label="Open the controls tutorial overlay">Tutorial</button>
-      <button type="button" class="pixel-button secondary" data-action="rename-walker" aria-label="Rename your walker">Rename walker</button>
-      <label>
-        Time of day
-        <select name="time-of-day">
-          <option value="morning" selected>Morning</option>
-          <option value="afternoon">Afternoon</option>
-          <option value="dusk">Dusk</option>
-          <option value="night">Night</option>
-        </select>
-      </label>
-      <label>
-        Weather
-        <select name="weather">
-          <option value="clear" selected>Clear</option>
-          <option value="drizzle">Drizzle</option>
-          <option value="rain">Rain</option>
-          <option value="thunderstorm">Thunderstorm</option>
-          <option value="fog">Fog</option>
-        </select>
-      </label>
-      <label>
-        Mood
-        <select name="mood">
-          <option value="calm" selected>Calm</option>
-          <option value="commuter">Commuter</option>
-          <option value="lively">Lively</option>
-          <option value="eerie">Eerie</option>
-        </select>
-      </label>
-      <label>
-        <input type="checkbox" name="low-graphics" data-setting="low-graphics" aria-label="Enable low graphics mode">
-        Low graphics mode
-      </label>
-      <label>
-        <input type="checkbox" name="reopen-tutorial" data-setting="reopen-tutorial" aria-label="Show the tutorial overlay again">
-        Show tutorial on next load
-      </label>
-      <button type="button" class="pixel-button tiny secondary" data-action="debug-toggle" aria-label="Toggle the debug notes panel">Toggle debug</button>
-    </div>
+    <details class="gastown-controls-drawer">
+      <summary>Settings + help</summary>
+      <div class="gastown-controls" role="group" aria-label="Simulator controls">
+        <button type="button" class="pixel-button secondary" data-action="pause">Pause</button>
+        <button type="button" class="pixel-button secondary" data-action="reset" aria-label="Reset to the start of the route">Reset</button>
+        <button type="button" class="pixel-button secondary" data-action="tutorial-open" aria-label="Open the controls tutorial overlay">Help</button>
+        <button type="button" class="pixel-button secondary" data-action="rename-walker" aria-label="Rename your walker">Rename</button>
+        <label>
+          Time
+          <select name="time-of-day">
+            <option value="morning" selected>Morning</option>
+            <option value="afternoon">Afternoon</option>
+            <option value="dusk">Dusk</option>
+            <option value="night">Night</option>
+          </select>
+        </label>
+        <label>
+          Weather
+          <select name="weather">
+            <option value="clear" selected>Clear</option>
+            <option value="drizzle">Drizzle</option>
+            <option value="rain">Rain</option>
+            <option value="thunderstorm">Thunderstorm</option>
+            <option value="fog">Fog</option>
+          </select>
+        </label>
+        <label>
+          Street mood
+          <select name="mood">
+            <option value="calm" selected>Calm</option>
+            <option value="commuter">Commuter</option>
+            <option value="lively">Lively</option>
+            <option value="eerie">Eerie</option>
+          </select>
+        </label>
+        <label>
+          <input type="checkbox" name="low-graphics" data-setting="low-graphics" aria-label="Enable low graphics mode">
+          Low graphics
+        </label>
+        <label>
+          <input type="checkbox" name="reopen-tutorial" data-setting="reopen-tutorial" aria-label="Show the tutorial overlay again">
+          Show help on load
+        </label>
+        <button type="button" class="pixel-button tiny secondary" data-action="debug-toggle" aria-label="Toggle the debug notes panel">Debug</button>
+      </div>
 
-    <section class="gastown-help" aria-label="Simulator controls guide">
-      <h2>Quick controls</h2>
-      <ul>
-        <li><strong>Click scene</strong> to enter look mode</li>
-        <li><strong>Mouse</strong> = look around</li>
-        <li><strong>W A S D</strong> = move / strafe</li>
-        <li><strong>Arrow keys</strong> = move forward/back + turn left/right</li>
-        <li><strong>Mouse wheel</strong> = look up/down (while focused/in play mode)</li>
-        <li><strong>Ctrl + ↑ / Ctrl + ↓</strong> = precise look up/down steps</li>
-        <li><strong>E / click</strong> = talk or log something nearby</li>
-        <li><strong>Esc</strong> = release pointer / pause</li>
-      </ul>
-    </section>
+      <section class="gastown-help" aria-label="Simulator controls guide">
+        <h2>Controls</h2>
+        <ul>
+          <li><strong>Click</strong> to step into the street</li>
+          <li><strong>Mouse</strong> look</li>
+          <li><strong>W A S D</strong> move</li>
+          <li><strong>Arrow keys</strong> move / turn</li>
+          <li><strong>E / click</strong> talk or log</li>
+          <li><strong>Esc</strong> close / release</li>
+        </ul>
+        <p class="gastown-help-note">AI voice talkback is optional. If voice or riff generation fails, text and play continue.</p>
+      </section>
+    </details>
 
     <section class="gastown-tutorial-overlay" data-tutorial-overlay role="dialog" aria-modal="true" aria-labelledby="gastown-tutorial-title" aria-describedby="gastown-tutorial-copy" hidden>
       <div class="gastown-dialog-panel">
         <div class="gastown-dialog-header">
-          <h2 id="gastown-tutorial-title">Welcome to the Gastown Simulator</h2>
+          <h2 id="gastown-tutorial-title">On the street</h2>
           <button type="button" class="pixel-button tiny secondary" data-action="tutorial-close" aria-label="Close tutorial overlay">Close</button>
         </div>
         <div class="gastown-dialog-body" id="gastown-tutorial-copy">
-          <p>Click the scene to lock the pointer, use the mouse to look around, and move with W A S D or the arrow keys.</p>
-          <p>Press E or click when a nearby local or street detail is in reach. You do not need to pick a route style first; the walk learns from what you linger on.</p>
-          <p>NPC voices use AI-generated speech when available. If audio or speech fails, the conversation stays on screen and the sim keeps moving.</p>
-          <p>Screen reader note: status updates, landmark callouts, and journal updates are announced below the simulator.</p>
+          <p>Name your walker if you want, then click in and move.</p>
+          <p>You will hear and see the route wake up quickly: locals, visitors, storefronts, and the pull toward the Steam Clock.</p>
+          <p>AI-generated voice is disclosed here in help, not in the live HUD. If it fails, dialog text stays on screen.</p>
         </div>
         <div class="gastown-dialog-actions">
-          <button type="button" class="pixel-button secondary" data-action="tutorial-start" aria-label="Start the simulator tutorial">Start tutorial</button>
-          <button type="button" class="pixel-button secondary" data-action="tutorial-close">Skip for now</button>
+          <button type="button" class="pixel-button secondary" data-action="tutorial-start" aria-label="Start the simulator tutorial">Start walk</button>
+          <button type="button" class="pixel-button secondary" data-action="tutorial-close">Skip</button>
         </div>
       </div>
     </section>
@@ -96,10 +97,10 @@ get_header();
           <h2 id="gastown-name-title">Name your walker</h2>
         </div>
         <div class="gastown-dialog-body">
-          <p>Give your walker a street name, or skip and keep it simple.</p>
+          <p>Optional. Keep it short.</p>
           <label class="gastown-name-field">
             <span>Walker name</span>
-            <input type="text" maxlength="24" autocomplete="nickname" data-walker-name-input placeholder="Walker">
+            <input type="text" maxlength="24" autocomplete="nickname" data-walker-name-input placeholder="SUZY">
           </label>
         </div>
         <div class="gastown-dialog-actions">
@@ -110,46 +111,16 @@ get_header();
     </section>
 
     <section class="gastown-hud" aria-label="Exploration HUD">
-      <div class="gastown-hud-top">
-        <div class="gastown-hud-identity">
-          <p class="gastown-hud-kicker">ON THE STREET</p>
-          <p class="gastown-hud-name" data-walker-name-display>Walker</p>
-          <p class="gastown-hud-subline">Get your bearings and see what the street gives you.</p>
-        </div>
-        <div class="gastown-hud-statuses">
-          <p class="gastown-status" data-sim-status aria-live="polite">Loading simulator...</p>
-          <p class="gastown-quest-status" data-sim-quest-status aria-live="polite">Street details log: inactive.</p>
-          <p class="gastown-pointer-status" data-sim-pointer-status aria-live="polite">Pointer unlocked.</p>
-          <p class="gastown-interact-prompt" data-sim-interact-prompt aria-live="polite" hidden></p>
-        </div>
-        <div class="gastown-hud-route">
-          <p class="gastown-expedition-label">Route completion</p>
-          <p class="gastown-expedition-value" data-sim-route-score aria-live="polite">0% of the corridor surveyed.</p>
-          <p class="gastown-hud-disclosure">AI voice talkback is optional and may stay silent if your browser or the API says no.</p>
-        </div>
+      <div class="gastown-hud-identity">
+        <p class="gastown-hud-kicker">ON THE STREET</p>
+        <p class="gastown-hud-name" data-walker-name-display>WALKER</p>
+        <p class="gastown-hud-subline" data-sim-status aria-live="polite">Click in to start.</p>
       </div>
-
-      <div class="gastown-hud-support">
-        <div class="gastown-hud-card gastown-hud-card--prompt">
-          <p class="gastown-expedition-label">Current drift</p>
-          <p class="gastown-expedition-value" data-sim-objective aria-live="polite">Get your bearings and see what the street gives you.</p>
-          <p class="gastown-expedition-value gastown-hud-next-step" data-sim-next-step aria-live="polite">Look around, move a little, and follow what feels alive.</p>
-        </div>
-        <div class="gastown-hud-card gastown-hud-card--journal">
-          <p class="gastown-expedition-label">Journal</p>
-          <ul class="gastown-expedition-list" data-sim-journal aria-live="polite">
-            <li>Arrive at the station threshold and get your bearings.</li>
-          </ul>
-        </div>
-        <div class="gastown-hud-card gastown-hud-card--details">
-          <p class="gastown-expedition-label">Street details log</p>
-          <ul class="gastown-expedition-list" data-sim-collectibles-log aria-live="polite">
-            <li>Newspaper box — not logged</li>
-            <li>Historic plaque — not logged</li>
-            <li>Painted brick panel — not logged</li>
-          </ul>
-        </div>
+      <div class="gastown-hud-route">
+        <p class="gastown-expedition-value" data-sim-route-score aria-live="polite">0% mapped</p>
+        <p class="gastown-hud-detail-count" data-sim-quest-status aria-live="polite">0 details</p>
       </div>
+      <p class="gastown-interact-prompt" data-sim-interact-prompt aria-live="polite" hidden></p>
     </section>
 
     <div class="gastown-sim-canvas" data-sim-canvas tabindex="-1">
@@ -159,30 +130,51 @@ get_header();
           <button type="button" class="gastown-minimap-zoom" data-action="minimap-zoom-in" aria-label="Zoom in minimap">+</button>
           <button type="button" class="gastown-minimap-zoom" data-action="minimap-zoom-out" aria-label="Zoom out minimap">−</button>
         </div>
-        <p class="gastown-minimap-mode-status" data-sim-minimap-mode-status aria-live="polite">Map mode: North-up — the top of the map is geographic north. Guidance: landmark callouts stay player-relative.</p>
-        <p class="gastown-minimap-tooltip" data-sim-minimap-tooltip aria-live="polite">Tip: press M twice quickly to switch between north-up and heading-up map modes.</p>
-        <p class="gastown-minimap-context" data-sim-minimap-context aria-live="polite"><strong>Now facing:</strong> north<br><strong>Nearest landmark:</strong> Waterfront Station threshold — ahead</p>
+        <p class="gastown-minimap-mode-status" data-sim-minimap-mode-status aria-live="polite">North-up map.</p>
+        <p class="gastown-minimap-tooltip" data-sim-minimap-tooltip aria-live="polite">Steam Clock ahead.</p>
+        <p class="gastown-minimap-context" data-sim-minimap-context aria-live="polite"><strong>Facing:</strong> north<br><strong>Nearest:</strong> station threshold</p>
         <canvas data-sim-minimap width="220" height="220"></canvas>
         <div class="gastown-minimap-compass" data-sim-compass aria-live="polite">Heading: north</div>
         <ul class="gastown-minimap-legend" data-sim-minimap-legend aria-label="Minimap legend">
           <li>You</li>
-          <li>Route line</li>
-          <li>Sidewalk / plaza</li>
-          <li>Road</li>
+          <li>Route</li>
+          <li>Street</li>
           <li>Landmark</li>
-          <li>Ambient hint</li>
-          <li>Observations</li>
         </ul>
         <p class="gastown-minimap-label" data-sim-minimap-landmark>Nearest landmark: Waterfront Station threshold — ahead</p>
       </aside>
       <pre class="gastown-route-debug-overlay" data-route-debug-overlay hidden></pre>
+      <div class="gastown-live-strip">
+        <p class="gastown-pointer-status" data-sim-pointer-status aria-live="polite">Pointer free</p>
+        <p class="gastown-landmark" data-sim-landmark aria-live="polite">Station threshold</p>
+        <p class="gastown-route-segment" data-sim-route-segment aria-live="polite">Start</p>
+      </div>
     </div>
 
-    <div class="gastown-meta-strip">
-      <p class="gastown-world-status" data-sim-world-status aria-live="polite">World data status: checking build provenance…</p>
-      <p class="gastown-landmark" data-sim-landmark aria-live="polite">Nearest landmark: Station threshold</p>
-      <p class="gastown-route-segment" data-sim-route-segment aria-live="polite">Route segment: Waterfront Station Threshold</p>
-    </div>
+    <details class="gastown-log-drawer">
+      <summary>Notes</summary>
+      <div class="gastown-meta-strip">
+        <p class="gastown-world-status" data-sim-world-status aria-live="polite">World data status: checking build provenance…</p>
+        <p class="gastown-expedition-value" data-sim-objective aria-live="polite">Steam Clock ahead.</p>
+        <p class="gastown-expedition-value gastown-hud-next-step" data-sim-next-step aria-live="polite">Follow the first bit of street energy.</p>
+      </div>
+      <div class="gastown-hud-support">
+        <div class="gastown-hud-card gastown-hud-card--journal">
+          <p class="gastown-expedition-label">Journal</p>
+          <ul class="gastown-expedition-list" data-sim-journal aria-live="polite">
+            <li>On the platform edge.</li>
+          </ul>
+        </div>
+        <div class="gastown-hud-card gastown-hud-card--details">
+          <p class="gastown-expedition-label">Logged</p>
+          <ul class="gastown-expedition-list" data-sim-collectibles-log aria-live="polite">
+            <li>Newspaper box — not logged</li>
+            <li>Historic plaque — not logged</li>
+            <li>Painted brick panel — not logged</li>
+          </ul>
+        </div>
+      </div>
+    </details>
 
     <section class="gastown-debug" data-debug-panel hidden>
       <h2>Debug notes</h2>
@@ -193,13 +185,9 @@ get_header();
         <li>Wheel and Ctrl+ArrowUp/Down also adjust pitch while focused/in play mode</li>
         <li>Walk bounds clamp keeps the player in the playable corridor slice</li>
         <li>Route debug can also be enabled with <code>?gastownDebug=1</code></li>
-        <li>Audio zones: station rumble, steam clock core, split-building nightlife edge</li>
+        <li>Audio zones: station rumble, sax busker, steam clock core, nightlife edge</li>
       </ul>
     </section>
-
-    <p class="gastown-teaser-snippet" hidden>
-      In progress: our Gastown first-person simulator is evolving quickly. We ship frequent updates, so if a change looks odd, please hard refresh and clear cache.
-    </p>
 
     <footer class="gastown-attribution" aria-live="polite">
       <p>Contains information licensed under the Open Government Licence – Vancouver.</p>


### PR DESCRIPTION
### Motivation
- Make the opening 20–30s feel alive and playful while drastically reducing HUD/paragraph text so the sim reads like a game, not a dashboard. 
- Fix dialog/escape/click resume interaction bugs so players never get stuck in dialog state and `E`-to-talk is reliable. 
- Add a lightweight AI-assisted busker system that returns structured riff specs (not MP3s) and synthesize them client-side, with robust fallbacks. 

### Description
- UI and layout: replaced the large dashboard-style HUD with a compact, game-like HUD (walker tag, one-line status, percent mapped, tiny prompt) and moved secondary controls/help/journal into collapsible drawers and overlays; updated `page-gastown-sim.php` and `assets/css/gastown-sim.css` to implement the new layout and tone. 
- Dialog & input flow: hardened dialog lifecycle and audio handling by centralizing speech stop logic, clearing dialog state on close, remembering whether pointer lock should resume, and supporting both `Esc` and click-to-resume paths to avoid dialog limbo; changes in `js/gastown-sim.js` update `openDialogForNpc()`, `closeDialog()`, speech control, and click/keydown handlers. 
- Interaction targeting & prompts: simplified and stabilized the interaction prompt UI and kept `E`/click behavior forgiving (nearest+facing+centering scoring preserved) while showing concise prompts like `E: talk` / `E: listen` / `E: log`; edits in `js/gastown-sim.js` adjust `updateInteractionTarget()` and scoring/prompt logic. 
- Busker riff system: added a new REST endpoint `se/v1/gastown-busker-riff` returning small structured riff specs (PHP in `functions.php`), with an OpenAI-backed attempt and a deterministic procedural fallback; client caches specs by mood/weather/time and synthesizes via Tone.js (new runtime utilities and scheduling in `js/gastown-sim.js`). 
- World & start-of-route life: moved the sax busker and tourist clusters closer to the route start, added photographer/cyclist/skateboarder placements, additional street props and signage (sushi/pub frontage, benches, planters) to populate the first seconds; changes in `assets/world/gastown-water-street.json` and dialog text in `assets/dialog/gastown.json`. 
- Street surface & visual stability: reworked ground materials and surface band styles to read as darker heritage pavers/cobblestone, reduced transparent overlay/reflection intensities and render-order issues to eliminate ghosting when turning around (changes in `js/gastown-sim.js` ground/tones/material setup). 

### Testing
- Ran static checks on modified JS with `node --check js/gastown-sim.js` (passed). 
- Ran PHP syntax checks with `php -l page-gastown-sim.php` and `php -l functions.php` (both passed). 
- Validated JSON for `assets/world/gastown-water-street.json` and `assets/dialog/gastown.json` via JSON parse (both valid). 
- Verified removal/minimization of player-facing “mode/thread” language via repository grep (no remaining dashboard-style phrasing surfaced in live HUD).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1062d64fc832ea7c1f4f6cac6a9fc)