### PR TITLE
Refresh Work With Suzy page for 2026 availability, senior roles, and scoped styles

### DIFF
--- a/page-work-with-suzy.php
+++ b/page-work-with-suzy.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Template Name: Select Side Projects
+Template Name: Work With Suzy
 */
 get_header();
 ?>
@@ -8,84 +8,117 @@ get_header();
 <main id="main-content" class="work-with-suzy-page">
     <article class="page-content work-with-suzy-content">
         <section class="crt-block wws-hero" aria-labelledby="work-with-suzy-title">
-            <p class="wws-kicker pixel-font">Select side projects • freelance collaborations • paid technical side quests</p>
-            <h1 id="work-with-suzy-title" class="retro-title glow-lite">Select Side Projects</h1>
-            <p class="wws-lead">I already have a full-time career. I also take on a limited number of paid side projects: weird-bug triage, QA/automation upgrades, advisory support, and creative-technical builds that need to ship.</p>
-            <a class="pixel-button wws-hero-cta" href="mailto:suzyeaston@icloud.com?subject=Select%20Side%20Projects%20%E2%80%94%20%5Bproject%5D">Collaborate With Suzy</a>
+            <p class="wws-kicker pixel-font">Available for senior roles • contract work • custom WordPress • QA/automation • practical AI builds</p>
+            <h1 id="work-with-suzy-title" class="retro-title glow-lite">Work With Suzy</h1>
+            <p class="wws-lead">I&rsquo;m open after the April 2026 Alida layoff and looking for the right mix of senior technical work, contract projects, and useful builds. I help teams untangle messy systems, ship practical tools, debug weird production issues, and turn &ldquo;why is this broken?&rdquo; into a plan.</p>
+            <p>My sweet spot is where support, QA, operations, software, and real users collide: custom WordPress, JavaScript/PHP fixes, workflow automation, API/integration debugging, SaaS troubleshooting, civic/data dashboards, and AI-assisted prototypes that actually do something.</p>
+            <div class="wws-actions" role="group" aria-label="Work With Suzy contact links">
+                <a class="pixel-button wws-hero-cta" href="mailto:suzyeaston@icloud.com?subject=Work%20With%20Suzy">Email Suzy</a>
+                <a class="pixel-button wws-secondary-button" href="https://www.linkedin.com/in/suzyeaston/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+                <a class="pixel-button wws-secondary-button" href="https://github.com/suzyeaston" target="_blank" rel="noopener noreferrer">View GitHub</a>
+            </div>
         </section>
 
         <section class="crt-block wws-section" aria-labelledby="what-i-help-with">
             <h2 id="what-i-help-with" class="pixel-font">What I can help with</h2>
             <div class="wws-grid">
                 <article class="wws-card">
-                    <h3>Technical troubleshooting &amp; escalations</h3>
-                    <p>When everyone says “it should work” and it still does not, I trace the issue across logs, APIs, integrations, and handoffs until we find the real problem.</p>
+                    <h3>Senior technical generalist / contract support</h3>
+                    <p>Need someone who can move between support, QA, ops, product, and engineering without dropping the thread? I can help diagnose issues, document reality, and get teams unstuck.</p>
                 </article>
                 <article class="wws-card">
-                    <h3>QA, test automation, and bug reproduction</h3>
-                    <p>I can tighten up test coverage, isolate flaky behavior, and help your team move from “random bug reports” to reproducible defects with clear next actions.</p>
+                    <h3>Custom WordPress builds and theme work</h3>
+                    <p>I work directly in custom WordPress themes: PHP templates, CSS, JavaScript, REST endpoints, integrations, performance cleanup, and practical site features without turning the site into a plugin junk drawer.</p>
                 </article>
                 <article class="wws-card">
-                    <h3>Workflow automation &amp; systems cleanup</h3>
-                    <p>If your team is held together by copy-paste rituals and duct tape, I can help streamline the flow and automate the repetitive pain.</p>
+                    <h3>QA automation and bug reproduction</h3>
+                    <p>I can turn vague bug reports into reproducible defects, tighten Cypress/JavaScript test coverage, validate releases, and build clearer QA workflows.</p>
                 </article>
                 <article class="wws-card">
-                    <h3>AI-assisted prototypes and practical builds</h3>
-                    <p>I use AI as leverage, not hype: rapid prototyping, internal helpers, and focused experiments that make real work easier.</p>
+                    <h3>IT operations and SaaS troubleshooting</h3>
+                    <p>Identity, access, endpoint, email, DNS, SSO/SAML, OAuth, SCIM, logs, alerts, escalations, weird SaaS behaviour &mdash; I like the messy stuff where systems and humans disagree.</p>
                 </article>
                 <article class="wws-card">
-                    <h3>WordPress and custom site improvements</h3>
-                    <p>Need your site to do something specific without becoming a plugin circus? I can implement upgrades, custom tweaks, and integrations that stay maintainable.</p>
+                    <h3>Workflow automation and internal tools</h3>
+                    <p>If your team is stuck in copy-paste rituals, spreadsheet archaeology, or manual checks, I can help design lightweight automation and internal tools that reduce the drag.</p>
                 </article>
                 <article class="wws-card">
-                    <h3>Cross-team technical advisory</h3>
-                    <p>Part support lead, part QA brain, part builder: I help teams stuck between product, support, and engineering align on what is actually broken and what to do next.</p>
+                    <h3>Practical AI-assisted prototypes</h3>
+                    <p>I use AI as leverage, not theatre: focused prototypes, summarizers, internal helpers, content workflows, dashboards, and code acceleration where the output is reviewable and useful.</p>
                 </article>
             </div>
+        </section>
+
+        <section class="crt-block wws-section" aria-labelledby="current-focus">
+            <h2 id="current-focus" class="pixel-font">Current focus</h2>
+            <p>Right now I&rsquo;m especially interested in work that combines technical problem-solving with useful, visible outcomes.</p>
+            <div class="wws-focus-grid">
+                <div class="wws-mode"><strong>Senior IT operations / support engineering roles</strong></div>
+                <div class="wws-mode"><strong>QA automation and release confidence</strong></div>
+                <div class="wws-mode"><strong>Custom WordPress and JavaScript/PHP builds</strong></div>
+                <div class="wws-mode"><strong>Vancouver SMB dashboards and local operations tools</strong></div>
+                <div class="wws-mode"><strong>Practical AI workflows for real teams</strong></div>
+                <div class="wws-mode"><strong>Short contract sprints that fix specific problems</strong></div>
+            </div>
+            <p>VanOps Radar is my current example of a Vancouver-first ops dashboard: a practical product layer for local businesses that need clearer signals around disruption, access, weather, utilities, events, and business continuity. <a href="<?php echo esc_url(home_url('/vanops-radar/')); ?>">See VanOps Radar</a>.</p>
         </section>
 
         <section class="crt-block wws-section" aria-labelledby="proof-of-life">
             <h2 id="proof-of-life" class="pixel-font">Proof of life</h2>
             <ul class="wws-proof-list">
-                <li><strong>11+ years</strong> across support, operations, QA, infrastructure, and automation.</li>
-                <li>Hands-on with <strong>SQL, logs, escalations, API/integration debugging, and discrepancy hunts</strong>.</li>
-                <li>Deep diagnostics in <strong>SSO/SAML, OAuth, SCIM, access and provisioning flows</strong>.</li>
-                <li>Built QA automation with <strong>Cypress, JavaScript, and CI/CD pipelines</strong>.</li>
-                <li>Built custom tools including <strong>an OpenAI-powered audio analyzer and an outage monitoring dashboard</strong>.</li>
-                <li>Comfortable translating between non-technical stakeholders and technical teams without the usual chaos.</li>
+                <li>11+ years across IT support, operations, QA, infrastructure, SaaS troubleshooting, and automation.</li>
+                <li>Senior IT Operations Analyst experience at Alida before the April 2026 company layoff.</li>
+                <li>Software QA experience at WineDirect using Cypress, JavaScript, CI/CD, API validation, and ecommerce/POS workflows.</li>
+                <li>Deep troubleshooting across SQL, logs, DNS, SSL, SSO/SAML, OAuth, SCIM, endpoint management, cloud systems, and production escalations.</li>
+                <li>Custom WordPress theme work on suzyeaston.ca, including VanOps Radar, Lousy Outages, Track Analyzer, ASMR Lab, and Gastown Simulator.</li>
+                <li>Former touring bassist and creative technologist, so I bring both systems thinking and real-world creative judgment.</li>
             </ul>
         </section>
 
         <section class="crt-block wws-section" aria-labelledby="good-fit">
             <h2 id="good-fit" class="pixel-font">Good fit if...</h2>
             <ul class="wws-fit-list">
-                <li>You need one-off help with a weird system issue and no time for blame ping-pong.</li>
-                <li>Your team needs a sharp outside operator who can debug across product, support, QA, and infrastructure.</li>
-                <li>You are a founder, creative, or operator who wants practical AI help without the hype circus.</li>
-                <li>You want experienced advisory + build support without adding a full-time role.</li>
+                <li>You need a senior technical generalist who can debug across product, support, QA, operations, and engineering.</li>
+                <li>You have a WordPress/custom site project that needs careful hands, not plugin chaos.</li>
+                <li>Your team needs QA automation, release support, or help turning messy bugs into reproducible cases.</li>
+                <li>You want practical AI or automation help with reviewable outputs and clear boundaries.</li>
+                <li>You are a founder, small business, creative team, or local operator who needs a useful technical partner.</li>
+                <li>You need someone contract-friendly while also being open to the right full-time senior role.</li>
             </ul>
         </section>
 
         <section class="crt-block wws-section" aria-labelledby="ways-to-work">
             <h2 id="ways-to-work" class="pixel-font">Ways we can work together</h2>
             <div class="wws-work-modes">
-                <div class="wws-mode"><strong>One-off troubleshooting session</strong><span>Fast triage and a plan you can execute immediately.</span></div>
-                <div class="wws-mode"><strong>Short technical audit</strong><span>Targeted review of a system, workflow, or recurring issue cluster.</span></div>
-                <div class="wws-mode"><strong>Implementation sprint</strong><span>Focused build/fix window to ship improvements quickly.</span></div>
-                <div class="wws-mode"><strong>Fractional technical support</strong><span>Ongoing help for teams that need steady hands, not full-time overhead.</span></div>
-                <div class="wws-mode"><strong>Build / fix / unblock advisory</strong><span>Practical guidance while your team executes.</span></div>
+                <div class="wws-mode"><strong>Senior role conversations</strong><span>For teams hiring someone who can bridge IT operations, QA, support engineering, automation, and practical product thinking.</span></div>
+                <div class="wws-mode"><strong>Contract QA / automation sprint</strong><span>A focused engagement to reproduce issues, improve test coverage, validate workflows, and reduce release panic.</span></div>
+                <div class="wws-mode"><strong>Custom WordPress build/fix sprint</strong><span>Theme work, templates, PHP/JS/CSS fixes, REST endpoints, custom pages, integrations, and cleanup.</span></div>
+                <div class="wws-mode"><strong>Weird bug triage</strong><span>Short, sharp investigation for the issue everyone has opinions about but nobody has pinned down.</span></div>
+                <div class="wws-mode"><strong>Practical AI / automation prototype</strong><span>A small scoped build that proves whether an AI-assisted workflow, dashboard, summarizer, or internal helper is worth pursuing.</span></div>
+                <div class="wws-mode"><strong>Fractional technical support</strong><span>Ongoing lightweight help for teams that need steady technical judgement without adding a full-time headcount.</span></div>
             </div>
         </section>
 
         <section class="crt-block wws-final-cta" aria-labelledby="work-with-suzy-contact">
-            <h2 id="work-with-suzy-contact" class="pixel-font">Need Help With a Weird Bug?</h2>
-            <p>Email me at <a href="mailto:suzyeaston@icloud.com?subject=Book%20a%20Side%20Quest%20%E2%80%94%20%5Bproject%5D">suzyeaston@icloud.com</a> with a short summary of the issue, timeline, and what "done" looks like.</p>
-            <p class="wws-subjects"><strong>Suggested subject lines:</strong> Book a Side Quest — [project] • Need Help With a Weird Bug • Build With Suzy</p>
-            <a class="pixel-button wws-final-button" href="mailto:suzyeaston@icloud.com?subject=Need%20Help%20With%20a%20Weird%20Bug">Book a Side Quest</a>
+            <h2 id="work-with-suzy-contact" class="pixel-font">Let&rsquo;s make the messy thing make sense</h2>
+            <p>Email me with the role, project, bug, workflow, or idea. Include what is broken, what &ldquo;done&rdquo; looks like, and any timeline or budget constraints. I&rsquo;ll tell you honestly whether I&rsquo;m a fit.</p>
+            <p>Email: <a href="mailto:suzyeaston@icloud.com?subject=Work%20With%20Suzy%20%E2%80%94%20%5Brole%2Fproject%5D">suzyeaston@icloud.com</a></p>
+            <a class="pixel-button wws-final-button" href="mailto:suzyeaston@icloud.com?subject=Work%20With%20Suzy%20%E2%80%94%20%5Brole%2Fproject%5D">Email Suzy</a>
+            <div class="wws-subject-list">
+                <p><strong>Suggested subject lines:</strong></p>
+                <ul>
+                    <li>Senior role conversation</li>
+                    <li>Contract QA sprint</li>
+                    <li>WordPress build/fix sprint</li>
+                    <li>Weird bug triage</li>
+                    <li>VanOps Radar / local dashboard</li>
+                    <li>Practical AI prototype</li>
+                </ul>
+            </div>
         </section>
 
         <section class="wws-boundaries" aria-label="Small print">
-            <p><strong>Small print:</strong> I&apos;m into thoughtful projects, honest teams, and practical outcomes. I am not available for crypto-casino nonsense, vague exposure deals, or shady growth spam.</p>
+            <p><strong>Small print:</strong> I&rsquo;m into thoughtful teams, practical outcomes, and useful builds. I&rsquo;m open to senior roles, contract work, and focused technical projects. I am not available for crypto-casino nonsense, vague exposure deals, shady growth spam, or projects where the plan is &ldquo;AI will magically fix it.&rdquo;</p>
         </section>
     </article>
 </main>

--- a/style.css
+++ b/style.css
@@ -3927,7 +3927,8 @@ body.page-template-page-bio-php .bio-content {
 .page-template-page-work-with-suzy .work-with-suzy-content {
     max-width: 980px;
     display: grid;
-    gap: 24px;
+    gap: 28px;
+    margin-top: 18px;
 }
 
 .page-template-page-work-with-suzy .wws-kicker {
@@ -3949,6 +3950,11 @@ body.page-template-page-bio-php .bio-content {
     padding: clamp(20px, 3.8vw, 34px);
 }
 
+.page-template-page-work-with-suzy .wws-section h2,
+.page-template-page-work-with-suzy .wws-final-cta h2 {
+    margin-bottom: 0.85rem;
+}
+
 .page-template-page-work-with-suzy .wws-hero .retro-title {
     margin-bottom: 14px;
     font-size: clamp(2rem, 6vw, 3.25rem);
@@ -3964,24 +3970,42 @@ body.page-template-page-bio-php .bio-content {
     color: var(--primary-color);
 }
 
+.page-template-page-work-with-suzy .wws-section p,
+.page-template-page-work-with-suzy .wws-final-cta p {
+    margin: 0 0 12px;
+}
+
+.page-template-page-work-with-suzy .wws-actions {
+    margin-top: 20px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+}
+
 .page-template-page-work-with-suzy .wws-hero-cta,
+.page-template-page-work-with-suzy .wws-secondary-button,
 .page-template-page-work-with-suzy .wws-final-button {
-    margin-top: 18px;
     display: inline-block;
+}
+
+.page-template-page-work-with-suzy .wws-secondary-button {
+    border-color: rgba(0, 255, 255, 0.45);
+    box-shadow: 0 0 10px rgba(0, 255, 255, 0.22);
 }
 
 .page-template-page-work-with-suzy .wws-grid {
     margin-top: 14px;
     display: grid;
-    gap: 14px;
-    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+    gap: 16px;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
 .page-template-page-work-with-suzy .wws-card {
     border: 1px solid rgba(57, 255, 20, 0.4);
     border-radius: 12px;
     background: rgba(5, 14, 9, 0.72);
-    padding: 16px;
+    padding: 18px;
 }
 
 .page-template-page-work-with-suzy .wws-card h3 {
@@ -3992,6 +4016,13 @@ body.page-template-page-bio-php .bio-content {
 
 .page-template-page-work-with-suzy .wws-card p {
     margin: 0;
+}
+
+.page-template-page-work-with-suzy .wws-focus-grid {
+    margin: 14px 0 18px;
+    display: grid;
+    gap: 10px;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
 }
 
 .page-template-page-work-with-suzy .wws-proof-list,
@@ -4010,7 +4041,7 @@ body.page-template-page-bio-php .bio-content {
 
 .page-template-page-work-with-suzy .wws-mode {
     border-left: 3px solid rgba(57, 255, 20, 0.62);
-    padding: 10px 12px;
+    padding: 11px 13px;
     background: rgba(8, 16, 9, 0.6);
 }
 
@@ -4031,9 +4062,22 @@ body.page-template-page-bio-php .bio-content {
     box-shadow: inset 0 0 30px rgba(255, 80, 214, 0.1), 0 0 24px rgba(255, 80, 214, 0.2);
 }
 
-.page-template-page-work-with-suzy .wws-subjects {
-    margin-top: 10px;
+.page-template-page-work-with-suzy .wws-subject-list {
+    margin-top: 14px;
+    padding-top: 10px;
+    border-top: 1px dashed rgba(255, 170, 241, 0.45);
+}
+
+.page-template-page-work-with-suzy .wws-subject-list p {
+    margin-bottom: 8px;
     color: #ffd7f6;
+}
+
+.page-template-page-work-with-suzy .wws-subject-list ul {
+    margin: 0;
+    padding-left: 20px;
+    display: grid;
+    gap: 6px;
 }
 
 .page-template-page-work-with-suzy .wws-boundaries {
@@ -4049,11 +4093,18 @@ body.page-template-page-bio-php .bio-content {
     }
 
     .page-template-page-work-with-suzy .wws-proof-list,
-    .page-template-page-work-with-suzy .wws-fit-list {
+    .page-template-page-work-with-suzy .wws-fit-list,
+    .page-template-page-work-with-suzy .wws-subject-list ul {
         padding-left: 18px;
     }
 
+    .page-template-page-work-with-suzy .wws-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
     .page-template-page-work-with-suzy .wws-hero-cta,
+    .page-template-page-work-with-suzy .wws-secondary-button,
     .page-template-page-work-with-suzy .wws-final-button {
         width: 100%;
         text-align: center;


### PR DESCRIPTION
### Motivation

- Reflect post–April 2026 availability and remove the outdated “I already have a full-time career” framing. 
- Reposition the page to target senior technical roles, contract work, custom WordPress builds, QA/automation, IT operations troubleshooting, workflow automation, and practical AI prototypes. 
- Keep the existing retro/CRT style while improving readability, CTA layout, and mobile behavior for recruiters, founders, SMBs, and contract clients.

### Description

- Updated `page-work-with-suzy.php` template name to `Work With Suzy`, replaced the hero with the new kicker, H1, lead/supporting copy, and added three hero CTAs (Email, LinkedIn, GitHub). 
- Replaced the “What I can help with” cards with the six refreshed service cards and added a new `Current focus` section that lists the six focal areas and references VanOps Radar via `home_url('/vanops-radar/')`. 
- Updated `Proof of life`, `Good fit if...`, `Ways we can work together`, the final CTA and mailto subject format (`Work With Suzy — [role/project]`), suggested subject lines, and tightened the small-print boundaries to match current availability. 
- Modified only scoped styles in `style.css` under `.page-template-page-work-with-suzy` to improve spacing, mobile wrapping of hero CTAs, card breathing room, and added scoped helpers (`.wws-actions`, `.wws-secondary-button`, `.wws-focus-grid`, `.wws-proof-list`, `.wws-subject-list`) while preserving global retro styling.

### Testing

- Ran a PHP syntax check with `php -l page-work-with-suzy.php`, which passed.
- Verified the changes are limited to the intended files (`page-work-with-suzy.php` and the `.page-template-page-work-with-suzy` block in `style.css`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eff87063f8832ebb73dcb2675ca214)