### PR TITLE
Upgrade homepage Galaga: real game states, HUD, collisions, and Rain City theming

### DIFF
--- a/js/hero-galaga.js
+++ b/js/hero-galaga.js
@@ -22,6 +22,9 @@
       primary: (rootStyles.getPropertyValue('--primary-color') || '#00ff00').trim(),
       secondary: (rootStyles.getPropertyValue('--secondary-color') || '#e60073').trim(),
       accent: (rootStyles.getPropertyValue('--accent-color') || '#ffff00').trim(),
+      rain: '#57f3ff',
+      ferry: '#92ffba',
+      magentaRain: '#ff48ce',
     };
 
     const canvas = document.createElement('canvas');
@@ -30,7 +33,12 @@
 
     const ui = document.createElement('div');
     ui.className = 'hero-galaga-ui';
-    ui.innerHTML = '<p class="hero-galaga-status">Score: <span data-galaga-score>0</span> · Lives: <span data-galaga-lives>3</span> · Wave: <span data-galaga-wave>1</span></p><p class="hero-galaga-help">←/→ (A/D) · Space · Esc</p><div class="hero-galaga-gameover" data-galaga-gameover hidden></div>';
+    ui.innerHTML = '' +
+      '<p class="hero-galaga-status" data-galaga-status>Rain City Defense</p>' +
+      '<p class="hero-galaga-scoreline">Score: <span data-galaga-score>000000</span> · Lives: <span data-galaga-lives>3</span> · Wave: <span data-galaga-wave>1</span></p>' +
+      '<p class="hero-galaga-help">A/D or ←/→ · Space fire · Esc exit</p>' +
+      '<p class="hero-galaga-wavecall" data-galaga-wavecall hidden></p>' +
+      '<div class="hero-galaga-gameover" data-galaga-gameover hidden></div>';
 
     const hint = document.createElement('div');
     hint.className = 'hero-galaga-hint';
@@ -51,13 +59,12 @@
     const livesEl = ui.querySelector('[data-galaga-lives]');
     const waveEl = ui.querySelector('[data-galaga-wave]');
     const gameOverEl = ui.querySelector('[data-galaga-gameover]');
+    const waveCallEl = ui.querySelector('[data-galaga-wavecall]');
     const startButton = hint.querySelector('.hero-galaga-start');
     const hintTextEl = hint.querySelector('[data-galaga-hint-text]');
 
     const state = {
-      mode: 'idle',
-      running: false,
-      gameOver: false,
+      mode: 'idle', // idle | playing | gameover
       width: 1,
       height: 1,
       dpr: Math.max(1, window.devicePixelRatio || 1),
@@ -65,13 +72,16 @@
       score: 0,
       lives: 3,
       wave: 1,
+      wavePending: false,
       player: null,
       playerBullets: [],
       enemyBullets: [],
       enemies: [],
+      particles: [],
       enemyDir: 1,
       enemyStepTimer: 0,
       enemyFireTimer: 0,
+      enemyDiveTimer: 0,
       keys: {
         left: false,
         right: false,
@@ -80,6 +90,9 @@
       lastShotAt: 0,
       lastFrame: 0,
       idleTick: 0,
+      shakeUntil: 0,
+      shakePower: 0,
+      waveCallUntil: 0,
       playfield: {
         x: 0,
         y: 0,
@@ -87,6 +100,26 @@
         h: 1,
       },
     };
+
+    const waveCalls = [
+      'WAVE 1 · RAIN CITY SIGNAL',
+      'WAVE 2 · GASTOWN STATIC',
+      'WAVE 3 · STEAM CLOCK SWARM',
+      'WAVE 4 · ALIEN FOG ROLLING IN',
+      'WAVE 5 · FALSE CREEK DISTRESS',
+    ];
+
+    function isPlaying() {
+      return state.mode === 'playing';
+    }
+
+    function shouldAnimateIdle() {
+      return !reducedMotionQuery.matches && desktopQuery.matches && state.mode === 'idle';
+    }
+
+    function nowMs() {
+      return performance.now();
+    }
 
     function clampPlayerToPlayfield() {
       if (!state.player) {
@@ -102,18 +135,9 @@
       const hintBottom = Math.max(12, state.height - (state.playfield.y + state.playfield.h) + 12);
       ui.style.left = state.playfield.x + 12 + 'px';
       ui.style.top = state.playfield.y + 12 + 'px';
-      ui.style.maxWidth = Math.max(200, state.playfield.w - 24) + 'px';
-
+      ui.style.maxWidth = Math.max(240, state.playfield.w - 24) + 'px';
       hint.style.left = state.playfield.x + 12 + 'px';
       hint.style.bottom = hintBottom + 'px';
-    }
-
-    function isActiveMode() {
-      return state.mode === 'active';
-    }
-
-    function shouldAnimateIdle() {
-      return !reducedMotionQuery.matches && desktopQuery.matches && state.mode === 'idle';
     }
 
     function sizeCanvas() {
@@ -131,6 +155,7 @@
         w: Math.min(state.width, Math.max(1, Math.round(mainRect.width))),
         h: Math.min(state.height, Math.max(260, Math.round(visibleH))),
       };
+
       canvas.width = Math.round(width * state.dpr);
       canvas.height = Math.round(height * state.dpr);
       canvas.style.width = width + 'px';
@@ -141,14 +166,18 @@
       clampPlayerToPlayfield();
       positionOverlayUI();
 
-      if (!isActiveMode()) {
+      if (!isPlaying()) {
         render();
       }
     }
 
+    function formatScore(value) {
+      return String(Math.max(0, value)).padStart(6, '0');
+    }
+
     function updateUI() {
-      scoreEl.textContent = String(state.score);
-      livesEl.textContent = String(state.lives);
+      scoreEl.textContent = formatScore(state.score);
+      livesEl.textContent = String(Math.max(0, state.lives));
       waveEl.textContent = String(state.wave);
     }
 
@@ -157,72 +186,99 @@
         return;
       }
 
-      if (isActiveMode()) {
+      if (isPlaying()) {
         hintTextEl.textContent = 'Esc to quit';
         startButton.hidden = true;
+        return;
+      }
+
+      if (state.mode === 'gameover') {
+        hintTextEl.textContent = 'Press G to reboot, or Esc to return';
       } else {
         hintTextEl.textContent = reducedMotionQuery.matches
-          ? 'Press G to play (manual motion)'
+          ? 'Press G to play (reduced motion)'
           : 'Press G to play';
-        startButton.hidden = false;
       }
+      startButton.hidden = false;
     }
 
-    function spawnWave(config) {
-      const options = config || {};
-      const cols = options.cols || 8;
-      const rows = options.rows || 4;
+    function showWaveCallout() {
+      const index = Math.min(waveCalls.length - 1, Math.max(0, state.wave - 1));
+      const label = waveCalls[index] || ('WAVE ' + state.wave + ' · RAIN CITY DEFENSE');
+      if (waveCallEl) {
+        waveCallEl.textContent = label;
+        waveCallEl.hidden = false;
+      }
+      state.waveCallUntil = nowMs() + 1600;
+    }
+
+    function clearTransientFx() {
+      state.particles = [];
+      state.shakeUntil = 0;
+      state.shakePower = 0;
+      heroGrid.classList.remove('galaga-hit');
+    }
+
+    function makeEnemy(row, col, cfg) {
       const enemyW = 22;
       const enemyH = 16;
-      const gapX = options.gapX || 18;
-      const gapY = options.gapY || 14;
-      const totalW = cols * enemyW + (cols - 1) * gapX;
+      const gapX = cfg.gapX;
+      const gapY = cfg.gapY;
+      const totalW = cfg.cols * enemyW + (cfg.cols - 1) * gapX;
       const startX = state.playfield.x + Math.max(10, (state.playfield.w - totalW) / 2);
-      const startY = state.playfield.y + (options.startY || 70);
+      const startY = state.playfield.y + cfg.startY;
+      const variants = ['drip', 'umbrella', 'ghost'];
+      return {
+        x: startX + col * (enemyW + gapX),
+        y: startY + row * (enemyH + gapY),
+        w: enemyW,
+        h: enemyH,
+        alive: true,
+        type: variants[(row + col) % variants.length],
+        baseX: startX + col * (enemyW + gapX),
+        baseY: startY + row * (enemyH + gapY),
+        diving: false,
+        diveVx: 0,
+        diveVy: 0,
+      };
+    }
+
+    function spawnWave() {
+      const cols = 7;
+      const rows = 4;
+      const cfg = {
+        cols: cols,
+        rows: rows,
+        gapX: 18,
+        gapY: 13,
+        startY: 66,
+      };
 
       state.enemies = [];
       for (let row = 0; row < rows; row += 1) {
         for (let col = 0; col < cols; col += 1) {
-          state.enemies.push({
-            x: startX + col * (enemyW + gapX),
-            y: startY + row * (enemyH + gapY),
-            w: enemyW,
-            h: enemyH,
-            alive: true,
-          });
+          state.enemies.push(makeEnemy(row, col, cfg));
         }
       }
 
       state.enemyDir = 1;
       state.enemyStepTimer = 0;
       state.enemyFireTimer = 0;
+      state.enemyDiveTimer = 0;
+      state.wavePending = false;
+      showWaveCallout();
     }
 
-    function initScene() {
-      state.playerBullets = [];
-      state.enemyBullets = [];
+    function initPlayer() {
       state.player = {
         w: 24,
         h: 14,
         x: state.playfield.x + state.playfield.w / 2 - 12,
         y: state.playfield.y + state.playfield.h - 14 - 18,
-        speed: 300,
+        speed: 320,
+        invulnerableUntil: 0,
+        hitFlashUntil: 0,
       };
-      spawnWave();
-      clampPlayerToPlayfield();
-    }
-
-    function initIdleScene() {
-      state.playerBullets = [];
-      state.enemyBullets = [];
-      state.player = {
-        w: 24,
-        h: 14,
-        x: state.playfield.x + state.playfield.w / 2 - 12,
-        y: state.playfield.y + state.playfield.h - 14 - 18,
-        speed: 300,
-      };
-      spawnWave({ cols: 5, rows: 2, gapX: 16, gapY: 12, startY: 86 });
       clampPlayerToPlayfield();
     }
 
@@ -230,19 +286,26 @@
       state.score = 0;
       state.lives = 3;
       state.wave = 1;
-      state.gameOver = false;
+      state.wavePending = false;
+      state.playerBullets = [];
+      state.enemyBullets = [];
       state.lastShotAt = 0;
-      initScene();
-      updateUI();
+      state.keys.left = false;
+      state.keys.right = false;
+      state.keys.fire = false;
+      clearTransientFx();
+      initPlayer();
+      spawnWave();
       gameOverEl.hidden = true;
-      gameOverEl.textContent = '';
+      gameOverEl.innerHTML = '';
+      updateUI();
     }
 
     function ensureLoopRunning() {
-      if (state.rafId || (!isActiveMode() && !shouldAnimateIdle())) {
+      if (state.rafId || (!isPlaying() && !shouldAnimateIdle())) {
         return;
       }
-      state.lastFrame = performance.now();
+      state.lastFrame = nowMs();
       state.rafId = window.requestAnimationFrame(loop);
     }
 
@@ -253,23 +316,37 @@
       }
     }
 
+    function initIdleScene() {
+      state.playerBullets = [];
+      state.enemyBullets = [];
+      state.particles = [];
+      initPlayer();
+      state.enemies = [];
+      for (let row = 0; row < 2; row += 1) {
+        for (let col = 0; col < 5; col += 1) {
+          state.enemies.push(makeEnemy(row, col, { cols: 5, gapX: 16, gapY: 12, startY: 82 }));
+        }
+      }
+    }
+
     function enterIdleMode() {
       state.mode = 'idle';
-      state.running = false;
-      state.gameOver = false;
+      state.wavePending = false;
       state.keys.left = false;
       state.keys.right = false;
       state.keys.fire = false;
-      state.playerBullets = [];
-      state.enemyBullets = [];
       state.idleTick = 0;
+      clearTransientFx();
 
       window.__SE_GALAGA_ACTIVE = false;
       heroGrid.dataset.galagaActive = 'false';
       heroGrid.classList.remove('is-galaga');
       canvas.style.pointerEvents = 'none';
       gameOverEl.hidden = true;
-      gameOverEl.textContent = '';
+      gameOverEl.innerHTML = '';
+      if (waveCallEl) {
+        waveCallEl.hidden = true;
+      }
       initIdleScene();
 
       updateHint();
@@ -282,14 +359,13 @@
     }
 
     function startGame() {
-      if (!desktopQuery.matches || isActiveMode()) {
+      if (!desktopQuery.matches || isPlaying()) {
         return;
       }
 
       stopLoop();
       canvas.tabIndex = 0;
-      state.mode = 'active';
-      state.running = true;
+      state.mode = 'playing';
       window.__SE_GALAGA_ACTIVE = true;
       heroGrid.dataset.galagaActive = 'true';
       heroGrid.classList.add('is-galaga');
@@ -301,15 +377,137 @@
       ensureLoopRunning();
     }
 
-    function stopGame() {
-      if (!isActiveMode()) {
+    function endGame(options) {
+      if (!options || options.toIdle) {
+        enterIdleMode();
         return;
       }
-      enterIdleMode();
+
+      state.mode = 'gameover';
+      state.keys.left = false;
+      state.keys.right = false;
+      state.keys.fire = false;
+      state.playerBullets = [];
+      state.enemyBullets = [];
+      window.__SE_GALAGA_ACTIVE = false;
+      heroGrid.dataset.galagaActive = 'false';
+      heroGrid.classList.remove('is-galaga');
+      canvas.style.pointerEvents = 'none';
+
+      gameOverEl.hidden = false;
+      gameOverEl.innerHTML = '<strong>SIGNAL LOST</strong><br>Final score: ' + formatScore(state.score) + '<br>Press G to reboot or Esc to quit';
+      updateHint();
+      render();
+      stopLoop();
     }
 
     function intersects(a, b) {
       return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
+    }
+
+    function circleOverlap(x1, y1, r1, x2, y2, r2) {
+      const dx = x1 - x2;
+      const dy = y1 - y2;
+      return (dx * dx + dy * dy) <= (r1 + r2) * (r1 + r2);
+    }
+
+    function spawnExplosion(x, y, count, palette) {
+      const colorset = palette || [colors.secondary, colors.accent, colors.rain, '#ffffff'];
+      const total = count || 12;
+      for (let i = 0; i < total; i += 1) {
+        const a = Math.random() * Math.PI * 2;
+        const speed = 40 + Math.random() * 180;
+        state.particles.push({
+          x: x,
+          y: y,
+          vx: Math.cos(a) * speed,
+          vy: Math.sin(a) * speed,
+          life: 0.28 + Math.random() * 0.36,
+          ttl: 0.28 + Math.random() * 0.36,
+          color: colorset[i % colorset.length],
+          size: 1 + Math.random() * 2.6,
+        });
+      }
+    }
+
+    function triggerShake(power, durationMs) {
+      if (reducedMotionQuery.matches) {
+        return;
+      }
+      state.shakePower = Math.max(state.shakePower, power);
+      state.shakeUntil = Math.max(state.shakeUntil, nowMs() + durationMs);
+      heroGrid.classList.remove('galaga-hit');
+      void heroGrid.offsetWidth;
+      heroGrid.classList.add('galaga-hit');
+    }
+
+    function playerHitbox() {
+      if (!state.player) {
+        return null;
+      }
+      return {
+        x: state.player.x + 5,
+        y: state.player.y + 3,
+        w: state.player.w - 10,
+        h: state.player.h - 4,
+      };
+    }
+
+    function isPlayerInvulnerable() {
+      return Boolean(state.player && state.player.invulnerableUntil > nowMs());
+    }
+
+    function damagePlayer() {
+      if (!state.player || isPlayerInvulnerable() || state.mode !== 'playing') {
+        return;
+      }
+
+      state.lives -= 1;
+      state.player.invulnerableUntil = nowMs() + 1500;
+      state.player.hitFlashUntil = state.player.invulnerableUntil;
+      spawnExplosion(state.player.x + state.player.w / 2, state.player.y + state.player.h / 2, 20, [colors.magentaRain, '#ffffff', colors.secondary]);
+      triggerShake(4, 220);
+
+      if (state.lives <= 0) {
+        state.lives = 0;
+        updateUI();
+        endGame({ toIdle: false });
+        return;
+      }
+
+      updateUI();
+    }
+
+    function destroyEnemy(enemy) {
+      enemy.alive = false;
+      const enemyScore = enemy.diving ? 250 : 100;
+      state.score += enemyScore;
+      spawnExplosion(enemy.x + enemy.w / 2, enemy.y + enemy.h / 2, enemy.diving ? 14 : 10);
+    }
+
+    function updateWaveProgression() {
+      const aliveCount = state.enemies.filter(function (enemy) {
+        return enemy.alive;
+      }).length;
+
+      if (aliveCount > 0 || state.wavePending || state.mode !== 'playing') {
+        return;
+      }
+
+      state.wavePending = true;
+      state.score += 150;
+      updateUI();
+
+      window.setTimeout(function () {
+        if (state.mode !== 'playing') {
+          return;
+        }
+        state.wave += 1;
+        state.playerBullets = [];
+        state.enemyBullets = [];
+        spawnWave();
+        updateUI();
+      }, 850);
     }
 
     function handleKeys(dt, now) {
@@ -321,8 +519,14 @@
       state.player.x += dir * state.player.speed * dt;
       clampPlayerToPlayfield();
 
-      if (state.keys.fire && now - state.lastShotAt > 180) {
-        state.playerBullets.push({ x: state.player.x + state.player.w / 2 - 2, y: state.player.y - 8, w: 4, h: 10, vy: -430 });
+      if (state.keys.fire && now - state.lastShotAt > 170) {
+        state.playerBullets.push({
+          x: state.player.x + state.player.w / 2 - 2,
+          y: state.player.y - 8,
+          w: 4,
+          h: 10,
+          vy: -460,
+        });
         state.lastShotAt = now;
       }
     }
@@ -332,18 +536,26 @@
         return;
       }
 
-      const stepInterval = Math.max(0.14, 0.5 - (state.wave - 1) * 0.04);
+      const living = state.enemies.filter(function (enemy) {
+        return enemy.alive;
+      });
+      if (!living.length) {
+        return;
+      }
+
+      const stepInterval = Math.max(0.12, 0.44 - (state.wave - 1) * 0.03);
       state.enemyStepTimer += dt;
 
       if (state.enemyStepTimer >= stepInterval) {
         state.enemyStepTimer = 0;
-        const stepX = 14 + state.wave * 1.2;
-        const stepY = 14;
+        const stepX = 12 + state.wave * 1.4;
+        const stepY = 11;
 
         let nextMinX = Infinity;
         let nextMaxX = -Infinity;
-        state.enemies.forEach(function (enemy) {
-          if (!enemy.alive) {
+
+        living.forEach(function (enemy) {
+          if (enemy.diving) {
             return;
           }
           const nextX = enemy.x + stepX * state.enemyDir;
@@ -354,8 +566,8 @@
         const playfieldRight = state.playfield.x + state.playfield.w;
         const hitEdge = nextMinX <= state.playfield.x + 8 || nextMaxX >= playfieldRight - 8;
 
-        state.enemies.forEach(function (enemy) {
-          if (!enemy.alive) {
+        living.forEach(function (enemy) {
+          if (enemy.diving) {
             return;
           }
           if (hitEdge) {
@@ -370,21 +582,52 @@
         }
       }
 
+      state.enemyDiveTimer += dt;
+      const diveInterval = Math.max(0.9, 2.8 - state.wave * 0.22);
+      if (state.enemyDiveTimer >= diveInterval) {
+        state.enemyDiveTimer = 0;
+        const candidates = living.filter(function (enemy) {
+          return !enemy.diving;
+        });
+
+        if (candidates.length && Math.random() < Math.min(0.6, 0.22 + state.wave * 0.06)) {
+          const diver = candidates[Math.floor(Math.random() * candidates.length)];
+          const targetX = state.player ? state.player.x + state.player.w / 2 : diver.x + diver.w / 2;
+          const fromX = diver.x + diver.w / 2;
+          diver.diving = true;
+          diver.diveVy = 120 + state.wave * 18;
+          diver.diveVx = Math.max(-90, Math.min(90, (targetX - fromX) * 1.25));
+        }
+      }
+
+      living.forEach(function (enemy) {
+        if (!enemy.diving) {
+          return;
+        }
+
+        enemy.x += enemy.diveVx * dt;
+        enemy.y += enemy.diveVy * dt;
+        enemy.diveVy += (110 + state.wave * 10) * dt;
+
+        if (enemy.y > state.playfield.y + state.playfield.h + 20) {
+          enemy.alive = false;
+        }
+      });
+
       state.enemyFireTimer += dt;
-      const fireInterval = Math.max(0.45, 1.2 - (state.wave - 1) * 0.08);
+      const fireInterval = Math.max(0.35, 1.1 - (state.wave - 1) * 0.07);
       if (state.enemyFireTimer >= fireInterval) {
         state.enemyFireTimer = 0;
-        const aliveEnemies = state.enemies.filter(function (enemy) {
-          return enemy.alive;
-        });
-        if (aliveEnemies.length) {
-          const shooter = aliveEnemies[Math.floor(Math.random() * aliveEnemies.length)];
+        const shooters = living.slice();
+        if (shooters.length) {
+          const shooter = shooters[Math.floor(Math.random() * shooters.length)];
           state.enemyBullets.push({
             x: shooter.x + shooter.w / 2 - 2,
             y: shooter.y + shooter.h,
             w: 4,
             h: 10,
-            vy: 240 + state.wave * 22,
+            vy: 220 + state.wave * 24,
+            rain: true,
           });
         }
       }
@@ -404,92 +647,154 @@
           bullet.y + bullet.h > state.playfield.y &&
           bullet.y < state.playfield.y + state.playfield.h;
       });
+
       state.enemyBullets = state.enemyBullets.filter(function (bullet) {
         return bullet.x + bullet.w > state.playfield.x &&
           bullet.x < state.playfield.x + state.playfield.w &&
-          bullet.y < state.playfield.y + state.playfield.h &&
-          bullet.y + bullet.h > state.playfield.y;
+          bullet.y + bullet.h > state.playfield.y &&
+          bullet.y < state.playfield.y + state.playfield.h;
+      });
+    }
+
+    function updateParticles(dt) {
+      state.particles.forEach(function (p) {
+        p.x += p.vx * dt;
+        p.y += p.vy * dt;
+        p.vx *= 0.98;
+        p.vy *= 0.98;
+        p.life -= dt;
+      });
+      state.particles = state.particles.filter(function (p) {
+        return p.life > 0;
       });
     }
 
     function resolveCollisions() {
+      const playerBox = playerHitbox();
+
       state.playerBullets = state.playerBullets.filter(function (bullet) {
         let hit = false;
         state.enemies.forEach(function (enemy) {
-          if (enemy.alive && intersects(bullet, enemy)) {
-            enemy.alive = false;
+          if (!enemy.alive) {
+            return;
+          }
+          const enemyHitbox = {
+            x: enemy.x + 2,
+            y: enemy.y + 1,
+            w: enemy.w - 4,
+            h: enemy.h - 2,
+          };
+          if (intersects(bullet, enemyHitbox)) {
+            destroyEnemy(enemy);
             hit = true;
-            state.score += 100;
           }
         });
         return !hit;
       });
 
-      if (state.player) {
+      if (state.player && playerBox) {
         state.enemyBullets = state.enemyBullets.filter(function (bullet) {
-          if (intersects(bullet, state.player)) {
-            state.lives -= 1;
+          if (bullet.y < state.playfield.y || bullet.y > state.playfield.y + state.playfield.h) {
+            return false;
+          }
+
+          const hit = circleOverlap(
+            bullet.x + bullet.w / 2,
+            bullet.y + bullet.h / 2,
+            3,
+            playerBox.x + playerBox.w / 2,
+            playerBox.y + playerBox.h / 2,
+            Math.max(5, Math.min(playerBox.w, playerBox.h) * 0.36)
+          );
+
+          if (hit) {
+            damagePlayer();
             return false;
           }
           return true;
         });
-      }
 
-      if (state.lives <= 0 && !state.gameOver) {
-        state.running = false;
-        state.gameOver = true;
-        gameOverEl.hidden = false;
-        gameOverEl.textContent = 'Game Over · Score ' + state.score + ' · Press Enter to restart or Esc to quit';
-      }
+        state.enemies.forEach(function (enemy) {
+          if (!enemy.alive) {
+            return;
+          }
 
-      const aliveCount = state.enemies.filter(function (enemy) {
-        return enemy.alive;
-      }).length;
+          if (enemy.y > state.playfield.y + state.playfield.h || enemy.y + enemy.h < state.playfield.y) {
+            return;
+          }
 
-      if (aliveCount === 0 && !state.gameOver) {
-        state.wave += 1;
-        state.playerBullets = [];
-        state.enemyBullets = [];
-        spawnWave();
+          const enemyHitbox = {
+            x: enemy.x + 2,
+            y: enemy.y + 1,
+            w: enemy.w - 4,
+            h: enemy.h - 2,
+          };
+          if (intersects(playerBox, enemyHitbox)) {
+            destroyEnemy(enemy);
+            damagePlayer();
+          }
+        });
       }
 
       const invaded = state.enemies.some(function (enemy) {
-        return enemy.alive && enemy.y + enemy.h >= state.playfield.y + state.playfield.h - 56;
+        return enemy.alive && enemy.y + enemy.h >= state.playfield.y + state.playfield.h - 52;
       });
 
-      if (invaded && !state.gameOver) {
+      if (invaded && state.mode === 'playing') {
         state.lives = 0;
-        state.running = false;
-        state.gameOver = true;
-        gameOverEl.hidden = false;
-        gameOverEl.textContent = 'Game Over · Invaded! · Press Enter to restart or Esc to quit';
+        updateUI();
+        endGame({ toIdle: false });
+        return;
       }
 
+      updateWaveProgression();
       updateUI();
     }
 
-    function drawPlayer() {
+    function drawPlayer(now) {
       if (!state.player) {
         return;
       }
 
+      const invulnerable = isPlayerInvulnerable();
+      if (invulnerable && !reducedMotionQuery.matches) {
+        const flicker = Math.floor(now / 80) % 2 === 0;
+        if (!flicker) {
+          return;
+        }
+      }
+
       const p = state.player;
-      ctx.fillStyle = colors.primary;
+      ctx.fillStyle = colors.ferry;
       ctx.fillRect(Math.round(p.x + 10), Math.round(p.y), 4, 3);
       ctx.fillRect(Math.round(p.x + 7), Math.round(p.y + 3), 10, 4);
       ctx.fillRect(Math.round(p.x + 3), Math.round(p.y + 7), 18, 4);
       ctx.fillRect(Math.round(p.x), Math.round(p.y + 11), 24, 3);
-      ctx.fillStyle = colors.accent;
+      ctx.fillStyle = colors.rain;
       ctx.fillRect(Math.round(p.x + 11), Math.round(p.y + 5), 2, 4);
+
+      if (invulnerable) {
+        ctx.strokeStyle = 'rgba(255, 255, 255, 0.75)';
+        ctx.lineWidth = 1;
+        ctx.strokeRect(Math.round(p.x - 2), Math.round(p.y - 2), p.w + 4, p.h + 4);
+      }
     }
 
     function drawEnemy(enemy, yOffset) {
       const drawY = enemy.y + (yOffset || 0);
-      ctx.fillStyle = colors.secondary;
+      const isGhost = enemy.type === 'ghost';
+      const isUmbrella = enemy.type === 'umbrella';
+      const baseColor = isGhost ? '#b983ff' : (isUmbrella ? colors.secondary : colors.magentaRain);
+      const eyeColor = isGhost ? colors.rain : colors.accent;
+
+      ctx.fillStyle = baseColor;
       ctx.fillRect(Math.round(enemy.x + 2), Math.round(drawY), enemy.w - 4, 3);
       ctx.fillRect(Math.round(enemy.x), Math.round(drawY + 3), enemy.w, 5);
       ctx.fillRect(Math.round(enemy.x + 4), Math.round(drawY + 8), enemy.w - 8, 3);
-      ctx.fillStyle = colors.accent;
+      if (isUmbrella) {
+        ctx.fillRect(Math.round(enemy.x + enemy.w / 2 - 1), Math.round(drawY + 11), 2, 4);
+      }
+      ctx.fillStyle = eyeColor;
       ctx.fillRect(Math.round(enemy.x + 5), Math.round(drawY + 4), 2, 2);
       ctx.fillRect(Math.round(enemy.x + enemy.w - 7), Math.round(drawY + 4), 2, 2);
     }
@@ -500,34 +805,76 @@
         ctx.fillRect(Math.round(bullet.x), Math.round(bullet.y), bullet.w, bullet.h);
       });
 
-      ctx.fillStyle = colors.primary;
       state.enemyBullets.forEach(function (bullet) {
+        ctx.fillStyle = bullet.rain ? colors.magentaRain : colors.primary;
         ctx.fillRect(Math.round(bullet.x), Math.round(bullet.y), bullet.w, bullet.h);
+        if (bullet.rain) {
+          ctx.fillStyle = 'rgba(255, 255, 255, 0.72)';
+          ctx.fillRect(Math.round(bullet.x + 1), Math.round(bullet.y + 2), 2, 2);
+        }
       });
     }
 
-    function render() {
+    function drawParticles() {
+      state.particles.forEach(function (p) {
+        const alpha = Math.max(0, p.life / p.ttl);
+        ctx.fillStyle = p.color;
+        ctx.globalAlpha = alpha;
+        ctx.fillRect(Math.round(p.x), Math.round(p.y), p.size, p.size);
+      });
+      ctx.globalAlpha = 1;
+    }
+
+    function getShakeOffset(now) {
+      if (reducedMotionQuery.matches || now >= state.shakeUntil) {
+        return { x: 0, y: 0 };
+      }
+      const power = state.shakePower * ((state.shakeUntil - now) / 220);
+      return {
+        x: (Math.random() * 2 - 1) * power,
+        y: (Math.random() * 2 - 1) * power,
+      };
+    }
+
+    function render(now) {
+      const renderNow = now || nowMs();
+      const shake = getShakeOffset(renderNow);
+
+      if (renderNow >= state.shakeUntil) {
+        state.shakePower = 0;
+        heroGrid.classList.remove('galaga-hit');
+      }
+
+      if (waveCallEl && renderNow >= state.waveCallUntil) {
+        waveCallEl.hidden = true;
+      }
+
       ctx.clearRect(0, 0, state.width, state.height);
       ctx.save();
+      ctx.translate(shake.x, shake.y);
       ctx.beginPath();
       ctx.rect(state.playfield.x, state.playfield.y, state.playfield.w, state.playfield.h);
       ctx.clip();
-      ctx.fillStyle = isActiveMode() ? 'rgba(0, 0, 0, 0.45)' : 'rgba(0, 0, 0, 0.18)';
+      ctx.fillStyle = isPlaying() ? 'rgba(0, 0, 0, 0.46)' : 'rgba(0, 0, 0, 0.18)';
       ctx.fillRect(state.playfield.x, state.playfield.y, state.playfield.w, state.playfield.h);
 
-      drawPlayer();
+      drawPlayer(renderNow);
 
-      const idleBob = isActiveMode() ? 0 : Math.sin(state.idleTick * 1.35) * 3;
+      const idleBob = isPlaying() ? 0 : Math.sin(state.idleTick * 1.35) * 3;
       state.enemies.forEach(function (enemy, index) {
-        if (enemy.alive) {
-          const offset = isActiveMode() ? 0 : idleBob + Math.sin(index * 0.7 + state.idleTick) * 1.25;
-          drawEnemy(enemy, offset);
+        if (!enemy.alive) {
+          return;
         }
+        const offset = isPlaying()
+          ? (enemy.diving ? Math.sin(renderNow * 0.015 + index) * 0.8 : 0)
+          : idleBob + Math.sin(index * 0.7 + state.idleTick) * 1.25;
+        drawEnemy(enemy, offset);
       });
 
       drawBullets();
+      drawParticles();
 
-      if (!isActiveMode()) {
+      if (!isPlaying()) {
         ctx.fillStyle = 'rgba(0, 0, 0, 0.22)';
         ctx.fillRect(state.playfield.x, state.playfield.y + state.playfield.h - 74, state.playfield.w, 74);
       }
@@ -539,18 +886,19 @@
       const dt = Math.min(0.033, (now - state.lastFrame) / 1000 || 0.016);
       state.lastFrame = now;
 
-      if (isActiveMode() && state.running) {
+      if (isPlaying()) {
         handleKeys(dt, now);
         updateEnemies(dt);
         updateBullets(dt);
+        updateParticles(dt);
         resolveCollisions();
       } else if (state.mode === 'idle') {
         state.idleTick += dt;
       }
 
-      render();
+      render(now);
 
-      if (isActiveMode() || shouldAnimateIdle()) {
+      if (isPlaying() || shouldAnimateIdle()) {
         state.rafId = window.requestAnimationFrame(loop);
       } else {
         state.rafId = 0;
@@ -566,7 +914,7 @@
     }
 
     function shouldBlockGameplayEvent(event) {
-      if (!isActiveMode()) {
+      if (!isPlaying()) {
         return false;
       }
 
@@ -586,14 +934,14 @@
       const code = event.code;
       const typing = isTypingTarget(event.target);
 
-      if (!isActiveMode() && !typing && code === 'KeyG') {
+      if (!typing && code === 'KeyG' && !isPlaying()) {
         startGame();
         event.preventDefault();
         event.stopPropagation();
         return;
       }
 
-      if (!isActiveMode()) {
+      if (!isPlaying() && state.mode !== 'gameover') {
         return;
       }
 
@@ -602,18 +950,13 @@
       }
 
       if (code === 'Escape') {
-        stopGame();
+        endGame({ toIdle: true });
         event.preventDefault();
         event.stopPropagation();
         return;
       }
 
-      if (state.gameOver && code === 'Enter') {
-        resetGame();
-        state.running = true;
-        state.lastFrame = performance.now();
-        event.preventDefault();
-        event.stopPropagation();
+      if (!isPlaying()) {
         return;
       }
 
@@ -634,7 +977,7 @@
     }, { capture: true });
 
     window.addEventListener('keyup', function (event) {
-      if (!isActiveMode()) {
+      if (!isPlaying()) {
         return;
       }
 
@@ -670,14 +1013,14 @@
       }
 
       heroGrid.classList.add('has-galaga');
-      if (!isActiveMode()) {
+      if (!isPlaying()) {
         enterIdleMode();
       }
     });
 
     reducedMotionQuery.addEventListener('change', function () {
       updateHint();
-      if (isActiveMode()) {
+      if (isPlaying()) {
         return;
       }
       if (shouldAnimateIdle()) {
@@ -703,7 +1046,6 @@
     heroGrid.classList.add('has-galaga');
     sizeCanvas();
     updateUI();
-    initScene();
     enterIdleMode();
   }
 

--- a/style.css
+++ b/style.css
@@ -2842,10 +2842,13 @@ body {
 }
 
 .page-template-page-home-php .hero-galaga-status,
+.page-template-page-home-php .hero-galaga-scoreline,
 .page-template-page-home-php .hero-galaga-help,
 .home .hero-galaga-status,
+.home .hero-galaga-scoreline,
 .home .hero-galaga-help,
 .front-page .hero-galaga-status,
+.front-page .hero-galaga-scoreline,
 .front-page .hero-galaga-help {
   margin: 0;
   display: inline-block;
@@ -2859,11 +2862,33 @@ body {
   padding: 4px 7px;
 }
 
+.page-template-page-home-php .hero-galaga-status,
+.home .hero-galaga-status,
+.front-page .hero-galaga-status {
+  color: #57f3ff;
+}
+
 .page-template-page-home-php .hero-galaga-help,
 .home .hero-galaga-help,
 .front-page .hero-galaga-help {
   margin-top: 0;
   color: var(--accent-color);
+}
+
+.page-template-page-home-php .hero-galaga-wavecall,
+.home .hero-galaga-wavecall,
+.front-page .hero-galaga-wavecall {
+  margin: 2px 0 0;
+  display: inline-block;
+  width: fit-content;
+  max-width: 100%;
+  white-space: normal;
+  word-break: break-word;
+  background: rgba(8, 6, 20, 0.82);
+  border: 1px solid rgba(255, 72, 206, 0.58);
+  border-radius: 4px;
+  color: #ff9deb;
+  padding: 5px 7px;
 }
 
 .page-template-page-home-php .hero-galaga-gameover,
@@ -2875,6 +2900,12 @@ body {
   border: 2px solid var(--secondary-color);
   color: var(--accent-color);
   padding: 10px;
+}
+
+.page-template-page-home-php .hero-galaga-gameover strong,
+.home .hero-galaga-gameover strong,
+.front-page .hero-galaga-gameover strong {
+  color: #ff9deb;
 }
 
 .page-template-page-home-php .hero-galaga-hint,
@@ -2966,6 +2997,26 @@ body {
   display: none;
 }
 
+@keyframes galagaHitFlash {
+  0% {
+    box-shadow: inset 0 0 0 999px rgba(255, 64, 185, 0.14);
+  }
+  100% {
+    box-shadow: inset 0 0 0 999px rgba(255, 64, 185, 0);
+  }
+}
+
+.page-template-page-home-php .hero-grid.galaga-hit::after,
+.home .hero-grid.galaga-hit::after,
+.front-page .hero-grid.galaga-hit::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 6;
+  animation: galagaHitFlash 180ms ease-out;
+}
+
 @media (max-width: 859px) {
   .page-template-page-home-php .hero-ship,
   .home .hero-ship,
@@ -2989,7 +3040,10 @@ body {
   .front-page .hero-grid::before,
   .page-template-page-home-php .hero-ship-trail,
   .home .hero-ship-trail,
-  .front-page .hero-ship-trail {
+  .front-page .hero-ship-trail,
+  .page-template-page-home-php .hero-grid.galaga-hit::after,
+  .home .hero-grid.galaga-hit::after,
+  .front-page .hero-grid.galaga-hit::after {
     animation: none !important;
   }
 }


### PR DESCRIPTION
### Motivation
- Make the homepage mini-Galaga feel like a complete, lightweight arcade easter egg with meaningful collisions, scoring, and a Vancouver-flavored identity while preserving homepage layout and accessibility. 
- Replace the toy-like behavior where hits did nothing with clear game feedback, state transitions, and fair collision logic.

### Description
- Rewrote and expanded `js/hero-galaga.js` to introduce clear game states (`idle` / `playing` / `gameover`), explicit `startGame()`/`endGame()`/`resetGame()` flows, and scoped keyboard handling (`G` to start/reboot, `Esc` to exit). 
- Implemented hit consequences: lives decrement on enemy or projectile hit, a 1.5s invulnerability window with flicker, explosion particle spawning, and a mild screen-shake / CRT hit flash that respects `prefers-reduced-motion`. 
- Added HUD and messaging: compact active HUD showing padded score, lives, wave, a “Rain City Defense” label, wave callouts (e.g. “WAVE 1 · RAIN CITY SIGNAL”), and a `SIGNAL LOST` game-over overlay with final score and reboot prompt. 
- Improved enemies and gameplay: formation marching, wave-based difficulty scaling, occasional diving enemies with higher reward, enemy projectiles (magenta rain bolts), wave-clear bonus score and delayed respawn, and simple particle explosions. 
- Tuned collision fairness and cleanup: smaller player hitbox, circle-based projectile overlap checks, offscreen projectile/enemy cleanup, and conservative bounding checks so invisible/offscreen entities do not damage the player. 
- Styling updates in `style.css` to support HUD elements, wave callout, game-over emphasis, reduced-motion-friendly hit flash (`.galaga-hit`), and color tweaks to reflect the Rain City / Vancouver motif. 
- Files changed: `js/hero-galaga.js`, `style.css`.

### Testing
- Ran a syntax check with `node --check js/hero-galaga.js` and it passed. 
- Ran the repository test suite with `npm test -- --watch=false`; the run reported pre-existing unrelated failures in Gastown/open-data tests (test suite output shows many unrelated failing tests), and there were no hero-galaga-specific test failures detectable in this environment. 
- Manual runtime validation notes: changes keep the gameplay scoped to desktop viewports, respect `prefers-reduced-motion`, use no heavy dependencies, and restore normal homepage interaction when the game is idle or exited.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1a67a590832e9bb8f94346643fb4)