### PR TITLE
Add SECURITY.md, local secrets example, and gitignore to prevent committing secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.env
+.env.*
+wp-config.php
+local-config.php
+secrets.php
+*.pem
+*.key
+.DS_Store

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Secret Handling
+- Never commit API keys, tokens, passwords, or other secrets to this repository.
+- Store production secrets in `wp-config.php` or environment variables.
+- If any secret reaches GitHub, rotate/revoke it immediately.
+
+## Expected Secrets
+The current application expects these secrets to be configured outside tracked source:
+- `OPENAI_API_KEY`
+- `THE_ODDS_API_KEY`
+- `CLOUDFLARE_TURNSTILE_SITE_KEY`
+- `CLOUDFLARE_TURNSTILE_SECRET_KEY`
+
+## Pre-push Checks
+- Run a secret scan before pushing (for example, with `gitleaks` or GitGuardian CLI).
+- Enable GitHub Secret Scanning and Push Protection where available.
+
+## Safe Collaboration Rules
+- Do not paste real secrets into Codex prompts, commit messages, README/docs files, screenshots, or issues.
+- Documentation examples must use placeholders only.

--- a/docs/local-secrets.example.md
+++ b/docs/local-secrets.example.md
@@ -1,0 +1,12 @@
+# Local Secret Configuration Example (Placeholders Only)
+
+This file is documentation only. It must contain placeholders only.
+
+Real values belong in `wp-config.php` or environment variables, not in committed source files.
+
+```php
+define( 'OPENAI_API_KEY', 'your-openai-key-here' );
+define( 'THE_ODDS_API_KEY', 'your-rotated-odds-api-key-here' );
+define( 'CLOUDFLARE_TURNSTILE_SITE_KEY', 'your-turnstile-site-key-here' );
+define( 'CLOUDFLARE_TURNSTILE_SECRET_KEY', 'your-turnstile-secret-key-here' );
+```


### PR DESCRIPTION
### Motivation
- Provide clear guidance to avoid committing secrets and list expected environment variables for the application.
- Prevent accidental inclusion of common secret files and OS artifacts in the repository.

### Description
- Add `SECURITY.md` that documents secret handling rules, pre-push checks, and the expected secrets (`OPENAI_API_KEY`, `THE_ODDS_API_KEY`, `CLOUDFLARE_TURNSTILE_SITE_KEY`, `CLOUDFLARE_TURNSTILE_SECRET_KEY`).
- Add `docs/local-secrets.example.md` with placeholder `wp-config.php` examples showing how to define required secret constants.
- Add `.gitignore` to ignore `.env` files, `wp-config.php`, `local-config.php`, `secrets.php`, `*.pem`, `*.key`, and `.DS_Store`.

### Testing
- No automated tests were added or required for these documentation and ignore-file changes.
- Secret-scanning and CI pre-push checks are recommended but were not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f10eba4314832ea6ac18ae824a5d6e)