### PR TITLE
Refine homepage CTA hierarchy and simplify section flow

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -40,9 +40,9 @@ get_header();
                 </div>
 
                 <div class="hero-cta-group">
-                    <a href="<?php echo esc_url(home_url('/page-gastown-sim/')); ?>" class="pixel-button hero-primary-cta">View flagship build</a>
+                    <a href="<?php echo esc_url(home_url('/page-gastown-sim/')); ?>" class="pixel-button hero-primary-cta">Enter Gastown Simulator</a>
                     <a href="<?php echo esc_url(home_url('/work-with-suzy/')); ?>" class="pixel-button hero-secondary-cta">Work with Suzy</a>
-                    <a href="<?php echo esc_url('https://github.com/suzyeaston/suzyeastonca'); ?>" class="pixel-button hero-secondary-cta" target="_blank" rel="noopener noreferrer">GitHub repo</a>
+                    <a href="<?php echo esc_url('https://www.linkedin.com/in/suzyeaston/'); ?>" class="pixel-button hero-tertiary-cta" target="_blank" rel="noopener noreferrer">LinkedIn</a>
                 </div>
                 <p class="hero-collab-link"><a href="<?php echo esc_url(home_url('/bio/')); ?>"><?php echo esc_html('Read bio →'); ?></a></p>
             </div>
@@ -82,7 +82,7 @@ get_header();
     ?>
     <section class="ai-film-feature crt-block" aria-labelledby="ai-film-feature-title">
         <div class="ai-film-feature__media">
-            <p class="ai-film-feature__badge pixel-font"><?php echo esc_html('NEW TRANSMISSION'); ?></p>
+            <p class="ai-film-feature__badge pixel-font"><?php echo esc_html('FEATURED CONVERSATION // ON AIR'); ?></p>
             <div class="ai-film-feature__embed-wrap">
                 <iframe
                     src="<?php echo esc_url($ai_film_club_embed_url); ?>"
@@ -93,16 +93,22 @@ get_header();
                     allowfullscreen>
                 </iframe>
             </div>
+            <div class="ai-film-feature__meta" aria-label="AI Film Club metadata">
+                <span><?php echo esc_html('AI FILM CLUB'); ?></span>
+                <span><?php echo esc_html('WITH MAYUMI ROLLINGS'); ?></span>
+                <span><?php echo esc_html('CREATIVE TECH'); ?></span>
+                <span><?php echo esc_html('VANCOUVER / ASMR LAB'); ?></span>
+            </div>
         </div>
         <div class="ai-film-feature__copy">
             <p class="ai-film-feature__kicker pixel-font"><?php echo esc_html('LATEST SIGNAL // AI FILM CLUB'); ?></p>
-            <h2 id="ai-film-feature-title" class="pixel-font"><?php echo esc_html('Fireside chat: building weird, useful AI film tools'); ?></h2>
-            <p><?php echo esc_html('I joined Mayumi Rollings for an AI Film Club fireside chat about the messy, exciting middle ground between prompting and building: ASMR Lab, Vancouver/Gastown scene experiments, procedural audio, creator control, and why I started making my own tools instead of just using whatever platform was handed to me.'); ?></p>
-            <p class="ai-film-feature__note"><?php echo esc_html('This is the story behind the lab: part film experiment, part product prototype, part “fine, I’ll build the thing myself.”'); ?></p>
+            <h2 id="ai-film-feature-title" class="pixel-font"><?php echo esc_html('AI Film Club fireside chat: building tools, not just prompts'); ?></h2>
+            <p><?php echo esc_html('I joined Mayumi Rollings for an AI Film Club fireside chat about the middle ground between prompting and building: ASMR Lab, Gastown/Vancouver scene experiments, procedural audio, creator control, and why I started making my own tools instead of waiting for a platform to fit.'); ?></p>
+            <p class="ai-film-feature__note"><?php echo esc_html('Part film experiment, part product prototype, part “fine, I’ll build it myself.”'); ?></p>
             <div class="ai-film-feature__actions" aria-label="AI Film Club and lab links">
                 <a class="pixel-button" href="<?php echo esc_url($ai_film_club_watch_url); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html('Watch the fireside chat'); ?></a>
                 <a class="pixel-button" href="<?php echo esc_url(home_url('/asmr-lab/')); ?>"><?php echo esc_html('Explore ASMR Lab'); ?></a>
-                <a class="pixel-button" href="<?php echo esc_url($ai_film_club_repo_url); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html('View GitHub repo'); ?></a>
+                <a class="pixel-button" href="<?php echo esc_url($ai_film_club_repo_url); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html('View source on GitHub'); ?></a>
             </div>
         </div>
     </section>
@@ -135,31 +141,25 @@ get_header();
                 <p class="selected-work__tags" aria-label="ASMR Lab technology tags"><span>AI film</span><span>Procedural audio</span><span>Creative tools</span></p>
                 <a class="pixel-button" href="<?php echo esc_url(home_url('/asmr-lab/')); ?>">Explore the Lab</a>
             </article>
+            <article class="selected-work__card">
+                <h3 class="pixel-font">Albini Q&amp;A</h3>
+                <p>An experimental voice-and-attitude-driven creative app inspired by Steve Albini: part tribute, part interactive web experiment, part chaos-tested music-tech artifact.</p>
+                <p class="selected-work__tags" aria-label="Albini Q and A technology tags"><span>AI</span><span>Music</span><span>Web experiment</span></p>
+                <a class="pixel-button" href="<?php echo esc_url(home_url('/albini-qa/')); ?>">Open Albini Q&amp;A</a>
+            </article>
         </div>
     </section>
 
     <section class="skills-home crt-block" aria-labelledby="skills-home-title">
-        <h2 id="skills-home-title" class="pixel-font">Systems I like untangling</h2>
+        <h2 id="skills-home-title" class="pixel-font">What I do best</h2>
         <ul class="skills-home__list">
             <li>QA automation and release confidence</li>
             <li>IT operations, identity, endpoint, and SaaS troubleshooting</li>
-            <li>Python/PowerShell/JavaScript automation</li>
-            <li>Practical AI prototypes and internal tools</li>
-            <li>Debugging weird production issues with calm, logs, and receipts</li>
-            <li>Music/audio/creative web experiments</li>
+            <li>Python, PowerShell, and JavaScript automation</li>
+            <li>Practical AI tools and internal tooling</li>
+            <li>Debugging messy production issues with calm, logs, and receipts</li>
+            <li>Music, audio, and creative web experiments</li>
         </ul>
-    </section>
-
-    <section class="build-public-home crt-block" aria-labelledby="build-public-title">
-        <h2 id="build-public-title" class="pixel-font">Built in public, not hand-waved</h2>
-        <p class="home-section-legend-links" aria-label="Build in public quick links">
-            <a href="https://github.com/suzyeaston/suzyeastonca" target="_blank" rel="noopener noreferrer">GitHub repo</a>
-            <span aria-hidden="true">//</span>
-            <a href="<?php echo esc_url(home_url('/projects/')); ?>">Project build logs</a>
-            <span aria-hidden="true">//</span>
-            <a href="<?php echo esc_url(home_url('/blog/')); ?>">Latest lab notes</a>
-        </p>
-        <p>This site is a working portfolio, not a static brochure. The experiments ship in public, the repo shows the process, and the rough edges are part of the proof: I build, test, revise, document, and keep moving.</p>
     </section>
 
     <section class="music-world crt-block" aria-labelledby="music-world-title">
@@ -179,12 +179,12 @@ get_header();
     </section>
 
     <section class="collab-invite-home crt-block" aria-labelledby="collab-invite-title">
-        <h2 id="collab-invite-title" class="pixel-font">Need a technical generalist with builder instincts?</h2>
-        <p>I’m open to senior technical roles, contract QA/automation work, practical AI prototypes, and debugging projects where the system is messy, the stakes are real, and someone needs to make the thing make sense.</p>
+        <h2 id="collab-invite-title" class="pixel-font">Available for senior roles, contract work, and strange useful builds</h2>
+        <p>I’m open to senior technical roles, contract QA/automation work, practical AI prototypes, and debugging projects where the system is messy and someone needs to make the thing make sense.</p>
         <div class="collab-invite-home__actions">
             <a href="<?php echo esc_url(home_url('/work-with-suzy/')); ?>" class="pixel-button">Work with Suzy</a>
+            <a href="<?php echo esc_url('https://www.linkedin.com/in/suzyeaston/'); ?>" target="_blank" rel="noopener noreferrer" class="pixel-button">LinkedIn</a>
             <a href="mailto:suzyeaston@icloud.com?subject=Work%20Inquiry" class="pixel-button">Email Suzy</a>
-            <a href="https://github.com/suzyeaston/suzyeastonca" target="_blank" rel="noopener noreferrer" class="pixel-button">View GitHub</a>
         </div>
     </section>
 

--- a/style.css
+++ b/style.css
@@ -2048,6 +2048,22 @@ body {
   border: 0;
 }
 
+.ai-film-feature__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.ai-film-feature__meta span {
+  border: 1px solid rgba(134, 255, 221, 0.42);
+  border-radius: 999px;
+  padding: 0.28rem 0.62rem;
+  font-size: 0.68rem;
+  letter-spacing: 0.07em;
+  color: #c9ffea;
+  background: rgba(9, 23, 20, 0.72);
+}
+
 .ai-film-feature__copy h2 {
   margin-top: 0;
   margin-bottom: 0.8rem;
@@ -3794,7 +3810,6 @@ body.page-template-page-bio-php .bio-content {
 /* Homepage repositioning blocks */
 .selected-work,
 .vancouver-tech-home,
-.build-public-home,
 .music-world,
 .collab-invite-home,
 .utility-nav-home {
@@ -3806,7 +3821,6 @@ body.page-template-page-bio-php .bio-content {
 
 .selected-work h2,
 .vancouver-tech-home h2,
-.build-public-home h2,
 .music-world h2,
 .collab-invite-home h2,
 .utility-nav-home h2 {
@@ -3816,7 +3830,6 @@ body.page-template-page-bio-php .bio-content {
 
 .selected-work__intro,
 .vancouver-tech-home__intro,
-.build-public-home p,
 .music-world p,
 .collab-invite-home p,
 .utility-nav-home p {
@@ -3929,11 +3942,6 @@ body.page-template-page-bio-php .bio-content {
   align-items: center;
 }
 
-.build-public-home {
-  border: 2px solid rgba(0, 255, 170, 0.4);
-  box-shadow: 0 0 20px rgba(0, 255, 170, 0.18);
-}
-
 .skills-home {
   margin: 34px auto;
   max-width: 960px;
@@ -3999,6 +4007,18 @@ body.page-template-page-bio-php .bio-content {
   margin-top: 0.8rem;
 }
 
+.hero-tertiary-cta {
+  border-color: rgba(145, 219, 255, 0.4);
+  color: #d7f4ff;
+  background: rgba(14, 33, 39, 0.72);
+}
+
+.hero-tertiary-cta:hover,
+.hero-tertiary-cta:focus {
+  border-color: rgba(173, 240, 255, 0.62);
+  color: #effcff;
+}
+
 .utility-nav-home__counter {
   color: #9bffc6;
   margin-bottom: 0.4rem;
@@ -4025,7 +4045,6 @@ body.page-template-page-bio-php .bio-content {
   .selected-work,
   .vancouver-tech-home,
   .skills-home,
-  .build-public-home,
   .music-world,
   .collab-invite-home,
   .utility-nav-home {
@@ -4039,5 +4058,9 @@ body.page-template-page-bio-php .bio-content {
 
   .hero-section .hero-cta-group {
     gap: 0.6rem;
+  }
+
+  .ai-film-feature__meta span {
+    font-size: 0.63rem;
   }
 }


### PR DESCRIPTION
### Motivation
- Make the homepage point visitors first to the flagship interactive project (Gastown Simulator), then to hiring/contract opportunities, and surface LinkedIn as the primary professional profile. 
- Reduce repeated GitHub/repo links and visual clutter so the page feels sharper and supports both portfolio browsing and job-search credibility. 
- Improve the AI Film Club media area so it reads as a purposeful broadcast feature with compact metadata rather than an awkward decorative element. 

### Description
- Updated `page-home.php` hero CTA stack so the primary button is `Enter Gastown Simulator`, the secondary is `Work with Suzy`, and the third is `LinkedIn` (external with `target="_blank" rel="noopener noreferrer"`).
- Reworked the AI Film Club block by replacing the large “NEW TRANSMISSION” treatment with a `FEATURED CONVERSATION // ON AIR` badge, adding a small metadata chip row, tightening heading/copy, and keeping the embedded YouTube panel and one GitHub source link.
- Added a new Featured Builds card for “Albini Q&A” with project description, tags, and a CTA linking to the existing ` /albini-qa/ ` route.
- Renamed the skills section from `Systems I like untangling` to `What I do best` and refined list copy for clearer professional framing.
- Removed the entire `Built in public, not hand-waved` section and the now-unused build-public styles to reduce repetition and improve flow.
- Updated collaboration CTA to read as a professional contact area and changed buttons to `Work with Suzy`, `LinkedIn`, and `Email Suzy` (removed GitHub from that block).
- Edited `style.css` to add styles for the AI Film Club metadata chips and a `hero-tertiary-cta` style for the LinkedIn button, and removed references to the removed `build-public-home` visuals; existing WordPress escaping (`esc_html`, `esc_attr`, `esc_url`) and routes were preserved.

### Testing
- Ran `php -l page-home.php` and it reported no syntax errors. 
- Ran `php -l header.php` and it reported no syntax errors. 
- No automated layout screenshots were taken in this environment, so visual checks on desktop and mobile should be performed after deploy to confirm spacing and responsiveness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef0c39ff2c832e9321c5a7d109af2b)