### PR TITLE
Promote Vancouver tech events on homepage with top-3 upcoming list

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -103,6 +103,50 @@ get_header();
         </div>
     </section>
 
+    <?php
+    $vancouver_events_payload = suzy_get_vancouver_tech_events();
+    $vancouver_events = [];
+    if ( isset( $vancouver_events_payload['events'] ) && is_array( $vancouver_events_payload['events'] ) ) {
+        $vancouver_events = $vancouver_events_payload['events'];
+    }
+    $vancouver_events_top = array_slice( $vancouver_events, 0, 3 );
+    ?>
+    <section class="vancouver-tech-home crt-block" aria-labelledby="vancouver-tech-home-title">
+        <h2 id="vancouver-tech-home-title" class="pixel-font">Vancouver tech events</h2>
+        <p class="vancouver-tech-home__intro">Local founder nights, meetups, and dev hangs pulled into one stream.</p>
+
+        <?php if ( empty( $vancouver_events_top ) ) : ?>
+            <p>No upcoming Vancouver events are cached right now. Hit the full page to refresh the feed.</p>
+        <?php else : ?>
+            <ul class="vancouver-tech-home__list">
+                <?php foreach ( $vancouver_events_top as $event ) : ?>
+                    <?php
+                    $event_start = isset( $event['start'] ) ? (int) $event['start'] : 0;
+                    $event_url   = isset( $event['url'] ) ? (string) $event['url'] : '';
+                    ?>
+                    <li class="vancouver-tech-home__item">
+                        <p class="vancouver-tech-home__time">
+                            <?php echo esc_html( $event_start > 0 ? wp_date( 'D, M j • g:i A T', $event_start ) : 'Date/time TBD' ); ?>
+                        </p>
+                        <a href="<?php echo esc_url( $event_url ); ?>" target="_blank" rel="noopener noreferrer" class="vancouver-tech-home__title">
+                            <?php echo esc_html( $event['title'] ?? 'Upcoming event' ); ?>
+                        </a>
+                        <p class="vancouver-tech-home__meta">
+                            <?php if ( ! empty( $event['location'] ) ) : ?>
+                                <span><?php echo esc_html( (string) $event['location'] ); ?></span>
+                            <?php endif; ?>
+                            <?php if ( ! empty( $event['source'] ) ) : ?>
+                                <span class="vancouver-tech-home__source"><?php echo esc_html( (string) $event['source'] ); ?></span>
+                            <?php endif; ?>
+                        </p>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php endif; ?>
+
+        <a class="pixel-button vancouver-tech-home__cta" href="<?php echo esc_url( home_url( '/vancouver-tech-events/' ) ); ?>">Browse all Vancouver tech events</a>
+    </section>
+
     <section class="build-public-home crt-block" aria-labelledby="build-public-title">
         <h2 id="build-public-title" class="pixel-font">Build in public / repo receipts</h2>
         <p class="home-section-legend-links" aria-label="Build in public quick links">

--- a/style.css
+++ b/style.css
@@ -3726,6 +3726,7 @@ body.page-template-page-bio-php .bio-content {
 
 /* Homepage repositioning blocks */
 .selected-work,
+.vancouver-tech-home,
 .build-public-home,
 .music-world,
 .collab-invite-home,
@@ -3737,6 +3738,7 @@ body.page-template-page-bio-php .bio-content {
 }
 
 .selected-work h2,
+.vancouver-tech-home h2,
 .build-public-home h2,
 .music-world h2,
 .collab-invite-home h2,
@@ -3746,6 +3748,7 @@ body.page-template-page-bio-php .bio-content {
 }
 
 .selected-work__intro,
+.vancouver-tech-home__intro,
 .build-public-home p,
 .music-world p,
 .collab-invite-home p,
@@ -3784,6 +3787,63 @@ body.page-template-page-bio-php .bio-content {
   color: #def9eb;
   line-height: 1.55;
   flex: 1;
+}
+
+.vancouver-tech-home {
+  border: 2px solid rgba(91, 184, 255, 0.45);
+  box-shadow: 0 0 18px rgba(91, 184, 255, 0.2);
+}
+
+.vancouver-tech-home__list {
+  list-style: none;
+  margin: 1rem 0 1.25rem;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.vancouver-tech-home__item {
+  border: 1px solid rgba(123, 198, 255, 0.38);
+  border-radius: 10px;
+  background: rgba(5, 17, 32, 0.45);
+  padding: 12px;
+}
+
+.vancouver-tech-home__time {
+  color: #9dd5ff;
+  font-size: 0.83rem;
+  margin: 0 0 0.35rem;
+  letter-spacing: 0.02em;
+}
+
+.vancouver-tech-home__title {
+  color: #e5f5ff;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.vancouver-tech-home__title:hover,
+.vancouver-tech-home__title:focus {
+  color: #ffffff;
+  text-decoration: underline;
+}
+
+.vancouver-tech-home__meta {
+  margin: 0.4rem 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem 0.7rem;
+  font-size: 0.82rem;
+  color: #c8ebff;
+}
+
+.vancouver-tech-home__source {
+  opacity: 0.82;
+}
+
+.vancouver-tech-home__cta {
+  display: inline-flex;
+  align-items: center;
 }
 
 .build-public-home {
@@ -3853,6 +3913,7 @@ body.page-template-page-bio-php .bio-content {
 
 @media (max-width: 760px) {
   .selected-work,
+  .vancouver-tech-home,
   .build-public-home,
   .music-world,
   .collab-invite-home,


### PR DESCRIPTION
### Motivation
- Surface the existing Vancouver tech events aggregator on the homepage so the `/vancouver-tech-events/` experience is discoverable and promoted alongside featured projects. 
- Highlight the nearest upcoming community events (top 3 by start time) to give visitors a quick glance at local meetups and founder/dev nights.

### Description
- Added a new homepage block in `page-home.php` that calls `suzy_get_vancouver_tech_events()`, selects the first three events, and renders start time, title (external link), location/source, and a CTA to the full events page. 
- Render includes a graceful fallback when no cached events are available and shows `Date/time TBD` when an event start timestamp is missing. 
- Introduced styles for the new block and event cards in `style.css` under `.vancouver-tech-home*` and integrated the block into existing homepage spacing and mobile rules. 
- No changes were made to the event-fetching or parsing logic; the section reuses the existing aggregator cache and output. 

### Testing
- Ran `php -l page-home.php` and it reported no syntax errors. 
- Ran `php -l inc/vancouver-tech-events.php` and it reported no syntax errors. 
- Verified files (`page-home.php`, `style.css`) updated without syntax issues in the working tree.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb63b49e3c832e88a1a2c1cab9755f)