### PR TITLE
Promote Active incidents on Lousy Outages and add VanOps Radar page template

### DIFF
--- a/assets/css/lousy-outages-page.css
+++ b/assets/css/lousy-outages-page.css
@@ -22,3 +22,22 @@
 .page-slug-lousy-outages .entry-header {
     scroll-margin-top: 80px;
 }
+
+.lousy-outages-page .lousy-outages-root {
+    display: grid;
+    gap: 20px;
+}
+
+.lousy-outages-page .lo-status-board {
+    margin-top: 8px;
+}
+
+.lousy-outages-page .lo-panel--report {
+    margin-top: 0;
+}
+
+@media (max-width: 768px) {
+    .lousy-outages-page .lousy-outages-root {
+        gap: 16px;
+    }
+}

--- a/assets/css/vanops-radar.css
+++ b/assets/css/vanops-radar.css
@@ -1,0 +1,140 @@
+.vanops-radar-page {
+  background: radial-gradient(circle at 10% 15%, rgba(90, 255, 206, 0.08), transparent 35%),
+    radial-gradient(circle at 85% 0%, rgba(126, 190, 255, 0.14), transparent 35%),
+    #0a1020;
+  color: #e9f2ff;
+}
+
+.vanops-radar {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 24px 16px 40px;
+  display: grid;
+  gap: 18px;
+}
+
+.vanops-card {
+  border: 1px solid rgba(128, 227, 214, 0.42);
+  border-radius: 14px;
+  padding: 18px;
+  background: linear-gradient(160deg, rgba(17, 28, 56, 0.94), rgba(9, 15, 32, 0.95));
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+}
+
+.vanops-eyebrow {
+  margin: 0 0 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.78rem;
+  color: #8ef8e6;
+}
+
+.vanops-hero h1,
+.vanops-section h2 {
+  margin: 0 0 10px;
+  line-height: 1.2;
+}
+
+.vanops-lede,
+.vanops-section p {
+  margin: 0;
+  color: rgba(233, 242, 255, 0.88);
+  max-width: 75ch;
+}
+
+.vanops-grid {
+  margin-top: 14px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.vanops-tile {
+  border: 1px solid rgba(142, 248, 230, 0.28);
+  border-radius: 12px;
+  padding: 14px;
+  background: rgba(7, 12, 24, 0.6);
+}
+
+.vanops-tile h3 {
+  margin: 0 0 8px;
+  font-size: 1rem;
+}
+
+.vanops-tile p {
+  margin: 0;
+  font-size: 0.92rem;
+}
+
+.vanops-tile span {
+  margin-top: 10px;
+  display: inline-block;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: rgba(255, 194, 102, 0.16);
+  border: 1px solid rgba(255, 194, 102, 0.45);
+  color: #ffd697;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.vanops-tile--live span {
+  background: rgba(132, 255, 193, 0.16);
+  border-color: rgba(132, 255, 193, 0.48);
+  color: #a6ffd0;
+}
+
+.vanops-live-preview .lousy-outages {
+  margin-top: 12px;
+}
+
+.vanops-skill-list {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 8px;
+}
+
+.vanops-button {
+  margin-top: 14px;
+  display: inline-block;
+  text-decoration: none;
+  color: #06141f;
+  background: linear-gradient(135deg, #88f7e2, #6ed4ff);
+  border: 1px solid rgba(173, 245, 255, 0.8);
+  border-radius: 999px;
+  padding: 10px 16px;
+  font-weight: 600;
+}
+
+.vanops-cta p {
+  margin-top: 8px;
+}
+
+.vanops-disclaimer {
+  margin: 0;
+  color: rgba(233, 242, 255, 0.72);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+@media (max-width: 900px) {
+  .vanops-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .vanops-radar {
+    padding: 18px 12px 30px;
+  }
+
+  .vanops-card {
+    padding: 14px;
+  }
+
+  .vanops-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/functions.php
+++ b/functions.php
@@ -132,6 +132,17 @@ function se_enqueue_lousy_outages_page_styles() {
 }
 add_action( 'wp_enqueue_scripts', 'se_enqueue_lousy_outages_page_styles' );
 
+function se_enqueue_vanops_radar_styles() {
+    if ( is_page_template( 'page-vanops-radar.php' ) || is_page( 'vanops-radar' ) ) {
+        $dir = get_stylesheet_directory();
+        $uri = get_stylesheet_directory_uri();
+        $path = '/assets/css/vanops-radar.css';
+        $version = file_exists( $dir . $path ) ? filemtime( $dir . $path ) : null;
+        wp_enqueue_style( 'se-vanops-radar', $uri . $path, array(), $version );
+    }
+}
+add_action( 'wp_enqueue_scripts', 'se_enqueue_vanops_radar_styles' );
+
 function se_enqueue_asmr_lab_assets() {
     if ( ! is_page_template( 'page-asmr-lab.php' ) ) {
         return;

--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -153,6 +153,7 @@
 
 .lo-incidents {
   display: block;
+  margin-bottom: 18px;
 }
 
 .lo-section {
@@ -693,9 +694,9 @@
 
 .lo-history__body {
   margin-top: 12px;
-  max-height: 80vh;
-  overflow-y: auto;
-  padding-right: 6px;
+  max-height: none;
+  overflow: visible;
+  padding-right: 0;
 }
 
 .lo-history__list {

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -536,6 +536,44 @@ function render_shortcode(): string {
             <button type="button" class="lo-mode-toggle__button is-active" data-lo-mode="incidents" aria-pressed="true">Incidents (0)</button>
             <button type="button" class="lo-mode-toggle__button" data-lo-mode="all" aria-pressed="false">All providers</button>
         </div>
+        <div class="lo-incidents" data-lo-incidents>
+            <section class="lo-section lo-section--incidents" data-lo-section="incidents">
+                <div class="lo-section__head">
+                    <h3 class="lo-block-title">Active incidents</h3>
+                </div>
+                <div class="lo-grid lo-grid--section" data-lo-section-grid="incidents"></div>
+            </section>
+            <section class="lo-section lo-section--collapsible" data-lo-section="signals">
+                <div class="lo-section__head">
+                    <button type="button" class="lo-section__toggle" data-lo-section-toggle="signals" aria-expanded="false">Signals (0)</button>
+                </div>
+                <div class="lo-grid lo-grid--section" data-lo-section-grid="signals" hidden></div>
+            </section>
+            <section class="lo-section lo-section--collapsible" data-lo-section="unverified">
+                <div class="lo-section__head">
+                    <button type="button" class="lo-section__toggle" data-lo-section-toggle="unverified" aria-expanded="false">Can’t verify (0)</button>
+                </div>
+                <div class="lo-grid lo-grid--section" data-lo-section-grid="unverified" hidden></div>
+            </section>
+        </div>
+        <?php if (LO_SHOW_WIDESPREAD) : ?>
+        <div class="lo-trending" data-lo-trending<?php echo $trending_active ? '' : ' hidden'; ?> data-lo-trending-generated="<?php echo esc_attr($trending_generated); ?>" aria-live="assertive">
+            <span class="lo-trending__icon" aria-hidden="true">⚡</span>
+            <div class="lo-trending__body">
+                <strong data-lo-trending-text>Potential widespread issues detected — check affected providers</strong>
+                <span class="lo-trending__reasons" data-lo-trending-reasons<?php echo $trending_signals ? '' : ' hidden'; ?>><?php echo esc_html($trending_signals ? 'Signals: ' . implode(', ', array_slice($trending_signals, 0, 6)) : ''); ?></span>
+            </div>
+        </div>
+        <?php endif; ?>
+        <div class="lo-hero" data-lo-hero hidden>
+            <article class="lo-card lo-card--hero">
+                <div class="lo-head">
+                    <h3 class="lo-title">No active incidents</h3>
+                </div>
+                <p class="lo-summary">Signals and verification issues are hidden by default.</p>
+                <p class="lo-card-meta">Last checked: <span data-lo-hero-time>—</span></p>
+            </article>
+        </div>
         <section class="lo-history" data-lo-history>
             <div class="lo-history__heading">
                 <div>
@@ -566,25 +604,7 @@ function render_shortcode(): string {
                 <p class="lo-history__error" data-lo-history-error hidden>Unable to load incident history right now.</p>
             </div>
         </section>
-        <?php if (LO_SHOW_WIDESPREAD) : ?>
-        <div class="lo-trending" data-lo-trending<?php echo $trending_active ? '' : ' hidden'; ?> data-lo-trending-generated="<?php echo esc_attr($trending_generated); ?>" aria-live="assertive">
-            <span class="lo-trending__icon" aria-hidden="true">⚡</span>
-            <div class="lo-trending__body">
-                <strong data-lo-trending-text>Potential widespread issues detected — check affected providers</strong>
-                <span class="lo-trending__reasons" data-lo-trending-reasons<?php echo $trending_signals ? '' : ' hidden'; ?>><?php echo esc_html($trending_signals ? 'Signals: ' . implode(', ', array_slice($trending_signals, 0, 6)) : ''); ?></span>
-            </div>
-        </div>
-        <?php endif; ?>
         <?php echo render_subscribe_shortcode(); ?>
-        <div class="lo-hero" data-lo-hero hidden>
-            <article class="lo-card lo-card--hero">
-                <div class="lo-head">
-                    <h3 class="lo-title">No active incidents</h3>
-                </div>
-                <p class="lo-summary">Signals and verification issues are hidden by default.</p>
-                <p class="lo-card-meta">Last checked: <span data-lo-hero-time>—</span></p>
-            </article>
-        </div>
         <div class="lo-external" data-lo-external>
             <article class="lo-card lo-card--external" data-provider-id="external-signals">
                 <div class="lo-head">
@@ -601,26 +621,6 @@ function render_shortcode(): string {
                     <?php endforeach; ?>
                 </ul>
             </article>
-        </div>
-        <div class="lo-incidents" data-lo-incidents>
-            <section class="lo-section lo-section--incidents" data-lo-section="incidents">
-                <div class="lo-section__head">
-                    <h3 class="lo-block-title">Active incidents</h3>
-                </div>
-                <div class="lo-grid lo-grid--section" data-lo-section-grid="incidents"></div>
-            </section>
-            <section class="lo-section lo-section--collapsible" data-lo-section="signals">
-                <div class="lo-section__head">
-                    <button type="button" class="lo-section__toggle" data-lo-section-toggle="signals" aria-expanded="false">Signals (0)</button>
-                </div>
-                <div class="lo-grid lo-grid--section" data-lo-section-grid="signals" hidden></div>
-            </section>
-            <section class="lo-section lo-section--collapsible" data-lo-section="unverified">
-                <div class="lo-section__head">
-                    <button type="button" class="lo-section__toggle" data-lo-section-toggle="unverified" aria-expanded="false">Can’t verify (0)</button>
-                </div>
-                <div class="lo-grid lo-grid--section" data-lo-section-grid="unverified" hidden></div>
-            </section>
         </div>
         <div class="lo-settings" data-lo-settings>
             <h3 class="lo-block-title">Customize view</h3>

--- a/page-lousy-outages.php
+++ b/page-lousy-outages.php
@@ -49,13 +49,33 @@ if ($unsub_success) {
   <div class="lousy-outages-root">
     <div class="lo-atmosphere">
       <h1 class="retro-title glow-lite">Lousy Outages</h1>
-      <p class="lo-atmosphere__lede">Retro radar for when the internet goes sideways.</p>
+      <p class="lo-atmosphere__lede">Live-ish radar for provider weirdness, broken SaaS, and internet gremlins.</p>
     </div>
     <?php if ($banner) : ?>
       <div class="lo-banner lo-banner--<?php echo esc_attr($tone); ?>">
         <p><?php echo esc_html($banner); ?></p>
       </div>
     <?php endif; ?>
+    <section class="lo-status-board">
+      <div class="lo-status-board__frame">
+        <header class="lo-status-board__header">
+          <div class="lo-status-board__lights" aria-hidden="true">
+            <span class="lo-led lo-led--green"></span>
+            <span class="lo-led lo-led--amber"></span>
+            <span class="lo-led lo-led--red"></span>
+          </div>
+          <div class="lo-status-board__titles">
+            <p class="lo-status-board__eyebrow">System Status Console</p>
+            <h2 class="lo-status-board__title">Current Outages</h2>
+          </div>
+          <div class="lo-status-board__badge" aria-hidden="true">v4.0 arcade build</div>
+        </header>
+        <div class="lo-status-board__body">
+          <div class="lo-scanline" aria-hidden="true"></div>
+          <?php echo do_shortcode('[lousy_outages]'); ?>
+        </div>
+      </div>
+    </section>
     <section class="lo-panel lo-panel--report" data-lo-report>
       <header class="lo-panel__header">
         <h2 class="lo-panel__title">Report a problem</h2>
@@ -139,26 +159,6 @@ if ($unsub_success) {
           <p class="lo-report__status" data-lo-report-status aria-live="polite"></p>
         </div>
       </form>
-    </section>
-    <section class="lo-status-board">
-      <div class="lo-status-board__frame">
-        <header class="lo-status-board__header">
-          <div class="lo-status-board__lights" aria-hidden="true">
-            <span class="lo-led lo-led--green"></span>
-            <span class="lo-led lo-led--amber"></span>
-            <span class="lo-led lo-led--red"></span>
-          </div>
-          <div class="lo-status-board__titles">
-            <p class="lo-status-board__eyebrow">System Status Console</p>
-            <h2 class="lo-status-board__title">Current Outages</h2>
-          </div>
-          <div class="lo-status-board__badge" aria-hidden="true">v4.0 arcade build</div>
-        </header>
-        <div class="lo-status-board__body">
-          <div class="lo-scanline" aria-hidden="true"></div>
-          <?php echo do_shortcode('[lousy_outages]'); ?>
-        </div>
-      </div>
     </section>
     <footer class="lo-support">
       <p class="lo-support__lead">If this dashboard makes your on-call a little less lousy, you can help keep it running:</p>

--- a/page-vanops-radar.php
+++ b/page-vanops-radar.php
@@ -1,0 +1,82 @@
+<?php
+/* Template Name: VanOps Radar */
+get_header();
+
+$work_with_suzy_page = get_page_by_path('work-with-suzy');
+$cta_url = ($work_with_suzy_page instanceof WP_Post)
+    ? get_permalink($work_with_suzy_page)
+    : 'mailto:suzyeaston@icloud.com?subject=VanOps%20Radar%20Custom%20Dashboard';
+?>
+
+<main class="vanops-radar-page">
+  <div class="vanops-radar">
+    <section class="vanops-hero vanops-card">
+      <p class="vanops-eyebrow">Vancouver operations intelligence for storefronts, venues, offices, and local teams.</p>
+      <h1>VanOps Radar</h1>
+      <p class="vanops-lede">A lightweight status and disruption board for Vancouver businesses that need to know what might affect customers, staff, deliveries, bookings, and events.</p>
+      <a class="vanops-button" href="<?php echo esc_url($cta_url); ?>">Ask about a custom dashboard</a>
+    </section>
+
+    <section class="vanops-section vanops-card">
+      <header>
+        <h2>What it watches</h2>
+        <p>Live today + planned connectors for broader local operations context.</p>
+      </header>
+      <div class="vanops-grid vanops-grid--watch">
+        <article class="vanops-tile vanops-tile--live"><h3>Internet/service outages</h3><p>Live now via provider status and incident feed monitoring.</p><span>Live signal</span></article>
+        <article class="vanops-tile"><h3>Road and access disruptions</h3><p>Traffic constraints around customer access, deliveries, and staffing routes.</p><span>Planned connector</span></article>
+        <article class="vanops-tile"><h3>Weather weirdness</h3><p>Localized weather patterns that trigger operational changes.</p><span>Coming next</span></article>
+        <article class="vanops-tile"><h3>Transit/service advisories</h3><p>Service disruptions that impact shift coverage and commute reliability.</p><span>Planned connector</span></article>
+        <article class="vanops-tile"><h3>Power/utility issues</h3><p>Utility incidents and restoration windows relevant to business continuity.</p><span>Coming next</span></article>
+        <article class="vanops-tile"><h3>Event-day operational risks</h3><p>Major crowd and schedule days including sports, concerts, and city events.</p><span>Planned connector</span></article>
+      </div>
+    </section>
+
+    <section class="vanops-section vanops-card vanops-live-preview">
+      <header>
+        <h2>Live provider signal preview</h2>
+        <p>Current production feed from the Lousy Outages status engine.</p>
+      </header>
+      <?php echo do_shortcode('[lousy_outages]'); ?>
+    </section>
+
+    <section class="vanops-section vanops-card">
+      <header>
+        <h2>Business use cases</h2>
+      </header>
+      <div class="vanops-grid vanops-grid--cases">
+        <article class="vanops-tile"><h3>Cafés and restaurants</h3><p>Plan staffing, deliveries, and POS contingency during provider instability.</p></article>
+        <article class="vanops-tile"><h3>Venues and event teams</h3><p>Track service risk before doors open and during guest-heavy windows.</p></article>
+        <article class="vanops-tile"><h3>Agencies and studios</h3><p>Prevent deadline surprises with visible signal checks for critical SaaS.</p></article>
+        <article class="vanops-tile"><h3>Retail storefronts</h3><p>Adapt staffing and customer messaging when service disruptions hit.</p></article>
+        <article class="vanops-tile"><h3>Coworking spaces</h3><p>Give members quick heads-up context on internet and platform reliability.</p></article>
+        <article class="vanops-tile"><h3>Local operators for WC26 surge days</h3><p>Prepare ahead for demand spikes and citywide operational pressure.</p></article>
+      </div>
+    </section>
+
+    <section class="vanops-section vanops-card">
+      <header>
+        <h2>Built by Suzanne Easton</h2>
+      </header>
+      <ul class="vanops-skill-list">
+        <li>IT Operations</li>
+        <li>QA automation</li>
+        <li>WordPress custom theme development</li>
+        <li>JavaScript dashboard UI</li>
+        <li>REST/API integration</li>
+        <li>civic/open-data product thinking</li>
+        <li>AI-assisted summarization roadmap</li>
+      </ul>
+    </section>
+
+    <section class="vanops-section vanops-card vanops-cta">
+      <h2>Need a status board for your business?</h2>
+      <p>I can build lightweight dashboards that pull together service health, public disruption feeds, and plain-language operational notes — without making your team babysit twelve tabs.</p>
+      <a class="vanops-button" href="<?php echo esc_url($cta_url); ?>">Work with Suzy</a>
+    </section>
+
+    <p class="vanops-disclaimer">VanOps Radar is an informational operations dashboard, not an emergency alert system. Always check official sources for safety-critical updates.</p>
+  </div>
+</main>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
### Motivation
- Make the most useful live status content (Active incidents) appear at the top of the existing Lousy Outages page so visitors see live outage tiles first. 
- Provide a business-facing wrapper called VanOps Radar that reuses the existing Lousy Outages status engine but frames it for Vancouver SMBs without renaming or duplicating plugin internals. 
- Preserve existing report/subscribe/history features and avoid breaking other theme features that rely on the status engine.

### Description
- Reordered `page-lousy-outages.php` so the hero and banner stay first and the status board (`<?php echo do_shortcode('[lousy_outages]'); ?>`) is rendered immediately after them, with the report form moved below and the support/footer kept after the form. 
- Updated the Lousy Outages lede copy to: "Live-ish radar for provider weirdness, broken SaaS, and internet gremlins." in `page-lousy-outages.php`. 
- Reworked `lousy-outages/public/shortcode.php` to render the **Active incidents** grid (and the adjacent Signals / Can’t verify collapsible sections) before history, subscribe, external signals, customize view, and the all-providers grid, while keeping the `Incidents / All providers` toggle and subscribe/history blocks intact. 
- Adjusted CSS to improve spacing and remove the inner history scroll container by editing `assets/css/lousy-outages-page.css` and `lousy-outages/assets/lousy-outages.css` so the promoted incidents feel less trapped and mobile layout remains usable. 
- Added a new WordPress page template `page-vanops-radar.php` (Template Name: VanOps Radar) that includes business-facing sections and embeds the live preview via the existing `[lousy_outages]` shortcode. 
- Added `assets/css/vanops-radar.css` for the VanOps Radar template styling and registered an enqueue in `functions.php` (`se_enqueue_vanops_radar_styles`) so the stylesheet is loaded only for the `page-vanops-radar.php` template or `vanops-radar` slug. 

### Testing
- Ran PHP syntax checks with `php -l` against `page-lousy-outages.php`, `page-vanops-radar.php`, `lousy-outages/public/shortcode.php`, and `functions.php`, and all returned "No syntax errors detected.". 
- Manual review of the modified templates and styles was performed to ensure the status shortcode remains `do_shortcode('[lousy_outages]')` and no plugin shortcodes/routes/namespaces were renamed. 
- Confirmed the Lousy Outages layout now places the status board before the report form and that `VanOps Radar` template files exist and will enqueue `assets/css/vanops-radar.css` when used.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efcdf14b30832e90afb3d840fe12fa)