### PR TITLE
Add Gastown startup sting (OpenAI TTS + local Tone.js synth) and compact HUD

### DIFF
--- a/assets/css/gastown-sim.css
+++ b/assets/css/gastown-sim.css
@@ -37,7 +37,6 @@
 .gastown-landmark,
 .gastown-route-segment,
 .gastown-world-status,
-.gastown-pointer-status,
 .gastown-quest-status,
 .gastown-hud-detail-count {
   margin: 0;
@@ -111,9 +110,9 @@
 
 .gastown-hud {
   display: grid;
-  grid-template-columns: minmax(220px, 1fr) auto;
-  gap: 0.6rem 0.75rem;
-  align-items: end;
+  grid-template-columns: minmax(180px, 1fr) auto;
+  gap: 0.45rem 0.6rem;
+  align-items: center;
 }
 
 .gastown-hud-identity,
@@ -156,7 +155,12 @@
 }
 
 .gastown-hud-subline {
-  margin: 0.25rem 0 0;
+  grid-column: 1 / -1;
+  margin: 0;
+  padding: 0.38rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 214, 138, 0.34);
+  background: rgba(22, 16, 8, 0.78);
   color: #ffe9b8;
 }
 
@@ -164,7 +168,7 @@
   display: grid;
   justify-items: end;
   gap: 0.16rem;
-  min-width: 140px;
+  min-width: 112px;
 }
 
 .gastown-hud-route .gastown-expedition-value {
@@ -176,6 +180,7 @@
 
 .gastown-hud-detail-count {
   color: #bdd8ff;
+  display: none;
 }
 
 .gastown-interact-prompt[hidden],
@@ -239,10 +244,9 @@
   top: 0.8rem;
   display: grid;
   gap: 0.35rem;
-  max-width: min(260px, 36vw);
+  max-width: min(220px, 32vw);
 }
 
-.gastown-pointer-status,
 .gastown-landmark,
 .gastown-route-segment,
 .gastown-world-status {
@@ -404,4 +408,34 @@
   .gastown-sim-shell { padding: 0.7rem; }
   .gastown-sim-canvas { min-height: 460px; }
   .gastown-live-strip { max-width: 46vw; }
+}
+
+
+.gastown-log-drawer .gastown-hud-support {
+  display: none;
+}
+
+.gastown-meta-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+  padding: 0 0.75rem 0.75rem;
+}
+
+@media (max-width: 860px) {
+  .gastown-hud {
+    grid-template-columns: 1fr;
+  }
+
+  .gastown-hud-route {
+    justify-items: start;
+  }
+
+  .gastown-meta-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .gastown-live-strip {
+    max-width: min(180px, 46vw);
+  }
 }

--- a/functions.php
+++ b/functions.php
@@ -273,6 +273,7 @@ function se_enqueue_gastown_sim_assets() {
                 'conversationEndpoint' => esc_url_raw( rest_url( 'se/v1/gastown-npc-chat' ) ),
                 'voiceEndpoint' => esc_url_raw( rest_url( 'se/v1/gastown-npc-voice' ) ),
                 'buskerRiffEndpoint' => esc_url_raw( rest_url( 'se/v1/gastown-busker-riff' ) ),
+                'startupStingEndpoint' => esc_url_raw( rest_url( 'se/v1/gastown-start-sting' ) ),
                 'nonce' => wp_create_nonce( 'wp_rest' ),
                 'defaultWeather' => 'clear',
                 'defaultMood'    => 'calm',
@@ -835,6 +836,12 @@ add_action('rest_api_init', function() {
         'callback'            => 'se_handle_gastown_busker_riff',
         'permission_callback' => '__return_true',
     ]);
+
+    register_rest_route('se/v1', '/gastown-start-sting', [
+        'methods'             => 'POST',
+        'callback'            => 'se_handle_gastown_start_sting',
+        'permission_callback' => '__return_true',
+    ]);
 });
 
 // =========================================
@@ -859,6 +866,178 @@ function get_custom_canucks_betting( WP_REST_Request $request ) {
 }
 
 
+
+
+function se_get_gastown_start_sting_fallback_spec() {
+    return array(
+        'tempo' => 96,
+        'key' => 'G minor',
+        'duration_bars' => 2,
+        'chord_hits' => array(
+            array( 'bar' => 1, 'beat' => 1, 'notes' => array( 'G3', 'Bb3', 'D4' ), 'length_beats' => 1.5, 'velocity' => 0.82 ),
+            array( 'bar' => 2, 'beat' => 1, 'notes' => array( 'Eb3', 'G3', 'Bb3' ), 'length_beats' => 1.25, 'velocity' => 0.76 ),
+        ),
+        'bass_notes' => array(
+            array( 'bar' => 1, 'beat' => 1, 'note' => 'G1', 'length_beats' => 1, 'velocity' => 0.92 ),
+            array( 'bar' => 1, 'beat' => 3, 'note' => 'D2', 'length_beats' => 0.75, 'velocity' => 0.78 ),
+            array( 'bar' => 2, 'beat' => 1, 'note' => 'Eb2', 'length_beats' => 1, 'velocity' => 0.88 ),
+            array( 'bar' => 2, 'beat' => 3, 'note' => 'F2', 'length_beats' => 0.75, 'velocity' => 0.74 ),
+        ),
+        'drum_pattern' => array(
+            'kick' => array( array( 'bar' => 1, 'beat' => 1 ), array( 'bar' => 1, 'beat' => 3.5 ), array( 'bar' => 2, 'beat' => 1 ), array( 'bar' => 2, 'beat' => 3 ) ),
+            'snare' => array( array( 'bar' => 1, 'beat' => 2.75 ), array( 'bar' => 2, 'beat' => 2.75 ) ),
+            'hat' => array(
+                array( 'bar' => 1, 'beat' => 1.5 ), array( 'bar' => 1, 'beat' => 2 ), array( 'bar' => 1, 'beat' => 2.5 ), array( 'bar' => 1, 'beat' => 4 ),
+                array( 'bar' => 2, 'beat' => 1.5 ), array( 'bar' => 2, 'beat' => 2 ), array( 'bar' => 2, 'beat' => 2.5 ), array( 'bar' => 2, 'beat' => 4 )
+            ),
+        ),
+        'lead_phrase' => array(
+            array( 'bar' => 1, 'beat' => 1.5, 'note' => 'D4', 'length_beats' => 0.5, 'velocity' => 0.82, 'articulation' => 'growl' ),
+            array( 'bar' => 1, 'beat' => 2, 'note' => 'F4', 'length_beats' => 0.5, 'velocity' => 0.78, 'articulation' => 'bend' ),
+            array( 'bar' => 1, 'beat' => 2.5, 'note' => 'G4', 'length_beats' => 1, 'velocity' => 0.9, 'articulation' => 'hold' ),
+            array( 'bar' => 2, 'beat' => 1.5, 'note' => 'Bb4', 'length_beats' => 0.5, 'velocity' => 0.8, 'articulation' => 'stab' ),
+            array( 'bar' => 2, 'beat' => 2, 'note' => 'G4', 'length_beats' => 0.75, 'velocity' => 0.84, 'articulation' => 'fall' ),
+            array( 'bar' => 2, 'beat' => 3, 'note' => 'D4', 'length_beats' => 1, 'velocity' => 0.74, 'articulation' => 'hold' ),
+        ),
+        'style_description' => 'gritty urban rock-adjacent welcome sting with a stylized sax lead; brisk, punchy, not lounge jazz',
+    );
+}
+
+function se_sanitize_gastown_start_sting_spec( $decoded, $fallback_spec ) {
+    if ( ! is_array( $decoded ) ) {
+        return $fallback_spec;
+    }
+
+    $spec = $fallback_spec;
+    $spec['tempo'] = max( 80, min( 132, intval( $decoded['tempo'] ?? $fallback_spec['tempo'] ) ) );
+    $spec['key'] = sanitize_text_field( (string) ( $decoded['key'] ?? $fallback_spec['key'] ) );
+    $spec['duration_bars'] = max( 2, min( 3, intval( $decoded['duration_bars'] ?? $fallback_spec['duration_bars'] ) ) );
+    $spec['style_description'] = sanitize_text_field( (string) ( $decoded['style_description'] ?? $fallback_spec['style_description'] ) );
+
+    $sanitize_note_events = static function( $events, $fallback_events, $allow_chords = false ) {
+        $clean = array();
+        foreach ( array_slice( is_array( $events ) ? $events : array(), 0, 12 ) as $event ) {
+            if ( ! is_array( $event ) ) {
+                continue;
+            }
+            $row = array(
+                'bar' => max( 1, min( 3, intval( $event['bar'] ?? 1 ) ) ),
+                'beat' => max( 1, min( 4, floatval( $event['beat'] ?? 1 ) ) ),
+                'length_beats' => min( 2.5, max( 0.25, floatval( $event['length_beats'] ?? 0.5 ) ) ),
+                'velocity' => min( 1, max( 0.35, floatval( $event['velocity'] ?? 0.8 ) ) ),
+            );
+            if ( $allow_chords ) {
+                $notes = array_values( array_slice( array_filter( array_map( 'sanitize_text_field', (array) ( $event['notes'] ?? array() ) ) ), 0, 4 ) );
+                if ( empty( $notes ) ) {
+                    continue;
+                }
+                $row['notes'] = $notes;
+            } else {
+                $note = sanitize_text_field( (string) ( $event['note'] ?? '' ) );
+                if ( '' === $note ) {
+                    continue;
+                }
+                $row['note'] = $note;
+            }
+            if ( isset( $event['articulation'] ) ) {
+                $row['articulation'] = sanitize_text_field( (string) $event['articulation'] );
+            }
+            $clean[] = $row;
+        }
+        return ! empty( $clean ) ? $clean : $fallback_events;
+    };
+
+    $spec['chord_hits'] = $sanitize_note_events( $decoded['chord_hits'] ?? array(), $fallback_spec['chord_hits'], true );
+    $spec['bass_notes'] = $sanitize_note_events( $decoded['bass_notes'] ?? array(), $fallback_spec['bass_notes'], false );
+    $spec['lead_phrase'] = $sanitize_note_events( $decoded['lead_phrase'] ?? array(), $fallback_spec['lead_phrase'], false );
+
+    $drum_pattern = is_array( $decoded['drum_pattern'] ?? null ) ? $decoded['drum_pattern'] : array();
+    foreach ( array( 'kick', 'snare', 'hat' ) as $piece ) {
+        $spec['drum_pattern'][ $piece ] = array();
+        foreach ( array_slice( is_array( $drum_pattern[ $piece ] ?? null ) ? $drum_pattern[ $piece ] : array(), 0, 12 ) as $event ) {
+            if ( ! is_array( $event ) ) {
+                continue;
+            }
+            $spec['drum_pattern'][ $piece ][] = array(
+                'bar' => max( 1, min( 3, intval( $event['bar'] ?? 1 ) ) ),
+                'beat' => max( 1, min( 4, floatval( $event['beat'] ?? 1 ) ) ),
+            );
+        }
+        if ( empty( $spec['drum_pattern'][ $piece ] ) ) {
+            $spec['drum_pattern'][ $piece ] = $fallback_spec['drum_pattern'][ $piece ];
+        }
+    }
+
+    return $spec;
+}
+
+function se_handle_gastown_start_sting( WP_REST_Request $request ) {
+    $walker_name = sanitize_text_field( (string) $request->get_param( 'walkerName' ) );
+    $walker_name = '' !== trim( $walker_name ) ? mb_substr( preg_replace( '/\s+/', ' ', trim( $walker_name ) ), 0, 24 ) : 'Walker';
+
+    $welcome_line = sprintf( 'Welcome to the Gastown Simulator, %s. Follow the street.', $walker_name );
+    $fallback_spec = se_get_gastown_start_sting_fallback_spec();
+    $result = array(
+        'ok' => true,
+        'walkerName' => $walker_name,
+        'welcomeText' => $welcome_line,
+        'voiceGenerated' => false,
+        'voiceFallback' => true,
+        'voiceFormat' => 'wav',
+        'voiceMimeType' => 'audio/wav',
+        'audioBase64' => '',
+        'musicSpecFallback' => true,
+        'musicSpec' => $fallback_spec,
+        'helpNote' => 'Startup welcome voice is AI-generated when available.',
+    );
+
+    $music_messages = array(
+        array(
+            'role' => 'system',
+            'content' => 'Return strict JSON only. Create a compact browser-synth startup sting spec for a Gastown walking simulator. Keep it gritty, urban, rock-adjacent, short, welcoming, not lounge jazz. Duration 3-6 seconds.',
+        ),
+        array(
+            'role' => 'user',
+            'content' => 'Return JSON with exactly these keys: tempo, key, duration_bars, chord_hits, bass_notes, drum_pattern, lead_phrase, style_description. chord_hits is an array of objects with bar, beat, notes, length_beats, velocity. bass_notes and lead_phrase are arrays of objects with bar, beat, note, length_beats, velocity; lead_phrase can also include articulation. drum_pattern is an object with kick, snare, hat arrays of {bar, beat}. Use 2 or 3 bars in 4/4.',
+        ),
+    );
+    $music_response = se_openai_chat( $music_messages, array(
+        'model' => 'gpt-4o-mini',
+        'temperature' => 0.7,
+        'max_tokens' => 450,
+        'response_format' => array( 'type' => 'json_object' ),
+    ), array( 'timeout' => 8 ) );
+
+    if ( ! is_wp_error( $music_response ) ) {
+        $music_text = trim( (string) ( $music_response['choices'][0]['message']['content'] ?? '' ) );
+        $music_decoded = json_decode( $music_text, true );
+        if ( is_array( $music_decoded ) ) {
+            $result['musicSpec'] = se_sanitize_gastown_start_sting_spec( $music_decoded, $fallback_spec );
+            $result['musicSpecFallback'] = false;
+        }
+    }
+
+    $speech = se_openai_tts(
+        $welcome_line,
+        array(
+            'model' => 'gpt-4o-mini-tts',
+            'voice' => 'alloy',
+            'response_format' => 'wav',
+            'instructions' => 'Read as a brisk game startup welcome. Short, punchy, warm, urban, no ad-libbing.',
+        ),
+        array( 'timeout' => 12 )
+    );
+
+    if ( ! is_wp_error( $speech ) ) {
+        $result['audioBase64'] = base64_encode( $speech['audio'] );
+        $result['voiceGenerated'] = true;
+        $result['voiceFallback'] = false;
+        $result['voiceFormat'] = $speech['format'];
+        $result['voiceMimeType'] = 'audio/wav';
+    }
+
+    return rest_ensure_response( $result );
+}
 
 function se_get_gastown_busker_riff_fallback( $mood = 'lively', $weather = 'clear', $time_of_day = 'morning' ) {
     $tempo = 'night' === $time_of_day ? 90 : ( 'lively' === $mood ? 108 : 96 );

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -155,6 +155,7 @@
     npcSpeechController: null,
     npcSpeechAudio: null,
     resumePointerAfterDialogClose: false,
+    startupSting: { pending: null, queued: false, hasPlayed: false, remoteRequested: false, currentVoiceAudio: null },
     clockTimer: null,
     boundaryNoticeTimer: null,
     currentMicroAreaId: '',
@@ -194,6 +195,35 @@
   const WALKER_NAME_STORAGE_KEY = 'gastownWalkerName';
   const NPC_SPEECH_CACHE_LIMIT = 18;
   const BUSKER_RIFF_CACHE_PREFIX = 'gastownBuskerRiff:';
+  const STARTUP_STING_FALLBACK_SPEC = {
+    tempo: 96,
+    key: 'G minor',
+    duration_bars: 2,
+    chord_hits: [
+      { bar: 1, beat: 1, notes: ['G3', 'Bb3', 'D4'], length_beats: 1.5, velocity: 0.82 },
+      { bar: 2, beat: 1, notes: ['Eb3', 'G3', 'Bb3'], length_beats: 1.25, velocity: 0.76 }
+    ],
+    bass_notes: [
+      { bar: 1, beat: 1, note: 'G1', length_beats: 1, velocity: 0.92 },
+      { bar: 1, beat: 3, note: 'D2', length_beats: 0.75, velocity: 0.78 },
+      { bar: 2, beat: 1, note: 'Eb2', length_beats: 1, velocity: 0.88 },
+      { bar: 2, beat: 3, note: 'F2', length_beats: 0.75, velocity: 0.74 }
+    ],
+    drum_pattern: {
+      kick: [{ bar: 1, beat: 1 }, { bar: 1, beat: 3.5 }, { bar: 2, beat: 1 }, { bar: 2, beat: 3 }],
+      snare: [{ bar: 1, beat: 2.75 }, { bar: 2, beat: 2.75 }],
+      hat: [{ bar: 1, beat: 1.5 }, { bar: 1, beat: 2 }, { bar: 1, beat: 2.5 }, { bar: 1, beat: 4 }, { bar: 2, beat: 1.5 }, { bar: 2, beat: 2 }, { bar: 2, beat: 2.5 }, { bar: 2, beat: 4 }]
+    },
+    lead_phrase: [
+      { bar: 1, beat: 1.5, note: 'D4', length_beats: 0.5, velocity: 0.82, articulation: 'growl' },
+      { bar: 1, beat: 2, note: 'F4', length_beats: 0.5, velocity: 0.78, articulation: 'bend' },
+      { bar: 1, beat: 2.5, note: 'G4', length_beats: 1, velocity: 0.9, articulation: 'hold' },
+      { bar: 2, beat: 1.5, note: 'Bb4', length_beats: 0.5, velocity: 0.8, articulation: 'stab' },
+      { bar: 2, beat: 2, note: 'G4', length_beats: 0.75, velocity: 0.84, articulation: 'fall' },
+      { bar: 2, beat: 3, note: 'D4', length_beats: 1, velocity: 0.74, articulation: 'hold' }
+    ],
+    style_description: 'gritty urban rock-adjacent welcome sting with a stylized sax lead; brisk, punchy, not lounge jazz'
+  };
   const ART_DIRECTION = {
     label: 'stylized realism with cinematic Vancouver rain-lighting',
     streetReflectionBoost: 0.22,
@@ -389,8 +419,12 @@
   function confirmWalkerName(value) {
     setWalkerName(value);
     closeWalkerNameOverlay();
+    state.startupSting.hasPlayed = false;
+    state.startupSting.remoteRequested = false;
+    state.startupSting.queued = false;
     pushJournalEntry('On the street as ' + state.walkerName + '.');
     setStatus(state.walkerName.toUpperCase() + ' ready. Click in.');
+    triggerStartupSting();
   }
 
   const QUEST_DEFINITIONS = {
@@ -468,7 +502,7 @@
 
   function renderProgressionUi() {
     if (routeScoreEl) {
-      routeScoreEl.textContent = Math.round(state.progression.routeCompletionScore) + '% mapped';
+      routeScoreEl.textContent = Math.round(state.progression.routeCompletionScore) + '% route';
     }
     if (collectiblesLogEl) {
       const deduped = [];
@@ -742,6 +776,162 @@
     if (pointerStatusEl) {
       pointerStatusEl.textContent = text;
     }
+  }
+
+  function getStartupStingFallbackSpec() {
+    return JSON.parse(JSON.stringify(STARTUP_STING_FALLBACK_SPEC));
+  }
+
+  function sanitizeStartupStingSpec(spec) {
+    const fallback = getStartupStingFallbackSpec();
+    if (!spec || typeof spec !== 'object') return fallback;
+    const sanitizeEvent = (event, chordMode) => {
+      if (!event || typeof event !== 'object') return null;
+      const base = {
+        bar: Math.max(1, Math.min(3, Number(event.bar) || 1)),
+        beat: Math.max(1, Math.min(4, Number(event.beat) || 1)),
+        length_beats: Math.max(0.25, Math.min(2.5, Number(event.length_beats) || 0.5)),
+        velocity: Math.max(0.35, Math.min(1, Number(event.velocity) || 0.8))
+      };
+      if (chordMode) {
+        const notes = Array.isArray(event.notes) ? event.notes.map((note) => String(note || '').trim()).filter(Boolean).slice(0, 4) : [];
+        if (!notes.length) return null;
+        base.notes = notes;
+      } else {
+        const note = String(event.note || '').trim();
+        if (!note) return null;
+        base.note = note;
+      }
+      if (event.articulation) base.articulation = String(event.articulation);
+      return base;
+    };
+    const specOut = {
+      tempo: Math.max(80, Math.min(132, Number(spec.tempo) || fallback.tempo)),
+      key: String(spec.key || fallback.key),
+      duration_bars: Math.max(2, Math.min(3, Number(spec.duration_bars) || fallback.duration_bars)),
+      chord_hits: (Array.isArray(spec.chord_hits) ? spec.chord_hits : []).map((event) => sanitizeEvent(event, true)).filter(Boolean),
+      bass_notes: (Array.isArray(spec.bass_notes) ? spec.bass_notes : []).map((event) => sanitizeEvent(event, false)).filter(Boolean),
+      drum_pattern: { kick: [], snare: [], hat: [] },
+      lead_phrase: (Array.isArray(spec.lead_phrase) ? spec.lead_phrase : []).map((event) => sanitizeEvent(event, false)).filter(Boolean),
+      style_description: String(spec.style_description || fallback.style_description)
+    };
+    ['kick', 'snare', 'hat'].forEach((piece) => {
+      specOut.drum_pattern[piece] = (spec.drum_pattern && Array.isArray(spec.drum_pattern[piece]) ? spec.drum_pattern[piece] : []).map((event) => ({
+        bar: Math.max(1, Math.min(3, Number(event && event.bar) || 1)),
+        beat: Math.max(1, Math.min(4, Number(event && event.beat) || 1))
+      }));
+      if (!specOut.drum_pattern[piece].length) specOut.drum_pattern[piece] = fallback.drum_pattern[piece];
+    });
+    if (!specOut.chord_hits.length) specOut.chord_hits = fallback.chord_hits;
+    if (!specOut.bass_notes.length) specOut.bass_notes = fallback.bass_notes;
+    if (!specOut.lead_phrase.length) specOut.lead_phrase = fallback.lead_phrase;
+    return specOut;
+  }
+
+  function decodeBase64ToUint8Array(base64) {
+    const binary = window.atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+  }
+
+  async function ensureToneReady() {
+    const Tone = getTone();
+    if (!Tone) return null;
+    try {
+      if (typeof Tone.start === 'function') await Tone.start();
+      state.audioUnlocked = true;
+      return Tone;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  async function fetchStartupStingPayload() {
+    if (!config.startupStingEndpoint) return null;
+    try {
+      const response = await window.fetch(config.startupStingEndpoint, {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json', 'X-WP-Nonce': config.nonce || '' },
+        body: JSON.stringify({ walkerName: state.walkerName || 'Walker' })
+      });
+      if (!response.ok) throw new Error('Startup sting request failed.');
+      return await response.json();
+    } catch (error) {
+      if (window.console && window.console.warn) window.console.warn('[Gastown Sim] Startup sting endpoint unavailable.', error);
+      return null;
+    }
+  }
+
+  function scheduleStartupVoice(payload, Tone, destination, startedAt) {
+    if (!payload || !payload.audioBase64 || !Tone) return;
+    try {
+      const player = new Tone.Player({ autostart: false, fadeOut: 0.12 }).connect(destination);
+      player.volume.value = -7;
+      player.load(URL.createObjectURL(new Blob([decodeBase64ToUint8Array(payload.audioBase64)], { type: payload.voiceMimeType || 'audio/wav' }))).then(() => {
+        player.start(startedAt + 0.08);
+        state.startupSting.currentVoiceAudio = player;
+      }).catch(() => {});
+    } catch (error) {}
+  }
+
+  async function playStartupStingNow(payload) {
+    const Tone = await ensureToneReady();
+    if (!Tone) return false;
+    const spec = sanitizeStartupStingSpec(payload && payload.musicSpec ? payload.musicSpec : getStartupStingFallbackSpec());
+    const master = new Tone.Gain(0.9).toDestination();
+    const limiter = new Tone.Limiter(-4).connect(master);
+    const chords = new Tone.PolySynth(Tone.Synth, { oscillator: { type: 'sawtooth' }, envelope: { attack: 0.01, decay: 0.18, sustain: 0.16, release: 0.55 }, volume: -14 }).connect(limiter);
+    const bass = new Tone.MonoSynth({ oscillator: { type: 'square' }, filter: { Q: 1, type: 'lowpass', rolloff: -24 }, envelope: { attack: 0.01, decay: 0.14, sustain: 0.35, release: 0.4 }, filterEnvelope: { attack: 0.01, decay: 0.16, sustain: 0.3, release: 0.3, baseFrequency: 90, octaves: 2.3 }, volume: -10 }).connect(limiter);
+    const lead = new Tone.Synth({ oscillator: { type: 'sawtooth3' }, envelope: { attack: 0.02, decay: 0.08, sustain: 0.25, release: 0.28 }, volume: -11 }).connect(new Tone.FeedbackDelay('16n', 0.18).connect(limiter));
+    const kick = new Tone.MembraneSynth({ pitchDecay: 0.025, octaves: 5, envelope: { attack: 0.001, decay: 0.22, sustain: 0, release: 0.05 }, volume: -7 }).connect(limiter);
+    const snare = new Tone.NoiseSynth({ noise: { type: 'pink' }, envelope: { attack: 0.001, decay: 0.16, sustain: 0 }, volume: -16 }).connect(limiter);
+    const hat = new Tone.MetalSynth({ frequency: 260, envelope: { attack: 0.001, decay: 0.08, release: 0.01 }, harmonicity: 5.1, modulationIndex: 16, resonance: 1800, octaves: 1.6, volume: -26 }).connect(limiter);
+    const beatToSeconds = 60 / spec.tempo;
+    const eventTime = (bar, beat) => Tone.now() + ((Math.max(1, bar) - 1) * 4 + (Math.max(1, beat) - 1)) * beatToSeconds + 0.05;
+    spec.chord_hits.forEach((event) => chords.triggerAttackRelease(event.notes, event.length_beats * beatToSeconds, eventTime(event.bar, event.beat), event.velocity));
+    spec.bass_notes.forEach((event) => bass.triggerAttackRelease(event.note, event.length_beats * beatToSeconds, eventTime(event.bar, event.beat), event.velocity));
+    spec.lead_phrase.forEach((event) => lead.triggerAttackRelease(event.note, event.length_beats * beatToSeconds, eventTime(event.bar, event.beat), event.velocity));
+    (spec.drum_pattern.kick || []).forEach((event) => kick.triggerAttackRelease('C1', '8n', eventTime(event.bar, event.beat), 0.95));
+    (spec.drum_pattern.snare || []).forEach((event) => snare.triggerAttackRelease('16n', eventTime(event.bar, event.beat), 0.6));
+    (spec.drum_pattern.hat || []).forEach((event) => hat.triggerAttackRelease('16n', eventTime(event.bar, event.beat), 0.28));
+    scheduleStartupVoice(payload, Tone, limiter, Tone.now());
+    const cleanupAfter = ((((spec.duration_bars || 2) * 4) + 2) * beatToSeconds * 1000);
+    window.setTimeout(() => { [chords, bass, lead, kick, snare, hat, limiter, master].forEach((node) => { try { if (node && typeof node.dispose === 'function') node.dispose(); } catch (error) {} }); }, cleanupAfter);
+    return true;
+  }
+
+  async function consumeStartupStingQueue() {
+    if (!state.startupSting.queued || state.startupSting.hasPlayed) return;
+    const payload = state.startupSting.pending || { musicSpec: getStartupStingFallbackSpec(), audioBase64: '' };
+    const played = await playStartupStingNow(payload);
+    if (played) {
+      state.startupSting.queued = false;
+      state.startupSting.hasPlayed = true;
+      setStatus(payload && payload.welcomeText ? payload.welcomeText : ('Welcome, ' + state.walkerName + '. Follow the street.'));
+    }
+  }
+
+  function queueStartupSting(payload) {
+    state.startupSting.pending = payload || { musicSpec: getStartupStingFallbackSpec(), audioBase64: '' };
+    state.startupSting.queued = true;
+    consumeStartupStingQueue();
+  }
+
+  async function triggerStartupSting() {
+    if (state.startupSting.remoteRequested) return;
+    state.startupSting.remoteRequested = true;
+    const payload = await fetchStartupStingPayload();
+    queueStartupSting(payload || {
+      ok: false,
+      walkerName: state.walkerName || 'Walker',
+      welcomeText: 'Welcome to the Gastown Simulator, ' + (state.walkerName || 'Walker') + '. Follow the street.',
+      audioBase64: '',
+      musicSpec: getStartupStingFallbackSpec(),
+      musicSpecFallback: true,
+      voiceFallback: true
+    });
   }
 
   function syncCameraProjection(mode) {
@@ -5200,6 +5390,10 @@
     }
     weatherSelect.addEventListener('change', (event) => applyWeather(event.target.value));
     moodSelect.addEventListener('change', (event) => applyMood(event.target.value));
+
+    ['pointerdown', 'keydown', 'touchstart'].forEach((eventName) => {
+      document.addEventListener(eventName, () => { consumeStartupStingQueue(); }, { passive: true });
+    });
 
     document.addEventListener('pointerlockchange', () => {
       if (state.cameraMode === 'street' && document.pointerLockElement === renderer.domElement) {

--- a/page-gastown-sim.php
+++ b/page-gastown-sim.php
@@ -69,7 +69,7 @@ get_header();
           <li><strong>E / click</strong> talk or log</li>
           <li><strong>Esc</strong> close / release</li>
         </ul>
-        <p class="gastown-help-note">AI voice talkback is optional. If voice or riff generation fails, text and play continue.</p>
+        <p class="gastown-help-note">Startup welcome voice is AI-generated when available. If OpenAI voice or music-spec generation fails, the walk still starts and local fallback audio can play.</p>
       </section>
     </details>
 
@@ -97,7 +97,7 @@ get_header();
           <h2 id="gastown-name-title">Name your walker</h2>
         </div>
         <div class="gastown-dialog-body">
-          <p>Optional. Keep it short.</p>
+          <p>Optional. Keep it short. A quick AI-generated welcome may play after this.</p>
           <label class="gastown-name-field">
             <span>Walker name</span>
             <input type="text" maxlength="24" autocomplete="nickname" data-walker-name-input placeholder="SUZY">
@@ -114,12 +114,11 @@ get_header();
       <div class="gastown-hud-identity">
         <p class="gastown-hud-kicker">ON THE STREET</p>
         <p class="gastown-hud-name" data-walker-name-display>WALKER</p>
-        <p class="gastown-hud-subline" data-sim-status aria-live="polite">Click in to start.</p>
       </div>
       <div class="gastown-hud-route">
-        <p class="gastown-expedition-value" data-sim-route-score aria-live="polite">0% mapped</p>
-        <p class="gastown-hud-detail-count" data-sim-quest-status aria-live="polite">0 details</p>
+        <p class="gastown-expedition-value" data-sim-route-score aria-live="polite">0% route</p>
       </div>
+      <p class="gastown-hud-subline" data-sim-status aria-live="polite">Click in to start.</p>
       <p class="gastown-interact-prompt" data-sim-interact-prompt aria-live="polite" hidden></p>
     </section>
 
@@ -145,35 +144,19 @@ get_header();
       </aside>
       <pre class="gastown-route-debug-overlay" data-route-debug-overlay hidden></pre>
       <div class="gastown-live-strip">
-        <p class="gastown-pointer-status" data-sim-pointer-status aria-live="polite">Pointer free</p>
         <p class="gastown-landmark" data-sim-landmark aria-live="polite">Station threshold</p>
         <p class="gastown-route-segment" data-sim-route-segment aria-live="polite">Start</p>
       </div>
     </div>
 
     <details class="gastown-log-drawer">
-      <summary>Notes</summary>
+      <summary>Route notes</summary>
       <div class="gastown-meta-strip">
         <p class="gastown-world-status" data-sim-world-status aria-live="polite">World data status: checking build provenance…</p>
         <p class="gastown-expedition-value" data-sim-objective aria-live="polite">Steam Clock ahead.</p>
         <p class="gastown-expedition-value gastown-hud-next-step" data-sim-next-step aria-live="polite">Follow the first bit of street energy.</p>
       </div>
-      <div class="gastown-hud-support">
-        <div class="gastown-hud-card gastown-hud-card--journal">
-          <p class="gastown-expedition-label">Journal</p>
-          <ul class="gastown-expedition-list" data-sim-journal aria-live="polite">
-            <li>On the platform edge.</li>
-          </ul>
-        </div>
-        <div class="gastown-hud-card gastown-hud-card--details">
-          <p class="gastown-expedition-label">Logged</p>
-          <ul class="gastown-expedition-list" data-sim-collectibles-log aria-live="polite">
-            <li>Newspaper box — not logged</li>
-            <li>Historic plaque — not logged</li>
-            <li>Painted brick panel — not logged</li>
-          </ul>
-        </div>
-      </div>
+
     </details>
 
     <section class="gastown-debug" data-debug-panel hidden>


### PR DESCRIPTION
### Motivation
- Provide an immediate, short startup audio "sting" after the player names (or skips naming) their walker to deliver a punchy welcome and musical intro. 
- Use OpenAI for a generated spoken welcome and for producing a compact JSON music spec while rendering the music locally in-browser to avoid hardcoded MP3 assets. 
- Keep the system optional, fast, and resilient so gameplay never blocks if remote services fail. 

### Description
- Add a new REST endpoint `se/v1/gastown-start-sting` that returns a walker-aware welcome line, an OpenAI TTS audio payload (via `gpt-4o-mini-tts`) encoded as base64 when available, and a strict JSON music spec produced with `gpt-4o-mini`, plus safe fallback spec and metadata; request/response logic and sanitizers live in `functions.php`. 
- Wire a `startupStingEndpoint` localize script variable and register the REST route so the client can request the welcome+spec payload. 
- Implement a lightweight in-browser renderer in `js/gastown-sim.js` that: sanitizes the returned spec, synthesizes a 3–6s sting (kick, bass, chords, stylized sax-like lead, hats/snare) with Tone.js, schedules playing of remote TTS audio if present, queues playback until audio is unlocked by a user gesture, and never blocks simulator startup (uses a built-in fallback spec if OpenAI calls fail). 
- Trigger the startup sting immediately after the walker-name modal is submitted or skipped, and include the chosen walker name (defaulting to `Walker`) in the welcome text. 
- Shorten and simplify the live HUD and HUD CSS (`page-gastown-sim.php` and `assets/css/gastown-sim.css`) to show only walker name, one short status line, route completion, and the tiny interact prompt; move AI-voice disclosure into the settings/help panel. 

### Testing
- Ran PHP syntax check with `php -l functions.php` and it returned no syntax errors. 
- Verified JavaScript syntax by evaluating `new Function(require('fs').readFileSync('js/gastown-sim.js','utf8'))` in Node and received a successful parse confirmation. 
- Performed static/code-path verification that the walker name submission calls `triggerStartupSting()`, that the endpoint request includes `walkerName`, the frontend sanitizes/uses the returned music spec and local fallback, Tone.js instruments synthesize the music (no static MP3s are downloaded), and OpenAI failures fall back without blocking gameplay.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c10ca4f128832ea360621c21b6915a)