### PR TITLE
Refine homepage tag chips, capability copy, and Galaga stage layout

### DIFF
--- a/js/hero-galaga.js
+++ b/js/hero-galaga.js
@@ -1,21 +1,21 @@
 (function () {
   function initHeroGalaga() {
     const heroGrid = document.querySelector('.hero-grid');
+    const gameStage = document.querySelector('.hero-game-stage');
+    const gameScreen = document.querySelector('.hero-game-stage__screen');
     const desktopQuery = window.matchMedia('(min-width: 860px)');
     const reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
 
     window.__SE_GALAGA_ACTIVE = false;
 
-    if (heroGrid) {
-      heroGrid.dataset.galagaReady = 'true';
-      heroGrid.dataset.galagaActive = 'false';
+    if (gameStage) {
+      gameStage.dataset.galagaReady = 'true';
+      gameStage.dataset.galagaActive = 'false';
     }
 
-    if (!heroGrid || !desktopQuery.matches) {
+    if (!heroGrid || !gameStage || !gameScreen || !desktopQuery.matches) {
       return;
     }
-
-    const heroMain = heroGrid.querySelector('.hero-main');
 
     const rootStyles = window.getComputedStyle(document.documentElement);
     const colors = {
@@ -34,9 +34,9 @@
     const ui = document.createElement('div');
     ui.className = 'hero-galaga-ui';
     ui.innerHTML = '' +
-      '<p class="hero-galaga-status" data-galaga-status>Rain City Defense</p>' +
+      '<p class="hero-galaga-status" data-galaga-status>RAIN CITY DEFENSE</p>' +
       '<p class="hero-galaga-scoreline">Score: <span data-galaga-score>000000</span> · Lives: <span data-galaga-lives>3</span> · Wave: <span data-galaga-wave>1</span></p>' +
-      '<p class="hero-galaga-help">A/D or ←/→ · Space fire · Esc exit</p>' +
+      '<p class="hero-galaga-help">WASD move // Space fire // Esc quit</p>' +
       '<p class="hero-galaga-wavecall" data-galaga-wavecall hidden></p>' +
       '<div class="hero-galaga-gameover" data-galaga-gameover hidden></div>';
 
@@ -44,9 +44,9 @@
     hint.className = 'hero-galaga-hint';
     hint.innerHTML = '<span class="hero-galaga-hint-text" data-galaga-hint-text></span><button type="button" class="hero-galaga-start">Play</button>';
 
-    heroGrid.appendChild(canvas);
-    heroGrid.appendChild(ui);
-    heroGrid.appendChild(hint);
+    gameScreen.appendChild(canvas);
+    gameScreen.appendChild(ui);
+    gameScreen.appendChild(hint);
 
     const ctx = canvas.getContext('2d', { alpha: true });
     if (!ctx) {
@@ -142,18 +142,15 @@
 
     function sizeCanvas() {
       state.dpr = Math.max(1, window.devicePixelRatio || 1);
-      const width = Math.max(1, heroGrid.clientWidth);
-      const height = Math.max(1, heroGrid.clientHeight);
-      const heroGridRect = heroGrid.getBoundingClientRect();
-      const mainRect = heroMain ? heroMain.getBoundingClientRect() : heroGridRect;
-      const visibleH = Math.min(mainRect.height, window.innerHeight - mainRect.top - 16);
+      const width = Math.max(1, gameScreen.clientWidth);
+      const height = Math.max(1, gameScreen.clientHeight);
       state.width = width;
       state.height = height;
       state.playfield = {
-        x: Math.max(0, Math.round(mainRect.left - heroGridRect.left)),
-        y: Math.max(0, Math.round(mainRect.top - heroGridRect.top)),
-        w: Math.min(state.width, Math.max(1, Math.round(mainRect.width))),
-        h: Math.min(state.height, Math.max(260, Math.round(visibleH))),
+        x: 0,
+        y: 0,
+        w: state.width,
+        h: state.height,
       };
 
       canvas.width = Math.round(width * state.dpr);
@@ -216,7 +213,7 @@
       state.particles = [];
       state.shakeUntil = 0;
       state.shakePower = 0;
-      heroGrid.classList.remove('galaga-hit');
+      gameScreen.classList.remove('galaga-hit');
     }
 
     function makeEnemy(row, col, cfg) {
@@ -339,8 +336,8 @@
       clearTransientFx();
 
       window.__SE_GALAGA_ACTIVE = false;
-      heroGrid.dataset.galagaActive = 'false';
-      heroGrid.classList.remove('is-galaga');
+      gameStage.dataset.galagaActive = 'false';
+      gameStage.classList.remove('is-galaga');
       canvas.style.pointerEvents = 'none';
       gameOverEl.hidden = true;
       gameOverEl.innerHTML = '';
@@ -367,8 +364,8 @@
       canvas.tabIndex = 0;
       state.mode = 'playing';
       window.__SE_GALAGA_ACTIVE = true;
-      heroGrid.dataset.galagaActive = 'true';
-      heroGrid.classList.add('is-galaga');
+      gameStage.dataset.galagaActive = 'true';
+      gameStage.classList.add('is-galaga');
       canvas.style.pointerEvents = 'auto';
 
       resetGame();
@@ -390,12 +387,12 @@
       state.playerBullets = [];
       state.enemyBullets = [];
       window.__SE_GALAGA_ACTIVE = false;
-      heroGrid.dataset.galagaActive = 'false';
-      heroGrid.classList.remove('is-galaga');
+      gameStage.dataset.galagaActive = 'false';
+      gameStage.classList.remove('is-galaga');
       canvas.style.pointerEvents = 'none';
 
       gameOverEl.hidden = false;
-      gameOverEl.innerHTML = '<strong>SIGNAL LOST</strong><br>Final score: ' + formatScore(state.score) + '<br>Press G to reboot or Esc to quit';
+      gameOverEl.innerHTML = '<strong>SIGNAL LOST</strong><br>Gastown overrun. Press G to reboot.';
       updateHint();
       render();
       stopLoop();
@@ -436,9 +433,9 @@
       }
       state.shakePower = Math.max(state.shakePower, power);
       state.shakeUntil = Math.max(state.shakeUntil, nowMs() + durationMs);
-      heroGrid.classList.remove('galaga-hit');
-      void heroGrid.offsetWidth;
-      heroGrid.classList.add('galaga-hit');
+      gameScreen.classList.remove('galaga-hit');
+      void gameScreen.offsetWidth;
+      gameScreen.classList.add('galaga-hit');
     }
 
     function playerHitbox() {
@@ -842,7 +839,7 @@
 
       if (renderNow >= state.shakeUntil) {
         state.shakePower = 0;
-        heroGrid.classList.remove('galaga-hit');
+        gameScreen.classList.remove('galaga-hit');
       }
 
       if (waveCallEl && renderNow >= state.waveCallUntil) {
@@ -1006,13 +1003,13 @@
       if (!event.matches) {
         stopLoop();
         window.__SE_GALAGA_ACTIVE = false;
-        heroGrid.classList.remove('is-galaga');
-        heroGrid.classList.remove('has-galaga');
-        heroGrid.dataset.galagaActive = 'false';
+        gameStage.classList.remove('is-galaga');
+        gameStage.classList.remove('has-galaga');
+        gameStage.dataset.galagaActive = 'false';
         return;
       }
 
-      heroGrid.classList.add('has-galaga');
+      gameStage.classList.add('has-galaga');
       if (!isPlaying()) {
         enterIdleMode();
       }
@@ -1038,12 +1035,12 @@
       : null;
 
     if (resizeObserver) {
-      resizeObserver.observe(heroGrid);
+      resizeObserver.observe(gameScreen);
     } else {
       window.addEventListener('resize', sizeCanvas, { passive: true });
     }
 
-    heroGrid.classList.add('has-galaga');
+    gameStage.classList.add('has-galaga');
     sizeCanvas();
     updateUI();
     enterIdleMode();

--- a/page-home.php
+++ b/page-home.php
@@ -72,6 +72,13 @@ get_header();
             </aside>
         </div>
 
+        <div class="hero-game-stage" aria-label="Rain City Defense arcade stage">
+            <p class="hero-game-stage__header pixel-font"><?php echo esc_html('RAIN CITY DEFENSE'); ?></p>
+            <div class="hero-game-stage__screen" role="region" aria-label="Rain City Defense game screen">
+                <p class="hero-game-stage__idle pixel-font"><?php echo esc_html('RAIN CITY DEFENSE'); ?><br><?php echo esc_html('Press G to play'); ?><br><?php echo esc_html('WASD move // Space fire // Esc quit'); ?></p>
+            </div>
+        </div>
+
         <p class="arcade-subtext">Retro-futurist lab mode: online</p>
     </div>
 
@@ -154,13 +161,13 @@ get_header();
     </section>
 
     <section class="skills-home crt-block" aria-labelledby="skills-home-title">
-        <h2 id="skills-home-title" class="pixel-font">What I do best</h2>
+        <h2 id="skills-home-title" class="pixel-font">Where I'm useful</h2>
         <ul class="skills-home__list">
             <li>QA automation and release confidence</li>
             <li>IT operations, identity, endpoint, and SaaS troubleshooting</li>
             <li>Python, PowerShell, and JavaScript automation</li>
-            <li>Practical AI tools and internal tooling</li>
-            <li>Debugging messy production issues with calm, logs, and receipts</li>
+            <li>Practical AI tools and internal workflows</li>
+            <li>Production debugging with logs, calm, and receipts</li>
             <li>Music, audio, and creative web experiments</li>
         </ul>
     </section>

--- a/style.css
+++ b/style.css
@@ -2070,33 +2070,33 @@ body {
   list-style: none;
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.45rem;
+  align-items: center;
 }
 
 .ai-film-feature__meta-list li {
-  position: relative;
   display: inline-flex;
   align-items: center;
-  width: fit-content;
+  width: auto;
+  min-width: 0;
+  min-height: 0;
   max-width: 100%;
-  padding: 0.42rem 0.78rem;
-  border: 1px solid rgba(126, 255, 215, 0.4);
-  border-radius: 0.36rem;
-  font-size: 0.66rem;
+  padding: 0.32rem 0.58rem;
+  border: 1px solid rgba(115, 239, 188, 0.42);
+  border-radius: 0.25rem;
+  font-size: 0.62rem;
   font-weight: 600;
-  letter-spacing: 0.07em;
+  letter-spacing: 0.06em;
+  line-height: 1.1;
   text-transform: uppercase;
   color: #d9fff2;
-  background: linear-gradient(180deg, rgba(9, 28, 23, 0.86), rgba(4, 14, 12, 0.9));
-  box-shadow: inset 0 0 0 1px rgba(0, 255, 181, 0.12), 0 0 10px rgba(0, 255, 191, 0.12);
-  text-shadow: 0 0 8px rgba(104, 255, 206, 0.35);
+  white-space: normal;
+  background: rgba(0, 12, 8, 0.72);
+  box-shadow: inset 0 0 0 1px rgba(0, 255, 181, 0.08);
 }
 
 .ai-film-feature__meta-list li::before {
-  content: "▹";
-  margin-right: 0.45rem;
-  color: rgba(109, 255, 201, 0.9);
-  font-size: 0.7rem;
+  content: none;
 }
 
 .ai-film-feature__copy h2 {
@@ -2690,6 +2690,50 @@ body {
   isolation: isolate;
 }
 
+.hero-game-stage {
+  margin: 0 auto 1.15rem;
+  max-width: min(1120px, 100%);
+  border: 1px solid rgba(115, 239, 188, 0.3);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background: linear-gradient(180deg, rgba(0, 14, 10, 0.82), rgba(0, 8, 8, 0.9));
+  box-shadow: inset 0 0 0 1px rgba(120, 255, 210, 0.08), 0 0 18px rgba(0, 255, 170, 0.12);
+}
+
+.hero-game-stage__header {
+  margin: 0 0 0.5rem;
+  font-size: 0.68rem;
+  letter-spacing: 0.14em;
+  color: #8ef6ff;
+}
+
+.hero-game-stage__screen {
+  position: relative;
+  overflow: hidden;
+  min-height: 220px;
+  border: 1px solid rgba(128, 225, 255, 0.42);
+  border-radius: 8px;
+  background:
+    repeating-linear-gradient(0deg, rgba(255, 255, 255, 0.03) 0 2px, rgba(0, 0, 0, 0) 2px 4px),
+    radial-gradient(circle at 50% 0%, rgba(44, 105, 118, 0.15), rgba(0, 0, 0, 0) 60%),
+    rgba(1, 6, 7, 0.95);
+}
+
+.hero-game-stage__idle {
+  margin: 0;
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-content: center;
+  text-align: center;
+  line-height: 1.5;
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  color: rgba(123, 255, 210, 0.72);
+  pointer-events: none;
+}
+
+
 .page-template-page-home-php .hero-main,
 .page-template-page-home-php .hero-side,
 .home .hero-main,
@@ -2961,39 +3005,36 @@ body {
   color: var(--accent-color);
 }
 
-.page-template-page-home-php .hero-grid.has-galaga .hero-galaga-canvas,
-.page-template-page-home-php .hero-grid.has-galaga .hero-galaga-hint,
-.home .hero-grid.has-galaga .hero-galaga-canvas,
-.home .hero-grid.has-galaga .hero-galaga-hint,
-.front-page .hero-grid.has-galaga .hero-galaga-canvas,
-.front-page .hero-grid.has-galaga .hero-galaga-hint {
+.page-template-page-home-php .hero-game-stage.has-galaga .hero-galaga-canvas,
+.page-template-page-home-php .hero-game-stage.has-galaga .hero-galaga-hint,
+.home .hero-game-stage.has-galaga .hero-galaga-canvas,
+.home .hero-game-stage.has-galaga .hero-galaga-hint,
+.front-page .hero-game-stage.has-galaga .hero-galaga-canvas,
+.front-page .hero-game-stage.has-galaga .hero-galaga-hint {
   display: block;
 }
 
-.page-template-page-home-php .hero-grid.is-galaga .hero-galaga-canvas,
-.home .hero-grid.is-galaga .hero-galaga-canvas,
-.front-page .hero-grid.is-galaga .hero-galaga-canvas {
+.page-template-page-home-php .hero-game-stage.is-galaga .hero-galaga-canvas,
+.home .hero-game-stage.is-galaga .hero-galaga-canvas,
+.front-page .hero-game-stage.is-galaga .hero-galaga-canvas {
   display: block;
 }
 
-.page-template-page-home-php .hero-grid.is-galaga .hero-galaga-ui,
-.home .hero-grid.is-galaga .hero-galaga-ui,
-.front-page .hero-grid.is-galaga .hero-galaga-ui {
+.page-template-page-home-php .hero-game-stage.is-galaga .hero-galaga-ui,
+.home .hero-game-stage.is-galaga .hero-galaga-ui,
+.front-page .hero-game-stage.is-galaga .hero-galaga-ui {
   display: flex;
 }
 
-.page-template-page-home-php .hero-grid.is-galaga .hero-ship,
-.page-template-page-home-php .hero-grid.is-galaga .hero-ship-trail,
-.home .hero-grid.is-galaga .hero-ship,
-.home .hero-grid.is-galaga .hero-ship-trail,
-.front-page .hero-grid.is-galaga .hero-ship,
-.front-page .hero-grid.is-galaga .hero-ship-trail {
-  display: none;
+.page-template-page-home-php .hero-game-stage.is-galaga .hero-game-stage__idle,
+.home .hero-game-stage.is-galaga .hero-game-stage__idle,
+.front-page .hero-game-stage.is-galaga .hero-game-stage__idle {
+  opacity: 0;
 }
 
-.page-template-page-home-php .hero-grid.is-galaga .hero-galaga-start,
-.home .hero-grid.is-galaga .hero-galaga-start,
-.front-page .hero-grid.is-galaga .hero-galaga-start {
+.page-template-page-home-php .hero-game-stage.is-galaga .hero-galaga-start,
+.home .hero-game-stage.is-galaga .hero-galaga-start,
+.front-page .hero-game-stage.is-galaga .hero-galaga-start {
   display: none;
 }
 
@@ -3006,9 +3047,9 @@ body {
   }
 }
 
-.page-template-page-home-php .hero-grid.galaga-hit::after,
-.home .hero-grid.galaga-hit::after,
-.front-page .hero-grid.galaga-hit::after {
+.page-template-page-home-php .hero-game-stage__screen.galaga-hit::after,
+.home .hero-game-stage__screen.galaga-hit::after,
+.front-page .hero-game-stage__screen.galaga-hit::after {
   content: "";
   position: absolute;
   inset: 0;
@@ -3041,9 +3082,9 @@ body {
   .page-template-page-home-php .hero-ship-trail,
   .home .hero-ship-trail,
   .front-page .hero-ship-trail,
-  .page-template-page-home-php .hero-grid.galaga-hit::after,
-  .home .hero-grid.galaga-hit::after,
-  .front-page .hero-grid.galaga-hit::after {
+  .page-template-page-home-php .hero-game-stage__screen.galaga-hit::after,
+  .home .hero-game-stage__screen.galaga-hit::after,
+  .front-page .hero-game-stage__screen.galaga-hit::after {
     animation: none !important;
   }
 }
@@ -3983,17 +4024,27 @@ body.page-template-page-bio-php .bio-content {
 .selected-work__tags {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: 0.45rem;
+  align-items: center;
   margin: 0;
 }
 
 .selected-work__tags span {
-  border: 1px solid rgba(115, 239, 188, 0.36);
-  border-radius: 999px;
-  padding: 0.24rem 0.55rem;
-  font-size: 0.7rem;
+  display: inline-flex;
+  align-items: center;
+  width: auto;
+  min-width: 0;
+  min-height: 0;
+  max-width: 100%;
+  border: 1px solid rgba(115, 239, 188, 0.42);
+  border-radius: 0.25rem;
+  padding: 0.32rem 0.58rem;
+  font-size: 0.68rem;
   letter-spacing: 0.05em;
+  line-height: 1.1;
   color: #bfffd9;
+  white-space: normal;
+  background: rgba(0, 12, 8, 0.72);
 }
 
 .vancouver-tech-home {
@@ -4242,13 +4293,21 @@ body.page-template-page-bio-php .bio-content {
     gap: 0.6rem;
   }
 
+  .hero-game-stage {
+    padding: 0.62rem;
+  }
+
+  .hero-game-stage__screen {
+    min-height: 190px;
+  }
+
   .ai-film-feature__meta-list {
     gap: 0.45rem;
   }
 
   .ai-film-feature__meta-list li {
-    font-size: 0.6rem;
-    letter-spacing: 0.06em;
-    padding: 0.36rem 0.65rem;
+    font-size: 0.58rem;
+    letter-spacing: 0.05em;
+    padding: 0.3rem 0.52rem;
   }
 }


### PR DESCRIPTION
### Motivation
- Clean up oversized/bubbled tag UI so short labels (e.g. “AI”, “APIs”) stop rendering as circles and reduce dead space on Featured Builds and AI Film Club metadata. 
- Make the hero mini-game live in a dedicated, bounded arcade stage so sprites and bullets no longer overlap hero headline/copy. 
- Replace the bland “What I do best” heading with a sharper, Suzy-specific heading and slightly tighten two list lines for tone.

### Description
- CSS: replaced circular/pill tag rules with compact terminal-style chips for `.selected-work__tags span` and `.ai-film-feature__meta-list li`, added `.hero-game-stage*` styling, and updated Galaga-related selectors to scope to the new stage container in `style.css`.
- Markup: added a `.hero-game-stage` block and `.hero-game-stage__screen` placeholder/idle instructions into `page-home.php` and renamed the skills heading to “Where I’m useful”, plus adjusted two list items for wording.
- JavaScript: reworked `js/hero-galaga.js` so the canvas, UI, and hint mount into `.hero-game-stage__screen`, calculate play bounds from that container, and route active/has/is-galaga classes and hit-flash to the stage/screen instead of the hero grid; also updated in-game copy (`RAIN CITY DEFENSE`, `WASD move // Space fire // Esc quit`, and new game-over wording).
- Files changed: `page-home.php`, `style.css`, `js/hero-galaga.js` (targeted refinements only; no new dependencies).

### Testing
- Ran `php -l page-home.php` and it reported no syntax errors. (passed)
- Ran `php -l header.php` and it reported no syntax errors. (passed)
- Ran `node --check js/hero-galaga.js` to validate JS parseability. (passed)
- Ran `npm test`; test run completed but the repo has pre-existing failing suites in the Gastown / open-data tests which are unrelated to this homepage refinement (many tests in that area fail and are pre-existing). (npm tests show unrelated failures)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef9df4b5dc832eb05af8aa030520b9)