### PR TITLE
Promote AI Film Club fireside chat on homepage

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -75,6 +75,38 @@ get_header();
         <p class="arcade-subtext">Retro-futurist lab mode: online</p>
     </div>
 
+    <?php
+    $ai_film_club_watch_url = 'https://www.youtube.com/watch?v=f2MdY3qcxt8';
+    $ai_film_club_embed_url = 'https://www.youtube-nocookie.com/embed/f2MdY3qcxt8';
+    $ai_film_club_repo_url = 'https://github.com/suzyeaston/suzyeastonca';
+    ?>
+    <section class="ai-film-feature crt-block" aria-labelledby="ai-film-feature-title">
+        <div class="ai-film-feature__media">
+            <p class="ai-film-feature__badge pixel-font"><?php echo esc_html('NEW TRANSMISSION'); ?></p>
+            <div class="ai-film-feature__embed-wrap">
+                <iframe
+                    src="<?php echo esc_url($ai_film_club_embed_url); ?>"
+                    title="<?php echo esc_attr('AI Film Club fireside chat with Mayumi Rollings'); ?>"
+                    loading="lazy"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                    referrerpolicy="strict-origin-when-cross-origin"
+                    allowfullscreen>
+                </iframe>
+            </div>
+        </div>
+        <div class="ai-film-feature__copy">
+            <p class="ai-film-feature__kicker pixel-font"><?php echo esc_html('LATEST SIGNAL // AI FILM CLUB'); ?></p>
+            <h2 id="ai-film-feature-title" class="pixel-font"><?php echo esc_html('Fireside chat: building weird, useful AI film tools'); ?></h2>
+            <p><?php echo esc_html('I joined Mayumi Rollings for an AI Film Club fireside chat about the messy, exciting middle ground between prompting and building: ASMR Lab, Vancouver/Gastown scene experiments, procedural audio, creator control, and why I started making my own tools instead of just using whatever platform was handed to me.'); ?></p>
+            <p class="ai-film-feature__note"><?php echo esc_html('This is the story behind the lab: part film experiment, part product prototype, part “fine, I’ll build the thing myself.”'); ?></p>
+            <div class="ai-film-feature__actions" aria-label="AI Film Club and lab links">
+                <a class="pixel-button" href="<?php echo esc_url($ai_film_club_watch_url); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html('Watch the fireside chat'); ?></a>
+                <a class="pixel-button" href="<?php echo esc_url(home_url('/asmr-lab/')); ?>"><?php echo esc_html('Explore ASMR Lab'); ?></a>
+                <a class="pixel-button" href="<?php echo esc_url($ai_film_club_repo_url); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html('View GitHub repo'); ?></a>
+            </div>
+        </div>
+    </section>
+
     <section class="selected-work crt-block" aria-labelledby="selected-work-title">
         <h2 id="selected-work-title" class="pixel-font">Featured builds</h2>
         <p class="selected-work__intro">Projects with a practical point of view: experiments that ship, teach, and stay useful.</p>

--- a/style.css
+++ b/style.css
@@ -1985,14 +1985,37 @@ body {
 
 
 .ai-film-feature {
-  margin: 40px auto;
-  max-width: 860px;
-  padding: 24px 28px;
-  border-radius: 12px;
+  margin: 34px auto 40px;
+  max-width: 1040px;
+  padding: 24px 26px;
+  border-radius: 14px;
   display: grid;
-  grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
-  gap: 20px;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  gap: 24px;
+  align-items: stretch;
+  border-color: #4cffd9;
+  box-shadow: 0 0 20px rgba(0, 255, 200, 0.24), inset 0 0 14px rgba(0, 255, 170, 0.1);
+}
+
+.ai-film-feature__media {
+  position: relative;
+  display: grid;
+  gap: 10px;
+}
+
+.ai-film-feature__badge {
+  display: inline-flex;
   align-items: center;
+  width: fit-content;
+  padding: 4px 10px;
+  border: 1px solid rgba(134, 255, 221, 0.7);
+  border-radius: 999px;
+  background: rgba(18, 18, 18, 0.75);
+  color: #baffea;
+  letter-spacing: 0.12em;
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  box-shadow: 0 0 10px rgba(0, 255, 183, 0.2);
 }
 
 .ai-film-feature__embed-wrap {
@@ -2044,6 +2067,11 @@ body {
   margin-bottom: 0.9rem;
   line-height: 1.65;
   color: #e8ffee;
+}
+
+.ai-film-feature__note {
+  font-weight: 600;
+  color: #c9ffe8;
 }
 
 .ai-film-feature__credit {


### PR DESCRIPTION
### Motivation
- Surface the new AI Film Club conversation as a prominent, on-brand signal that supports the site narrative of a builder-led creative technologist. 
- Place a focused, polished feature near the hero so the video reads as evidence of practical creative work, not random media. 

### Description
- Added a new `ai-film-feature` section directly after the hero in `page-home.php` with URL variables for the watch page, privacy-friendly embed, and repo link, and preserved WordPress escaping via `esc_url()`, `esc_html()`, and `esc_attr()`. 
- Inserted a responsive `youtube-nocookie` iframe (16:9 wrapper) with `title`, `loading="lazy"`, `allowfullscreen`, playback `allow` attributes, and `referrerpolicy` for privacy. 
- Added three CTAs with correct target/rel rules: `Watch the fireside chat` (external, opens new tab with `rel="noopener noreferrer"`), `Explore ASMR Lab` (internal), and `View GitHub repo` (external, new tab). 
- Refined the existing `.ai-film-feature` styles in `style.css` (layout grid tuning, badge chip, neon/CRT accents, note styling, shadows) and relied on the existing mobile breakpoint that stacks the feature to a single column. 

### Testing
- Ran `php -l page-home.php` with no syntax errors detected. 
- Ran `npm test`; the test run completed but reported repository test failures unrelated to the homepage change (test summary: 52 passed, 15 failed in Gastown/sync-cov areas). 
- Verified the homepage additions do not remove visitor tracker logic or existing project cards and did not change `header.php`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef09352574832e8cd66b8b28d736b4)