### PR TITLE
Fix Pacific Static collision/game-over flow and rename vessel to LIONS GATE

### DIFF
--- a/js/hero-galaga.js
+++ b/js/hero-galaga.js
@@ -31,14 +31,14 @@
     }
 
     function debugLog(message, detail) {
-      if (!debugEnabled || !window.console || typeof window.console.log !== 'function') {
+      if (!debugEnabled || !window.console || typeof window.console.debug !== 'function') {
         return;
       }
       if (typeof detail === 'undefined') {
-        window.console.log('[Pacific Static]', message);
+        window.console.debug('[Pacific Static]', message);
         return;
       }
-      window.console.log('[Pacific Static]', message, detail);
+      window.console.debug('[Pacific Static]', message, detail);
     }
 
     const rootStyles = window.getComputedStyle(document.documentElement);
@@ -59,6 +59,7 @@
     ui.className = 'hero-galaga-ui';
     ui.innerHTML = '' +
       '<p class="hero-galaga-status" data-galaga-status>PACIFIC STATIC</p>' +
+      '<p class="hero-galaga-vessel">Vessel: LIONS GATE</p>' +
       '<p class="hero-galaga-scoreline">Score: <span data-galaga-score>000000</span> // Lives: <span data-galaga-lives>3</span> // Wave: <span data-galaga-wave>1</span></p>' +
       '<p class="hero-galaga-help">WASD move // Space fire // Esc quit</p>' +
       '<p class="hero-galaga-wavecall" data-galaga-wavecall hidden></p>';
@@ -72,7 +73,7 @@
       '</div>' +
       '<div class="hero-galaga-panel hero-galaga-panel--gameover hero-galaga-overlay--gameover hero-galaga-gameover" data-galaga-gameover-panel hidden>' +
         '<p class="hero-galaga-gameover__title">SIGNAL LOST</p>' +
-        '<p class="hero-galaga-gameover__line">The Pacific Static swallowed the feed.</p>' +
+        '<p class="hero-galaga-gameover__line">LIONS GATE destroyed.</p>' +
         '<p class="hero-galaga-gameover__stats">Score: <span data-galaga-final-score>000000</span></p>' +
         '<p class="hero-galaga-gameover__stats">Wave: <span data-galaga-final-wave>1</span></p>' +
         '<p class="hero-galaga-gameover__line">Press G to reboot.</p>' +
@@ -134,6 +135,7 @@
       shakePower: 0,
       waveCallUntil: 0,
       nextWaveAt: 0,
+      gameOverReason: '',
       playfield: {
         x: 0,
         y: 0,
@@ -279,7 +281,7 @@
       idlePanelEl.hidden = !isIdle;
       gameOverPanelEl.hidden = !isGameOver;
 
-      hintTextEl.innerHTML = 'PACIFIC STATIC<br>Defend the Vancouver signal.<br>Press G to play.<br>WASD move // Space fire // Esc quit';
+      hintTextEl.innerHTML = 'PACIFIC STATIC<br>Vessel: LIONS GATE<br>Defend the Vancouver signal.<br>Press G to play.<br>WASD move // Space fire // Esc quit';
       if (startButton) {
         startButton.hidden = !isIdle;
       }
@@ -390,7 +392,6 @@
         y: state.playfield.y + state.playfield.h - 14 - 18,
         speed: 320,
         invulnerableUntil: 0,
-        hitFlashUntil: 0,
       };
       clampPlayerToPlayfield();
     }
@@ -400,6 +401,7 @@
       state.lives = 3;
       state.wave = 1;
       state.wavePending = false;
+      state.gameOverReason = '';
       state.playerBullets = [];
       state.enemyBullets = [];
       state.lastShotAt = 0;
@@ -497,7 +499,11 @@
     }
 
     function triggerGameOver(reason) {
-      debugLog('game over', reason || 'unknown');
+      if (state.mode === 'gameover') {
+        return;
+      }
+      state.gameOverReason = reason || 'unknown';
+      debugLog('triggerGameOver', state.gameOverReason);
       state.keys.left = false;
       state.keys.right = false;
       state.keys.fire = false;
@@ -573,21 +579,31 @@
       return Boolean(state.player && state.player.invulnerableUntil > nowMs());
     }
 
-    function damagePlayer() {
-      if (!state.player || isPlayerInvulnerable() || state.mode !== 'playing') {
+    function spawnPlayerHitEffect() {
+      if (!state.player) {
+        return;
+      }
+      spawnExplosion(state.player.x + state.player.w / 2, state.player.y + state.player.h / 2, 20, [colors.magentaRain, '#ffffff', colors.secondary]);
+      triggerShake(4, 220);
+    }
+
+    function damagePlayer(reason) {
+      const damageReason = reason || 'hit';
+      if (!state.player || state.mode !== 'playing') {
+        return;
+      }
+      if (isPlayerInvulnerable()) {
         return;
       }
 
-      state.lives -= 1;
+      state.lives = Math.max(0, state.lives - 1);
       state.player.invulnerableUntil = nowMs() + 1500;
-      state.player.hitFlashUntil = state.player.invulnerableUntil;
-      spawnExplosion(state.player.x + state.player.w / 2, state.player.y + state.player.h / 2, 20, [colors.magentaRain, '#ffffff', colors.secondary]);
-      triggerShake(4, 220);
+      spawnPlayerHitEffect();
+      debugLog('damagePlayer', { reason: damageReason, lives: state.lives });
 
       if (state.lives <= 0) {
-        state.lives = 0;
         updateUI();
-        triggerGameOver('no_lives');
+        triggerGameOver(damageReason);
         return;
       }
 
@@ -838,7 +854,7 @@
           );
 
           if (hit) {
-            damagePlayer();
+            damagePlayer('projectile');
             return false;
           }
           return true;
@@ -861,7 +877,7 @@
           };
           if (intersects(playerBox, enemyHitbox)) {
             destroyEnemy(enemy);
-            damagePlayer();
+            damagePlayer('collision');
           }
         });
       }
@@ -877,10 +893,7 @@
       });
 
       if (invaded && state.mode === 'playing') {
-        state.lives = 0;
-        updateUI();
-        triggerGameOver('invaded');
-        return;
+        damagePlayer('invaded');
       }
 
       updateWaveProgression(nowMs());
@@ -991,7 +1004,9 @@
       ctx.beginPath();
       ctx.rect(state.playfield.x, state.playfield.y, state.playfield.w, state.playfield.h);
       ctx.clip();
-      ctx.fillStyle = isPlaying() ? 'rgba(0, 0, 0, 0.46)' : 'rgba(0, 0, 0, 0.18)';
+      ctx.fillStyle = isPlaying()
+        ? 'rgba(0, 0, 0, 0.46)'
+        : (state.mode === 'gameover' ? 'rgba(0, 0, 0, 0.62)' : 'rgba(0, 0, 0, 0.18)');
       ctx.fillRect(state.playfield.x, state.playfield.y, state.playfield.w, state.playfield.h);
 
       drawPlayer(renderNow);

--- a/page-home.php
+++ b/page-home.php
@@ -75,7 +75,7 @@ get_header();
         <div class="hero-game-stage" tabindex="0" aria-label="Pacific Static mini arcade game">
             <p class="hero-game-stage__header pixel-font"><?php echo esc_html('PACIFIC STATIC'); ?></p>
             <div class="hero-game-stage__screen" role="region" aria-label="Pacific Static game screen">
-                <p class="hero-game-stage__idle pixel-font"><?php echo esc_html('PACIFIC STATIC'); ?><br><?php echo esc_html('Defend the Vancouver signal.'); ?><br><?php echo esc_html('Press G to play.'); ?><br><?php echo esc_html('WASD move // Space fire // Esc quit'); ?></p>
+                <p class="hero-game-stage__idle pixel-font"><?php echo esc_html('PACIFIC STATIC'); ?><br><?php echo esc_html('Vessel: LIONS GATE'); ?><br><?php echo esc_html('Defend the Vancouver signal.'); ?><br><?php echo esc_html('Press G to play.'); ?><br><?php echo esc_html('WASD move // Space fire // Esc quit'); ?></p>
             </div>
             <p class="hero-game-stage__mobile-note"><?php echo esc_html('Mini arcade available on keyboard screens.'); ?></p>
         </div>

--- a/style.css
+++ b/style.css
@@ -2900,12 +2900,15 @@ body {
 }
 
 .page-template-page-home-php .hero-galaga-status,
+.page-template-page-home-php .hero-galaga-vessel,
 .page-template-page-home-php .hero-galaga-scoreline,
 .page-template-page-home-php .hero-galaga-help,
 .home .hero-galaga-status,
+.home .hero-galaga-vessel,
 .home .hero-galaga-scoreline,
 .home .hero-galaga-help,
 .front-page .hero-galaga-status,
+.front-page .hero-galaga-vessel,
 .front-page .hero-galaga-scoreline,
 .front-page .hero-galaga-help {
   margin: 0;
@@ -2931,6 +2934,12 @@ body {
 .front-page .hero-galaga-help {
   margin-top: 0;
   color: var(--accent-color);
+}
+
+.page-template-page-home-php .hero-galaga-vessel,
+.home .hero-galaga-vessel,
+.front-page .hero-galaga-vessel {
+  color: #cbffe7;
 }
 
 .page-template-page-home-php .hero-galaga-wavecall,
@@ -3095,6 +3104,17 @@ body {
 .front-page .hero-game-stage[data-galaga-state="gameover"] .hero-galaga-overlay {
   display: flex;
   pointer-events: auto;
+}
+
+.page-template-page-home-php .hero-game-stage[data-galaga-state="gameover"] .hero-game-stage__screen::before,
+.home .hero-game-stage[data-galaga-state="gameover"] .hero-game-stage__screen::before,
+.front-page .hero-game-stage[data-galaga-state="gameover"] .hero-game-stage__screen::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 5;
+  pointer-events: none;
 }
 
 .page-template-page-home-php .hero-game-stage[data-galaga-state="gameover"] .hero-galaga-scoreline,


### PR DESCRIPTION
### Motivation
- The mini-game treated enemy collisions as immediate fatal crashes and allowed repeated game-over triggers, causing the overlay to appear while sprites remained active and the loop felt stuck.
- Small UX tweak to introduce a vessel name (LIONS GATE) in HUD/idle/game-over copy for a tasteful in-game identity detail.

### Description
- Centralized player damage into a single `damagePlayer(reason)` path that enforces invulnerability windows, clamps `state.lives` to never go negative, spawns hit FX, and only calls `triggerGameOver(...)` when lives reach 0.
- Routed enemy body collisions, enemy projectiles, and invasion conditions through `damagePlayer('collision'|'projectile'|'invaded')` and ensured enemies/bullets are removed on hit so one contact cannot drain multiple lives.
- Hardened `triggerGameOver(reason)` with an early guard to prevent repeated calls and store a `state.gameOverReason`, and ensured inputs/projectiles are cleared and the loop stopped cleanly when game-over is entered.
- Added `spawnPlayerHitEffect()` to encapsulate explosion/shake effects and made the player temporarily invulnerable and flicker after damage for ~1.5s.
- UI/copy changes: added a compact `Vessel: LIONS GATE` HUD line and updated idle and game-over copy to reference the vessel; updated `debugLog` to use `console.debug` when debug is enabled.
- Visual polish: dim the playfield slightly on game-over via a CSS pseudo-element so the frozen frame behind the SIGNAL LOST panel reads intentionally, and added styling for the new vessel HUD label.
- Files changed: `js/hero-galaga.js`, `style.css`, and `page-home.php` (idle text).

### Testing
- `node --check js/hero-galaga.js` — succeeded. 
- `php -l page-home.php` — succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efc3d58a70832eae06f8f6daed5b09)