### PR TITLE
PACIFIC STATIC: add game-over overlay and reboot loop

### DIFF
--- a/js/hero-galaga.js
+++ b/js/hero-galaga.js
@@ -21,7 +21,7 @@
 
     function debugWarn(message) {
       if (debugEnabled && window.console && typeof window.console.warn === 'function') {
-        window.console.warn('[Rain City Defense]', message);
+        window.console.warn('[Pacific Static]', message);
       }
     }
 
@@ -30,10 +30,10 @@
         return;
       }
       if (typeof detail === 'undefined') {
-        window.console.log('[Rain City Defense]', message);
+        window.console.log('[Pacific Static]', message);
         return;
       }
-      window.console.log('[Rain City Defense]', message, detail);
+      window.console.log('[Pacific Static]', message, detail);
     }
 
     const rootStyles = window.getComputedStyle(document.documentElement);
@@ -53,19 +53,31 @@
     const ui = document.createElement('div');
     ui.className = 'hero-galaga-ui';
     ui.innerHTML = '' +
-      '<p class="hero-galaga-status" data-galaga-status>RAIN CITY DEFENSE</p>' +
+      '<p class="hero-galaga-status" data-galaga-status>PACIFIC STATIC</p>' +
       '<p class="hero-galaga-scoreline">Score: <span data-galaga-score>000000</span> // Lives: <span data-galaga-lives>3</span> // Wave: <span data-galaga-wave>1</span></p>' +
       '<p class="hero-galaga-help">WASD move // Space fire // Esc quit</p>' +
-      '<p class="hero-galaga-wavecall" data-galaga-wavecall hidden></p>' +
-      '<div class="hero-galaga-gameover" data-galaga-gameover hidden></div>';
+      '<p class="hero-galaga-wavecall" data-galaga-wavecall hidden></p>';
 
-    const hint = document.createElement('div');
-    hint.className = 'hero-galaga-hint';
-    hint.innerHTML = '<span class="hero-galaga-hint-text" data-galaga-hint-text></span><button type="button" class="hero-galaga-start">Play</button>';
+    const overlay = document.createElement('div');
+    overlay.className = 'hero-galaga-overlay hero-galaga-overlay--idle';
+    overlay.innerHTML = '' +
+      '<div class="hero-galaga-panel hero-galaga-panel--idle" data-galaga-idle-panel>' +
+        '<p class="hero-galaga-hint-text" data-galaga-hint-text></p>' +
+        '<button type="button" class="hero-galaga-reboot" data-galaga-reboot>Reboot Signal</button>' +
+      '</div>' +
+      '<div class="hero-galaga-panel hero-galaga-panel--gameover hero-galaga-gameover" data-galaga-gameover-panel hidden>' +
+        '<p class="hero-galaga-gameover__title">SIGNAL LOST</p>' +
+        '<p class="hero-galaga-gameover__line">The Pacific Static swallowed the feed.</p>' +
+        '<p class="hero-galaga-gameover__stats">Score: <span data-galaga-final-score>000000</span></p>' +
+        '<p class="hero-galaga-gameover__stats">Wave: <span data-galaga-final-wave>1</span></p>' +
+        '<p class="hero-galaga-gameover__line">Press G to reboot.</p>' +
+        '<button type="button" class="hero-galaga-reboot" data-galaga-reboot>Reboot Signal</button>' +
+        '<p class="hero-galaga-gameover__exit">Esc to exit</p>' +
+      '</div>';
 
     gameScreen.appendChild(canvas);
     gameScreen.appendChild(ui);
-    gameScreen.appendChild(hint);
+    gameScreen.appendChild(overlay);
 
     const ctx = canvas.getContext('2d', { alpha: true });
     if (!ctx) {
@@ -77,10 +89,13 @@
     const scoreEl = ui.querySelector('[data-galaga-score]');
     const livesEl = ui.querySelector('[data-galaga-lives]');
     const waveEl = ui.querySelector('[data-galaga-wave]');
-    const gameOverEl = ui.querySelector('[data-galaga-gameover]');
     const waveCallEl = ui.querySelector('[data-galaga-wavecall]');
-    const startButton = hint.querySelector('.hero-galaga-start');
-    const hintTextEl = hint.querySelector('[data-galaga-hint-text]');
+    const idlePanelEl = overlay.querySelector('[data-galaga-idle-panel]');
+    const gameOverPanelEl = overlay.querySelector('[data-galaga-gameover-panel]');
+    const rebootButtons = overlay.querySelectorAll('[data-galaga-reboot]');
+    const hintTextEl = overlay.querySelector('[data-galaga-hint-text]');
+    const finalScoreEl = overlay.querySelector('[data-galaga-final-score]');
+    const finalWaveEl = overlay.querySelector('[data-galaga-final-wave]');
 
     const state = {
       mode: 'idle', // idle | playing | gameover
@@ -122,11 +137,11 @@
     };
 
     const waveCalls = [
-      'WAVE 1 // RAIN CITY SIGNAL',
-      'WAVE 2 // GASTOWN STATIC',
+      'WAVE 1 // VANCOUVER SIGNAL',
+      'WAVE 2 // GASTOWN GHOSTS',
       'WAVE 3 // STEAM CLOCK SWARM',
-      'WAVE 4 // ALIEN FOG ROLLING IN',
-      'WAVE 5 · FALSE CREEK DISTRESS',
+      'WAVE 4 // SEABUS DRONES',
+      'WAVE 5 // PACIFIC STATIC',
     ];
 
     function setGalagaState(mode) {
@@ -222,7 +237,7 @@
 
       if (!hasUsablePlayfield && isPlaying()) {
         showMessage('Signal weak. Resize window and press G to reboot.');
-        endGame({ toIdle: true });
+        exitToIdle();
       }
 
       if (!isPlaying()) {
@@ -240,41 +255,53 @@
       waveEl.textContent = String(state.wave);
     }
 
-    function updateHint() {
-      if (!hintTextEl || !startButton) {
+    function updateOverlay() {
+      if (!overlay || !idlePanelEl || !gameOverPanelEl || !hintTextEl) {
         return;
       }
 
       if (isPlaying()) {
-        hint.hidden = true;
-        startButton.hidden = true;
+        overlay.hidden = true;
+        overlay.classList.remove('hero-galaga-overlay--idle', 'hero-galaga-overlay--gameover');
         return;
       }
 
-      hint.hidden = false;
-      startButton.hidden = false;
+      overlay.hidden = false;
 
       if (state.mode === 'gameover') {
-        hintTextEl.innerHTML = '<strong>SIGNAL LOST</strong><br>Gastown overrun.<br>Press G to reboot.';
+        overlay.classList.remove('hero-galaga-overlay--idle');
+        overlay.classList.add('hero-galaga-overlay--gameover');
+        idlePanelEl.hidden = true;
+        gameOverPanelEl.hidden = false;
       } else {
-        hintTextEl.innerHTML = 'RAIN CITY DEFENSE<br>Defend the weird little Rain City signal.<br>Press G to play<br>WASD move // Space fire // Esc quit';
+        overlay.classList.remove('hero-galaga-overlay--gameover');
+        overlay.classList.add('hero-galaga-overlay--idle');
+        idlePanelEl.hidden = false;
+        gameOverPanelEl.hidden = true;
+        hintTextEl.innerHTML = 'PACIFIC STATIC<br>Defend the Vancouver signal.<br>Press G to play.<br>WASD move // Space fire // Esc quit';
       }
-      startButton.textContent = state.mode === 'gameover' ? 'Reboot' : 'Play';
     }
 
     function showMessage(message) {
       if (hintTextEl) {
         hintTextEl.innerHTML = message;
       }
-      hint.hidden = false;
-      if (startButton) {
-        startButton.hidden = false;
+      state.mode = 'idle';
+      updateOverlay();
+    }
+
+    function updateGameOverOverlay() {
+      if (finalScoreEl) {
+        finalScoreEl.textContent = formatScore(state.score);
+      }
+      if (finalWaveEl) {
+        finalWaveEl.textContent = String(state.wave);
       }
     }
 
     function showWaveCallout() {
       const index = Math.min(waveCalls.length - 1, Math.max(0, state.wave - 1));
-      const label = waveCalls[index] || ('WAVE ' + state.wave + ' · RAIN CITY DEFENSE');
+      const label = waveCalls[index] || ('WAVE ' + state.wave + ' // PACIFIC STATIC');
       if (waveCallEl) {
         waveCallEl.textContent = label;
         waveCallEl.hidden = false;
@@ -379,9 +406,8 @@
       clearTransientFx();
       initPlayer();
       spawnWave();
-      gameOverEl.hidden = true;
-      gameOverEl.innerHTML = '';
       updateUI();
+      updateGameOverOverlay();
     }
 
     function startLoop() {
@@ -427,14 +453,12 @@
       gameStage.dataset.galagaActive = 'false';
       setGalagaState('idle');
       canvas.style.pointerEvents = 'none';
-      gameOverEl.hidden = true;
-      gameOverEl.innerHTML = '';
       if (waveCallEl) {
         waveCallEl.hidden = true;
       }
       initIdleScene();
 
-      updateHint();
+      updateOverlay();
       render();
       if (shouldAnimateIdle()) {
         startLoop();
@@ -443,7 +467,7 @@
       }
     }
 
-    function startGame() {
+    function restartGame() {
       if (!desktopQuery.matches || isPlaying()) {
         return;
       }
@@ -463,29 +487,19 @@
       canvas.style.pointerEvents = 'auto';
 
       resetGame();
-      hint.hidden = true;
-      startButton.hidden = true;
-      gameOverEl.hidden = true;
-      gameOverEl.innerHTML = '';
       if (waveCallEl) {
         waveCallEl.hidden = true;
         waveCallEl.textContent = '';
       }
-      updateHint();
+      updateOverlay();
       canvas.focus({ preventScroll: true });
       debugLog('game start');
       startLoop();
     }
 
-    function endGame(options) {
-      if (!options || options.toIdle) {
-        debugLog('game exit to idle');
-        enterIdleMode();
-        return;
-      }
-
+    function triggerGameOver(reason) {
       state.mode = 'gameover';
-      debugLog('game over', options && options.reason ? options.reason : 'unknown');
+      debugLog('game over', reason || 'unknown');
       state.keys.left = false;
       state.keys.right = false;
       state.keys.fire = false;
@@ -496,11 +510,15 @@
       setGalagaState('gameover');
       canvas.style.pointerEvents = 'none';
 
-      gameOverEl.hidden = true;
-      gameOverEl.innerHTML = '';
-      updateHint();
+      updateGameOverOverlay();
+      updateOverlay();
       render();
       stopLoop();
+    }
+
+    function exitToIdle() {
+      debugLog('game exit to idle');
+      enterIdleMode();
     }
 
     function intersects(a, b) {
@@ -573,7 +591,7 @@
       if (state.lives <= 0) {
         state.lives = 0;
         updateUI();
-        endGame({ toIdle: false, reason: 'no_lives' });
+        triggerGameOver('no_lives');
         return;
       }
 
@@ -865,7 +883,7 @@
       if (invaded && state.mode === 'playing') {
         state.lives = 0;
         updateUI();
-        endGame({ toIdle: false, reason: 'invaded' });
+        triggerGameOver('invaded');
         return;
       }
 
@@ -1018,7 +1036,7 @@
 
         render(now);
       } catch (error) {
-        console.error('[Rain City Defense] Game loop crashed:', error);
+        console.error('[Pacific Static] Game loop crashed:', error);
         debugLog('loop crash', error);
         state.mode = 'idle';
         setGalagaState('idle');
@@ -1049,20 +1067,20 @@
       return code === 'ArrowLeft' || code === 'ArrowRight' || code === 'KeyA' || code === 'KeyD' || code === 'Space';
     }
 
-    if (startButton) {
-      startButton.addEventListener('click', function (event) {
+    rebootButtons.forEach(function (button) {
+      button.addEventListener('click', function (event) {
         event.preventDefault();
         event.stopPropagation();
-        startGame();
+        restartGame();
       });
-    }
+    });
 
     window.addEventListener('keydown', function (event) {
       const code = event.code;
       const typing = isTypingTarget(event.target);
 
       if (!typing && code === 'KeyG' && !isPlaying()) {
-        startGame();
+        restartGame();
         event.preventDefault();
         event.stopPropagation();
         return;
@@ -1077,7 +1095,7 @@
       }
 
       if (code === 'Escape') {
-        endGame({ toIdle: true });
+        exitToIdle();
         event.preventDefault();
         event.stopPropagation();
         return;
@@ -1146,7 +1164,7 @@
     });
 
     reducedMotionQuery.addEventListener('change', function () {
-      updateHint();
+      updateOverlay();
       if (isPlaying()) {
         return;
       }

--- a/page-home.php
+++ b/page-home.php
@@ -72,10 +72,10 @@ get_header();
             </aside>
         </div>
 
-        <div class="hero-game-stage" aria-label="Rain City Defense arcade stage">
-            <p class="hero-game-stage__header pixel-font"><?php echo esc_html('RAIN CITY DEFENSE'); ?></p>
-            <div class="hero-game-stage__screen" role="region" aria-label="Rain City Defense game screen">
-                <p class="hero-game-stage__idle pixel-font"><?php echo esc_html('RAIN CITY DEFENSE'); ?><br><?php echo esc_html('Defend the weird little Rain City signal.'); ?><br><?php echo esc_html('Press G to play'); ?><br><?php echo esc_html('WASD move // Space fire // Esc quit'); ?></p>
+        <div class="hero-game-stage" aria-label="Pacific Static arcade stage">
+            <p class="hero-game-stage__header pixel-font"><?php echo esc_html('PACIFIC STATIC'); ?></p>
+            <div class="hero-game-stage__screen" role="region" aria-label="Pacific Static game screen">
+                <p class="hero-game-stage__idle pixel-font"><?php echo esc_html('PACIFIC STATIC'); ?><br><?php echo esc_html('Defend the Vancouver signal.'); ?><br><?php echo esc_html('Press G to play.'); ?><br><?php echo esc_html('WASD move // Space fire // Esc quit'); ?></p>
             </div>
             <p class="hero-game-stage__mobile-note"><?php echo esc_html('Mini arcade available on keyboard screens.'); ?></p>
         </div>

--- a/style.css
+++ b/style.css
@@ -2949,45 +2949,43 @@ body {
   padding: 5px 7px;
 }
 
-.page-template-page-home-php .hero-galaga-gameover,
-.home .hero-galaga-gameover,
-.front-page .hero-galaga-gameover {
-  margin-top: 0;
-  max-width: 100%;
-  background: transparent;
-  border: 0;
-  color: #ffb7ef;
-  padding: 0;
-}
-
-.page-template-page-home-php .hero-galaga-gameover strong,
-.home .hero-galaga-gameover strong,
-.front-page .hero-galaga-gameover strong {
-  color: #ff9deb;
-}
-
-.page-template-page-home-php .hero-galaga-hint,
-.home .hero-galaga-hint,
-.front-page .hero-galaga-hint {
+.page-template-page-home-php .hero-galaga-overlay,
+.home .hero-galaga-overlay,
+.front-page .hero-galaga-overlay {
   position: absolute;
   inset: 50% auto auto 50%;
   transform: translate(-50%, -50%);
   z-index: 6;
-  padding: 10px 12px;
+  pointer-events: auto;
+  min-width: min(92%, 460px);
+  max-width: min(92%, 460px);
+}
+
+.page-template-page-home-php .hero-galaga-panel,
+.home .hero-galaga-panel,
+.front-page .hero-galaga-panel {
+  padding: 12px 14px;
   font-size: 0.54rem;
   letter-spacing: 0.04em;
   color: #cbffe7;
-  border: 1px solid rgba(128, 225, 255, 0.44);
+  border: 1px solid rgba(128, 225, 255, 0.5);
   border-radius: 8px;
-  background: rgba(0, 0, 0, 0.78);
+  background: rgba(5, 7, 16, 0.82);
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 10px;
   text-align: center;
-  min-width: min(92%, 460px);
-  max-width: min(92%, 460px);
-  pointer-events: auto;
+  box-shadow: 0 0 0 1px rgba(255, 72, 206, 0.22), 0 0 18px rgba(87, 243, 255, 0.2);
+}
+
+.page-template-page-home-php .hero-galaga-overlay--gameover .hero-galaga-panel,
+.home .hero-galaga-overlay--gameover .hero-galaga-panel,
+.front-page .hero-galaga-overlay--gameover .hero-galaga-panel {
+  border-color: rgba(255, 72, 206, 0.72);
+  background:
+    linear-gradient(180deg, rgba(255, 72, 206, 0.12), rgba(10, 7, 20, 0.9) 45%),
+    repeating-linear-gradient(180deg, rgba(255, 255, 255, 0.04) 0, rgba(255, 255, 255, 0.04) 1px, transparent 2px, transparent 3px);
 }
 
 .page-template-page-home-php .hero-galaga-hint-text,
@@ -2996,9 +2994,28 @@ body {
   line-height: 1.45;
 }
 
-.page-template-page-home-php .hero-galaga-start,
-.home .hero-galaga-start,
-.front-page .hero-galaga-start {
+.page-template-page-home-php .hero-galaga-gameover__title,
+.home .hero-galaga-gameover__title,
+.front-page .hero-galaga-gameover__title {
+  margin: 0;
+  color: #ff9deb;
+}
+
+.page-template-page-home-php .hero-galaga-gameover__line,
+.page-template-page-home-php .hero-galaga-gameover__stats,
+.page-template-page-home-php .hero-galaga-gameover__exit,
+.home .hero-galaga-gameover__line,
+.home .hero-galaga-gameover__stats,
+.home .hero-galaga-gameover__exit,
+.front-page .hero-galaga-gameover__line,
+.front-page .hero-galaga-gameover__stats,
+.front-page .hero-galaga-gameover__exit {
+  margin: 0;
+}
+
+.page-template-page-home-php .hero-galaga-reboot,
+.home .hero-galaga-reboot,
+.front-page .hero-galaga-reboot {
   appearance: none;
   border: 1px solid var(--primary-color);
   background: rgba(0, 0, 0, 0.75);
@@ -3012,12 +3029,12 @@ body {
   cursor: pointer;
 }
 
-.page-template-page-home-php .hero-galaga-start:hover,
-.page-template-page-home-php .hero-galaga-start:focus-visible,
-.home .hero-galaga-start:hover,
-.home .hero-galaga-start:focus-visible,
-.front-page .hero-galaga-start:hover,
-.front-page .hero-galaga-start:focus-visible {
+.page-template-page-home-php .hero-galaga-reboot:hover,
+.page-template-page-home-php .hero-galaga-reboot:focus-visible,
+.home .hero-galaga-reboot:hover,
+.home .hero-galaga-reboot:focus-visible,
+.front-page .hero-galaga-reboot:hover,
+.front-page .hero-galaga-reboot:focus-visible {
   border-color: var(--accent-color);
   color: var(--accent-color);
 }
@@ -3028,9 +3045,9 @@ body {
   display: block;
 }
 
-.page-template-page-home-php .hero-game-stage.has-galaga .hero-galaga-hint,
-.home .hero-game-stage.has-galaga .hero-galaga-hint,
-.front-page .hero-game-stage.has-galaga .hero-galaga-hint {
+.page-template-page-home-php .hero-game-stage.has-galaga .hero-galaga-overlay,
+.home .hero-game-stage.has-galaga .hero-galaga-overlay,
+.front-page .hero-game-stage.has-galaga .hero-galaga-overlay {
   display: flex;
 }
 
@@ -3052,12 +3069,9 @@ body {
   display: flex;
 }
 
-.page-template-page-home-php .hero-game-stage.is-galaga .hero-galaga-hint,
-.home .hero-game-stage.is-galaga .hero-galaga-hint,
-.front-page .hero-game-stage.is-galaga .hero-galaga-hint,
-.page-template-page-home-php .hero-game-stage[data-galaga-state="playing"] .hero-galaga-hint,
-.home .hero-game-stage[data-galaga-state="playing"] .hero-galaga-hint,
-.front-page .hero-game-stage[data-galaga-state="playing"] .hero-galaga-hint {
+.page-template-page-home-php .hero-game-stage[data-galaga-state="playing"] .hero-galaga-overlay,
+.home .hero-game-stage[data-galaga-state="playing"] .hero-galaga-overlay,
+.front-page .hero-game-stage[data-galaga-state="playing"] .hero-galaga-overlay {
   display: none;
   pointer-events: none;
 }
@@ -3077,21 +3091,9 @@ body {
   display: none;
 }
 
-.page-template-page-home-php .hero-game-stage.is-galaga .hero-galaga-start,
-.home .hero-game-stage.is-galaga .hero-galaga-start,
-.front-page .hero-game-stage.is-galaga .hero-galaga-start {
-  display: none;
-}
-
-.page-template-page-home-php .hero-game-stage[data-galaga-state="gameover"] .hero-galaga-start,
-.home .hero-game-stage[data-galaga-state="gameover"] .hero-galaga-start,
-.front-page .hero-game-stage[data-galaga-state="gameover"] .hero-galaga-start {
-  display: inline-flex;
-}
-
-.page-template-page-home-php .hero-galaga-hint[hidden],
-.home .hero-galaga-hint[hidden],
-.front-page .hero-galaga-hint[hidden] {
+.page-template-page-home-php .hero-galaga-overlay[hidden],
+.home .hero-galaga-overlay[hidden],
+.front-page .hero-galaga-overlay[hidden] {
   display: none !important;
   pointer-events: none;
 }
@@ -4275,9 +4277,9 @@ body.page-template-page-bio-php .bio-content {
   max-width: min(360px, calc(100vw - 32px));
 }
 
-.page-template-page-home-php .hero-galaga-hint,
-.home .hero-galaga-hint,
-.front-page .hero-galaga-hint {
+.page-template-page-home-php .hero-galaga-overlay,
+.home .hero-galaga-overlay,
+.front-page .hero-galaga-overlay {
   inset: 50% auto auto 50%;
 }
 


### PR DESCRIPTION
### Motivation
- The homepage mini-game had no clear game-over or replay loop and still used the old “Rain City Defense” label, so the experience felt unfinished. 
- The change aims to make the arcade stage behave like a tiny cabinet with explicit `idle` / `playing` / `gameover` states, a visible restart control, and clearer Vancouver/cyber branding. 

### Description
- Replaced branding and copy in `page-home.php` and runtime UI to `PACIFIC STATIC` and updated the idle text and ARIA labels to match the new name. 
- Reworked `js/hero-galaga.js` to add explicit state handling (`idle`, `playing`, `gameover`), new functions `restartGame`, `triggerGameOver`, and `exitToIdle`, and to stop the gameplay loop on game over. 
- Introduced a structured overlay DOM (idle panel + game-over panel) with a visible, keyboard-accessible `Reboot Signal` button, final score/wave display, and `SIGNAL LOST` messaging, and wired keyboard controls so `G` starts/reboots and `Esc` returns to idle. 
- Updated wave labels and console prefixes and added overlay styling in `style.css` to visually separate idle vs game-over panels while preserving existing layout and accessibility considerations. 

### Testing
- Ran `node --check js/hero-galaga.js` which completed with no syntax errors. 
- Ran `php -l page-home.php` which reported no syntax errors. 
- Searched for remaining occurrences of the old brand string with `rg` and confirmed the runtime/markup strings were updated (no remaining matches in the changed files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efbbb29548832e8ea5d167cb9b22dc)