### PR TITLE
Remove tag badges and "Where I'm useful" skills section from home page

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -131,52 +131,34 @@ get_header();
             <article class="selected-work__card">
                 <h3 class="pixel-font">Gastown Simulator</h3>
                 <p>First-person Vancouver prototype using browser rendering, civic/open-data world files, route anchors, weather/time-of-day controls, and iterative product design.</p>
-                <p class="selected-work__tags" aria-label="Gastown Simulator technology tags"><span>Three.js</span><span>Civic data</span><span>Worldbuilding</span></p>
                 <a class="pixel-button" href="<?php echo esc_url(home_url('/page-gastown-sim/')); ?>">Enter Gastown</a>
             </article>
             <article class="selected-work__card">
                 <h3 class="pixel-font">VanOps Radar</h3>
                 <p>Vancouver operations intelligence for storefronts, venues, offices, and local teams — a practical disruption board for road access, transit, weather, utility issues, event-day risks, and business continuity signals.</p>
-                <p class="selected-work__tags" aria-label="VanOps Radar technology tags"><span>Vancouver Ops</span><span>Civic Data</span><span>Dashboards</span></p>
                 <a class="pixel-button" href="<?php echo esc_url(home_url('/vanops-radar/')); ?>">Open VanOps Radar</a>
             </article>
             <article class="selected-work__card">
                 <h3 class="pixel-font">Track Analyzer</h3>
                 <p>AI feedback tool for musicians: upload a track, get practical mix notes, and move faster from “something&rsquo;s off” to “that&rsquo;s the problem.”</p>
-                <p class="selected-work__tags" aria-label="Track Analyzer technology tags"><span>AI</span><span>Audio</span><span>Musician tools</span></p>
                 <a class="pixel-button" href="<?php echo esc_url(home_url('/suzys-track-analyzer/')); ?>">Analyze a Track</a>
             </article>
             <article class="selected-work__card">
                 <h3 class="pixel-font">Lousy Outages</h3>
                 <p>Retro internet/provider outage tracker and status-page experiment — the weird monitoring lab behind some of the signal ideas.</p>
-                <p class="selected-work__tags" aria-label="Lousy Outages technology tags"><span>Status Pages</span><span>Monitoring</span><span>Retro Lab</span></p>
                 <a class="pixel-button" href="<?php echo esc_url(home_url('/lousy-outages/')); ?>">View Lousy Outages</a>
             </article>
             <article class="selected-work__card">
                 <h3 class="pixel-font">ASMR Lab / Rain City Experiments</h3>
                 <p>Procedural audio-visual experiments where storyboards, synths, browser visuals, and AI prompts meet in the weird part of the lab.</p>
-                <p class="selected-work__tags" aria-label="ASMR Lab technology tags"><span>AI film</span><span>Procedural audio</span><span>Creative tools</span></p>
                 <a class="pixel-button" href="<?php echo esc_url(home_url('/asmr-lab/')); ?>">Explore the Lab</a>
             </article>
             <article class="selected-work__card">
                 <h3 class="pixel-font">Albini Q&amp;A</h3>
                 <p>An experimental voice-and-attitude-driven creative app inspired by Steve Albini: part tribute, part interactive web experiment, part chaos-tested music-tech artifact.</p>
-                <p class="selected-work__tags" aria-label="Albini Q and A technology tags"><span>AI</span><span>Music</span><span>Web experiment</span></p>
                 <a class="pixel-button" href="<?php echo esc_url(home_url('/albini-qa/')); ?>">Open Albini Q&amp;A</a>
             </article>
         </div>
-    </section>
-
-    <section class="skills-home crt-block" aria-labelledby="skills-home-title">
-        <h2 id="skills-home-title" class="pixel-font">Where I'm useful</h2>
-        <ul class="skills-home__list">
-            <li>QA automation and release confidence</li>
-            <li>IT operations, identity, endpoint, and SaaS troubleshooting</li>
-            <li>Python, PowerShell, and JavaScript automation</li>
-            <li>Practical AI tools and internal workflows</li>
-            <li>Production debugging with logs, calm, and receipts</li>
-            <li>Music, audio, and creative web experiments</li>
-        </ul>
     </section>
 
     <section class="music-world crt-block" aria-labelledby="music-world-title">

--- a/style.css
+++ b/style.css
@@ -4122,31 +4122,6 @@ body.page-template-page-bio-php .bio-content {
   flex: 1;
 }
 
-.selected-work__tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-  align-items: center;
-  margin: 0;
-}
-
-.selected-work__tags span {
-  display: inline-flex;
-  align-items: center;
-  width: auto;
-  min-width: 0;
-  min-height: 0;
-  max-width: 100%;
-  border: 1px solid rgba(115, 239, 188, 0.42);
-  border-radius: 0.25rem;
-  padding: 0.32rem 0.58rem;
-  font-size: 0.68rem;
-  letter-spacing: 0.05em;
-  line-height: 1.1;
-  color: #bfffd9;
-  white-space: normal;
-  background: rgba(0, 12, 8, 0.72);
-}
 
 .vancouver-tech-home {
   border: 2px solid rgba(91, 184, 255, 0.45);
@@ -4205,32 +4180,6 @@ body.page-template-page-bio-php .bio-content {
   align-items: center;
 }
 
-.skills-home {
-  margin: 34px auto;
-  max-width: 960px;
-  padding: 24px 28px;
-  border-radius: 12px;
-  border: 2px solid rgba(255, 188, 92, 0.38);
-  box-shadow: 0 0 18px rgba(255, 188, 92, 0.16);
-}
-
-.skills-home h2 {
-  margin: 0 0 0.9rem;
-  color: #ffe8ba;
-}
-
-.skills-home__list {
-  margin: 0;
-  padding-left: 1.1rem;
-  display: grid;
-  gap: 0.6rem;
-}
-
-.skills-home__list li {
-  color: #fff5dc;
-  line-height: 1.6;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-}
 
 .home-section-legend-links {
   display: flex;
@@ -4378,7 +4327,6 @@ body.page-template-page-bio-php .bio-content {
 @media (max-width: 760px) {
   .selected-work,
   .vancouver-tech-home,
-  .skills-home,
   .music-world,
   .collab-invite-home,
   .utility-nav-home {


### PR DESCRIPTION
### Motivation

- Simplify and declutter the home page by removing per-project tag badges and the standalone skills summary block.
- Reduce CSS surface area by deleting unused styles tied to the removed UI elements. 
- Make the featured builds cards and responsive layout leaner and easier to maintain.

### Description

- Removed the tag badge markup from each featured work card in `page-home.php` (deleted `p.selected-work__tags` elements).
- Removed the entire `skills-home` section from `page-home.php` (the "Where I'm useful" block).
- Deleted the corresponding CSS rules for `.selected-work__tags` and `.skills-home` from `style.css` and removed `.skills-home` from the responsive selector list.

### Testing

- Ran PHP lint on `page-home.php` with `php -l` and it reported no syntax errors. 
- Ran CSS linting on `style.css` (via `stylelint`) and it completed without errors. 
- Performed a local visual smoke check of the home page to verify layout and responsiveness after removals (no automated failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eff4c81948832ebaac38693197fb3d)