### PR TITLE
Add Projects page template and scoped cyberpunk styling

### DIFF
--- a/page-projects.php
+++ b/page-projects.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * Template Name: Projects
+ */
+
+get_header();
+
+$project_url = static function (string $slug, string $fallback_path = ''): string {
+    $page = get_page_by_path($slug);
+
+    if ($page instanceof WP_Post) {
+        return get_permalink($page);
+    }
+
+    if ($fallback_path === '') {
+        $fallback_path = '/' . trim($slug, '/') . '/';
+    }
+
+    return home_url($fallback_path);
+};
+?>
+<main id="main-content" class="projects-page">
+    <div class="projects-shell">
+        <section class="projects-hero projects-section" aria-labelledby="projects-title">
+            <p class="projects-eyebrow pixel-font">Build log // useful weird systems</p>
+            <h1 id="projects-title" class="retro-title glow-lite">Projects</h1>
+            <p class="projects-lead">A field guide to the tools, prototypes, dashboards, music-tech experiments, civic builds, and strange useful systems I&rsquo;m building in public.</p>
+            <p>Some are polished enough to use. Some are live prototypes. Some are weird little labs that teach me what to build next. The common thread: practical systems, creative taste, and enough technical grit to make the thing actually work.</p>
+            <div class="projects-actions" role="group" aria-label="Projects page jumps and primary links">
+                <a class="pixel-button" href="#featured-projects">Featured builds</a>
+                <a class="pixel-button" href="#creative-labs">Creative labs</a>
+                <a class="pixel-button" href="<?php echo esc_url(home_url('/work-with-suzy/')); ?>">Work with Suzy</a>
+            </div>
+        </section>
+
+        <section id="featured-projects" class="projects-section" aria-labelledby="featured-projects-title">
+            <div class="projects-section-header">
+                <h2 id="featured-projects-title" class="pixel-font">Featured builds</h2>
+                <p>The main projects I&rsquo;d point a recruiter, client, collaborator, or curious Vancouver human toward first.</p>
+            </div>
+            <div class="projects-grid projects-grid--featured">
+                <article class="projects-card projects-card--featured">
+                    <h3 class="pixel-font">VanOps Radar</h3>
+                    <p class="projects-card__status"><strong>Status:</strong> Current product experiment</p>
+                    <p>A Vancouver-first operations dashboard concept for small and medium businesses that need clearer signals around road access, transit, weather, utilities, events, and business continuity.</p>
+                    <p class="projects-card__proof"><strong>What it proves:</strong> Civic product thinking, dashboards, local operations, SMB positioning, and practical web development.</p>
+                    <div class="projects-card__actions">
+                        <a class="pixel-button" href="<?php echo esc_url($project_url('vanops-radar')); ?>">Open VanOps Radar</a>
+                    </div>
+                </article>
+
+                <article class="projects-card projects-card--featured">
+                    <h3 class="pixel-font">Gastown Simulator</h3>
+                    <p class="projects-card__status"><strong>Status:</strong> Live prototype / desktop-first</p>
+                    <p>A first-person Vancouver corridor prototype from Waterfront Station toward Water Street and the Steam Clock, using browser rendering, civic/open-data world files, route anchors, weather/time-of-day controls, and iterative product design.</p>
+                    <p class="projects-card__proof"><strong>What it proves:</strong> Three.js-style worldbuilding, civic data pipelines, browser interaction, debugging, and build-in-public persistence.</p>
+                    <div class="projects-card__actions">
+                        <a class="pixel-button" href="<?php echo esc_url($project_url('page-gastown-sim', '/page-gastown-sim/')); ?>">Enter Gastown</a>
+                    </div>
+                </article>
+
+                <article class="projects-card projects-card--featured">
+                    <h3 class="pixel-font">Lousy Outages</h3>
+                    <p class="projects-card__status"><strong>Status:</strong> Active monitoring lab</p>
+                    <p>A retro internet/provider outage tracker and status-page experiment with provider feeds, alert ideas, public utility energy, and chaos-monitoring personality.</p>
+                    <p class="projects-card__proof"><strong>What it proves:</strong> Status dashboards, monitoring UX, REST/plugin architecture, provider signal handling, and operational thinking.</p>
+                    <div class="projects-card__actions">
+                        <a class="pixel-button" href="<?php echo esc_url($project_url('lousy-outages')); ?>">View Lousy Outages</a>
+                    </div>
+                </article>
+
+                <article class="projects-card projects-card--featured">
+                    <h3 class="pixel-font">Track Analyzer</h3>
+                    <p class="projects-card__status"><strong>Status:</strong> Live music-tech tool</p>
+                    <p>An AI-assisted feedback tool for musicians: upload a track, get practical mix notes, and move faster from &ldquo;something feels off&rdquo; to &ldquo;that is probably the problem.&rdquo;</p>
+                    <p class="projects-card__proof"><strong>What it proves:</strong> AI-assisted workflows, audio/product thinking, upload UX, OpenAI integration, and musician-first design.</p>
+                    <div class="projects-card__actions">
+                        <a class="pixel-button" href="<?php echo esc_url($project_url('suzys-track-analyzer', '/suzys-track-analyzer/')); ?>">Analyze a Track</a>
+                    </div>
+                </article>
+            </div>
+        </section>
+
+        <section id="creative-labs" class="projects-section" aria-labelledby="creative-labs-title">
+            <div class="projects-section-header">
+                <h2 id="creative-labs-title" class="pixel-font">Creative labs</h2>
+                <p>Experiments where music, AI, browser visuals, retro interfaces, and Vancouver rain all start yelling into the same effects pedal.</p>
+            </div>
+            <div class="projects-grid">
+                <article class="projects-card">
+                    <h3 class="pixel-font">ASMR Lab / Rain City Experiments</h3>
+                    <p class="projects-card__status"><strong>Status:</strong> Rebuild in progress</p>
+                    <p>Procedural audio-visual experiments for storyboarded micro-scenes, browser foley, synchronized timelines, Vancouver route presets, and AI-assisted creative control.</p>
+                    <p class="projects-card__proof"><strong>What it proves:</strong> Audio engines, visual timelines, prompt-to-structure workflows, creative tooling, and experimental UX.</p>
+                    <div class="projects-card__actions">
+                        <a class="pixel-button" href="<?php echo esc_url($project_url('asmr-lab')); ?>">Explore ASMR Lab</a>
+                    </div>
+                </article>
+
+                <article class="projects-card">
+                    <h3 class="pixel-font">Albini Q&amp;A</h3>
+                    <p class="projects-card__status"><strong>Status:</strong> Music-tech experiment</p>
+                    <p>An interactive creative app inspired by Steve Albini&rsquo;s public voice and engineering ethos: part tribute, part music-technology playground, part quote-grounded interface experiment.</p>
+                    <p class="projects-card__proof"><strong>What it proves:</strong> Voice, archives, UI personality, quote handling, and creative AI boundaries.</p>
+                    <div class="projects-card__actions">
+                        <a class="pixel-button" href="<?php echo esc_url($project_url('albini-qa')); ?>">Open Albini Q&amp;A</a>
+                    </div>
+                </article>
+
+                <article class="projects-card">
+                    <h3 class="pixel-font">Riff Generator</h3>
+                    <p class="projects-card__status"><strong>Status:</strong> Small creative utility</p>
+                    <p>A quick creative prompt machine for music ideas, riffs, and songwriting sparks.</p>
+                    <p class="projects-card__proof"><strong>What it proves:</strong> Small-tool thinking, playful UX, and musician-focused utility.</p>
+                    <div class="projects-card__actions">
+                        <a class="pixel-button" href="<?php echo esc_url($project_url('riff-generator')); ?>">Generate a Riff</a>
+                    </div>
+                </article>
+
+                <article class="projects-card">
+                    <h3 class="pixel-font">Arcade / Canucks Puck Bash</h3>
+                    <p class="projects-card__status"><strong>Status:</strong> Playable web toy</p>
+                    <p>Retro arcade energy, hockey chaos, and browser-game experimentation living inside the same custom WordPress universe.</p>
+                    <p class="projects-card__proof"><strong>What it proves:</strong> Canvas/game UI thinking, interaction loops, fun as product glue, and Vancouver sports nonsense in the best way.</p>
+                    <div class="projects-card__actions">
+                        <a class="pixel-button" href="<?php echo esc_url($project_url('arcade')); ?>">Open Arcade</a>
+                    </div>
+                </article>
+            </div>
+        </section>
+
+        <section id="vancouver-builds" class="projects-section" aria-labelledby="vancouver-builds-title">
+            <div class="projects-section-header">
+                <h2 id="vancouver-builds-title" class="pixel-font">Vancouver, civic, and community builds</h2>
+                <p>Local-first experiments and pages connected to Vancouver, civic life, community, advocacy, events, and useful public information.</p>
+            </div>
+            <div class="projects-grid">
+                <article class="projects-card">
+                    <h3 class="pixel-font">VanOps Radar</h3>
+                    <p class="projects-card__status"><strong>Status:</strong> Local disruption intelligence</p>
+                    <p>A Vancouver SMB operations dashboard concept for local disruption intelligence and business continuity.</p>
+                    <div class="projects-card__actions">
+                        <a class="pixel-button" href="<?php echo esc_url($project_url('vanops-radar')); ?>">Open VanOps Radar</a>
+                    </div>
+                </article>
+
+                <article class="projects-card">
+                    <h3 class="pixel-font">Gastown Simulator</h3>
+                    <p class="projects-card__status"><strong>Status:</strong> Browser world prototype</p>
+                    <p>A browser-based Vancouver worldbuilding prototype using local route logic and civic/open-data thinking.</p>
+                    <div class="projects-card__actions">
+                        <a class="pixel-button" href="<?php echo esc_url($project_url('page-gastown-sim', '/page-gastown-sim/')); ?>">Enter Gastown</a>
+                    </div>
+                </article>
+
+                <article class="projects-card">
+                    <h3 class="pixel-font">Advocacy updates</h3>
+                    <p class="projects-card__status"><strong>Status:</strong> Civic notebook</p>
+                    <p>A place for tenant-rights, DTES, city council, and civic advocacy notes as Suzy keeps building a stronger public voice in Vancouver.</p>
+                    <div class="projects-card__actions">
+                        <a class="pixel-button" href="<?php echo esc_url($project_url('advocacy')); ?>">Read advocacy updates</a>
+                    </div>
+                </article>
+
+                <article class="projects-card">
+                    <h3 class="pixel-font">Coffee for Builders</h3>
+                    <p class="projects-card__status"><strong>Status:</strong> Community experiment</p>
+                    <p>A lightweight invitation for local builders, makers, founders, musicians, technologists, and practical weirdos to connect without networking-event cosplay.</p>
+                    <div class="projects-card__actions">
+                        <a class="pixel-button" href="<?php echo esc_url($project_url('coffee-for-builders')); ?>">Coffee for Builders</a>
+                    </div>
+                </article>
+            </div>
+        </section>
+
+        <section class="projects-section" aria-labelledby="more-signals-title">
+            <div class="projects-section-header">
+                <h2 id="more-signals-title" class="pixel-font">More signals</h2>
+            </div>
+            <div class="projects-mini-grid">
+                <a class="projects-card" href="<?php echo esc_url($project_url('music-releases')); ?>"><strong>Music Releases</strong></a>
+                <a class="projects-card" href="<?php echo esc_url($project_url('podcast')); ?>"><strong>Podcast</strong></a>
+                <a class="projects-card" href="<?php echo esc_url(home_url('/bio/')); ?>"><strong>Bio</strong></a>
+                <a class="projects-card" href="<?php echo esc_url(home_url('/work-with-suzy/')); ?>"><strong>Work With Suzy</strong></a>
+                <a class="projects-card" href="https://github.com/suzyeaston/suzyeastonca" target="_blank" rel="noopener noreferrer"><strong>GitHub source</strong></a>
+            </div>
+        </section>
+
+        <section class="projects-section" aria-labelledby="how-i-build-title">
+            <div class="projects-section-header">
+                <h2 id="how-i-build-title" class="pixel-font">How I build</h2>
+                <p>I build in public, use the site as a working lab, and treat prototypes as proof. A project does not need to be perfect to be useful &mdash; it needs to reveal the next problem clearly.</p>
+            </div>
+            <div class="projects-method-grid">
+                <article class="projects-card"><h3 class="pixel-font">Practical first</h3><p>Tools should solve a real workflow or teach something concrete.</p></article>
+                <article class="projects-card"><h3 class="pixel-font">Weird is allowed</h3><p>Personality is not a bug. It helps people remember the thing.</p></article>
+                <article class="projects-card"><h3 class="pixel-font">Systems matter</h3><p>The fun layer still needs sane data, caching, APIs, fallbacks, and debugging.</p></article>
+                <article class="projects-card"><h3 class="pixel-font">Ship, learn, revise</h3><p>The point is momentum: build the smallest useful version, test it, then make it sharper.</p></article>
+            </div>
+        </section>
+
+        <section class="projects-final-cta projects-section" aria-labelledby="projects-cta-title">
+            <h2 id="projects-cta-title" class="pixel-font">Want to build something useful and slightly dangerous?</h2>
+            <p>I&rsquo;m open to senior technical roles, contract web development, QA/automation work, custom WordPress builds, dashboards, practical AI prototypes, and weird bug triage.</p>
+            <div class="projects-actions" role="group" aria-label="Work with Suzy and contact links">
+                <a class="pixel-button" href="<?php echo esc_url(home_url('/work-with-suzy/')); ?>">Work with Suzy</a>
+                <a class="pixel-button" href="mailto:suzyeaston@icloud.com?subject=Project%20Inquiry">Email Suzy</a>
+                <a class="pixel-button" href="https://github.com/suzyeaston/suzyeastonca" target="_blank" rel="noopener noreferrer">View GitHub</a>
+            </div>
+        </section>
+    </div>
+</main>
+<?php
+get_footer();

--- a/style.css
+++ b/style.css
@@ -4466,3 +4466,220 @@ body.page-template-page-bio-php .bio-content {
     display: none;
   }
 }
+
+/* Projects page */
+.page-template-page-projects {
+    --projects-bg: #040815;
+    --projects-panel: rgba(8, 14, 32, 0.88);
+    --projects-panel-alt: rgba(12, 20, 44, 0.9);
+    --projects-cyan: #39f5ff;
+    --projects-teal: #35e7c6;
+    --projects-magenta: #ff4fd8;
+    --projects-purple: #8b5cf6;
+    --projects-text: #f3f7ff;
+    --projects-muted: rgba(243, 247, 255, 0.82);
+    --projects-green: #6dff87;
+}
+
+.page-template-page-projects .projects-page {
+    background: radial-gradient(circle at 12% 8%, rgba(57, 245, 255, 0.09), transparent 45%),
+        radial-gradient(circle at 88% 90%, rgba(255, 79, 216, 0.08), transparent 50%),
+        var(--projects-bg);
+    color: var(--projects-text);
+}
+
+.page-template-page-projects .projects-shell {
+    max-width: 1080px;
+    margin: 18px auto 36px;
+    display: grid;
+    gap: 22px;
+}
+
+.page-template-page-projects .projects-section {
+    border: 1px solid rgba(57, 245, 255, 0.34);
+    border-radius: 16px;
+    background: linear-gradient(160deg, var(--projects-panel), var(--projects-panel-alt));
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02), 0 16px 36px rgba(0, 0, 0, 0.42);
+    padding: clamp(20px, 3.2vw, 32px);
+}
+
+.page-template-page-projects .projects-hero {
+    border-color: rgba(57, 245, 255, 0.52);
+}
+
+.page-template-page-projects .projects-eyebrow {
+    margin: 0 0 12px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--projects-teal);
+    font-size: clamp(0.72rem, 1.4vw, 0.86rem);
+}
+
+.page-template-page-projects .projects-hero .retro-title,
+.page-template-page-projects .projects-section h2 {
+    margin: 0 0 12px;
+    color: var(--projects-cyan);
+    text-shadow: 0 0 14px rgba(57, 245, 255, 0.28);
+}
+
+.page-template-page-projects .projects-hero .retro-title {
+    font-size: clamp(2rem, 5.4vw, 3.2rem);
+    line-height: 1.06;
+}
+
+.page-template-page-projects .projects-lead {
+    margin: 0 0 10px;
+    max-width: 78ch;
+    font-size: clamp(1rem, 1.9vw, 1.16rem);
+    line-height: 1.6;
+    color: var(--projects-text);
+}
+
+.page-template-page-projects .projects-section p,
+.page-template-page-projects .projects-section li {
+    margin: 0 0 12px;
+    color: var(--projects-muted);
+    line-height: 1.62;
+}
+
+.page-template-page-projects .projects-actions {
+    margin-top: 16px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.page-template-page-projects .projects-actions .pixel-button {
+    border-color: rgba(57, 245, 255, 0.46);
+    box-shadow: 0 0 14px rgba(57, 245, 255, 0.14);
+}
+
+.page-template-page-projects .projects-actions .pixel-button:nth-child(2) {
+    border-color: rgba(139, 92, 246, 0.55);
+    box-shadow: 0 0 14px rgba(139, 92, 246, 0.22);
+}
+
+.page-template-page-projects .projects-actions .pixel-button:last-child {
+    border-color: rgba(255, 79, 216, 0.64);
+    box-shadow: 0 0 16px rgba(255, 79, 216, 0.24);
+}
+
+.page-template-page-projects .projects-section-header {
+    margin-bottom: 12px;
+}
+
+.page-template-page-projects .projects-grid,
+.page-template-page-projects .projects-method-grid {
+    display: grid;
+    gap: 14px;
+    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+}
+
+.page-template-page-projects .projects-grid--featured {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.page-template-page-projects .projects-card {
+    border: 1px solid rgba(57, 245, 255, 0.24);
+    border-radius: 12px;
+    background: rgba(9, 16, 36, 0.84);
+    padding: 16px;
+    min-height: 170px;
+}
+
+.page-template-page-projects .projects-card--featured {
+    border-color: rgba(53, 231, 198, 0.5);
+    box-shadow: inset 0 0 0 1px rgba(53, 231, 198, 0.2);
+}
+
+.page-template-page-projects .projects-card h3 {
+    margin: 0 0 9px;
+    color: #a6fbff;
+    line-height: 1.35;
+    font-size: 1.02rem;
+}
+
+.page-template-page-projects .projects-card__status {
+    display: inline-block;
+    margin: 0 0 10px;
+    padding: 4px 9px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 79, 216, 0.44);
+    background: rgba(42, 14, 53, 0.38);
+    color: #ffe3fa;
+    font-size: 0.78rem;
+    letter-spacing: 0.01em;
+}
+
+.page-template-page-projects .projects-card__proof {
+    margin-top: 10px;
+    color: #d5f8ff;
+    border-top: 1px dashed rgba(57, 245, 255, 0.3);
+    padding-top: 10px;
+}
+
+.page-template-page-projects .projects-card__actions {
+    margin-top: 14px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 9px;
+}
+
+.page-template-page-projects .projects-card__actions .pixel-button {
+    min-height: 40px;
+}
+
+.page-template-page-projects .projects-mini-grid {
+    display: grid;
+    gap: 10px;
+    grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+}
+
+.page-template-page-projects .projects-mini-grid .projects-card {
+    min-height: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    text-decoration: none;
+    color: var(--projects-text);
+    transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.page-template-page-projects .projects-mini-grid .projects-card strong {
+    color: var(--projects-cyan);
+    font-size: 0.94rem;
+}
+
+.page-template-page-projects .projects-mini-grid .projects-card:hover,
+.page-template-page-projects .projects-mini-grid .projects-card:focus-visible {
+    border-color: rgba(109, 255, 135, 0.6);
+    transform: translateY(-1px);
+    outline: none;
+}
+
+.page-template-page-projects .projects-final-cta {
+    border-color: rgba(255, 79, 216, 0.56);
+    box-shadow: inset 0 0 0 1px rgba(255, 79, 216, 0.12), 0 20px 40px rgba(26, 4, 33, 0.42), 0 0 24px rgba(139, 92, 246, 0.2);
+}
+
+.page-template-page-projects .projects-final-cta h2 {
+    color: var(--projects-magenta);
+    text-shadow: 0 0 12px rgba(255, 79, 216, 0.26);
+}
+
+@media (max-width: 700px) {
+    .page-template-page-projects .projects-shell {
+        gap: 16px;
+    }
+
+    .page-template-page-projects .projects-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .page-template-page-projects .projects-actions .pixel-button {
+        width: 100%;
+        text-align: center;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a dedicated, polished `/projects/` page that surfaces Suzy’s active builds, experiments, civic work, music-tech projects, and archives in the site’s existing Vancouver/cyberpunk visual language. 
- Keep changes isolated (no edits to individual project pages, homepage layout, JS, plugins, or `functions.php`) while ensuring links degrade safely if page slugs are missing.

### Description
- Added a new page template `page-projects.php` (Template Name: Projects) that renders a structured Projects page with hero, featured builds, creative labs, Vancouver/community builds, more signals, "How I build" method cards, and a final CTA. 
- Implemented a local `project_url` resolver closure inside `page-projects.php` that tries `get_page_by_path($slug)` then falls back to `home_url('/slug/')` (or provided fallback path).
- Populated the required project cards and links (VanOps Radar, Gastown Simulator, Lousy Outages, Track Analyzer, ASMR Lab, Albini Q&A, Riff Generator, Arcade, Advocacy, Coffee for Builders, Music Releases, Podcast, Bio, Work With Suzy, GitHub). 
- Added scoped CSS to `style.css` under `.page-template-page-projects` and `.projects-page` to implement the deep-navy / cyan / magenta palette and responsive card layouts without touching global or other page styles.

### Testing
- Ran `php -l page-projects.php` which reported "No syntax errors detected in page-projects.php" (succeeded). 
- Verified the template file exists with `test -f page-projects.php` (succeeded) and inspected `style.css` additions to confirm styles are under `.page-template-page-projects` (verification commands succeeded). 
- Performed repository checks to confirm only `page-projects.php` and `style.css` were modified (verification commands succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f000b08714832ea1b80e65fa05399c)