### PR TITLE
Refine AI Film Club metadata into compact retro chips

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -94,10 +94,13 @@ get_header();
                 </iframe>
             </div>
             <div class="ai-film-feature__meta" aria-label="AI Film Club metadata">
-                <span><?php echo esc_html('AI FILM CLUB'); ?></span>
-                <span><?php echo esc_html('WITH MAYUMI ROLLINGS'); ?></span>
-                <span><?php echo esc_html('CREATIVE TECH'); ?></span>
-                <span><?php echo esc_html('VANCOUVER / ASMR LAB'); ?></span>
+                <p class="ai-film-feature__meta-label pixel-font"><?php echo esc_html('SESSION INFO'); ?></p>
+                <ul class="ai-film-feature__meta-list">
+                    <li><?php echo esc_html('AI Film Club'); ?></li>
+                    <li><?php echo esc_html('With Mayumi Rollings'); ?></li>
+                    <li><?php echo esc_html('Creative Tech'); ?></li>
+                    <li><?php echo esc_html('Vancouver / ASMR Lab'); ?></li>
+                </ul>
             </div>
         </div>
         <div class="ai-film-feature__copy">

--- a/style.css
+++ b/style.css
@@ -2051,19 +2051,52 @@ body {
 }
 
 .ai-film-feature__meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
+  display: grid;
+  gap: 0.5rem;
+  margin-top: 0.1rem;
 }
 
-.ai-film-feature__meta span {
-  border: 1px solid rgba(134, 255, 221, 0.42);
-  border-radius: 999px;
-  padding: 0.28rem 0.62rem;
-  font-size: 0.68rem;
+.ai-film-feature__meta-label {
+  margin: 0;
+  font-size: 0.62rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(145, 255, 224, 0.84);
+}
+
+.ai-film-feature__meta-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.ai-film-feature__meta-list li {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  max-width: 100%;
+  padding: 0.42rem 0.78rem;
+  border: 1px solid rgba(126, 255, 215, 0.4);
+  border-radius: 0.36rem;
+  font-size: 0.66rem;
+  font-weight: 600;
   letter-spacing: 0.07em;
-  color: #c9ffea;
-  background: rgba(9, 23, 20, 0.72);
+  text-transform: uppercase;
+  color: #d9fff2;
+  background: linear-gradient(180deg, rgba(9, 28, 23, 0.86), rgba(4, 14, 12, 0.9));
+  box-shadow: inset 0 0 0 1px rgba(0, 255, 181, 0.12), 0 0 10px rgba(0, 255, 191, 0.12);
+  text-shadow: 0 0 8px rgba(104, 255, 206, 0.35);
+}
+
+.ai-film-feature__meta-list li::before {
+  content: "▹";
+  margin-right: 0.45rem;
+  color: rgba(109, 255, 201, 0.9);
+  font-size: 0.7rem;
 }
 
 .ai-film-feature__copy h2 {
@@ -4155,7 +4188,13 @@ body.page-template-page-bio-php .bio-content {
     gap: 0.6rem;
   }
 
-  .ai-film-feature__meta span {
-    font-size: 0.63rem;
+  .ai-film-feature__meta-list {
+    gap: 0.45rem;
+  }
+
+  .ai-film-feature__meta-list li {
+    font-size: 0.6rem;
+    letter-spacing: 0.06em;
+    padding: 0.36rem 0.65rem;
   }
 }


### PR DESCRIPTION
### Motivation
- The existing metadata for the AI Film Club section rendered as large, empty rounded outlines that created visual dead space and read like placeholders rather than intentional UI. 
- The aim is to make the metadata supportive, compact, and to give it a retro/terminal aesthetic that complements the feature without overpowering the headline or CTAs.

### Description
- Reworked markup in `page-home.php` to replace the inline span pills with a labeled `SESSION INFO` block containing a semantic `ul`/`li` chip list while preserving WordPress escaping. (files: `page-home.php`)
- Replaced the previous pill CSS with a retro-terminal chip treatment in `style.css`: chips are `fit-content`, have reduced padding (`~0.42rem 0.78rem`), subtle border/glow, a dark gradient background, uppercase styling, and a small `▹` prefix to create rhythm. (files: `style.css`)
- Adjusted layout for tidy wrapping and spacing using flex-wrap and grid for the meta container, and tuned responsive rules so chips scale down cleanly on mobile. (files: `style.css`)
- Kept the YouTube embed and existing CTA buttons untouched to avoid breaking interaction or layout. (files: `page-home.php`)

### Testing
- Ran `php -l page-home.php` and received no syntax errors, confirming the updated template is valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef106ae50c832e9fe7e0cac5818fa5)