### PR TITLE
Refine “Work With Suzy” copy and add scoped cyberpunk styling

### DIFF
--- a/page-work-with-suzy.php
+++ b/page-work-with-suzy.php
@@ -8,10 +8,11 @@ get_header();
 <main id="main-content" class="work-with-suzy-page">
     <article class="page-content work-with-suzy-content">
         <section class="crt-block wws-hero" aria-labelledby="work-with-suzy-title">
-            <p class="wws-kicker pixel-font">Available for senior roles • contract work • custom WordPress • QA/automation • practical AI builds</p>
+            <p class="wws-kicker pixel-font wws-eyebrow">Available for senior roles • contract work • web development • QA automation • practical AI builds</p>
             <h1 id="work-with-suzy-title" class="retro-title glow-lite">Work With Suzy</h1>
-            <p class="wws-lead">I&rsquo;m open after the April 2026 Alida layoff and looking for the right mix of senior technical work, contract projects, and useful builds. I help teams untangle messy systems, ship practical tools, debug weird production issues, and turn &ldquo;why is this broken?&rdquo; into a plan.</p>
-            <p>My sweet spot is where support, QA, operations, software, and real users collide: custom WordPress, JavaScript/PHP fixes, workflow automation, API/integration debugging, SaaS troubleshooting, civic/data dashboards, and AI-assisted prototypes that actually do something.</p>
+            <p class="wws-lead">I&rsquo;m currently available for senior technical roles, contract projects, and focused builds that need someone who can untangle messy systems and ship practical tools.</p>
+            <p class="wws-hero-subcopy">I work across web development, custom WordPress, JavaScript/PHP, QA automation, IT operations, API/integration debugging, dashboards, workflow automation, and AI-assisted prototypes with reviewable outputs.</p>
+            <p class="wws-hero-subcopy">My sweet spot is the messy middle where support, QA, operations, software, and real users collide &mdash; the place where &ldquo;it should work&rdquo; turns into &ldquo;here&rsquo;s what&rsquo;s actually broken.&rdquo;</p>
             <div class="wws-actions" role="group" aria-label="Work With Suzy contact links">
                 <a class="pixel-button wws-hero-cta" href="mailto:suzyeaston@icloud.com?subject=Work%20With%20Suzy">Email Suzy</a>
                 <a class="pixel-button wws-secondary-button" href="https://www.linkedin.com/in/suzyeaston/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
@@ -22,17 +23,17 @@ get_header();
         <section class="crt-block wws-section" aria-labelledby="what-i-help-with">
             <h2 id="what-i-help-with" class="pixel-font">What I can help with</h2>
             <div class="wws-grid">
-                <article class="wws-card">
-                    <h3>Senior technical generalist / contract support</h3>
-                    <p>Need someone who can move between support, QA, ops, product, and engineering without dropping the thread? I can help diagnose issues, document reality, and get teams unstuck.</p>
+                <article class="wws-card wws-card--featured">
+                    <h3>Web development and custom builds</h3>
+                    <p>Custom site features, landing pages, dashboards, JavaScript/PHP fixes, API integrations, data displays, and practical web tools that solve a real workflow instead of just looking busy.</p>
                 </article>
                 <article class="wws-card">
-                    <h3>Custom WordPress builds and theme work</h3>
-                    <p>I work directly in custom WordPress themes: PHP templates, CSS, JavaScript, REST endpoints, integrations, performance cleanup, and practical site features without turning the site into a plugin junk drawer.</p>
+                    <h3>Custom WordPress and theme work</h3>
+                    <p>I work directly in custom WordPress themes: PHP templates, CSS, JavaScript, REST endpoints, custom pages, integrations, performance cleanup, and maintainable site improvements without plugin chaos.</p>
                 </article>
                 <article class="wws-card">
                     <h3>QA automation and bug reproduction</h3>
-                    <p>I can turn vague bug reports into reproducible defects, tighten Cypress/JavaScript test coverage, validate releases, and build clearer QA workflows.</p>
+                    <p>I can turn vague bug reports into reproducible defects, tighten Cypress/JavaScript test coverage, validate releases, and help teams move from panic to proof.</p>
                 </article>
                 <article class="wws-card">
                     <h3>IT operations and SaaS troubleshooting</h3>
@@ -40,7 +41,7 @@ get_header();
                 </article>
                 <article class="wws-card">
                     <h3>Workflow automation and internal tools</h3>
-                    <p>If your team is stuck in copy-paste rituals, spreadsheet archaeology, or manual checks, I can help design lightweight automation and internal tools that reduce the drag.</p>
+                    <p>If your team is stuck in copy-paste rituals, spreadsheet archaeology, or manual checks, I can design lightweight automation and internal tools that reduce the drag.</p>
                 </article>
                 <article class="wws-card">
                     <h3>Practical AI-assisted prototypes</h3>
@@ -51,23 +52,23 @@ get_header();
 
         <section class="crt-block wws-section" aria-labelledby="current-focus">
             <h2 id="current-focus" class="pixel-font">Current focus</h2>
-            <p>Right now I&rsquo;m especially interested in work that combines technical problem-solving with useful, visible outcomes.</p>
+            <p>Right now I&rsquo;m looking for work that combines technical problem-solving with useful, visible outcomes.</p>
             <div class="wws-focus-grid">
-                <div class="wws-mode"><strong>Senior IT operations / support engineering roles</strong></div>
+                <div class="wws-mode"><strong>Senior technical generalist roles</strong></div>
+                <div class="wws-mode"><strong>Contract web development and WordPress builds</strong></div>
                 <div class="wws-mode"><strong>QA automation and release confidence</strong></div>
-                <div class="wws-mode"><strong>Custom WordPress and JavaScript/PHP builds</strong></div>
-                <div class="wws-mode"><strong>Vancouver SMB dashboards and local operations tools</strong></div>
+                <div class="wws-mode"><strong>IT operations / support engineering</strong></div>
+                <div class="wws-mode"><strong>Vancouver SMB dashboards and local ops tools</strong></div>
                 <div class="wws-mode"><strong>Practical AI workflows for real teams</strong></div>
-                <div class="wws-mode"><strong>Short contract sprints that fix specific problems</strong></div>
             </div>
-            <p>VanOps Radar is my current example of a Vancouver-first ops dashboard: a practical product layer for local businesses that need clearer signals around disruption, access, weather, utilities, events, and business continuity. <a href="<?php echo esc_url(home_url('/vanops-radar/')); ?>">See VanOps Radar</a>.</p>
+            <p>VanOps Radar is my current Vancouver-first product experiment: a local operations dashboard concept for businesses that need clearer signals around access, weather, utilities, events, and business continuity. <a class="wws-highlight-link" href="<?php echo esc_url(home_url('/vanops-radar/')); ?>">See VanOps Radar</a>.</p>
         </section>
 
         <section class="crt-block wws-section" aria-labelledby="proof-of-life">
             <h2 id="proof-of-life" class="pixel-font">Proof of life</h2>
             <ul class="wws-proof-list">
                 <li>11+ years across IT support, operations, QA, infrastructure, SaaS troubleshooting, and automation.</li>
-                <li>Senior IT Operations Analyst experience at Alida before the April 2026 company layoff.</li>
+                <li>Senior IT Operations Analyst experience supporting SaaS teams, identity/access workflows, endpoint operations, escalations, and production troubleshooting.</li>
                 <li>Software QA experience at WineDirect using Cypress, JavaScript, CI/CD, API validation, and ecommerce/POS workflows.</li>
                 <li>Deep troubleshooting across SQL, logs, DNS, SSL, SSO/SAML, OAuth, SCIM, endpoint management, cloud systems, and production escalations.</li>
                 <li>Custom WordPress theme work on suzyeaston.ca, including VanOps Radar, Lousy Outages, Track Analyzer, ASMR Lab, and Gastown Simulator.</li>
@@ -92,7 +93,7 @@ get_header();
             <div class="wws-work-modes">
                 <div class="wws-mode"><strong>Senior role conversations</strong><span>For teams hiring someone who can bridge IT operations, QA, support engineering, automation, and practical product thinking.</span></div>
                 <div class="wws-mode"><strong>Contract QA / automation sprint</strong><span>A focused engagement to reproduce issues, improve test coverage, validate workflows, and reduce release panic.</span></div>
-                <div class="wws-mode"><strong>Custom WordPress build/fix sprint</strong><span>Theme work, templates, PHP/JS/CSS fixes, REST endpoints, custom pages, integrations, and cleanup.</span></div>
+                <div class="wws-mode"><strong>Web development / WordPress build sprint</strong><span>Custom WordPress theme work, landing pages, PHP/JS/CSS fixes, REST endpoints, dashboards, integrations, data displays, and cleanup.</span></div>
                 <div class="wws-mode"><strong>Weird bug triage</strong><span>Short, sharp investigation for the issue everyone has opinions about but nobody has pinned down.</span></div>
                 <div class="wws-mode"><strong>Practical AI / automation prototype</strong><span>A small scoped build that proves whether an AI-assisted workflow, dashboard, summarizer, or internal helper is worth pursuing.</span></div>
                 <div class="wws-mode"><strong>Fractional technical support</strong><span>Ongoing lightweight help for teams that need steady technical judgement without adding a full-time headcount.</span></div>
@@ -107,12 +108,12 @@ get_header();
             <div class="wws-subject-list">
                 <p><strong>Suggested subject lines:</strong></p>
                 <ul>
-                    <li>Senior role conversation</li>
-                    <li>Contract QA sprint</li>
-                    <li>WordPress build/fix sprint</li>
-                    <li>Weird bug triage</li>
-                    <li>VanOps Radar / local dashboard</li>
+                    <li>Web development / WordPress sprint</li>
+                    <li>Custom dashboard build</li>
                     <li>Practical AI prototype</li>
+                    <li>Contract QA sprint</li>
+                    <li>Senior role conversation</li>
+                    <li>Weird bug triage</li>
                 </ul>
             </div>
         </section>

--- a/style.css
+++ b/style.css
@@ -3924,59 +3924,111 @@ body.page-template-page-bio-php .bio-content {
 }
 
 /* Work With Suzy page */
+.page-template-page-work-with-suzy {
+    --wws-bg: #050816;
+    --wws-panel: rgba(8, 14, 32, 0.88);
+    --wws-panel-2: rgba(13, 20, 46, 0.86);
+    --wws-cyan: #39f5ff;
+    --wws-teal: #35e7c6;
+    --wws-magenta: #ff4fd8;
+    --wws-purple: #8b5cf6;
+    --wws-text: #f4f7ff;
+    --wws-muted: rgba(244, 247, 255, 0.76);
+    --wws-green-accent: #39ff14;
+}
+
+.page-template-page-work-with-suzy .work-with-suzy-page {
+    background: radial-gradient(circle at 18% 10%, rgba(57, 245, 255, 0.09), transparent 42%),
+        radial-gradient(circle at 82% 86%, rgba(255, 79, 216, 0.08), transparent 48%),
+        var(--wws-bg);
+}
+
 .page-template-page-work-with-suzy .work-with-suzy-content {
     max-width: 980px;
     display: grid;
-    gap: 28px;
+    gap: 24px;
     margin-top: 18px;
 }
 
-.page-template-page-work-with-suzy .wws-kicker {
-    margin: 0 0 10px;
-    color: rgba(57, 255, 20, 0.88);
-    letter-spacing: 0.08em;
+.page-template-page-work-with-suzy .wws-kicker,
+.page-template-page-work-with-suzy .wws-eyebrow {
+    margin: 0 0 12px;
+    color: var(--wws-teal);
+    letter-spacing: 0.04em;
     text-transform: uppercase;
-    font-size: 0.78rem;
+    line-height: 1.5;
+    font-size: clamp(0.72rem, 1.5vw, 0.86rem);
 }
 
 .page-template-page-work-with-suzy .wws-hero,
 .page-template-page-work-with-suzy .wws-section,
 .page-template-page-work-with-suzy .wws-final-cta {
     position: relative;
-    border: 2px solid rgba(57, 255, 20, 0.52);
+    border: 1px solid rgba(57, 245, 255, 0.42);
     border-radius: 16px;
-    background: linear-gradient(155deg, rgba(6, 10, 6, 0.95), rgba(4, 18, 13, 0.9));
-    box-shadow: inset 0 0 28px rgba(57, 255, 20, 0.08), 0 0 24px rgba(57, 255, 20, 0.2);
-    padding: clamp(20px, 3.8vw, 34px);
+    background: linear-gradient(150deg, var(--wws-panel), var(--wws-panel-2));
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02), 0 16px 40px rgba(0, 0, 0, 0.45);
+    padding: clamp(20px, 3.6vw, 34px);
 }
 
 .page-template-page-work-with-suzy .wws-section h2,
 .page-template-page-work-with-suzy .wws-final-cta h2 {
-    margin-bottom: 0.85rem;
+    margin-bottom: 0.9rem;
+    color: var(--wws-cyan);
+    text-shadow: 0 0 12px rgba(57, 245, 255, 0.28);
 }
 
 .page-template-page-work-with-suzy .wws-hero .retro-title {
-    margin-bottom: 14px;
-    font-size: clamp(2rem, 6vw, 3.25rem);
+    margin-bottom: 12px;
+    font-size: clamp(2rem, 5.2vw, 3rem);
+    line-height: 1.05;
+    color: var(--wws-cyan);
+    text-shadow: 0 0 14px rgba(57, 245, 255, 0.35), 0 0 24px rgba(139, 92, 246, 0.2);
 }
 
 .page-template-page-work-with-suzy .wws-lead,
+.page-template-page-work-with-suzy .wws-hero-subcopy,
 .page-template-page-work-with-suzy .wws-section p,
 .page-template-page-work-with-suzy .wws-section li,
 .page-template-page-work-with-suzy .wws-final-cta p,
-.page-template-page-work-with-suzy .wws-boundaries p {
+.page-template-page-work-with-suzy .wws-boundaries p,
+.page-template-page-work-with-suzy .wws-mode span {
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-    line-height: 1.75;
-    color: var(--primary-color);
+    line-height: 1.65;
+    color: var(--wws-text);
+    font-size: clamp(0.94rem, 1.6vw, 1.03rem);
+}
+
+.page-template-page-work-with-suzy .wws-lead {
+    max-width: 75ch;
+    margin: 0 0 10px;
+}
+
+.page-template-page-work-with-suzy .wws-hero-subcopy {
+    max-width: 78ch;
+    margin: 0 0 10px;
+    color: var(--wws-muted);
 }
 
 .page-template-page-work-with-suzy .wws-section p,
 .page-template-page-work-with-suzy .wws-final-cta p {
     margin: 0 0 12px;
+    color: var(--wws-muted);
+}
+
+.page-template-page-work-with-suzy .wws-section a,
+.page-template-page-work-with-suzy .wws-final-cta a {
+    color: var(--wws-cyan);
+}
+
+.page-template-page-work-with-suzy .wws-highlight-link {
+    color: var(--wws-teal);
+    text-decoration: underline;
+    text-underline-offset: 2px;
 }
 
 .page-template-page-work-with-suzy .wws-actions {
-    margin-top: 20px;
+    margin-top: 18px;
     display: flex;
     flex-wrap: wrap;
     gap: 10px;
@@ -3987,35 +4039,50 @@ body.page-template-page-bio-php .bio-content {
 .page-template-page-work-with-suzy .wws-secondary-button,
 .page-template-page-work-with-suzy .wws-final-button {
     display: inline-block;
+    border-color: rgba(57, 245, 255, 0.45);
+    box-shadow: 0 0 14px rgba(57, 245, 255, 0.18);
 }
 
 .page-template-page-work-with-suzy .wws-secondary-button {
-    border-color: rgba(0, 255, 255, 0.45);
-    box-shadow: 0 0 10px rgba(0, 255, 255, 0.22);
+    border-color: rgba(139, 92, 246, 0.55);
+    box-shadow: 0 0 14px rgba(139, 92, 246, 0.24);
+}
+
+.page-template-page-work-with-suzy .wws-final-button {
+    border-color: rgba(255, 79, 216, 0.7);
+    box-shadow: 0 0 16px rgba(255, 79, 216, 0.28);
 }
 
 .page-template-page-work-with-suzy .wws-grid {
     margin-top: 14px;
     display: grid;
-    gap: 16px;
+    gap: 14px;
     grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
 .page-template-page-work-with-suzy .wws-card {
-    border: 1px solid rgba(57, 255, 20, 0.4);
+    border: 1px solid rgba(57, 245, 255, 0.28);
     border-radius: 12px;
-    background: rgba(5, 14, 9, 0.72);
+    background: rgba(9, 16, 36, 0.8);
+    min-height: 215px;
     padding: 18px;
+}
+
+.page-template-page-work-with-suzy .wws-card--featured {
+    border-color: rgba(53, 231, 198, 0.5);
+    box-shadow: inset 0 0 0 1px rgba(53, 231, 198, 0.22);
 }
 
 .page-template-page-work-with-suzy .wws-card h3 {
     margin: 0 0 10px;
-    font-size: 1.02rem;
-    color: #b9ff8a;
+    font-size: 1.03rem;
+    line-height: 1.35;
+    color: var(--wws-teal);
 }
 
 .page-template-page-work-with-suzy .wws-card p {
     margin: 0;
+    color: var(--wws-muted);
 }
 
 .page-template-page-work-with-suzy .wws-focus-grid {
@@ -4040,37 +4107,36 @@ body.page-template-page-bio-php .bio-content {
 }
 
 .page-template-page-work-with-suzy .wws-mode {
-    border-left: 3px solid rgba(57, 255, 20, 0.62);
+    border-left: 3px solid rgba(57, 245, 255, 0.64);
     padding: 11px 13px;
-    background: rgba(8, 16, 9, 0.6);
+    background: rgba(9, 15, 34, 0.72);
 }
 
 .page-template-page-work-with-suzy .wws-mode strong {
     display: block;
     margin-bottom: 4px;
-    color: #d5ffb6;
-}
-
-.page-template-page-work-with-suzy .wws-mode span {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-    color: rgba(223, 255, 211, 0.88);
+    color: var(--wws-cyan);
     font-size: 0.98rem;
 }
 
+.page-template-page-work-with-suzy .wws-mode span {
+    color: var(--wws-muted);
+}
+
 .page-template-page-work-with-suzy .wws-final-cta {
-    border-color: rgba(255, 80, 214, 0.52);
-    box-shadow: inset 0 0 30px rgba(255, 80, 214, 0.1), 0 0 24px rgba(255, 80, 214, 0.2);
+    border-color: rgba(255, 79, 216, 0.55);
+    box-shadow: inset 0 0 0 1px rgba(255, 79, 216, 0.14), 0 20px 45px rgba(26, 4, 33, 0.45), 0 0 30px rgba(139, 92, 246, 0.22);
 }
 
 .page-template-page-work-with-suzy .wws-subject-list {
     margin-top: 14px;
     padding-top: 10px;
-    border-top: 1px dashed rgba(255, 170, 241, 0.45);
+    border-top: 1px dashed rgba(255, 79, 216, 0.5);
 }
 
 .page-template-page-work-with-suzy .wws-subject-list p {
     margin-bottom: 8px;
-    color: #ffd7f6;
+    color: #ffd9fb;
 }
 
 .page-template-page-work-with-suzy .wws-subject-list ul {
@@ -4081,10 +4147,14 @@ body.page-template-page-bio-php .bio-content {
 }
 
 .page-template-page-work-with-suzy .wws-boundaries {
-    border: 1px dashed rgba(57, 255, 20, 0.45);
+    border: 1px dashed rgba(57, 245, 255, 0.42);
     border-radius: 12px;
     padding: 14px 16px;
-    background: rgba(2, 8, 3, 0.65);
+    background: rgba(8, 14, 32, 0.74);
+}
+
+.page-template-page-work-with-suzy .wws-boundaries strong {
+    color: var(--wws-green-accent);
 }
 
 @media (max-width: 700px) {


### PR DESCRIPTION
### Motivation
- Make the /work-with-suzy/ page read more polished and recruiter/client friendly by removing a prominent layoff/company mention and foregrounding availability and senior/contract web development skills. 
- Shift the visual theme away from a harsh neon-green CRT toward a darker cyberpunk Vancouver palette (navy + cyan/teal + magenta/purple) while keeping Suzy’s personality intact.
- Reframe offerings to emphasize web development, custom WordPress, QA automation, IT operations, dashboards, and practical AI prototypes for clearer positioning.
- Keep changes scoped to the Work With Suzy page and its page-specific styles only.

### Description
- Updated hero copy in `page-work-with-suzy.php` to remove the explicit “Alida/layoff” mention, add the new kicker, set `H1` to “Work With Suzy”, replace the lead with an availability-first sentence, and add two short supporting paragraphs; preserved Email/LinkedIn/GitHub CTAs. 
- Rewrote the six "What I can help with" cards to foreground: (1) Web development and custom builds (featured), (2) Custom WordPress and theme work, (3) QA automation and bug reproduction, (4) IT operations and SaaS troubleshooting, (5) Workflow automation and internal tools, and (6) Practical AI-assisted prototypes. 
- Tightened the “Current focus” section and VanOps Radar copy, replaced the Alida layoff line in “Proof of life” with neutral senior SaaS ops experience text, updated the “Ways we can work together” mode for broader web/dev language, and refreshed final CTA suggested subject lines (including `Web development / WordPress sprint`, `Custom dashboard build`, `Practical AI prototype`, etc.). 
- Replaced the page-scoped CSS under `.page-template-page-work-with-suzy` in `style.css` with a new set of CSS variables (`--wws-*`) and applied palette/styling changes (deep navy background, cyan/teal headings, magenta/purple CTA glow, off-white body text, toned-down green accent, improved spacing, card sizing, and responsive behavior); added a small set of helper classes like `.wws-hero-subcopy`, `.wws-eyebrow`, `.wws-highlight-link`, and `.wws-card--featured` to support layout and visuals. 
- All edits were limited to `page-work-with-suzy.php` and the `.page-template-page-work-with-suzy` section of `style.css` only.

### Testing
- Ran PHP lint on the edited template with `php -l page-work-with-suzy.php` and received no syntax errors. (pass)
- Reviewed the resulting diff with `git diff -- page-work-with-suzy.php style.css` to confirm changes were limited to the requested files and sections. (pass)
- No automated visual/browser tests were run in this CLI pass, so please validate rendering in a browser on desktop and mobile following the provided test checklist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69effaadd398832ebf0f24e3aa291f02)