### PR TITLE
Add hold-to-run, reauthor fallback Gastown world, and improve minimap

### DIFF
--- a/__tests__/gastown-sim-config.test.js
+++ b/__tests__/gastown-sim-config.test.js
@@ -39,5 +39,6 @@ test('simulator page copy presents working corridor as intended product', () => 
 
   assert.match(php, /Gastown working corridor/);
   assert.match(php, /deterministic local world build/);
+  assert.match(php, /hold to run/);
   assert.doesNotMatch(php, /AI-generated welcome/);
 });

--- a/__tests__/gastown-sim-resilience.test.js
+++ b/__tests__/gastown-sim-resilience.test.js
@@ -44,3 +44,17 @@ test('runtime init renders core world first and defers optional systems', () => 
   assert.match(block, /try \{ if \(RUNTIME_PROFILE\.deferAudioSetup\) setupAudio\(state\.world\); \}/);
   assert.match(block, /setStatus\('Gastown working corridor ready\. Click in to explore\.'/);
 });
+
+test('movement model supports hold-to-run with smooth activation and reset', () => {
+  assert.match(src, /const HOLD_TO_RUN_THRESHOLD_SECONDS = 0\.34/);
+  assert.match(src, /const HOLD_TO_RUN_FORWARD_MULTIPLIER = 1\.58/);
+  assert.match(src, /function updateHoldToRunState\(delta, forwardInput\)/);
+  assert.match(src, /state\.motion\.runHoldSeconds \+= delta/);
+  assert.match(src, /state\.motion\.runActive = !state\.gait\.precise && state\.cameraMode === 'street' && \(holdRunActive \|\| shiftRunActive\)/);
+  assert.match(src, /function getDynamicMovementProfile\(baseProfile, runState\)/);
+  assert.match(src, /runForwardFactor = forward > 0 \? \(1 \+ \(\(HOLD_TO_RUN_FORWARD_MULTIPLIER - 1\) \* movementProfile\.runBlend\)\) : 1/);
+  assert.match(src, /runStrafeFactor = 1 - \(movementProfile\.runBlend \* 0\.17\)/);
+  assert.match(src, /state\.motion\.runBlend = 0;/);
+  assert.match(src, /state\.motion\.runHoldSeconds = 0;/);
+  assert.match(src, /state\.motion\.runActive = false;/);
+});

--- a/__tests__/gastown-world-generator.test.js
+++ b/__tests__/gastown-world-generator.test.js
@@ -85,6 +85,11 @@ test('generator keeps world polygons valid with existing or generated output', (
       assert.equal(data.navigator.focusCorridor.length >= 4, true, 'working fallback should expose at least west leg, plaza loop, east leg, and Cambie crossing minimap corridors');
       assert.equal(data.navigator.focusCorridor.some((segment) => segment.id === 'steam-clock-plaza-loop'), true, 'working fallback should expose a plaza loop in navigator data');
       assert.equal(data.navigator.focusCorridor.some((segment) => segment.id === 'cambie-crossing'), true, 'working fallback should expose a Cambie crossing in navigator data');
+      data.navigator.focusCorridor.forEach((segment) => {
+        assert.equal(Array.isArray(segment.points), true, segment.id + ' should expose minimap points');
+        assert.equal(segment.points.length >= 2, true, segment.id + ' should expose at least two minimap points');
+        assertFinitePoints(segment.points);
+      });
 
       const steamClockNode = data.nodes.find((node) => node.id === 'steam-clock');
       const approachNode = data.route.centerline.find((node) => node.id === 'steam-clock-approach');
@@ -141,6 +146,7 @@ test('committed world json files include the expanded intersection-based fallbac
     assert.equal(data.meta.buildClassification, 'approximate-fallback', relPath + ' should keep fallback build classification explicit');
     assert.match(data.meta.provenanceSummary, /Approximate fallback corridor retained/, relPath + ' should keep fallback provenance explicit');
     assert.ok(data.nodes.some((node) => node.id === 'water-cordova-seam'), relPath + ' should include the Water/Cordova seam node');
+    assert.equal(data.nodes.find((node) => node.id === 'steam-clock').label, 'Cambie / Steam Clock corner', relPath + ' should label the Steam Clock node as a corner');
     assert.ok(data.nodes.some((node) => node.id === 'maple-tree-square-edge'), relPath + ' should include the Maple Tree Square edge node');
     assert.ok(data.nodes.some((node) => node.id === 'water-cambie-intersection'), relPath + ' should include the Water/Cambie intersection node');
     assert.ok(Array.isArray(data.streetscape.surfaceBands) && data.streetscape.surfaceBands.length === 48, relPath + ' should constrain surface band clutter while allowing the hero block extra wear detail');

--- a/assets/world/gastown-water-street.json
+++ b/assets/world/gastown-water-street.json
@@ -73,9 +73,9 @@
       },
       {
         "id": "steam-clock",
-        "label": "Steam Clock plaza",
-        "x": 181.97,
-        "z": -154.73
+        "label": "Cambie / Steam Clock corner",
+        "x": 181.87,
+        "z": -154.81
       },
       {
         "id": "maple-tree-square-edge",
@@ -104,8 +104,8 @@
         "z": -186.87
       },
       {
-        "x": 186.97,
-        "z": -178.73
+        "x": 186.87,
+        "z": -178.81
       },
       {
         "x": 232.34,
@@ -132,8 +132,8 @@
         "z": -11
       }
     ],
-    "streetWidth": 9.8,
-    "sidewalkWidth": 5.199999999999999,
+    "streetWidth": 8.4,
+    "sidewalkWidth": 5.8999999999999995,
     "softBoundary": 3.6,
     "hardResetDistance": 12
   },
@@ -159,8 +159,8 @@
     {
       "id": "storefront-edge",
       "label": "Storefront edge",
-      "x": 125.74,
-      "z": -110.65
+      "x": 125.81,
+      "z": -110.6
     },
     {
       "id": "water-street-mid-block",
@@ -171,20 +171,20 @@
     {
       "id": "alley-threshold",
       "label": "Alley threshold",
-      "x": 195.52,
-      "z": -139.23
+      "x": 195.42,
+      "z": -139.31
     },
     {
       "id": "steam-clock",
-      "label": "Steam Clock plaza",
-      "x": 181.97,
-      "z": -154.73
+      "label": "Cambie / Steam Clock corner",
+      "x": 181.87,
+      "z": -154.81
     },
     {
       "id": "landmark-corner",
       "label": "Landmark corner",
-      "x": 181.63,
-      "z": -156.76
+      "x": 181.53,
+      "z": -156.84
     },
     {
       "id": "maple-tree-square-edge",
@@ -314,20 +314,20 @@
         "label": "Steam Clock plaza",
         "points": [
           {
-            "x": 183.71,
-            "z": -153.39
+            "x": 183.61,
+            "z": -153.47
           },
           {
-            "x": 184.52,
-            "z": -155.92
+            "x": 184.42,
+            "z": -156
           },
           {
-            "x": 181.65,
-            "z": -157.76
+            "x": 181.55,
+            "z": -157.84
           },
           {
-            "x": 180.14,
-            "z": -156.14
+            "x": 180.04,
+            "z": -156.21
           }
         ]
       },
@@ -420,64 +420,64 @@
         "surface": "road",
         "polygon": [
           {
-            "x": -3.16,
-            "z": -3.75
+            "x": -2.71,
+            "z": -3.21
           },
           {
-            "x": 25.88,
-            "z": -28.23
+            "x": 26.33,
+            "z": -27.7
           },
           {
-            "x": 60.08,
-            "z": -56.12
+            "x": 60.51,
+            "z": -55.57
           },
           {
-            "x": 107.31,
-            "z": -91.77
+            "x": 107.73,
+            "z": -91.21
           },
           {
-            "x": 149.37,
-            "z": -122.89
+            "x": 149.79,
+            "z": -122.33
           },
           {
-            "x": 194.95,
-            "z": -152.46
+            "x": 194.45,
+            "z": -151.97
           },
           {
-            "x": 192.39,
-            "z": -142.15
+            "x": 191.84,
+            "z": -142.58
           },
           {
-            "x": 184.63,
-            "z": -148.13
+            "x": 185.18,
+            "z": -147.7
           },
           {
-            "x": 188.01,
-            "z": -145.54
+            "x": 188.51,
+            "z": -146.03
           },
           {
-            "x": 155.26,
-            "z": -115.06
+            "x": 154.84,
+            "z": -115.62
           },
           {
-            "x": 113.18,
-            "z": -83.92
+            "x": 112.76,
+            "z": -84.48
           },
           {
-            "x": 66.13,
-            "z": -48.41
+            "x": 65.69,
+            "z": -48.96
           },
           {
-            "x": 32.14,
-            "z": -20.69
+            "x": 31.69,
+            "z": -21.23
           },
           {
-            "x": 3.16,
-            "z": 3.75
+            "x": 2.71,
+            "z": 3.21
           },
           {
-            "x": -3.16,
-            "z": -3.75
+            "x": -2.71,
+            "z": -3.21
           }
         ]
       },
@@ -486,24 +486,24 @@
         "surface": "road",
         "polygon": [
           {
-            "x": 190.53,
-            "z": -162.34
+            "x": 190.1,
+            "z": -161.79
           },
           {
-            "x": 204.62,
-            "z": -151.47
+            "x": 204.2,
+            "z": -150.92
           },
           {
-            "x": 196.75,
-            "z": -141.26
+            "x": 197.17,
+            "z": -141.81
           },
           {
-            "x": 182.65,
-            "z": -152.12
+            "x": 183.08,
+            "z": -152.68
           },
           {
-            "x": 190.53,
-            "z": -162.34
+            "x": 190.1,
+            "z": -161.79
           }
         ]
       },
@@ -512,32 +512,32 @@
         "surface": "road",
         "polygon": [
           {
-            "x": 202.15,
-            "z": -155.46
+            "x": 201.64,
+            "z": -155.85
           },
           {
-            "x": 188.73,
-            "z": -145.43
+            "x": 189.12,
+            "z": -145.94
           },
           {
-            "x": 206.77,
-            "z": -176.22
+            "x": 207.28,
+            "z": -175.82
           },
           {
-            "x": 213.91,
-            "z": -170.71
+            "x": 213.4,
+            "z": -171.11
           },
           {
-            "x": 194.23,
-            "z": -152.57
+            "x": 193.84,
+            "z": -152.06
           },
           {
-            "x": 195.01,
-            "z": -160.96
+            "x": 195.52,
+            "z": -160.57
           },
           {
-            "x": 202.15,
-            "z": -155.46
+            "x": 201.64,
+            "z": -155.85
           }
         ]
       },
@@ -546,32 +546,32 @@
         "surface": "road",
         "polygon": [
           {
-            "x": 204.64,
-            "z": -167.42
+            "x": 204.19,
+            "z": -167.65
           },
           {
-            "x": 194.58,
-            "z": -147.3
+            "x": 194.13,
+            "z": -147.55
           },
           {
-            "x": 182.51,
-            "z": -127.19
+            "x": 182.07,
+            "z": -127.45
           },
           {
-            "x": 176.46,
-            "z": -130.82
+            "x": 176.89,
+            "z": -130.56
           },
           {
-            "x": 188.39,
-            "z": -150.7
+            "x": 188.83,
+            "z": -150.46
           },
           {
-            "x": 198.33,
-            "z": -170.58
+            "x": 198.78,
+            "z": -170.35
           },
           {
-            "x": 204.64,
-            "z": -167.42
+            "x": 204.19,
+            "z": -167.65
           }
         ]
       }
@@ -582,32 +582,32 @@
         "side": "south",
         "polygon": [
           {
-            "x": 3.27,
-            "z": 3.88
+            "x": 2.82,
+            "z": 3.35
           },
           {
-            "x": 32.26,
-            "z": -20.55
+            "x": 31.81,
+            "z": -21.09
           },
           {
-            "x": 66.24,
-            "z": -48.26
+            "x": 65.81,
+            "z": -48.82
           },
           {
-            "x": 113.29,
-            "z": -83.77
+            "x": 112.87,
+            "z": -84.34
           },
           {
-            "x": 155.37,
-            "z": -114.92
+            "x": 154.95,
+            "z": -115.48
           },
           {
-            "x": 195.1,
-            "z": -145.37
+            "x": 194.6,
+            "z": -145.87
           },
           {
-            "x": 214.36,
-            "z": -170.36
+            "x": 213.81,
+            "z": -170.79
           },
           {
             "x": 218.5,
@@ -638,8 +638,8 @@
             "z": 7.88
           },
           {
-            "x": 3.27,
-            "z": 3.88
+            "x": 2.82,
+            "z": 3.35
           }
         ]
       },
@@ -676,32 +676,32 @@
             "z": -180.12
           },
           {
-            "x": 206.38,
-            "z": -176.52
+            "x": 206.93,
+            "z": -176.09
           },
           {
-            "x": 187.92,
-            "z": -152.57
+            "x": 188.42,
+            "z": -152.07
           },
           {
-            "x": 149.31,
-            "z": -122.97
+            "x": 149.73,
+            "z": -122.41
           },
           {
-            "x": 107.25,
-            "z": -91.85
+            "x": 107.67,
+            "z": -91.29
           },
           {
-            "x": 60.01,
-            "z": -56.2
+            "x": 60.45,
+            "z": -55.65
           },
           {
-            "x": 25.82,
-            "z": -28.31
+            "x": 26.27,
+            "z": -27.77
           },
           {
-            "x": -3.22,
-            "z": -3.82
+            "x": -2.77,
+            "z": -3.29
           },
           {
             "x": -7.03,
@@ -740,24 +740,24 @@
         "side": "storefront",
         "polygon": [
           {
-            "x": 121.49,
-            "z": -118.73
+            "x": 121.54,
+            "z": -118.69
           },
           {
-            "x": 134.47,
-            "z": -108.72
+            "x": 134.53,
+            "z": -108.68
           },
           {
-            "x": 129.83,
-            "z": -102.7
+            "x": 129.89,
+            "z": -102.66
           },
           {
-            "x": 116.85,
-            "z": -112.71
+            "x": 116.9,
+            "z": -112.67
           },
           {
-            "x": 121.49,
-            "z": -118.73
+            "x": 121.54,
+            "z": -118.69
           }
         ]
       },
@@ -766,24 +766,24 @@
         "side": "alley",
         "polygon": [
           {
-            "x": 195.05,
-            "z": -144.52
+            "x": 194.95,
+            "z": -144.6
           },
           {
-            "x": 200.75,
-            "z": -140.12
+            "x": 200.65,
+            "z": -140.2
           },
           {
-            "x": 195.99,
-            "z": -133.95
+            "x": 195.89,
+            "z": -134.02
           },
           {
-            "x": 190.29,
-            "z": -138.34
+            "x": 190.19,
+            "z": -138.42
           },
           {
-            "x": 195.05,
-            "z": -144.52
+            "x": 194.95,
+            "z": -144.6
           }
         ]
       },
@@ -792,16 +792,16 @@
         "side": "west",
         "polygon": [
           {
-            "x": 198.33,
-            "z": -170.58
+            "x": 198.78,
+            "z": -170.35
           },
           {
-            "x": 188.39,
-            "z": -150.7
+            "x": 188.83,
+            "z": -150.46
           },
           {
-            "x": 176.46,
-            "z": -130.82
+            "x": 176.89,
+            "z": -130.56
           },
           {
             "x": 171.17,
@@ -816,8 +816,8 @@
             "z": -173.34
           },
           {
-            "x": 198.33,
-            "z": -170.58
+            "x": 198.78,
+            "z": -170.35
           }
         ]
       },
@@ -852,24 +852,24 @@
         "side": "corner",
         "polygon": [
           {
-            "x": 187.44,
-            "z": -161.37
+            "x": 187.84,
+            "z": -161.07
           },
           {
-            "x": 194.41,
-            "z": -156
+            "x": 194.81,
+            "z": -155.69
           },
           {
-            "x": 189.77,
-            "z": -149.98
+            "x": 190.17,
+            "z": -149.67
           },
           {
-            "x": 182.8,
-            "z": -155.35
+            "x": 183.2,
+            "z": -155.05
           },
           {
-            "x": 187.44,
-            "z": -161.37
+            "x": 187.84,
+            "z": -161.07
           }
         ]
       },
@@ -878,24 +878,24 @@
         "side": "plaza",
         "polygon": [
           {
-            "x": 180.01,
-            "z": -164.51
+            "x": 179.91,
+            "z": -164.59
           },
           {
-            "x": 190.78,
-            "z": -156.21
+            "x": 190.68,
+            "z": -156.29
           },
           {
-            "x": 182.11,
-            "z": -144.96
+            "x": 182.01,
+            "z": -145.04
           },
           {
-            "x": 171.34,
-            "z": -153.27
+            "x": 171.24,
+            "z": -153.34
           },
           {
-            "x": 180.01,
-            "z": -164.51
+            "x": 179.91,
+            "z": -164.59
           }
         ]
       },
@@ -904,24 +904,24 @@
         "side": "corner",
         "polygon": [
           {
-            "x": 180.17,
-            "z": -162.56
+            "x": 180.07,
+            "z": -162.63
           },
           {
-            "x": 187.61,
-            "z": -156.82
+            "x": 187.51,
+            "z": -156.9
           },
           {
-            "x": 183.1,
-            "z": -150.96
+            "x": 183,
+            "z": -151.04
           },
           {
-            "x": 175.65,
-            "z": -156.7
+            "x": 175.55,
+            "z": -156.77
           },
           {
-            "x": 180.17,
-            "z": -162.56
+            "x": 180.07,
+            "z": -162.63
           }
         ]
       },
@@ -4751,9 +4751,9 @@
     {
       "id": "steam-clock-hero",
       "label": "Gastown Steam Clock",
-      "x": 181.97,
+      "x": 181.87,
       "y": 0,
-      "z": -154.73,
+      "z": -154.81,
       "yaw": -1.4421,
       "ground_emphasis_radius": 5.2,
       "steamVentOffsets": [
@@ -4810,9 +4810,9 @@
       "id": "steam-clock",
       "label": "Gastown Steam Clock",
       "kind": "clock",
-      "x": 181.97,
+      "x": 181.87,
       "y": 0,
-      "z": -154.73,
+      "z": -154.81,
       "radius": 5.2,
       "scale": 1.28,
       "cue": "A brick-and-stone plaza opens at the intersection and stages the Steam Clock at the corner landmark moment."
@@ -4887,18 +4887,18 @@
     {
       "id": "starter-prop-bench-clock",
       "kind": "bench",
-      "x": 179.12,
+      "x": 179.02,
       "y": 0,
-      "z": -154.65,
+      "z": -154.73,
       "yaw": 4.0557,
       "scale": 1.04
     },
     {
       "id": "starter-prop-clock-box",
       "kind": "newspaper_box",
-      "x": 180.88,
+      "x": 180.78,
       "y": 0,
-      "z": -157.59,
+      "z": -157.67,
       "yaw": 0,
       "scale": 0.98
     },
@@ -4932,9 +4932,9 @@
     {
       "id": "starter-prop-clock-plaque",
       "kind": "utility_box",
-      "x": 180.77,
+      "x": 180.67,
       "y": 0,
-      "z": -156.29,
+      "z": -156.37,
       "yaw": -2.2275,
       "scale": 0.65
     },
@@ -5029,8 +5029,8 @@
       "dialogId": "busker_clock_corner",
       "interactRadius": 3,
       "idleSpot": {
-        "x": 181.63,
-        "z": -150.7
+        "x": 181.53,
+        "z": -150.77
       }
     },
     {
@@ -5085,17 +5085,17 @@
       "dialogId": "tourist_clock_stop",
       "interactRadius": 2.2,
       "idleSpot": {
-        "x": 185.52,
-        "z": -154.27
+        "x": 185.42,
+        "z": -154.34
       },
       "patrol": [
         {
-          "x": 184.55,
-          "z": -153.5
+          "x": 184.45,
+          "z": -153.58
         },
         {
-          "x": 186.25,
-          "z": -154.72
+          "x": 186.15,
+          "z": -154.79
         }
       ]
     },
@@ -5109,17 +5109,17 @@
       "dialogId": "tourist_clock_stop",
       "interactRadius": 2.2,
       "idleSpot": {
-        "x": 184.59,
-        "z": -155.36
+        "x": 184.49,
+        "z": -155.44
       },
       "patrol": [
         {
-          "x": 183.89,
-          "z": -154.77
+          "x": 183.79,
+          "z": -154.85
         },
         {
-          "x": 185.22,
-          "z": -155.76
+          "x": 185.12,
+          "z": -155.84
         }
       ]
     },
@@ -5134,8 +5134,8 @@
       "dialogId": "tourist_clock_photo",
       "interactRadius": 2.4,
       "idleSpot": {
-        "x": 180.05,
-        "z": -155.2
+        "x": 179.95,
+        "z": -155.28
       }
     },
     {
@@ -5148,17 +5148,17 @@
       "dialogId": "tourist_clock_stop",
       "interactRadius": 2.2,
       "idleSpot": {
-        "x": 183.47,
-        "z": -157.99
+        "x": 183.37,
+        "z": -158.07
       },
       "patrol": [
         {
-          "x": 183.28,
-          "z": -157.26
+          "x": 183.18,
+          "z": -157.33
         },
         {
-          "x": 183.78,
-          "z": -158.89
+          "x": 183.68,
+          "z": -158.97
         }
       ]
     }
@@ -5211,24 +5211,24 @@
       "nodeId": "storefront-edge",
       "polygon": [
         {
-          "x": 121.49,
-          "z": -118.73
+          "x": 121.54,
+          "z": -118.69
         },
         {
-          "x": 134.47,
-          "z": -108.72
+          "x": 134.53,
+          "z": -108.68
         },
         {
-          "x": 129.83,
-          "z": -102.7
+          "x": 129.89,
+          "z": -102.66
         },
         {
-          "x": 116.85,
-          "z": -112.71
+          "x": 116.9,
+          "z": -112.67
         },
         {
-          "x": 121.49,
-          "z": -118.73
+          "x": 121.54,
+          "z": -118.69
         }
       ],
       "stopReasons": [
@@ -5247,24 +5247,24 @@
       "nodeId": "alley-threshold",
       "polygon": [
         {
-          "x": 195.05,
-          "z": -144.52
+          "x": 194.95,
+          "z": -144.6
         },
         {
-          "x": 200.75,
-          "z": -140.12
+          "x": 200.65,
+          "z": -140.2
         },
         {
-          "x": 195.99,
-          "z": -133.95
+          "x": 195.89,
+          "z": -134.02
         },
         {
-          "x": 190.29,
-          "z": -138.34
+          "x": 190.19,
+          "z": -138.42
         },
         {
-          "x": 195.05,
-          "z": -144.52
+          "x": 194.95,
+          "z": -144.6
         }
       ],
       "stopReasons": [
@@ -5278,29 +5278,29 @@
     },
     {
       "id": "steam-clock-plaza",
-      "label": "Steam Clock plaza",
+      "label": "Cambie / Steam Clock corner",
       "identity": "plaza",
       "nodeId": "steam-clock",
       "polygon": [
         {
-          "x": 180.01,
-          "z": -164.51
+          "x": 179.91,
+          "z": -164.59
         },
         {
-          "x": 190.78,
-          "z": -156.21
+          "x": 190.68,
+          "z": -156.29
         },
         {
-          "x": 182.11,
-          "z": -144.96
+          "x": 182.01,
+          "z": -145.04
         },
         {
-          "x": 171.34,
-          "z": -153.27
+          "x": 171.24,
+          "z": -153.34
         },
         {
-          "x": 180.01,
-          "z": -164.51
+          "x": 179.91,
+          "z": -164.59
         }
       ],
       "stopReasons": [
@@ -5319,24 +5319,24 @@
       "nodeId": "landmark-corner",
       "polygon": [
         {
-          "x": 180.17,
-          "z": -162.56
+          "x": 180.07,
+          "z": -162.63
         },
         {
-          "x": 187.61,
-          "z": -156.82
+          "x": 187.51,
+          "z": -156.9
         },
         {
-          "x": 183.1,
-          "z": -150.96
+          "x": 183,
+          "z": -151.04
         },
         {
-          "x": 175.65,
-          "z": -156.7
+          "x": 175.55,
+          "z": -156.77
         },
         {
-          "x": 180.17,
-          "z": -162.56
+          "x": 180.07,
+          "z": -162.63
         }
       ],
       "stopReasons": [
@@ -5437,98 +5437,98 @@
       },
       {
         "id": "starter-lamp-2",
-        "x": 12.66,
-        "z": -23.23,
+        "x": 12.67,
+        "z": -23.24,
         "height": 5.4
       },
       {
         "id": "starter-lamp-3",
-        "x": 25.03,
-        "z": -8.55,
+        "x": 25.05,
+        "z": -8.56,
         "height": 5.4
       },
       {
         "id": "starter-lamp-4",
-        "x": 31.74,
-        "z": -39.08,
+        "x": 31.77,
+        "z": -39.1,
         "height": 5.4
       },
       {
         "id": "starter-lamp-5",
-        "x": 43.88,
-        "z": -24.2,
+        "x": 43.91,
+        "z": -24.22,
         "height": 5.4
       },
       {
         "id": "starter-lamp-6",
-        "x": 50.84,
-        "z": -54.65,
+        "x": 50.89,
+        "z": -54.69,
         "height": 5.4
       },
       {
         "id": "starter-lamp-7",
-        "x": 62.98,
-        "z": -39.77,
+        "x": 63.03,
+        "z": -39.81,
         "height": 5.4
       },
       {
         "id": "starter-lamp-8",
-        "x": 70.62,
-        "z": -69.96,
+        "x": 70.68,
+        "z": -70.01,
         "height": 5.4
       },
       {
         "id": "starter-lamp-9",
-        "x": 82.18,
-        "z": -54.64,
+        "x": 82.25,
+        "z": -54.69,
         "height": 5.4
       },
       {
         "id": "starter-lamp-10",
-        "x": 90.29,
-        "z": -84.81,
+        "x": 90.38,
+        "z": -84.87,
         "height": 5.4
       },
       {
         "id": "starter-lamp-11",
-        "x": 101.86,
-        "z": -69.49,
+        "x": 101.94,
+        "z": -69.55,
         "height": 5.4
       },
       {
         "id": "starter-lamp-12",
-        "x": 110.08,
-        "z": -99.66,
+        "x": 110.18,
+        "z": -99.74,
         "height": 5.4
       },
       {
         "id": "starter-lamp-13",
-        "x": 121.5,
-        "z": -84.23,
+        "x": 121.6,
+        "z": -84.3,
         "height": 5.4
       },
       {
         "id": "starter-lamp-14",
-        "x": 129.89,
-        "z": -114.33,
+        "x": 130.01,
+        "z": -114.41,
         "height": 5.4
       },
       {
         "id": "starter-lamp-15",
-        "x": 141.31,
-        "z": -98.89,
+        "x": 141.43,
+        "z": -98.98,
         "height": 5.4
       },
       {
         "id": "starter-lamp-16",
-        "x": 149.54,
-        "z": -128.94,
+        "x": 149.67,
+        "z": -129.05,
         "height": 5.4
       },
       {
         "id": "starter-lamp-17",
-        "x": 161.22,
-        "z": -113.71,
+        "x": 161.35,
+        "z": -113.81,
         "height": 5.4
       }
     ],
@@ -5547,70 +5547,70 @@
       },
       {
         "id": "starter-tree-2",
-        "x": 24.51,
-        "z": -36.79,
+        "x": 24.54,
+        "z": -36.82,
         "radius": 1.4
       },
       {
         "id": "starter-tree-3",
-        "x": 40.19,
-        "z": -17.57,
+        "x": 40.21,
+        "z": -17.6,
         "radius": 1.4
       },
       {
         "id": "starter-tree-4",
-        "x": 57.69,
-        "z": -63.71,
+        "x": 57.74,
+        "z": -63.75,
         "radius": 1.4
       },
       {
         "id": "starter-tree-5",
-        "x": 72.63,
-        "z": -43.92,
+        "x": 72.68,
+        "z": -43.96,
         "radius": 1.4
       },
       {
         "id": "starter-tree-6",
-        "x": 91.42,
-        "z": -89.17,
+        "x": 91.5,
+        "z": -89.23,
         "radius": 1.4
       },
       {
         "id": "starter-tree-7",
-        "x": 106.36,
-        "z": -69.37,
+        "x": 106.44,
+        "z": -69.44,
         "radius": 1.4
       },
       {
         "id": "starter-tree-8",
-        "x": 125.39,
-        "z": -114.48,
+        "x": 125.51,
+        "z": -114.57,
         "radius": 1.4
       },
       {
         "id": "starter-tree-9",
-        "x": 140.15,
-        "z": -94.55,
+        "x": 140.26,
+        "z": -94.63,
         "radius": 1.4
       }
     ],
     "bollards": [
       {
         "id": "clock-bollard-a",
-        "x": 184.02,
-        "z": -153.15
+        "x": 183.92,
+        "z": -153.22
       },
       {
         "id": "clock-bollard-b",
-        "x": 185.21,
-        "z": -155.01,
+        "x": 185.11,
+        "z": -155.09,
         "chain_to": "clock-bollard-a"
       }
     ],
     "surfaceBands": [
       {
         "segment_id": "waterfront-station-threshold",
-        "width": 9.6,
+        "width": 8.23,
         "length": 19.61,
         "yaw": 2.2712,
         "offset_x": 0,
@@ -5621,7 +5621,7 @@
       },
       {
         "segment_id": "waterfront-station-threshold",
-        "width": 2.74,
+        "width": 2.35,
         "length": 15.91,
         "yaw": 2.2712,
         "offset_x": 0,
@@ -5632,10 +5632,10 @@
       },
       {
         "segment_id": "waterfront-station-threshold",
-        "width": 1.08,
+        "width": 0.92,
         "length": 19.24,
         "yaw": 2.2712,
-        "offset_x": 4.02,
+        "offset_x": 3.44,
         "offset_z": 0,
         "tone": "curb_grime",
         "opacity": 0.2,
@@ -5643,10 +5643,10 @@
       },
       {
         "segment_id": "waterfront-station-threshold",
-        "width": 1.08,
+        "width": 0.92,
         "length": 19.24,
         "yaw": 2.2712,
-        "offset_x": -4.02,
+        "offset_x": -3.44,
         "offset_z": 0,
         "tone": "curb_grime",
         "opacity": 0.2,
@@ -5654,7 +5654,7 @@
       },
       {
         "segment_id": "gastown-beat-1",
-        "width": 9.6,
+        "width": 8.23,
         "length": 19.61,
         "yaw": 2.2548,
         "offset_x": 0,
@@ -5665,7 +5665,7 @@
       },
       {
         "segment_id": "gastown-beat-1",
-        "width": 2.74,
+        "width": 2.35,
         "length": 15.91,
         "yaw": 2.2548,
         "offset_x": 0,
@@ -5676,10 +5676,10 @@
       },
       {
         "segment_id": "gastown-beat-1",
-        "width": 1.08,
+        "width": 0.92,
         "length": 19.24,
         "yaw": 2.2548,
-        "offset_x": 4.02,
+        "offset_x": 3.44,
         "offset_z": 0,
         "tone": "curb_grime",
         "opacity": 0.2,
@@ -5687,10 +5687,10 @@
       },
       {
         "segment_id": "gastown-beat-1",
-        "width": 1.08,
+        "width": 0.92,
         "length": 19.24,
         "yaw": 2.2548,
-        "offset_x": -4.02,
+        "offset_x": -3.44,
         "offset_z": 0,
         "tone": "curb_grime",
         "opacity": 0.2,
@@ -5698,7 +5698,7 @@
       },
       {
         "segment_id": "water-cordova-seam",
-        "width": 9.6,
+        "width": 8.23,
         "length": 19.61,
         "yaw": 2.2279,
         "offset_x": 0,
@@ -5709,7 +5709,7 @@
       },
       {
         "segment_id": "water-cordova-seam",
-        "width": 2.74,
+        "width": 2.35,
         "length": 15.91,
         "yaw": 2.2279,
         "offset_x": 0,
@@ -5720,10 +5720,10 @@
       },
       {
         "segment_id": "water-cordova-seam",
-        "width": 1.08,
+        "width": 0.92,
         "length": 19.24,
         "yaw": 2.2279,
-        "offset_x": 4.02,
+        "offset_x": 3.44,
         "offset_z": 0,
         "tone": "curb_grime",
         "opacity": 0.2,
@@ -5731,10 +5731,10 @@
       },
       {
         "segment_id": "water-cordova-seam",
-        "width": 1.08,
+        "width": 0.92,
         "length": 19.24,
         "yaw": 2.2279,
-        "offset_x": -4.02,
+        "offset_x": -3.44,
         "offset_z": 0,
         "tone": "curb_grime",
         "opacity": 0.2,
@@ -5742,7 +5742,7 @@
       },
       {
         "segment_id": "gastown-beat-3",
-        "width": 9.6,
+        "width": 8.23,
         "length": 19.61,
         "yaw": 2.213,
         "offset_x": 0,
@@ -5753,7 +5753,7 @@
       },
       {
         "segment_id": "gastown-beat-3",
-        "width": 2.74,
+        "width": 2.35,
         "length": 15.91,
         "yaw": 2.213,
         "offset_x": 0,
@@ -5764,10 +5764,10 @@
       },
       {
         "segment_id": "gastown-beat-3",
-        "width": 1.08,
+        "width": 0.92,
         "length": 19.24,
         "yaw": 2.213,
-        "offset_x": 4.02,
+        "offset_x": 3.44,
         "offset_z": 0,
         "tone": "curb_grime",
         "opacity": 0.2,
@@ -5775,10 +5775,10 @@
       },
       {
         "segment_id": "gastown-beat-3",
-        "width": 1.08,
+        "width": 0.92,
         "length": 19.24,
         "yaw": 2.213,
-        "offset_x": -4.02,
+        "offset_x": -3.44,
         "offset_z": 0,
         "tone": "curb_grime",
         "opacity": 0.2,
@@ -5786,7 +5786,7 @@
       },
       {
         "segment_id": "water-street-mid-block",
-        "width": 9.6,
+        "width": 8.23,
         "length": 19.61,
         "yaw": 2.2136,
         "offset_x": 0,
@@ -5797,7 +5797,7 @@
       },
       {
         "segment_id": "water-street-mid-block",
-        "width": 2.74,
+        "width": 2.35,
         "length": 15.91,
         "yaw": 2.2136,
         "offset_x": 0,
@@ -5808,10 +5808,10 @@
       },
       {
         "segment_id": "water-street-mid-block",
-        "width": 1.08,
+        "width": 0.92,
         "length": 19.24,
         "yaw": 2.2136,
-        "offset_x": 4.02,
+        "offset_x": 3.44,
         "offset_z": 0,
         "tone": "curb_grime",
         "opacity": 0.2,
@@ -5819,10 +5819,10 @@
       },
       {
         "segment_id": "water-street-mid-block",
-        "width": 1.08,
+        "width": 0.92,
         "length": 19.24,
         "yaw": 2.2136,
-        "offset_x": -4.02,
+        "offset_x": -3.44,
         "offset_z": 0,
         "tone": "curb_grime",
         "opacity": 0.2,
@@ -5830,9 +5830,9 @@
       },
       {
         "segment_id": "steam-clock-approach",
-        "width": 9.6,
-        "length": 11.46,
-        "yaw": -2.2547,
+        "width": 8.23,
+        "length": 11.59,
+        "yaw": -2.2546,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "asphalt_patchwork",
@@ -5841,9 +5841,9 @@
       },
       {
         "segment_id": "steam-clock-approach",
-        "width": 2.74,
-        "length": 9.3,
-        "yaw": -2.2547,
+        "width": 2.35,
+        "length": 9.4,
+        "yaw": -2.2546,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "tram_polish",
@@ -5852,10 +5852,10 @@
       },
       {
         "segment_id": "steam-clock-approach",
-        "width": 1.08,
-        "length": 11.24,
-        "yaw": -2.2547,
-        "offset_x": 4.02,
+        "width": 0.92,
+        "length": 11.37,
+        "yaw": -2.2546,
+        "offset_x": 3.44,
         "offset_z": 0,
         "tone": "curb_grime",
         "opacity": 0.2,
@@ -5863,10 +5863,10 @@
       },
       {
         "segment_id": "steam-clock-approach",
-        "width": 1.08,
-        "length": 11.24,
-        "yaw": -2.2547,
-        "offset_x": -4.02,
+        "width": 0.92,
+        "length": 11.37,
+        "yaw": -2.2546,
+        "offset_x": -3.44,
         "offset_z": 0,
         "tone": "curb_grime",
         "opacity": 0.2,
@@ -5874,9 +5874,9 @@
       },
       {
         "segment_id": "steam-clock-approach",
-        "width": 6.08,
-        "length": 3.89,
-        "yaw": -2.2547,
+        "width": 5.21,
+        "length": 3.94,
+        "yaw": -2.2546,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "setts_patch",
@@ -5885,9 +5885,9 @@
       },
       {
         "segment_id": "steam-clock-approach",
-        "width": 8.04,
+        "width": 6.89,
         "length": 7.2,
-        "yaw": -2.2547,
+        "yaw": -2.2546,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "intersection_pavers",
@@ -5896,9 +5896,9 @@
       },
       {
         "segment_id": "steam-clock-approach",
-        "width": 4.12,
+        "width": 3.53,
         "length": 5.8,
-        "yaw": -2.2547,
+        "yaw": -2.2546,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "cobble_break",
@@ -5907,10 +5907,10 @@
       },
       {
         "segment_id": "steam-clock-approach",
-        "width": 2.55,
+        "width": 2.18,
         "length": 4.8,
-        "yaw": -2.2547,
-        "offset_x": 1.76,
+        "yaw": -2.2546,
+        "offset_x": 1.51,
         "offset_z": 0,
         "tone": "service_wear",
         "opacity": 0.16,
@@ -5918,10 +5918,10 @@
       },
       {
         "segment_id": "steam-clock-approach",
-        "width": 2.55,
+        "width": 2.18,
         "length": 4.8,
-        "yaw": -2.2547,
-        "offset_x": -1.76,
+        "yaw": -2.2546,
+        "offset_x": -1.51,
         "offset_z": 0,
         "tone": "service_wear",
         "opacity": 0.16,
@@ -5929,9 +5929,9 @@
       },
       {
         "segment_id": "steam-clock",
-        "width": 9.6,
+        "width": 8.23,
         "length": 19.61,
-        "yaw": 2.1543,
+        "yaw": 2.1507,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "asphalt_patchwork",
@@ -5940,9 +5940,9 @@
       },
       {
         "segment_id": "steam-clock",
-        "width": 2.74,
+        "width": 2.35,
         "length": 15.91,
-        "yaw": 2.1543,
+        "yaw": 2.1507,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "tram_polish",
@@ -5951,10 +5951,10 @@
       },
       {
         "segment_id": "steam-clock",
-        "width": 1.08,
+        "width": 0.92,
         "length": 19.24,
-        "yaw": 2.1543,
-        "offset_x": 4.02,
+        "yaw": 2.1507,
+        "offset_x": 3.44,
         "offset_z": 0,
         "tone": "curb_grime",
         "opacity": 0.2,
@@ -5962,10 +5962,10 @@
       },
       {
         "segment_id": "steam-clock",
-        "width": 1.08,
+        "width": 0.92,
         "length": 19.24,
-        "yaw": 2.1543,
-        "offset_x": -4.02,
+        "yaw": 2.1507,
+        "offset_x": -3.44,
         "offset_z": 0,
         "tone": "curb_grime",
         "opacity": 0.2,
@@ -5973,9 +5973,9 @@
       },
       {
         "segment_id": "steam-clock",
-        "width": 6.08,
+        "width": 5.21,
         "length": 6.66,
-        "yaw": 2.1543,
+        "yaw": 2.1507,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "setts_patch",
@@ -5984,9 +5984,9 @@
       },
       {
         "segment_id": "steam-clock",
-        "width": 8.04,
+        "width": 6.89,
         "length": 9.99,
-        "yaw": 2.1543,
+        "yaw": 2.1507,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "intersection_pavers",
@@ -5995,9 +5995,9 @@
       },
       {
         "segment_id": "steam-clock",
-        "width": 4.12,
+        "width": 3.53,
         "length": 5.8,
-        "yaw": 2.1543,
+        "yaw": 2.1507,
         "offset_x": 0,
         "offset_z": 0,
         "tone": "cobble_break",
@@ -6006,10 +6006,10 @@
       },
       {
         "segment_id": "steam-clock",
-        "width": 2.55,
+        "width": 2.18,
         "length": 4.8,
-        "yaw": 2.1543,
-        "offset_x": 1.76,
+        "yaw": 2.1507,
+        "offset_x": 1.51,
         "offset_z": 0,
         "tone": "service_wear",
         "opacity": 0.16,
@@ -6017,10 +6017,10 @@
       },
       {
         "segment_id": "steam-clock",
-        "width": 2.55,
+        "width": 2.18,
         "length": 4.8,
-        "yaw": 2.1543,
-        "offset_x": -1.76,
+        "yaw": 2.1507,
+        "offset_x": -1.51,
         "offset_z": 0,
         "tone": "service_wear",
         "opacity": 0.16,
@@ -6028,7 +6028,7 @@
       },
       {
         "segment_id": "maple-tree-square-edge",
-        "width": 9.6,
+        "width": 8.23,
         "length": 19.61,
         "yaw": -0.6078,
         "offset_x": 0,
@@ -6039,7 +6039,7 @@
       },
       {
         "segment_id": "maple-tree-square-edge",
-        "width": 2.74,
+        "width": 2.35,
         "length": 15.91,
         "yaw": -0.6078,
         "offset_x": 0,
@@ -6050,10 +6050,10 @@
       },
       {
         "segment_id": "maple-tree-square-edge",
-        "width": 1.08,
+        "width": 0.92,
         "length": 19.24,
         "yaw": -0.6078,
-        "offset_x": 4.02,
+        "offset_x": 3.44,
         "offset_z": 0,
         "tone": "curb_grime",
         "opacity": 0.2,
@@ -6061,10 +6061,10 @@
       },
       {
         "segment_id": "maple-tree-square-edge",
-        "width": 1.08,
+        "width": 0.92,
         "length": 19.24,
         "yaw": -0.6078,
-        "offset_x": -4.02,
+        "offset_x": -3.44,
         "offset_z": 0,
         "tone": "curb_grime",
         "opacity": 0.2,
@@ -6072,7 +6072,7 @@
       },
       {
         "segment_id": "maple-tree-square-edge",
-        "width": 6.08,
+        "width": 5.21,
         "length": 6.66,
         "yaw": -0.6078,
         "offset_x": 0,
@@ -6083,7 +6083,7 @@
       },
       {
         "segment_id": "cambie-rise-continuation",
-        "width": 9.6,
+        "width": 8.23,
         "length": 19.61,
         "yaw": 2.5338,
         "offset_x": 0,
@@ -6094,7 +6094,7 @@
       },
       {
         "segment_id": "cambie-rise-continuation",
-        "width": 2.74,
+        "width": 2.35,
         "length": 15.91,
         "yaw": 2.5338,
         "offset_x": 0,
@@ -6105,10 +6105,10 @@
       },
       {
         "segment_id": "cambie-rise-continuation",
-        "width": 1.08,
+        "width": 0.92,
         "length": 19.24,
         "yaw": 2.5338,
-        "offset_x": 4.02,
+        "offset_x": 3.44,
         "offset_z": 0,
         "tone": "curb_grime",
         "opacity": 0.2,
@@ -6116,10 +6116,10 @@
       },
       {
         "segment_id": "cambie-rise-continuation",
-        "width": 1.08,
+        "width": 0.92,
         "length": 19.24,
         "yaw": 2.5338,
-        "offset_x": -4.02,
+        "offset_x": -3.44,
         "offset_z": 0,
         "tone": "curb_grime",
         "opacity": 0.2,
@@ -6127,7 +6127,7 @@
       },
       {
         "segment_id": "cambie-rise-continuation",
-        "width": 6.08,
+        "width": 5.21,
         "length": 6.66,
         "yaw": 2.5338,
         "offset_x": 0,
@@ -6153,10 +6153,11 @@
     ]
   },
   "spawn": {
-    "x": 6.88,
+    "x": 33.26,
     "y": 1.7,
-    "z": -5.8,
-    "yaw": -0.8704
+    "z": -28.03,
+    "yaw": -0.8704,
+    "pitch": -0.035
   },
   "bounds": {
     "floorY": 0,

--- a/js/gastown-sim.js
+++ b/js/gastown-sim.js
@@ -177,6 +177,9 @@
       currentSpeed: 0,
       smoothedSpeed: 0,
       surface: 'sidewalk',
+      runActive: false,
+      runBlend: 0,
+      runHoldSeconds: 0,
       bobPhase: 0,
       bobOffset: 0,
       swayOffset: 0,
@@ -224,6 +227,10 @@
   };
 
   const DEFAULT_EYE_HEIGHT = 1.7;
+  const HOLD_TO_RUN_THRESHOLD_SECONDS = 0.34;
+  const HOLD_TO_RUN_RAMP_IN = 5.8;
+  const HOLD_TO_RUN_RAMP_OUT = 8.2;
+  const HOLD_TO_RUN_FORWARD_MULTIPLIER = 1.58;
   const WALKER_NAME_STORAGE_KEY = 'gastownWalkerName';
   const NPC_SPEECH_CACHE_LIMIT = 18;
   const BAND_ARRANGEMENT_CACHE_PREFIX = 'gastownBandArrangement:';
@@ -1435,6 +1442,46 @@
     };
   }
 
+
+  function updateHoldToRunState(delta, forwardInput) {
+    const sustainedForward = forwardInput > 0 && !state.move.backward;
+    if (sustainedForward) {
+      state.motion.runHoldSeconds += delta;
+    } else {
+      state.motion.runHoldSeconds = 0;
+    }
+    const holdRunActive = sustainedForward && state.motion.runHoldSeconds >= HOLD_TO_RUN_THRESHOLD_SECONDS;
+    const shiftRunActive = sustainedForward && state.gait.traverse && !state.gait.precise;
+    state.motion.runActive = !state.gait.precise && state.cameraMode === 'street' && (holdRunActive || shiftRunActive);
+
+    const rampSpeed = state.motion.runActive ? HOLD_TO_RUN_RAMP_IN : HOLD_TO_RUN_RAMP_OUT;
+    state.motion.runBlend = THREE.MathUtils.lerp(state.motion.runBlend || 0, state.motion.runActive ? 1 : 0, 1 - Math.exp(-delta * rampSpeed));
+    if (!sustainedForward && state.motion.runBlend < 0.015) {
+      state.motion.runBlend = 0;
+      state.motion.runActive = false;
+    }
+
+    return {
+      active: state.motion.runActive,
+      blend: state.motion.runBlend,
+    };
+  }
+
+  function getDynamicMovementProfile(baseProfile, runState) {
+    const blend = runState && Number.isFinite(runState.blend) ? runState.blend : 0;
+    return {
+      label: blend > 0.6 ? 'run' : baseProfile.label,
+      maxSpeed: baseProfile.maxSpeed * (1 + ((HOLD_TO_RUN_FORWARD_MULTIPLIER - 1) * blend)),
+      acceleration: baseProfile.acceleration * (1 + (blend * 0.12)),
+      deceleration: baseProfile.deceleration * (1 + (blend * 0.08)),
+      turnSpeed: baseProfile.turnSpeed * (1 - (blend * 0.06)),
+      bobAmount: baseProfile.bobAmount * (1 + (blend * 0.28)),
+      swayAmount: baseProfile.swayAmount * (1 + (blend * 0.18)),
+      stepInterval: baseProfile.stepInterval * (1 - (blend * 0.22)),
+      runBlend: blend,
+    };
+  }
+
   function detectPlayerSurface() {
     if (!state.world || !state.world.zones) {
       return 'sidewalk';
@@ -1671,6 +1718,9 @@
     state.gait.precise = false;
     state.gait.traverse = false;
     state.velocity.set(0, 0, 0);
+    state.motion.runBlend = 0;
+    state.motion.runHoldSeconds = 0;
+    state.motion.runActive = false;
     state.motion.footstepTimer = 0;
   }
 
@@ -5056,6 +5106,26 @@
     ctx.restore();
   }
 
+
+  function getMinimapSidewalkStyle(zone) {
+    const side = (zone && zone.side) || '';
+    if (side === 'plaza') {
+      return { fill: '#7f8fa0', stroke: 'rgba(238, 224, 198, 0.62)' };
+    }
+    if (side === 'corner' || side === 'storefront') {
+      return { fill: '#6f7f92', stroke: 'rgba(218, 227, 238, 0.56)' };
+    }
+    return { fill: '#5d7083', stroke: 'rgba(211, 226, 242, 0.5)' };
+  }
+
+  function getMinimapStreetStyle(zone) {
+    const id = (zone && zone.id) || '';
+    if (id === 'water-cambie-intersection-roadway') {
+      return { fill: '#253f53', stroke: 'rgba(129, 164, 196, 0.72)' };
+    }
+    return { fill: '#1a2f41', stroke: 'rgba(86, 117, 149, 0.68)' };
+  }
+
   function drawMinimap() {
     if (!minimapState.ctx || !state.world || !minimapState.worldMetrics) {
       return;
@@ -5077,10 +5147,12 @@
     ctx.strokeRect(0.5, 0.5, minimapState.width - 1, minimapState.height - 1);
 
     (state.world.zones.sidewalk || []).forEach((zone) => {
-      drawPolygon(zone.polygon, metrics, pad, '#5d7083', 'rgba(211, 226, 242, 0.5)', 1.2, view, projectionOptions);
+      const style = getMinimapSidewalkStyle(zone);
+      drawPolygon(zone.polygon, metrics, pad, style.fill, style.stroke, 1.2, view, projectionOptions);
     });
     (state.world.zones.street || []).forEach((zone) => {
-      drawPolygon(zone.polygon, metrics, pad, '#1a2f41', 'rgba(86, 117, 149, 0.68)', 1.15, view, projectionOptions);
+      const style = getMinimapStreetStyle(zone);
+      drawPolygon(zone.polygon, metrics, pad, style.fill, style.stroke, 1.15, view, projectionOptions);
     });
     (state.world.microAreas || []).forEach((area) => {
       drawPolygon(area.polygon, metrics, pad, 'rgba(255, 210, 135, 0.72)', 'rgba(255, 210, 135, 0.08)', 0.85, view, projectionOptions);
@@ -5164,7 +5236,7 @@
       ctx.setLineDash([]);
     }
 
-    const majorNodes = ['waterfront-station-threshold', 'water-street-mid-block', 'water-cambie-intersection', 'steam-clock', 'maple-tree-square-edge'];
+    const majorNodes = ['waterfront-station-threshold', 'water-cordova-seam', 'water-street-mid-block', 'water-cambie-intersection', 'steam-clock', 'maple-tree-square-edge'];
     state.world.nodes.forEach((node) => {
       if (!majorNodes.includes(node.id)) return;
       const markerPoint = node.id === 'steam-clock' ? getMinimapLandmarkAnchor(node, state.world) : node;
@@ -5179,7 +5251,7 @@
       ctx.textAlign = 'left';
       ctx.textBaseline = 'middle';
       if (node.id === 'waterfront-station-threshold') {
-        ctx.fillText('Station', mini.x + 6, mini.y - 5);
+        ctx.fillText('Waterfront', mini.x + 6, mini.y - 5);
       }
       if (node.id === 'steam-clock') {
         const steamClockLabelAnchor = {
@@ -5189,11 +5261,17 @@
         const labelMini = projectWorldToMinimap(steamClockLabelAnchor, metrics, pad, view, projectionOptions);
         ctx.fillText('Steam Clock', labelMini.x + 5, labelMini.y - 4);
       }
+      if (node.id === 'water-cordova-seam') {
+        ctx.fillText('Water/Cordova', mini.x + 6, mini.y - 5);
+      }
       if (node.id === 'water-cambie-intersection') {
         ctx.fillText('Cambie', mini.x + 6, mini.y - 5);
       }
       if (node.id === 'water-street-mid-block') {
-        ctx.fillText('Water St', mini.x + 6, mini.y + 7);
+        ctx.fillText('Water St mid', mini.x + 6, mini.y + 7);
+      }
+      if (node.id === 'maple-tree-square-edge') {
+        ctx.fillText('Maple Tree Sq', mini.x + 6, mini.y + 7);
       }
     });
 
@@ -5511,9 +5589,11 @@
   }
 
   function movePlayer(delta) {
-    const movementProfile = getMovementProfile();
+    const baseMovementProfile = getMovementProfile();
     const forward = Number(state.move.forward) - Number(state.move.backward);
     const strafe = Number(state.move.right) - Number(state.move.left);
+    const runState = updateHoldToRunState(delta, forward);
+    const movementProfile = getDynamicMovementProfile(baseMovementProfile, runState);
     const turning = Number(state.turn.right) - Number(state.turn.left);
 
     if (turning !== 0) {
@@ -5521,7 +5601,9 @@
       player.rotation.y = state.yaw;
     }
 
-    const input = new THREE.Vector3(strafe, 0, -forward);
+    const runForwardFactor = forward > 0 ? (1 + ((HOLD_TO_RUN_FORWARD_MULTIPLIER - 1) * movementProfile.runBlend)) : 1;
+    const runStrafeFactor = 1 - (movementProfile.runBlend * 0.17);
+    const input = new THREE.Vector3(strafe * runStrafeFactor, 0, -forward * runForwardFactor);
     if (input.lengthSq() > 1) {
       input.normalize();
     }
@@ -5588,6 +5670,10 @@
     if (code === 'ArrowRight') state.turn.right = pressed;
     if (code === 'AltLeft' || code === 'AltRight') state.gait.precise = pressed;
     if (code === 'ShiftLeft' || code === 'ShiftRight') state.gait.traverse = pressed;
+    if ((code === 'KeyW' || code === 'ArrowUp') && !pressed) {
+      state.motion.runHoldSeconds = 0;
+      state.motion.runActive = false;
+    }
   }
 
   function handlePitchKeyControl(event) {
@@ -5619,6 +5705,9 @@
     state.motion.bobOffset = 0;
     state.motion.swayOffset = 0;
     state.motion.bobPhase = 0;
+    state.motion.runBlend = 0;
+    state.motion.runHoldSeconds = 0;
+    state.motion.runActive = false;
     state.motion.footstepTimer = 0;
     if (state.cameraMode === 'overview') {
       applyOverviewCameraPose();

--- a/page-gastown-sim.php
+++ b/page-gastown-sim.php
@@ -65,8 +65,8 @@ get_header();
         <ul>
           <li><strong>Click</strong> to step into the street</li>
           <li><strong>Mouse</strong> look</li>
-          <li><strong>W A S D</strong> move</li>
-          <li><strong>Arrow keys</strong> move / turn</li>
+          <li><strong>W / ↑</strong> hold to run (Shift still works)</li>
+          <li><strong>A S D + arrows</strong> move / turn</li>
           <li><strong>E / click</strong> interact</li>
           <li><strong>Esc</strong> close / release</li>
         </ul>

--- a/scripts/generate-gastown-world.js
+++ b/scripts/generate-gastown-world.js
@@ -889,8 +889,8 @@ function makeStarterWorld(outputPath, options = {}) {
   const intersectionFrame = starterRouteFrame(waterCenterline, Math.max(0, polylineLength(waterCenterline) * 0.9));
   const rowProps = getProps(rowWidthFeature);
   const rightOfWayWidth = sanitizeNumber(Number(rowProps.right_of_way_width || rowProps.row_width || rowProps.width_m), streetContextFeatures.length ? 19.6 : 20.2);
-  const streetWidth = sanitizeNumber(Number(rowProps.carriageway_width || rowProps.roadway_width || rowProps.street_width), streetContextFeatures.length ? 9.4 : 9.8);
-  const sidewalkWidth = sanitizeNumber(Number(rowProps.sidewalk_width || ((rightOfWayWidth - streetWidth) / 2)), Array.isArray(reference.buildingCues && reference.buildingCues.features) ? 5.1 : 4.9);
+  const streetWidth = sanitizeNumber(Number(rowProps.carriageway_width || rowProps.roadway_width || rowProps.street_width), streetContextFeatures.length ? 8.8 : 8.4);
+  const sidewalkWidth = sanitizeNumber(Number(rowProps.sidewalk_width || ((rightOfWayWidth - streetWidth) / 2)), Array.isArray(reference.buildingCues && reference.buildingCues.features) ? 5.4 : 5.2);
   const softBoundary = 3.6;
   const streetHalf = streetWidth / 2;
   const sidewalkOuter = streetHalf + sidewalkWidth;
@@ -932,7 +932,7 @@ function makeStarterWorld(outputPath, options = {}) {
     { id: 'gastown-beat-3', label: 'West Water Street', x: Number(samplePointAtDistance(waterCenterline, polylineLength(waterCenterline) * 0.4).x.toFixed(2)), z: Number(samplePointAtDistance(waterCenterline, polylineLength(waterCenterline) * 0.4).z.toFixed(2)) },
     { id: 'water-street-mid-block', label: 'Water Street mid block', x: Number(layout.midBlock.x.toFixed(2)), z: Number(layout.midBlock.z.toFixed(2)) },
     { id: 'steam-clock-approach', label: 'Steam Clock approach', x: Number((intersectionPoint.x - (intersectionFrame.tangent.x * 5.1)).toFixed(2)), z: Number((intersectionPoint.z - (intersectionFrame.tangent.z * 5.1)).toFixed(2)) },
-    { id: 'steam-clock', label: 'Steam Clock plaza', x: Number(layout.clock.x.toFixed(2)), z: Number(layout.clock.z.toFixed(2)) },
+    { id: 'steam-clock', label: 'Cambie / Steam Clock corner', x: Number(layout.clock.x.toFixed(2)), z: Number(layout.clock.z.toFixed(2)) },
     { id: 'maple-tree-square-edge', label: 'Maple Tree Square edge', x: Number(layout.mapleEdge.x.toFixed(2)), z: Number(layout.mapleEdge.z.toFixed(2)) },
     { id: 'cambie-rise-continuation', label: 'Cambie rise continuation', x: Number(layout.cambie.x.toFixed(2)), z: Number(layout.cambie.z.toFixed(2)) },
   ];
@@ -1144,7 +1144,7 @@ function makeStarterWorld(outputPath, options = {}) {
   }
 
   const spawnDir = normalize({ x: centerline[1].x - centerline[0].x, z: centerline[1].z - centerline[0].z });
-  const spawn = { x: Number((centerline[0].x + (spawnDir.x * 9)).toFixed(2)), y: 1.7, z: Number((centerline[0].z + (spawnDir.z * 9)).toFixed(2)), yaw: Number(Math.atan2(-spawnDir.x, -spawnDir.z).toFixed(4)) };
+  const spawn = { x: Number((centerline[1].x + (spawnDir.x * 5.2)).toFixed(2)), y: 1.7, z: Number((centerline[1].z + (spawnDir.z * 5.2)).toFixed(2)), yaw: Number(Math.atan2(-spawnDir.x, -spawnDir.z).toFixed(4)), pitch: -0.035 };
 
   const props = [
     placeStarterProp(waterCenterline, 18, -(sidewalkOuter + 0.55), 'starter-prop-threshold-box', 'newspaper_box', { scale: 1.05 }),
@@ -1225,7 +1225,7 @@ function makeStarterWorld(outputPath, options = {}) {
       { id: 'storefront-edge', label: 'Storefront edge', x: Number((layout.midBlock.x - (intersectionFrame.normal.x * (streetHalf + (sidewalkWidth * 0.88)))).toFixed(2)), z: Number((layout.midBlock.z - (intersectionFrame.normal.z * (streetHalf + (sidewalkWidth * 0.88)))).toFixed(2)) },
       { ...centerline[4], label: 'Water Street mid block' },
       { id: 'alley-threshold', label: 'Alley threshold', x: Number((intersectionPoint.x - (intersectionFrame.tangent.x * 8.8) + (intersectionFrame.normal.x * (streetHalf + (sidewalkWidth * 0.82)))).toFixed(2)), z: Number((intersectionPoint.z - (intersectionFrame.tangent.z * 8.8) + (intersectionFrame.normal.z * (streetHalf + (sidewalkWidth * 0.82)))).toFixed(2)) },
-      { ...centerline[6], label: 'Steam Clock plaza' },
+      { ...centerline[6], label: 'Cambie / Steam Clock corner' },
       { id: 'landmark-corner', label: 'Landmark corner', x: Number((layout.clock.x + (layout.plaza.tangent.x * 1.4) + (layout.plaza.normal.x * 1.5)).toFixed(2)), z: Number((layout.clock.z + (layout.plaza.tangent.z * 1.4) + (layout.plaza.normal.z * 1.5)).toFixed(2)) },
       { ...centerline[7], label: 'Maple Tree Square edge' },
       { id: 'transit-edge', label: 'Transit edge', x: Number((layout.cambie.x - (layout.plaza.normal.x * 2.2) - (layout.plaza.tangent.x * 1.8)).toFixed(2)), z: Number((layout.cambie.z - (layout.plaza.normal.z * 2.2) - (layout.plaza.tangent.z * 1.8)).toFixed(2)) },
@@ -1309,7 +1309,7 @@ function makeStarterWorld(outputPath, options = {}) {
       { id: 'station-plaza', label: 'Station plaza', identity: 'transit edge', nodeId: 'station-plaza', polygon: stationPlaza, stopReasons: ['Watch people spill out from Waterfront Station.', 'Reorient before committing to Water Street.'], returnReasons: ['It works as a reliable reset point.', 'The wider pad gives you a clear view back into Gastown.'] },
       { id: 'storefront-edge', label: 'Storefront edge', identity: 'storefront edge', nodeId: 'storefront-edge', polygon: storefrontEdge, stopReasons: ['Window-shop the heritage frontage rhythm.', 'Use the pocket as a pause between the station and the clock.'], returnReasons: ['It makes a good midway meeting point.', 'The tighter edge reveals the street from a different angle on the way back.'] },
       { id: 'alley-threshold', label: 'Alley threshold', identity: 'alley threshold', nodeId: 'alley-threshold', polygon: alleyThreshold, stopReasons: ['Peek into the service lane without leaving the public edge.', 'Listen for the quieter pocket off the main block.'], returnReasons: ['It turns the approach into a loop instead of a one-way run.', 'The threshold frames the Steam Clock corner from the side.'] },
-      { id: 'steam-clock-plaza', label: 'Steam Clock plaza', identity: 'plaza', nodeId: 'steam-clock', polygon: plazaPad, stopReasons: ['Pause for the clock, seating, and busker activity.', 'Use the open pad to decide where to head next.'], returnReasons: ['The plaza is the natural social hub.', 'It links back out to Water Street and Maple Tree Square.'] },
+      { id: 'steam-clock-plaza', label: 'Cambie / Steam Clock corner', identity: 'plaza', nodeId: 'steam-clock', polygon: plazaPad, stopReasons: ['Pause for the clock, seating, and busker activity.', 'Use the open pad to decide where to head next.'], returnReasons: ['The plaza is the natural social hub.', 'It links back out to Water Street and Maple Tree Square.'] },
       { id: 'landmark-corner', label: 'Landmark corner', identity: 'landmark corner', nodeId: 'landmark-corner', polygon: landmarkCorner, stopReasons: ['Take in the clock and corner facades together.', 'Catch the diagonal view into Maple Tree Square.'], returnReasons: ['It is the clearest landmark rendezvous point.', 'The corner keeps changing depending on approach direction.'] },
       { id: 'maple-tree-square-pocket', label: 'Maple Tree Square pocket', identity: 'plaza edge', nodeId: 'maple-tree-square-edge', polygon: mapleTriangle, stopReasons: ['Step to the square edge for the crossroads feel.', 'Use the pocket as the eastern half of the loop.'], returnReasons: ['It rewards a second pass after circling the clock.', 'The square reads differently when you approach from Cambie.'] },
       { id: 'transit-edge', label: 'Transit edge', identity: 'transit edge', nodeId: 'transit-edge', polygon: transitEdge, stopReasons: ['Look uphill toward the Cambie continuation.', 'Feel the district open toward the station/transit seam.'], returnReasons: ['It gives the loop a practical edge instead of a dead end.', 'The shift in grade changes your sense of the block.'] },


### PR DESCRIPTION
### Motivation
- Improve the fallback-first Gastown simulator so the route feels faster, more playable, and unmistakably like Water Street / Steam Clock without adding remote/AI dependencies.
- Address movement flatness by adding an expressive forward-run intent for keyboard users while keeping precise exploration and existing Shift behavior.
- Make the authored fallback geometry and minimap communicate plaza, corner, and corridor character (Steam Clock corner, Water/Cordova seam, Maple Tree Square) more clearly.

### Description
- Implemented hold-to-run in `js/gastown-sim.js` with explicit runtime state (`runHoldSeconds`, `runBlend`, `runActive`), constants for threshold/ramp, a smooth ramp-in/out (`updateHoldToRunState`) and a blended movement profile (`getDynamicMovementProfile`) that biases forward speed (~1.58x at full blend) and reduces strafing during run.
- Integrated run blending into `movePlayer` so forward hold or Shift triggers run without breaking pointer lock or existing keyboard controls, and ensured clean reset on key release, pause, and spawn/reset paths.
- Improved minimap drawing in `js/gastown-sim.js` by adding sidewalk/street styling helpers, stronger labels and additional major nodes (Waterfront, Water/Cordova seam, Water St mid, Cambie/Steam Clock, Maple Tree Sq), and ensured navigator focusCorridor points are validated and drawn.
- Re-authored fallback geometry in `scripts/generate-gastown-world.js`: narrowed carriageway, widened sidewalks, more asymmetric frontage/framing, relabeled Steam Clock as a corner anchor, and adjusted spawn position/orientation (added a small pitch) to present a stronger first impression; regenerated `assets/world/gastown-water-street.json` to commit the updated deterministic world.
- Updated UI help copy in `page-gastown-sim.php` to document the hold-to-run control and extended tests to assert hold-to-run logic and improved world/minimap metadata.

### Testing
- Regenerated the canonical fallback with `node scripts/generate-gastown-world.js`, which produced `assets/world/gastown-water-street.json` (route ~296.0m) successfully.
- Ran the test suite with `node --test __tests__/gastown-sim-config.test.js __tests__/gastown-world-generator.test.js __tests__/gastown-world-loader-normalize.test.js __tests__/gastown-sim-resilience.test.js` and all tests passed (23/23).
- Verified the new hold-to-run code is present and exercised by unit assertions added in `__tests__/gastown-sim-resilience.test.js` and generator/minimap expectations in `__tests__/gastown-world-generator.test.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3621cd2a8832ea9bc4cdf23a308c0)