### PR TITLE
Fix Rain City Defense idle overlay remaining visible during gameplay

### DIFF
--- a/js/hero-galaga.js
+++ b/js/hero-galaga.js
@@ -201,17 +201,18 @@
 
       if (isPlaying()) {
         hint.hidden = true;
+        startButton.hidden = true;
         return;
       }
 
       hint.hidden = false;
+      startButton.hidden = false;
 
       if (state.mode === 'gameover') {
         hintTextEl.innerHTML = '<strong>SIGNAL LOST</strong><br>Gastown overrun.<br>Press G to reboot.';
       } else {
         hintTextEl.innerHTML = 'RAIN CITY DEFENSE<br>Defend the weird little Rain City signal.<br>Press G to play<br>WASD move // Space fire // Esc quit';
       }
-      startButton.hidden = false;
       startButton.textContent = state.mode === 'gameover' ? 'Reboot' : 'Play';
     }
 
@@ -397,6 +398,14 @@
       canvas.style.pointerEvents = 'auto';
 
       resetGame();
+      hint.hidden = true;
+      startButton.hidden = true;
+      gameOverEl.hidden = true;
+      gameOverEl.innerHTML = '';
+      if (waveCallEl) {
+        waveCallEl.hidden = true;
+        waveCallEl.textContent = '';
+      }
       updateHint();
       canvas.focus({ preventScroll: true });
       ensureLoopRunning();
@@ -419,8 +428,8 @@
       setGalagaState('gameover');
       canvas.style.pointerEvents = 'none';
 
-      gameOverEl.hidden = false;
-      gameOverEl.innerHTML = '<strong>SIGNAL LOST</strong><br>Gastown overrun.<br>Press G to reboot.';
+      gameOverEl.hidden = true;
+      gameOverEl.innerHTML = '';
       updateHint();
       render();
       stopLoop();

--- a/style.css
+++ b/style.css
@@ -3034,6 +3034,12 @@ body {
   display: flex;
 }
 
+.page-template-page-home-php .hero-game-stage.has-galaga .hero-game-stage__idle,
+.home .hero-game-stage.has-galaga .hero-game-stage__idle,
+.front-page .hero-game-stage.has-galaga .hero-game-stage__idle {
+  display: none;
+}
+
 .page-template-page-home-php .hero-game-stage.is-galaga .hero-galaga-canvas,
 .home .hero-game-stage.is-galaga .hero-galaga-canvas,
 .front-page .hero-game-stage.is-galaga .hero-galaga-canvas {
@@ -3044,6 +3050,16 @@ body {
 .home .hero-game-stage.is-galaga .hero-galaga-ui,
 .front-page .hero-game-stage.is-galaga .hero-galaga-ui {
   display: flex;
+}
+
+.page-template-page-home-php .hero-game-stage.is-galaga .hero-galaga-hint,
+.home .hero-game-stage.is-galaga .hero-galaga-hint,
+.front-page .hero-game-stage.is-galaga .hero-galaga-hint,
+.page-template-page-home-php .hero-game-stage[data-galaga-state="playing"] .hero-galaga-hint,
+.home .hero-game-stage[data-galaga-state="playing"] .hero-galaga-hint,
+.front-page .hero-game-stage[data-galaga-state="playing"] .hero-galaga-hint {
+  display: none;
+  pointer-events: none;
 }
 
 .page-template-page-home-php .hero-game-stage[data-galaga-state="gameover"] .hero-galaga-scoreline,
@@ -3058,7 +3074,7 @@ body {
 .page-template-page-home-php .hero-game-stage.is-galaga .hero-game-stage__idle,
 .home .hero-game-stage.is-galaga .hero-game-stage__idle,
 .front-page .hero-game-stage.is-galaga .hero-game-stage__idle {
-  opacity: 0;
+  display: none;
 }
 
 .page-template-page-home-php .hero-game-stage.is-galaga .hero-galaga-start,
@@ -3071,6 +3087,13 @@ body {
 .home .hero-game-stage[data-galaga-state="gameover"] .hero-galaga-start,
 .front-page .hero-game-stage[data-galaga-state="gameover"] .hero-galaga-start {
   display: inline-flex;
+}
+
+.page-template-page-home-php .hero-galaga-hint[hidden],
+.home .hero-galaga-hint[hidden],
+.front-page .hero-galaga-hint[hidden] {
+  display: none !important;
+  pointer-events: none;
 }
 
 @keyframes galagaHitFlash {


### PR DESCRIPTION
### Motivation
- The centered idle/start overlay remained visible after the mini-game started, overlapping active gameplay and HUD; CSS showed the hint while only the Play button was hidden.
- The goal is to make overlay visibility strictly driven by game state (`idle` / `playing` / `gameover`) so no instructional copy overlays active play.

### Description
- JavaScript: updated `updateHint()` in `js/hero-galaga.js` to explicitly hide both the hint container and start button when the game is `playing`, and to correctly set start text for `gameover` vs `idle` states.
- JavaScript: hardened `startGame()` to clear/hide stale UI before starting the loop by hiding `hint`, `startButton`, `gameOverEl`, and `waveCallEl` so nothing remains over the canvas when play begins.
- JavaScript: simplified `endGame()` to rely on the centered hint for the game-over message and keep the internal `gameOverEl` hidden to avoid duplicate overlays.
- CSS: added state-aware rules in `style.css` to hide the static PHP fallback `.hero-game-stage__idle` when JS initializes (`.has-galaga`) and to hide `.hero-galaga-hint` during `.is-galaga` / `data-galaga-state=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efa4d7c614832ea83c0fd7c76323cd)