### PR TITLE
Polish /projects/ hero typography and remove “dangerous” CTA language

### DIFF
--- a/page-projects.php
+++ b/page-projects.php
@@ -22,10 +22,10 @@ $project_url = static function (string $slug, string $fallback_path = ''): strin
 <main id="main-content" class="projects-page">
     <div class="projects-shell">
         <section class="projects-hero projects-section" aria-labelledby="projects-title">
-            <p class="projects-eyebrow pixel-font">Build log // useful weird systems</p>
-            <h1 id="projects-title" class="retro-title glow-lite">Projects</h1>
-            <p class="projects-lead">A field guide to the tools, prototypes, dashboards, music-tech experiments, civic builds, and strange useful systems I&rsquo;m building in public.</p>
-            <p>Some are polished enough to use. Some are live prototypes. Some are weird little labs that teach me what to build next. The common thread: practical systems, creative taste, and enough technical grit to make the thing actually work.</p>
+            <p class="projects-eyebrow projects-hero__eyebrow pixel-font">Build log // useful weird systems</p>
+            <h1 id="projects-title" class="projects-hero__title">Projects</h1>
+            <p class="projects-lead projects-hero__lead">A field guide to the tools, prototypes, dashboards, music-tech experiments, civic builds, and strange useful systems I&rsquo;m building in public.</p>
+            <p class="projects-hero__support">Some are polished enough to use. Some are live prototypes. Some are weird little labs that teach me what to build next. The common thread: practical systems, creative taste, and enough technical grit to make the thing actually work.</p>
             <div class="projects-actions" role="group" aria-label="Projects page jumps and primary links">
                 <a class="pixel-button" href="#featured-projects">Featured builds</a>
                 <a class="pixel-button" href="#creative-labs">Creative labs</a>
@@ -200,7 +200,7 @@ $project_url = static function (string $slug, string $fallback_path = ''): strin
         </section>
 
         <section class="projects-final-cta projects-section" aria-labelledby="projects-cta-title">
-            <h2 id="projects-cta-title" class="pixel-font">Want to build something useful and slightly dangerous?</h2>
+            <h2 id="projects-cta-title" class="pixel-font">Want to build something useful and memorable?</h2>
             <p>I&rsquo;m open to senior technical roles, contract web development, QA/automation work, custom WordPress builds, dashboards, practical AI prototypes, and weird bug triage.</p>
             <div class="projects-actions" role="group" aria-label="Work with Suzy and contact links">
                 <a class="pixel-button" href="<?php echo esc_url(home_url('/work-with-suzy/')); ?>">Work with Suzy</a>

--- a/style.css
+++ b/style.css
@@ -4505,34 +4505,56 @@ body.page-template-page-bio-php .bio-content {
 
 .page-template-page-projects .projects-hero {
     border-color: rgba(57, 245, 255, 0.52);
+    background: linear-gradient(160deg, rgba(8, 18, 45, 0.95), rgba(9, 20, 54, 0.9));
+    padding: clamp(24px, 4.2vw, 42px);
 }
 
-.page-template-page-projects .projects-eyebrow {
+.page-template-page-projects .projects-eyebrow,
+.page-template-page-projects .projects-hero__eyebrow {
     margin: 0 0 12px;
     letter-spacing: 0.04em;
     text-transform: uppercase;
     color: var(--projects-teal);
     font-size: clamp(0.72rem, 1.4vw, 0.86rem);
+    line-height: 1.55;
+    background: transparent;
+    display: inline-flex;
+    padding: 0;
 }
 
 .page-template-page-projects .projects-hero .retro-title,
+.page-template-page-projects .projects-hero__title,
 .page-template-page-projects .projects-section h2 {
     margin: 0 0 12px;
     color: var(--projects-cyan);
-    text-shadow: 0 0 14px rgba(57, 245, 255, 0.28);
+    text-shadow: 0 0 14px rgba(57, 245, 255, 0.24);
+    background: transparent;
 }
 
-.page-template-page-projects .projects-hero .retro-title {
-    font-size: clamp(2rem, 5.4vw, 3.2rem);
-    line-height: 1.06;
+.page-template-page-projects .projects-hero .retro-title,
+.page-template-page-projects .projects-hero__title {
+    font-family: "Press Start 2P", cursive;
+    font-size: clamp(3rem, 8vw, 6rem);
+    line-height: 1.03;
+    letter-spacing: 0.02em;
+    color: #71f7ff;
+    text-shadow: 0 0 20px rgba(57, 245, 255, 0.25);
+    padding: 0;
 }
 
-.page-template-page-projects .projects-lead {
+.page-template-page-projects .projects-hero .retro-title.glow-lite {
+    color: #71f7ff;
+    text-shadow: 0 0 20px rgba(57, 245, 255, 0.25);
+}
+
+.page-template-page-projects .projects-lead,
+.page-template-page-projects .projects-hero__lead {
     margin: 0 0 10px;
     max-width: 78ch;
-    font-size: clamp(1rem, 1.9vw, 1.16rem);
-    line-height: 1.6;
+    font-size: clamp(1.2rem, 2.4vw, 1.75rem);
+    line-height: 1.5;
     color: var(--projects-text);
+    background: transparent;
 }
 
 .page-template-page-projects .projects-section p,
@@ -4540,6 +4562,14 @@ body.page-template-page-bio-php .bio-content {
     margin: 0 0 12px;
     color: var(--projects-muted);
     line-height: 1.62;
+}
+
+.page-template-page-projects .projects-hero__support {
+    max-width: 76ch;
+    font-size: clamp(1rem, 1.5vw, 1.12rem);
+    line-height: 1.72;
+    color: rgba(243, 247, 255, 0.92);
+    background: transparent;
 }
 
 .page-template-page-projects .projects-actions {
@@ -4597,6 +4627,12 @@ body.page-template-page-bio-php .bio-content {
     color: #a6fbff;
     line-height: 1.35;
     font-size: 1.02rem;
+}
+
+.page-template-page-projects .projects-card p {
+    font-size: 0.98rem;
+    line-height: 1.68;
+    color: rgba(243, 247, 255, 0.9);
 }
 
 .page-template-page-projects .projects-card__status {
@@ -4660,12 +4696,22 @@ body.page-template-page-bio-php .bio-content {
 
 .page-template-page-projects .projects-final-cta {
     border-color: rgba(255, 79, 216, 0.56);
+    background: linear-gradient(155deg, rgba(24, 9, 52, 0.92), rgba(13, 20, 54, 0.92));
     box-shadow: inset 0 0 0 1px rgba(255, 79, 216, 0.12), 0 20px 40px rgba(26, 4, 33, 0.42), 0 0 24px rgba(139, 92, 246, 0.2);
 }
 
 .page-template-page-projects .projects-final-cta h2 {
-    color: var(--projects-magenta);
-    text-shadow: 0 0 12px rgba(255, 79, 216, 0.26);
+    color: #ff7ee8;
+    text-shadow: 0 0 10px rgba(255, 79, 216, 0.22), 0 0 16px rgba(57, 245, 255, 0.16);
+    background: transparent;
+    margin-bottom: 14px;
+}
+
+.page-template-page-projects .projects-final-cta p {
+    font-size: clamp(1rem, 1.5vw, 1.1rem);
+    line-height: 1.72;
+    color: rgba(243, 247, 255, 0.92);
+    background: transparent;
 }
 
 @media (max-width: 700px) {
@@ -4681,5 +4727,22 @@ body.page-template-page-bio-php .bio-content {
     .page-template-page-projects .projects-actions .pixel-button {
         width: 100%;
         text-align: center;
+    }
+
+    .page-template-page-projects .projects-hero .retro-title,
+    .page-template-page-projects .projects-hero__title {
+        font-size: clamp(2.35rem, 16vw, 3.2rem);
+        line-height: 1.08;
+        overflow-wrap: anywhere;
+    }
+
+    .page-template-page-projects .projects-hero__support,
+    .page-template-page-projects .projects-section p {
+        overflow-wrap: anywhere;
+    }
+
+    .page-template-page-projects .projects-grid,
+    .page-template-page-projects .projects-method-grid {
+        grid-template-columns: 1fr;
     }
 }


### PR DESCRIPTION
### Motivation
- Clean up the Projects page hero which was visually heavy due to blocky pixel treatments and black text strips, while keeping the site’s cyberpunk/retro tone.
- Remove the word “dangerous” from the final CTA and make the closing section more polished and recruiter/client-friendly.
- Improve overall readability and mobile behavior for the Projects page without touching unrelated templates or JS.

### Description
- Updated `page-projects.php` to add semantic hero classes (`projects-hero__eyebrow`, `projects-hero__title`, `projects-hero__lead`, `projects-hero__support`) and preserved existing hero content and action links.
- Changed final CTA heading text to: `Want to build something useful and memorable?` and left the body copy and buttons intact.
- Modified `style.css` only inside the `.page-template-page-projects` scope to: provide a dark navy/cyberpunk panel background for the hero, remove opaque black background strips on hero text by setting `background: transparent`, control H1 sizing with `clamp()` and a cyan/teal glow, increase lead/support readability with adjusted font sizes and line-height, and refine project card and final-CTA typography and colors to be off-white and more legible.
- Added mobile-specific tweaks so the hero title wraps safely, buttons stack/wrap cleanly, and project grids collapse to a single column.

### Testing
- Ran `php -l page-projects.php` and received no PHP syntax errors.
- Searched updated files with `rg` for banned wording (`dangerous|risky|scary|unsafe`) and confirmed no matches in `page-projects.php` or `style.css`.
- Manually reviewed the diff to confirm only `page-projects.php` and `style.css` were changed and that hero links/buttons were unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f002f01174832e85f5620dc35d6c1d)