### PR TITLE
Replace 'Suzanne Easton' with 'Suzy Easton' across site

### DIFF
--- a/assets/brand/suzanne-logo.svg
+++ b/assets/brand/suzanne-logo.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="420" height="150" viewBox="0 0 420 150" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Suzanne (Suzy) Easton logo">
+<svg width="420" height="150" viewBox="0 0 420 150" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Suzy Easton logo">
   <defs>
     <linearGradient id="neon" x1="0" y1="0" x2="420" y2="0" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#B9FF66"/>
@@ -44,12 +44,7 @@
     <text x="210" y="56" text-anchor="middle"
           font-family="'Press Start 2P', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif"
           font-size="18" letter-spacing="0.5"
-          fill="url(#fillGrad)" stroke="url(#neon)" stroke-width="1.2">SUZANNE</text>
-
-    <text x="210" y="74" text-anchor="middle"
-          font-family="'Press Start 2P', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif"
-          font-size="10" letter-spacing="0.2"
-          fill="url(#fillGrad)" stroke="url(#neon)" stroke-width="1">(SUZY)</text>
+          fill="url(#fillGrad)" stroke="url(#neon)" stroke-width="1.2">SUZY</text>
 
     <text x="210" y="112" text-anchor="middle"
           font-family="'Press Start 2P', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif"

--- a/header.php
+++ b/header.php
@@ -165,8 +165,7 @@
   <!-- Header wordmark (compact bar) -->
   <div class="se-header-branding">
     <a href="<?php echo esc_url( home_url( '/' ) ); ?>" class="se-header-wordmark">
-      <span class="se-header-name-main">SUZANNE</span>
-      <span class="se-header-name-nick">(SUZY)</span>
+      <span class="se-header-name-main">SUZY</span>
       <span class="se-header-name-last">EASTON</span>
     </a>
   </div>

--- a/lousy-outages/includes/Feed.php
+++ b/lousy-outages/includes/Feed.php
@@ -100,7 +100,7 @@ class Feed {
     <title><?php echo esc_html('Lousy Outages — Arcade Ops Feed'); ?></title>
     <atom:link href="<?php echo $self; ?>" rel="self" type="application/rss+xml" />
     <link><?php echo esc_url(home_url('/lousy-outages/')); ?></link>
-    <description><?php echo esc_html('Fast, loud, and slightly neon. Outage pings from Suzanne (Suzy) Easton’s console.'); ?></description>
+    <description><?php echo esc_html('Fast, loud, and slightly neon. Outage pings from Suzy Easton’s console.'); ?></description>
     <language>en-US</language>
     <lastBuildDate><?php echo esc_html($lastUpdated); ?></lastBuildDate>
     <?php foreach ($items as $item) : ?>
@@ -280,7 +280,7 @@ class Feed {
                 'link'        => home_url('/lousy-outages/'),
                 'guid'        => 'lousy-outages-incidents-empty-' . gmdate('YmdHis'),
                 'pubDate'     => self::format_rss_date(gmdate('c')),
-                'description' => 'Enjoy the silence. Suzanne will holler if something breaks.',
+                'description' => 'Enjoy the silence. Suzy will holler if something breaks.',
                 'timestamp'   => time(),
             ];
         }

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -111,7 +111,7 @@ function lousy_outages_activate() {
     lousy_outages_create_page();
     Subscriptions::create_table();
     Subscriptions::schedule_purge();
-    $default_email = 'suzanneeaston@gmail.com';
+    $default_email = 'suzyeaston@gmail.com';
     $stored_email  = get_option( 'lousy_outages_email' );
     if ( empty( $stored_email ) && is_email( $default_email ) ) {
         update_option( 'lousy_outages_email', sanitize_email( $default_email ) );

--- a/page-home.php
+++ b/page-home.php
@@ -8,9 +8,9 @@ get_header();
         <div class="hero-grid">
             <?php
             $hero_eyebrow = apply_filters('se_home_hero_eyebrow', 'Vancouver, BC • Built in public');
-            $hero_logo_label = apply_filters('se_home_hero_title', 'Suzanne (Suzy) Easton');
-            $hero_logo_top = apply_filters('se_home_hero_logo_top', 'Suzanne');
-            $hero_logo_mid = apply_filters('se_home_hero_logo_mid', '(Suzy)');
+            $hero_logo_label = apply_filters('se_home_hero_title', 'Suzy Easton');
+            $hero_logo_top = apply_filters('se_home_hero_logo_top', 'Suzy');
+            $hero_logo_mid = apply_filters('se_home_hero_logo_mid', '');
             $hero_logo_bottom = apply_filters('se_home_hero_logo_bottom', 'Easton');
             $hero_logo_top_text = function_exists('mb_strtoupper') ? mb_strtoupper($hero_logo_top, 'UTF-8') : strtoupper($hero_logo_top);
             $hero_logo_mid_text = function_exists('mb_strtoupper') ? mb_strtoupper($hero_logo_mid, 'UTF-8') : strtoupper($hero_logo_mid);
@@ -27,7 +27,9 @@ get_header();
                         <p class="hero-wordmark" aria-label="<?php echo esc_attr($hero_logo_label); ?>">
                             <span class="line1">
                                 <?php echo esc_html($hero_logo_top_text); ?>
-                                <small><?php echo esc_html($hero_logo_mid_text); ?></small>
+                                <?php if (!empty($hero_logo_mid_text)) : ?>
+                                    <small><?php echo esc_html($hero_logo_mid_text); ?></small>
+                                <?php endif; ?>
                             </span>
                             <span class="line2"><?php echo esc_html($hero_logo_bottom_text); ?></span>
                         </p>


### PR DESCRIPTION
### Motivation
- The site and a bundled plugin used the variant `Suzanne` in several places which should be normalized to the public-facing name `Suzy Easton` for consistency.
- Update the default contact email used by the plugin to match the `suzy` username rather than the old `suzanne` address.

### Description
- Updated homepage hero defaults in `page-home.php` so the visible label is `Suzy Easton`, the top wordmark reads `Suzy`, and the optional nickname line is conditionally hidden when empty.
- Changed the compact header wordmark in `header.php` to display `SUZY EASTON` (removed the empty nickname span).
- Updated the branded SVG at `assets/brand/suzanne-logo.svg` to adjust the `aria-label` and visible top text from `Suzanne` to `Suzy`.
- Replaced copy in the Lousy Outages feed at `lousy-outages/includes/Feed.php` to reference `Suzy Easton` and adjusted the empty-feed message to say `Suzy will holler...`.
- Switched the plugin default notification email in `lousy-outages/lousy-outages.php` from `suzanneeaston@gmail.com` to `suzyeaston@gmail.com`.

### Testing
- Ran PHP syntax checks with `php -l` on `header.php`, `page-home.php`, `lousy-outages/includes/Feed.php`, and `lousy-outages/lousy-outages.php` and received no syntax errors.
- Verified there are no remaining occurrences of the legacy variants by running `rg -n "SUZANNE|Suzanne|suzanneeaston" /workspace/suzyeastonca` which returned no matches.
- Confirmed the modified files were updated without introducing syntax issues by re-running the PHP lint checks after edits and they all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c235a86460832ea87398ef4ec26515)