### PR TITLE
Refocus VanOps Radar on Vancouver SMB ops and feature it on homepage

### DIFF
--- a/assets/css/vanops-radar.css
+++ b/assets/css/vanops-radar.css
@@ -6,26 +6,26 @@
 }
 
 .vanops-radar {
-  max-width: 1100px;
+  max-width: 1120px;
   margin: 0 auto;
-  padding: 24px 16px 40px;
+  padding: 28px 16px 44px;
   display: grid;
   gap: 18px;
 }
 
 .vanops-card {
-  border: 1px solid rgba(128, 227, 214, 0.42);
+  border: 1px solid rgba(128, 227, 214, 0.38);
   border-radius: 14px;
-  padding: 18px;
+  padding: 20px;
   background: linear-gradient(160deg, rgba(17, 28, 56, 0.94), rgba(9, 15, 32, 0.95));
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.34);
 }
 
 .vanops-eyebrow {
   margin: 0 0 8px;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  font-size: 0.78rem;
+  font-size: 0.77rem;
   color: #8ef8e6;
 }
 
@@ -36,10 +36,46 @@
 }
 
 .vanops-lede,
+.vanops-support,
 .vanops-section p {
   margin: 0;
-  color: rgba(233, 242, 255, 0.88);
-  max-width: 75ch;
+  color: rgba(233, 242, 255, 0.9);
+  max-width: 78ch;
+  line-height: 1.55;
+}
+
+.vanops-support {
+  margin-top: 10px;
+}
+
+.vanops-actions {
+  margin-top: 16px;
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.vanops-button {
+  display: inline-block;
+  text-decoration: none;
+  color: #06141f;
+  background: linear-gradient(135deg, #88f7e2, #6ed4ff);
+  border: 1px solid rgba(173, 245, 255, 0.8);
+  border-radius: 999px;
+  padding: 10px 16px;
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+.vanops-button--secondary {
+  color: #daf7ff;
+  background: rgba(110, 212, 255, 0.1);
+  border-color: rgba(142, 248, 230, 0.5);
+}
+
+.vanops-section header {
+  display: grid;
+  gap: 8px;
 }
 
 .vanops-grid {
@@ -49,43 +85,70 @@
   gap: 12px;
 }
 
-.vanops-tile {
+.vanops-tile,
+.vanops-signal-card {
   border: 1px solid rgba(142, 248, 230, 0.28);
   border-radius: 12px;
   padding: 14px;
-  background: rgba(7, 12, 24, 0.6);
+  background: rgba(7, 12, 24, 0.62);
 }
 
-.vanops-tile h3 {
+.vanops-tile h3,
+.vanops-signal-card h3 {
   margin: 0 0 8px;
   font-size: 1rem;
 }
 
-.vanops-tile p {
+.vanops-tile p,
+.vanops-signal-card p {
   margin: 0;
   font-size: 0.92rem;
+  line-height: 1.45;
 }
 
-.vanops-tile span {
-  margin-top: 10px;
-  display: inline-block;
+.vanops-signal-card p + p {
+  margin-top: 8px;
+}
+
+.vanops-status-pill {
+  display: inline-flex;
+  align-items: center;
   padding: 3px 8px;
   border-radius: 999px;
   background: rgba(255, 194, 102, 0.16);
   border: 1px solid rgba(255, 194, 102, 0.45);
   color: #ffd697;
   font-size: 0.72rem;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.05em;
 }
 
-.vanops-tile--live span {
-  background: rgba(132, 255, 193, 0.16);
-  border-color: rgba(132, 255, 193, 0.48);
-  color: #a6ffd0;
+.vanops-status-pill--demo {
+  background: rgba(126, 190, 255, 0.2);
+  border-color: rgba(126, 190, 255, 0.52);
+  color: #b8ddff;
 }
 
-.vanops-live-preview .lousy-outages {
+.vanops-status-pill--roadmap {
+  background: rgba(184, 145, 255, 0.18);
+  border-color: rgba(184, 145, 255, 0.46);
+  color: #dcc8ff;
+}
+
+.vanops-signal-meta {
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.vanops-use-case-grid .vanops-tile {
+  min-height: 148px;
+}
+
+.vanops-data-roadmap .vanops-skill-list {
   margin-top: 12px;
 }
 
@@ -94,18 +157,6 @@
   padding-left: 18px;
   display: grid;
   gap: 8px;
-}
-
-.vanops-button {
-  margin-top: 14px;
-  display: inline-block;
-  text-decoration: none;
-  color: #06141f;
-  background: linear-gradient(135deg, #88f7e2, #6ed4ff);
-  border: 1px solid rgba(173, 245, 255, 0.8);
-  border-radius: 999px;
-  padding: 10px 16px;
-  font-weight: 600;
 }
 
 .vanops-cta p {
@@ -119,7 +170,7 @@
   text-align: center;
 }
 
-@media (max-width: 900px) {
+@media (max-width: 960px) {
   .vanops-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -127,7 +178,7 @@
 
 @media (max-width: 640px) {
   .vanops-radar {
-    padding: 18px 12px 30px;
+    padding: 18px 12px 32px;
   }
 
   .vanops-card {
@@ -136,5 +187,15 @@
 
   .vanops-grid {
     grid-template-columns: 1fr;
+  }
+
+  .vanops-actions {
+    flex-direction: column;
+  }
+
+  .vanops-button,
+  .vanops-button--secondary {
+    text-align: center;
+    width: 100%;
   }
 }

--- a/page-home.php
+++ b/page-home.php
@@ -135,6 +135,12 @@ get_header();
                 <a class="pixel-button" href="<?php echo esc_url(home_url('/page-gastown-sim/')); ?>">Enter Gastown</a>
             </article>
             <article class="selected-work__card">
+                <h3 class="pixel-font">VanOps Radar</h3>
+                <p>Vancouver operations intelligence for storefronts, venues, offices, and local teams — a practical disruption board for road access, transit, weather, utility issues, event-day risks, and business continuity signals.</p>
+                <p class="selected-work__tags" aria-label="VanOps Radar technology tags"><span>Vancouver Ops</span><span>Civic Data</span><span>Dashboards</span></p>
+                <a class="pixel-button" href="<?php echo esc_url(home_url('/vanops-radar/')); ?>">Open VanOps Radar</a>
+            </article>
+            <article class="selected-work__card">
                 <h3 class="pixel-font">Track Analyzer</h3>
                 <p>AI feedback tool for musicians: upload a track, get practical mix notes, and move faster from “something&rsquo;s off” to “that&rsquo;s the problem.”</p>
                 <p class="selected-work__tags" aria-label="Track Analyzer technology tags"><span>AI</span><span>Audio</span><span>Musician tools</span></p>
@@ -142,9 +148,9 @@ get_header();
             </article>
             <article class="selected-work__card">
                 <h3 class="pixel-font">Lousy Outages</h3>
-                <p>Retro terminal outage tracker for modern service chaos: status clarity, provider feeds, alert hooks, and public utility.</p>
-                <p class="selected-work__tags" aria-label="Lousy Outages technology tags"><span>APIs</span><span>Monitoring</span><span>WordPress</span></p>
-                <a class="pixel-button" href="<?php echo esc_url(home_url('/lousy-outages/')); ?>">View Outages</a>
+                <p>Retro internet/provider outage tracker and status-page experiment — the weird monitoring lab behind some of the signal ideas.</p>
+                <p class="selected-work__tags" aria-label="Lousy Outages technology tags"><span>Status Pages</span><span>Monitoring</span><span>Retro Lab</span></p>
+                <a class="pixel-button" href="<?php echo esc_url(home_url('/lousy-outages/')); ?>">View Lousy Outages</a>
             </article>
             <article class="selected-work__card">
                 <h3 class="pixel-font">ASMR Lab / Rain City Experiments</h3>

--- a/page-vanops-radar.php
+++ b/page-vanops-radar.php
@@ -11,67 +11,110 @@ $cta_url = ($work_with_suzy_page instanceof WP_Post)
 <main class="vanops-radar-page">
   <div class="vanops-radar">
     <section class="vanops-hero vanops-card">
-      <p class="vanops-eyebrow">Vancouver operations intelligence for storefronts, venues, offices, and local teams.</p>
+      <p class="vanops-eyebrow">Vancouver SMB operations dashboard</p>
       <h1>VanOps Radar</h1>
-      <p class="vanops-lede">A lightweight status and disruption board for Vancouver businesses that need to know what might affect customers, staff, deliveries, bookings, and events.</p>
-      <a class="vanops-button" href="<?php echo esc_url($cta_url); ?>">Ask about a custom dashboard</a>
+      <p class="vanops-lede">A lightweight local disruption board for Vancouver businesses that need to know what might affect customers, staff, deliveries, bookings, and events.</p>
+      <p class="vanops-support">Built for cafés, venues, offices, agencies, retailers, coworking spaces, and local operators who do not have time to babysit twelve tabs before opening.</p>
+      <div class="vanops-actions">
+        <a class="vanops-button" href="<?php echo esc_url($cta_url); ?>">Ask about a custom dashboard</a>
+        <a class="vanops-button vanops-button--secondary" href="#vanops-preview">See the Vancouver ops preview</a>
+      </div>
     </section>
 
     <section class="vanops-section vanops-card">
       <header>
         <h2>What it watches</h2>
-        <p>Live today + planned connectors for broader local operations context.</p>
+        <p>Local-first disruption categories for business planning, staffing, and continuity.</p>
       </header>
       <div class="vanops-grid vanops-grid--watch">
-        <article class="vanops-tile vanops-tile--live"><h3>Internet/service outages</h3><p>Live now via provider status and incident feed monitoring.</p><span>Live signal</span></article>
-        <article class="vanops-tile"><h3>Road and access disruptions</h3><p>Traffic constraints around customer access, deliveries, and staffing routes.</p><span>Planned connector</span></article>
-        <article class="vanops-tile"><h3>Weather weirdness</h3><p>Localized weather patterns that trigger operational changes.</p><span>Coming next</span></article>
-        <article class="vanops-tile"><h3>Transit/service advisories</h3><p>Service disruptions that impact shift coverage and commute reliability.</p><span>Planned connector</span></article>
-        <article class="vanops-tile"><h3>Power/utility issues</h3><p>Utility incidents and restoration windows relevant to business continuity.</p><span>Coming next</span></article>
-        <article class="vanops-tile"><h3>Event-day operational risks</h3><p>Major crowd and schedule days including sports, concerts, and city events.</p><span>Planned connector</span></article>
+        <article class="vanops-tile"><h3>Roads and access</h3><p>Monitor route friction that can affect delivery timing, customer arrivals, and staff punctuality.</p><span class="vanops-status-pill">Planned connector</span></article>
+        <article class="vanops-tile"><h3>Transit and commute</h3><p>Track commute reliability patterns to inform shift planning and service-hour decisions.</p><span class="vanops-status-pill">Planned connector</span></article>
+        <article class="vanops-tile"><h3>Weather and seasonal risk</h3><p>Prepare for rain, heat, snow, wind, and seasonal disruptions that change demand and safety posture.</p><span class="vanops-status-pill">Planned connector</span></article>
+        <article class="vanops-tile"><h3>Power and utilities</h3><p>Plan around utility risk that can impact POS systems, refrigeration, lighting, and Wi-Fi reliability.</p><span class="vanops-status-pill">Planned connector</span></article>
+        <article class="vanops-tile"><h3>Major events and crowd pressure</h3><p>Model high-demand windows and congestion risk around concerts, matches, festivals, and surge days.</p><span class="vanops-status-pill vanops-status-pill--demo">Demo signal</span></article>
+        <article class="vanops-tile"><h3>Public-realm / neighbourhood issues</h3><p>Surface nearby conditions that influence customer confidence, access comfort, and staff safety.</p><span class="vanops-status-pill vanops-status-pill--roadmap">Roadmap</span></article>
       </div>
     </section>
 
-    <section class="vanops-section vanops-card vanops-live-preview">
+    <section id="vanops-preview" class="vanops-section vanops-card vanops-status-board">
       <header>
-        <h2>Live provider signal preview</h2>
-        <p>Current production feed from the Lousy Outages status engine.</p>
+        <h2>Vancouver ops board</h2>
+        <p>A local-first preview of the disruptions VanOps Radar is designed to track for businesses. Live civic connectors are being added carefully; demo and planned signals are labelled clearly.</p>
       </header>
-      <?php echo do_shortcode('[lousy_outages]'); ?>
+      <div class="vanops-grid">
+        <article class="vanops-signal-card">
+          <h3>Road and access disruptions</h3>
+          <p class="vanops-signal-meta"><strong>Data status:</strong> <span class="vanops-status-pill">Planned connector</span></p>
+          <p><strong>Business impact:</strong> Delivery routes, customer access, staff arrival times.</p>
+          <p><strong>Operator action:</strong> Check access routes before peak hours and post customer-facing notes if needed.</p>
+        </article>
+        <article class="vanops-signal-card">
+          <h3>Transit and commute impacts</h3>
+          <p class="vanops-signal-meta"><strong>Data status:</strong> <span class="vanops-status-pill">Planned connector</span></p>
+          <p><strong>Business impact:</strong> Staff scheduling, customer arrival patterns, event-day delays.</p>
+          <p><strong>Operator action:</strong> Watch for commute disruptions before opening, closing, or event windows.</p>
+        </article>
+        <article class="vanops-signal-card">
+          <h3>Weather weirdness</h3>
+          <p class="vanops-signal-meta"><strong>Data status:</strong> <span class="vanops-status-pill">Planned connector</span></p>
+          <p><strong>Business impact:</strong> Patio decisions, staffing, foot traffic, safety prep, and cancellation risk.</p>
+          <p><strong>Operator action:</strong> Prepare rain, heat, snow, or wind contingencies and update booking notes.</p>
+        </article>
+        <article class="vanops-signal-card">
+          <h3>Power and utility issues</h3>
+          <p class="vanops-signal-meta"><strong>Data status:</strong> <span class="vanops-status-pill">Planned connector</span></p>
+          <p><strong>Business impact:</strong> POS systems, refrigeration, Wi-Fi, lighting, and service continuity.</p>
+          <p><strong>Operator action:</strong> Keep offline payment, signage, and customer communication backups ready.</p>
+        </article>
+        <article class="vanops-signal-card">
+          <h3>Major event / crowd pressure</h3>
+          <p class="vanops-signal-meta"><strong>Data status:</strong> <span class="vanops-status-pill vanops-status-pill--demo">Demo signal</span></p>
+          <p><strong>Business impact:</strong> Demand spikes, street congestion, lineups, delivery timing, and customer-flow pressure.</p>
+          <p><strong>Operator action:</strong> Plan staffing, inventory, signage, and service windows around major events.</p>
+        </article>
+        <article class="vanops-signal-card">
+          <h3>Local public-realm issues</h3>
+          <p class="vanops-signal-meta"><strong>Data status:</strong> <span class="vanops-status-pill vanops-status-pill--demo">Demo signal</span></p>
+          <p><strong>Business impact:</strong> Construction, public-space issues, access concerns, and nearby neighbourhood conditions.</p>
+          <p><strong>Operator action:</strong> Track nearby conditions that may affect customer confidence and staff safety.</p>
+        </article>
+      </div>
     </section>
 
     <section class="vanops-section vanops-card">
       <header>
-        <h2>Business use cases</h2>
+        <h2>Built for Vancouver operators</h2>
       </header>
-      <div class="vanops-grid vanops-grid--cases">
-        <article class="vanops-tile"><h3>Cafés and restaurants</h3><p>Plan staffing, deliveries, and POS contingency during provider instability.</p></article>
-        <article class="vanops-tile"><h3>Venues and event teams</h3><p>Track service risk before doors open and during guest-heavy windows.</p></article>
-        <article class="vanops-tile"><h3>Agencies and studios</h3><p>Prevent deadline surprises with visible signal checks for critical SaaS.</p></article>
-        <article class="vanops-tile"><h3>Retail storefronts</h3><p>Adapt staffing and customer messaging when service disruptions hit.</p></article>
-        <article class="vanops-tile"><h3>Coworking spaces</h3><p>Give members quick heads-up context on internet and platform reliability.</p></article>
-        <article class="vanops-tile"><h3>Local operators for WC26 surge days</h3><p>Prepare ahead for demand spikes and citywide operational pressure.</p></article>
+      <div class="vanops-grid vanops-use-case-grid">
+        <article class="vanops-tile"><h3>Storefronts and cafés</h3><p>Adjust opening checklists, staffing, and customer messaging when road access or weather shifts demand.</p></article>
+        <article class="vanops-tile"><h3>Venues and event teams</h3><p>Plan service windows around crowd spikes, transit delays, and event-adjacent neighbourhood pressure.</p></article>
+        <article class="vanops-tile"><h3>Offices and agencies</h3><p>Set practical hybrid-day and client-meeting expectations when commute and utility conditions change.</p></article>
+        <article class="vanops-tile"><h3>Coworking spaces</h3><p>Provide member updates on access, commute, and local disruptions before arrival peaks.</p></article>
+        <article class="vanops-tile"><h3>Retail and service businesses</h3><p>Protect conversion and service continuity with early signals for staffing, delivery, and neighbourhood risks.</p></article>
+        <article class="vanops-tile"><h3>WC26 / major event readiness</h3><p>Prepare for citywide demand surges with staffing, inventory, queue flow, and customer communications plans.</p></article>
       </div>
     </section>
 
-    <section class="vanops-section vanops-card">
+    <section class="vanops-section vanops-card vanops-data-roadmap">
       <header>
-        <h2>Built by Suzanne Easton</h2>
+        <h2>Data roadmap</h2>
       </header>
+      <p>VanOps Radar is designed to connect local operational signals into one readable board. The MVP starts with clearly labelled demo/planned signals, then grows into a real local ops layer.</p>
       <ul class="vanops-skill-list">
-        <li>IT Operations</li>
-        <li>QA automation</li>
-        <li>WordPress custom theme development</li>
-        <li>JavaScript dashboard UI</li>
-        <li>REST/API integration</li>
-        <li>civic/open-data product thinking</li>
-        <li>AI-assisted summarization roadmap</li>
+        <li>City of Vancouver open data</li>
+        <li>Road and access disruption feeds</li>
+        <li>Transit advisories</li>
+        <li>Weather alerts</li>
+        <li>Power/utility outage notices</li>
+        <li>Major event calendars</li>
+        <li>Plain-language AI summaries</li>
+        <li>Custom dashboards for individual businesses or neighbourhoods</li>
       </ul>
     </section>
 
     <section class="vanops-section vanops-card vanops-cta">
       <h2>Need a status board for your business?</h2>
-      <p>I can build lightweight dashboards that pull together service health, public disruption feeds, and plain-language operational notes — without making your team babysit twelve tabs.</p>
+      <p>I can build lightweight dashboards that pull together local disruption signals and plain-language operational notes for Vancouver teams.</p>
       <a class="vanops-button" href="<?php echo esc_url($cta_url); ?>">Work with Suzy</a>
     </section>
 


### PR DESCRIPTION
### Motivation
- VanOps Radar was mixed with the Lousy Outages provider-status UI and was not highlighted on the homepage, which made it read like a generic provider-status product rather than a Vancouver-specific SMB operations/disruption board. 
- The intent is to clearly position VanOps Radar as a lightweight, local-first operations dashboard for Vancouver businesses and to feature it in the homepage Featured builds grid.

### Description
- Updated `page-home.php` to add a new **VanOps Radar** card near the top of the Featured builds grid and revised the **Lousy Outages** card copy/tags/button to clearly present it as the retro/provider outage lab. 
- Reworked `page-vanops-radar.php` to use SMB-focused hero copy and CTAs, removed the embedded `[lousy_outages]` shortcode, replaced the provider preview with a Vancouver ops board (`id="vanops-preview"`) containing the six requested signal cards, replaced the "What it watches" grid with Vancouver-local categories and status pills, and added the "Built for Vancouver operators" and "Data roadmap" sections. 
- Rewrote `assets/css/vanops-radar.css` to remove Lousy Outages embed-specific styles, add styles for `.vanops-actions`, `.vanops-button--secondary`, `.vanops-status-board`, `.vanops-signal-card`, `.vanops-status-pill`, `.vanops-signal-meta`, `.vanops-use-case-grid`, and `.vanops-data-roadmap`, and improve spacing, typography, and mobile responsiveness.

### Testing
- Ran `php -l page-vanops-radar.php` and `php -l page-home.php`, and both returned "No syntax errors detected." 
- Searched `page-vanops-radar.php` for the `[lousy_outages]` shortcode and for provider/status keywords using `rg -n "lousy_outages|Live provider signal preview|AWS|GitHub|Slack|Cloudflare"` and confirmed the shortcode/provider preview text is no longer present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eff182df38832eae6345dbe5259cca)