### PR TITLE
Fix Rain City Defense gameplay state and polish homepage hero copy

### DIFF
--- a/js/hero-galaga.js
+++ b/js/hero-galaga.js
@@ -5,6 +5,7 @@
     const gameScreen = document.querySelector('.hero-game-stage__screen');
     const desktopQuery = window.matchMedia('(min-width: 860px)');
     const reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const debugEnabled = Boolean(window.__SE_GALAGA_DEBUG);
 
     window.__SE_GALAGA_ACTIVE = false;
 
@@ -15,6 +16,12 @@
 
     if (!heroGrid || !gameStage || !gameScreen || !desktopQuery.matches) {
       return;
+    }
+
+    function debugWarn(message) {
+      if (debugEnabled && window.console && typeof window.console.warn === 'function') {
+        window.console.warn('[Rain City Defense]', message);
+      }
     }
 
     const rootStyles = window.getComputedStyle(document.documentElement);
@@ -35,7 +42,7 @@
     ui.className = 'hero-galaga-ui';
     ui.innerHTML = '' +
       '<p class="hero-galaga-status" data-galaga-status>RAIN CITY DEFENSE</p>' +
-      '<p class="hero-galaga-scoreline">Score: <span data-galaga-score>000000</span> · Lives: <span data-galaga-lives>3</span> · Wave: <span data-galaga-wave>1</span></p>' +
+      '<p class="hero-galaga-scoreline">Score: <span data-galaga-score>000000</span> // Lives: <span data-galaga-lives>3</span> // Wave: <span data-galaga-wave>1</span></p>' +
       '<p class="hero-galaga-help">WASD move // Space fire // Esc quit</p>' +
       '<p class="hero-galaga-wavecall" data-galaga-wavecall hidden></p>' +
       '<div class="hero-galaga-gameover" data-galaga-gameover hidden></div>';
@@ -102,12 +109,21 @@
     };
 
     const waveCalls = [
-      'WAVE 1 · RAIN CITY SIGNAL',
-      'WAVE 2 · GASTOWN STATIC',
-      'WAVE 3 · STEAM CLOCK SWARM',
-      'WAVE 4 · ALIEN FOG ROLLING IN',
+      'WAVE 1 // RAIN CITY SIGNAL',
+      'WAVE 2 // GASTOWN STATIC',
+      'WAVE 3 // STEAM CLOCK SWARM',
+      'WAVE 4 // ALIEN FOG ROLLING IN',
       'WAVE 5 · FALSE CREEK DISTRESS',
     ];
+
+    function setGalagaState(mode) {
+      gameStage.dataset.galagaState = mode;
+      if (mode === 'playing' || mode === 'gameover') {
+        gameStage.classList.add('is-galaga');
+      } else {
+        gameStage.classList.remove('is-galaga');
+      }
+    }
 
     function isPlaying() {
       return state.mode === 'playing';
@@ -132,12 +148,9 @@
     }
 
     function positionOverlayUI() {
-      const hintBottom = Math.max(12, state.height - (state.playfield.y + state.playfield.h) + 12);
       ui.style.left = state.playfield.x + 12 + 'px';
       ui.style.top = state.playfield.y + 12 + 'px';
       ui.style.maxWidth = Math.max(240, state.playfield.w - 24) + 'px';
-      hint.style.left = state.playfield.x + 12 + 'px';
-      hint.style.bottom = hintBottom + 'px';
     }
 
     function sizeCanvas() {
@@ -152,6 +165,9 @@
         w: state.width,
         h: state.height,
       };
+      if (state.width < 220 || state.height < 170) {
+        debugWarn('Game screen is too small for reliable gameplay.');
+      }
 
       canvas.width = Math.round(width * state.dpr);
       canvas.height = Math.round(height * state.dpr);
@@ -184,19 +200,19 @@
       }
 
       if (isPlaying()) {
-        hintTextEl.textContent = 'Esc to quit';
-        startButton.hidden = true;
+        hint.hidden = true;
         return;
       }
 
+      hint.hidden = false;
+
       if (state.mode === 'gameover') {
-        hintTextEl.textContent = 'Press G to reboot, or Esc to return';
+        hintTextEl.innerHTML = '<strong>SIGNAL LOST</strong><br>Gastown overrun.<br>Press G to reboot.';
       } else {
-        hintTextEl.textContent = reducedMotionQuery.matches
-          ? 'Press G to play (reduced motion)'
-          : 'Press G to play';
+        hintTextEl.innerHTML = 'RAIN CITY DEFENSE<br>Defend the weird little Rain City signal.<br>Press G to play<br>WASD move // Space fire // Esc quit';
       }
       startButton.hidden = false;
+      startButton.textContent = state.mode === 'gameover' ? 'Reboot' : 'Play';
     }
 
     function showWaveCallout() {
@@ -242,13 +258,25 @@
 
     function spawnWave() {
       const cols = 7;
-      const rows = 4;
+      const rows = state.playfield.h < 260 ? 3 : 4;
+      const enemyH = 16;
+      const minStartY = 34;
+      const maxStartY = 56;
+      const startYBase = Math.round(state.playfield.h * 0.18);
+      const startY = Math.max(minStartY, Math.min(maxStartY, startYBase));
+      const baseGapY = state.playfield.h < 260 ? 10 : 13;
+      const maxFormationBottom = state.playfield.h * 0.58;
+      const totalEnemyHeight = rows * enemyH;
+      const totalGapHeight = Math.max(0, rows - 1) * baseGapY;
+      const tentativeBottom = startY + totalEnemyHeight + totalGapHeight;
+      const overflow = Math.max(0, tentativeBottom - maxFormationBottom);
+      const adjustedStartY = Math.max(24, startY - overflow);
       const cfg = {
         cols: cols,
         rows: rows,
         gapX: 18,
-        gapY: 13,
-        startY: 66,
+        gapY: baseGapY,
+        startY: adjustedStartY,
       };
 
       state.enemies = [];
@@ -317,13 +345,8 @@
       state.playerBullets = [];
       state.enemyBullets = [];
       state.particles = [];
-      initPlayer();
+      state.player = null;
       state.enemies = [];
-      for (let row = 0; row < 2; row += 1) {
-        for (let col = 0; col < 5; col += 1) {
-          state.enemies.push(makeEnemy(row, col, { cols: 5, gapX: 16, gapY: 12, startY: 82 }));
-        }
-      }
     }
 
     function enterIdleMode() {
@@ -337,7 +360,7 @@
 
       window.__SE_GALAGA_ACTIVE = false;
       gameStage.dataset.galagaActive = 'false';
-      gameStage.classList.remove('is-galaga');
+      setGalagaState('idle');
       canvas.style.pointerEvents = 'none';
       gameOverEl.hidden = true;
       gameOverEl.innerHTML = '';
@@ -361,11 +384,16 @@
       }
 
       stopLoop();
+      if (state.playfield.w < 220 || state.playfield.h < 170) {
+        debugWarn('Game start blocked due to invalid game dimensions.');
+        enterIdleMode();
+        return;
+      }
       canvas.tabIndex = 0;
       state.mode = 'playing';
       window.__SE_GALAGA_ACTIVE = true;
       gameStage.dataset.galagaActive = 'true';
-      gameStage.classList.add('is-galaga');
+      setGalagaState('playing');
       canvas.style.pointerEvents = 'auto';
 
       resetGame();
@@ -388,11 +416,11 @@
       state.enemyBullets = [];
       window.__SE_GALAGA_ACTIVE = false;
       gameStage.dataset.galagaActive = 'false';
-      gameStage.classList.remove('is-galaga');
+      setGalagaState('gameover');
       canvas.style.pointerEvents = 'none';
 
       gameOverEl.hidden = false;
-      gameOverEl.innerHTML = '<strong>SIGNAL LOST</strong><br>Gastown overrun. Press G to reboot.';
+      gameOverEl.innerHTML = '<strong>SIGNAL LOST</strong><br>Gastown overrun.<br>Press G to reboot.';
       updateHint();
       render();
       stopLoop();
@@ -734,7 +762,13 @@
       }
 
       const invaded = state.enemies.some(function (enemy) {
-        return enemy.alive && enemy.y + enemy.h >= state.playfield.y + state.playfield.h - 52;
+        if (!enemy.alive) {
+          return false;
+        }
+        const playerZoneY = state.player
+          ? state.player.y + Math.max(4, state.player.h * 0.25)
+          : state.playfield.y + state.playfield.h - 28;
+        return enemy.y + enemy.h >= playerZoneY;
       });
 
       if (invaded && state.mode === 'playing') {
@@ -871,11 +905,6 @@
       drawBullets();
       drawParticles();
 
-      if (!isPlaying()) {
-        ctx.fillStyle = 'rgba(0, 0, 0, 0.22)';
-        ctx.fillRect(state.playfield.x, state.playfield.y + state.playfield.h - 74, state.playfield.w, 74);
-      }
-
       ctx.restore();
     }
 
@@ -1003,7 +1032,7 @@
       if (!event.matches) {
         stopLoop();
         window.__SE_GALAGA_ACTIVE = false;
-        gameStage.classList.remove('is-galaga');
+        setGalagaState('idle');
         gameStage.classList.remove('has-galaga');
         gameStage.dataset.galagaActive = 'false';
         return;

--- a/page-home.php
+++ b/page-home.php
@@ -5,8 +5,8 @@ get_header();
 
 <main id="homepage-content">
     <?php
-    $hero_eyebrow = apply_filters('se_home_hero_eyebrow', 'Vancouver, BC • Creative technology • QA automation • Music tools');
-    $hero_headline = apply_filters('se_home_hero_headline', 'I build strange, useful systems.');
+    $hero_eyebrow = apply_filters('se_home_hero_eyebrow', 'Vancouver, BC • QA automation • IT operations • Creative AI');
+    $hero_headline = apply_filters('se_home_hero_headline', 'I build strange, useful things.');
     $hero_logo_label = apply_filters('se_home_hero_title', 'Suzy Easton');
     $hero_logo_top = apply_filters('se_home_hero_logo_top', 'Suzy');
     $hero_logo_mid = apply_filters('se_home_hero_logo_mid', '');
@@ -26,17 +26,17 @@ get_header();
                 <h1 class="hero-core-headline"><?php echo esc_html($hero_headline); ?></h1>
 
                 <p class="hero-copy">
-                    <?php echo esc_html('I’m Suzy Easton — a senior technical generalist, musician, and creative technologist turning messy systems into working tools: QA automation, IT operations, practical AI prototypes, civic/open-data experiments, and music tech.'); ?>
+                    <?php echo esc_html('I’m Suzy Easton — a senior technical generalist, musician, and creative technologist who turns messy workflows, flaky systems, and half-formed ideas into practical outcomes. My work spans QA automation, IT operations, AI prototypes, civic/open-data experiments, music tech, and public projects like Lousy Outages.'); ?>
                 </p>
 
                 <p class="hero-availability">
-                    <?php echo esc_html('Recently available after a company-wide layoff. Open to senior technical roles, contract debugging, QA automation, and sharp creative-tech builds.'); ?>
+                    <?php echo esc_html('Available for senior technical roles, contract QA/automation work, practical AI prototypes, and useful weird builds.'); ?>
                 </p>
 
                 <div class="hero-status-chips" aria-label="Current status">
-                    <span class="hero-status-chip"><strong><?php echo esc_html('BUILD STATUS:'); ?></strong> <?php echo esc_html('SHIPPING'); ?></span>
+                    <span class="hero-status-chip"><strong><?php echo esc_html('BUILD MODE:'); ?></strong> <?php echo esc_html('SHIPPING'); ?></span>
                     <span class="hero-status-chip"><strong><?php echo esc_html('LOCATION:'); ?></strong> <?php echo esc_html('VANCOUVER'); ?></span>
-                    <span class="hero-status-chip"><strong><?php echo esc_html('MODE:'); ?></strong> <?php echo esc_html('OPEN TO WORK'); ?></span>
+                    <span class="hero-status-chip"><strong><?php echo esc_html('STATUS:'); ?></strong> <?php echo esc_html('OPEN TO WORK'); ?></span>
                 </div>
 
                 <div class="hero-cta-group">
@@ -75,8 +75,9 @@ get_header();
         <div class="hero-game-stage" aria-label="Rain City Defense arcade stage">
             <p class="hero-game-stage__header pixel-font"><?php echo esc_html('RAIN CITY DEFENSE'); ?></p>
             <div class="hero-game-stage__screen" role="region" aria-label="Rain City Defense game screen">
-                <p class="hero-game-stage__idle pixel-font"><?php echo esc_html('RAIN CITY DEFENSE'); ?><br><?php echo esc_html('Press G to play'); ?><br><?php echo esc_html('WASD move // Space fire // Esc quit'); ?></p>
+                <p class="hero-game-stage__idle pixel-font"><?php echo esc_html('RAIN CITY DEFENSE'); ?><br><?php echo esc_html('Defend the weird little Rain City signal.'); ?><br><?php echo esc_html('Press G to play'); ?><br><?php echo esc_html('WASD move // Space fire // Esc quit'); ?></p>
             </div>
+            <p class="hero-game-stage__mobile-note"><?php echo esc_html('Mini arcade available on keyboard screens.'); ?></p>
         </div>
 
         <p class="arcade-subtext">Retro-futurist lab mode: online</p>

--- a/style.css
+++ b/style.css
@@ -2722,15 +2722,29 @@ body {
 .hero-game-stage__idle {
   margin: 0;
   position: absolute;
-  inset: 0;
-  display: grid;
+  left: 50%;
+  bottom: 16px;
+  transform: translateX(-50%);
+  display: inline-grid;
   place-content: center;
   text-align: center;
   line-height: 1.5;
   font-size: 0.6rem;
   letter-spacing: 0.08em;
-  color: rgba(123, 255, 210, 0.72);
+  color: rgba(180, 255, 235, 0.9);
+  background: rgba(0, 0, 0, 0.72);
+  border: 1px solid rgba(128, 225, 255, 0.42);
+  border-radius: 8px;
+  padding: 10px 12px;
+  max-width: min(92%, 460px);
   pointer-events: none;
+  z-index: 3;
+}
+
+.hero-game-stage__mobile-note {
+  margin: 0.55rem 0 0;
+  font-size: 0.6rem;
+  color: rgba(154, 236, 255, 0.88);
 }
 
 
@@ -2938,12 +2952,12 @@ body {
 .page-template-page-home-php .hero-galaga-gameover,
 .home .hero-galaga-gameover,
 .front-page .hero-galaga-gameover {
-  margin-top: 10px;
-  max-width: min(90%, 560px);
-  background: rgba(10, 10, 10, 0.84);
-  border: 2px solid var(--secondary-color);
-  color: var(--accent-color);
-  padding: 10px;
+  margin-top: 0;
+  max-width: 100%;
+  background: transparent;
+  border: 0;
+  color: #ffb7ef;
+  padding: 0;
 }
 
 .page-template-page-home-php .hero-galaga-gameover strong,
@@ -2956,27 +2970,30 @@ body {
 .home .hero-galaga-hint,
 .front-page .hero-galaga-hint {
   position: absolute;
-  bottom: 12px;
-  left: 12px;
-  top: auto;
-  right: auto;
-  z-index: 4;
-  padding: 6px 10px;
-  font-size: 0.52rem;
+  inset: 50% auto auto 50%;
+  transform: translate(-50%, -50%);
+  z-index: 6;
+  padding: 10px 12px;
+  font-size: 0.54rem;
   letter-spacing: 0.04em;
-  color: var(--accent-color);
-  border: 1px solid rgba(128, 225, 255, 0.35);
-  background: rgba(0, 0, 0, 0.62);
-  display: inline-flex;
+  color: #cbffe7;
+  border: 1px solid rgba(128, 225, 255, 0.44);
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.78);
+  display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
+  text-align: center;
+  min-width: min(92%, 460px);
+  max-width: min(92%, 460px);
   pointer-events: auto;
 }
 
 .page-template-page-home-php .hero-galaga-hint-text,
 .home .hero-galaga-hint-text,
 .front-page .hero-galaga-hint-text {
-  line-height: 1.2;
+  line-height: 1.45;
 }
 
 .page-template-page-home-php .hero-galaga-start,
@@ -3006,12 +3023,15 @@ body {
 }
 
 .page-template-page-home-php .hero-game-stage.has-galaga .hero-galaga-canvas,
-.page-template-page-home-php .hero-game-stage.has-galaga .hero-galaga-hint,
 .home .hero-game-stage.has-galaga .hero-galaga-canvas,
-.home .hero-game-stage.has-galaga .hero-galaga-hint,
-.front-page .hero-game-stage.has-galaga .hero-galaga-canvas,
-.front-page .hero-game-stage.has-galaga .hero-galaga-hint {
+.front-page .hero-game-stage.has-galaga .hero-galaga-canvas {
   display: block;
+}
+
+.page-template-page-home-php .hero-game-stage.has-galaga .hero-galaga-hint,
+.home .hero-game-stage.has-galaga .hero-galaga-hint,
+.front-page .hero-game-stage.has-galaga .hero-galaga-hint {
+  display: flex;
 }
 
 .page-template-page-home-php .hero-game-stage.is-galaga .hero-galaga-canvas,
@@ -3026,6 +3046,15 @@ body {
   display: flex;
 }
 
+.page-template-page-home-php .hero-game-stage[data-galaga-state="gameover"] .hero-galaga-scoreline,
+.page-template-page-home-php .hero-game-stage[data-galaga-state="gameover"] .hero-galaga-help,
+.home .hero-game-stage[data-galaga-state="gameover"] .hero-galaga-scoreline,
+.home .hero-game-stage[data-galaga-state="gameover"] .hero-galaga-help,
+.front-page .hero-game-stage[data-galaga-state="gameover"] .hero-galaga-scoreline,
+.front-page .hero-game-stage[data-galaga-state="gameover"] .hero-galaga-help {
+  display: none;
+}
+
 .page-template-page-home-php .hero-game-stage.is-galaga .hero-game-stage__idle,
 .home .hero-game-stage.is-galaga .hero-game-stage__idle,
 .front-page .hero-game-stage.is-galaga .hero-game-stage__idle {
@@ -3036,6 +3065,12 @@ body {
 .home .hero-game-stage.is-galaga .hero-galaga-start,
 .front-page .hero-game-stage.is-galaga .hero-galaga-start {
   display: none;
+}
+
+.page-template-page-home-php .hero-game-stage[data-galaga-state="gameover"] .hero-galaga-start,
+.home .hero-game-stage[data-galaga-state="gameover"] .hero-galaga-start,
+.front-page .hero-game-stage[data-galaga-state="gameover"] .hero-galaga-start {
+  display: inline-flex;
 }
 
 @keyframes galagaHitFlash {
@@ -4220,7 +4255,7 @@ body.page-template-page-bio-php .bio-content {
 .page-template-page-home-php .hero-galaga-hint,
 .home .hero-galaga-hint,
 .front-page .hero-galaga-hint {
-  bottom: clamp(18px, 2.2vw, 28px);
+  inset: 50% auto auto 50%;
 }
 
 @media (min-width: 860px) and (max-width: 1240px) {
@@ -4301,6 +4336,10 @@ body.page-template-page-bio-php .bio-content {
     min-height: 190px;
   }
 
+  .hero-game-stage__mobile-note {
+    display: block;
+  }
+
   .ai-film-feature__meta-list {
     gap: 0.45rem;
   }
@@ -4309,5 +4348,11 @@ body.page-template-page-bio-php .bio-content {
     font-size: 0.58rem;
     letter-spacing: 0.05em;
     padding: 0.3rem 0.52rem;
+  }
+}
+
+@media (min-width: 761px) {
+  .hero-game-stage__mobile-note {
+    display: none;
   }
 }


### PR DESCRIPTION
### Motivation
- Make the Rain City Defense mini-arcade playable and visually tidy on the homepage by fixing state transitions, spawn layout, and overlay collisions. No external skills were used.

### Description
- Game logic: adjusted `spawnWave()` to compute rows/gaps/startY from the stage height and cap formation depth so enemies never spawn in the player zone, and changed invasion detection to compare enemy bottoms to a relative `playerZoneY` rather than a fixed hardcoded offset. (`js/hero-galaga.js`)
- State & UI: separated idle/playing/gameover overlays, hid idle enemies during attract mode, moved the hint into a centered overlay, made the Play button start/restart reliably, added `setGalagaState()` and small debug warnings, and prevented game start on tiny screens. (`js/hero-galaga.js`, `style.css`)
- Copy: updated hero eyebrow/headline, body copy, availability line, and status chips to remove layoff phrasing, reduce repetition, and mention public work like Lousy Outages; updated the idle/game and HUD text in the game to clearer phrasing and separators. (`page-home.php`, `js/hero-galaga.js`)
- CSS/layout: repositioned the idle panel and hint so they do not overlap sprites, added a compact game-over presentation and a mobile helper note (`Mini arcade available on keyboard screens`), and adjusted visibility rules so HUD/help hide during game-over overlays. (`style.css`)

### Testing
- `php -l page-home.php` — passed (no syntax errors).
- `php -l header.php` — passed (no syntax errors in header file referenced).
- `node --check js/hero-galaga.js` — passed (no syntax errors detected).
- `npm test` — executed; several existing unrelated test suites failed in other parts of the repo (e.g. `__tests__/gastown-dialog.test.js`, `__tests__/gastown-world-generator.test.js`, `__tests__/sync-cov-open-data.test.js`), failures are pre-existing and not caused by these changes.

Note: manual browser validation of interactive gameplay (start with `G` / Play, movement, firing, collisions, Esc to exit, and restart) should be performed in a browser to confirm behavior and layout on desktop and mobile; the patch implements the acceptance criteria detailed in the change description.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efa0cacb78832eb1969b6a0a2d384c)