### PR TITLE
Redesign /bio/ into static Vancouver “signal chain” page and remove crawl assets

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -85,22 +85,6 @@ function retro_game_music_theme_scripts() {
         );
     }
 
-    if ( is_page_template( 'page-bio.php' ) || is_page( 'bio' ) ) {
-        wp_enqueue_script(
-            'tone-js',
-            'https://unpkg.com/tone@14.7.77/build/Tone.js',
-            array(),
-            '14.7.77',
-            true
-        );
-        wp_enqueue_script(
-            'bio-crawl',
-            get_template_directory_uri() . '/js/bio-crawl.js',
-            array( 'tone-js' ),
-            filemtime( get_template_directory() . '/js/bio-crawl.js' ),
-            true
-        );
-    }
 }
 add_action('wp_enqueue_scripts', 'retro_game_music_theme_scripts');
 

--- a/page-bio.php
+++ b/page-bio.php
@@ -3,43 +3,77 @@
 Template Name: Bio Page
 */
 get_header();
+
+$hero_actions = array(
+    array('label' => 'Work With Suzy', 'url' => '/work-with-suzy/'),
+    array('label' => 'Projects', 'url' => '/projects/'),
+    array('label' => 'Email Suzy', 'url' => 'mailto:suzyeaston@icloud.com?subject=Bio%20page%20inquiry'),
+    array('label' => 'LinkedIn', 'url' => 'https://www.linkedin.com/in/suzyeaston/'),
+    array('label' => 'Bandcamp', 'url' => 'https://suzyeaston.bandcamp.com'),
+);
+
+$main_cards = array(
+    array('label' => 'SIDE A', 'title' => 'Noise, nerve, and timing', 'body' => 'Before tech became the main stage, I played bass in Vancouver bands including Minto/The Smokes and Seafoam, toured across Canada, appeared on MuchMusic, and recorded in Chicago with Steve Albini. Music taught me how to troubleshoot under pressure, collaborate with intense people, trust my ear, and keep the whole thing moving when the signal gets messy.'),
+    array('label' => 'SIDE B', 'title' => 'Systems under pressure', 'body' => 'I\'ve spent 12+ years working across QA automation, IT operations, support engineering, SaaS platforms, identity, endpoint/security, cloud-connected infrastructure, APIs, and production troubleshooting. I build tests, scripts, alerts, docs, dashboards, and workflows that make fragile systems easier to understand and harder to break.'),
+    array('label' => 'SIDE C', 'title' => 'The public lab', 'body' => 'My site is part portfolio, part arcade cabinet, part notebook, part product lab. I use it to build in public with WordPress/PHP, JavaScript, AI-assisted workflows, audio experiments, civic/open-data ideas, and Vancouver-flavoured tools that are strange enough to be memorable and useful enough to keep shipping.'),
+    array('label' => 'SIDE D', 'title' => 'Vancouver signal', 'body' => 'A lot of my work starts with the city around me: transit, venues, small businesses, housing pressure, weird outages, civic data, rain, noise, and the feeling that useful tools should have personality. I\'m interested in technology that helps real people navigate messy systems — not just shinier dashboards for people who already have too many dashboards.'),
+);
 ?>
-
 <main id="main-content">
-    <section class="page-content">
-        <div class="bio-content">
-<div class="bio-crawl-wrap" aria-label="Bio opening crawl">
-  <button
-    class="bio-crawl-sound-toggle"
-    type="button"
-    aria-pressed="false"
-    aria-label="Suzy’s Music Bio Theme Song: Off"
-  >Suzy’s Music Bio Theme Song: Off</button>
-  <div class="bio-crawl-camera">
-    <div class="bio-crawl-track">
-      <div class="bio-crawl">
-        <div class="bio-crawl-content">
-          <h1 class="bio-crawl-title">SUZY EASTON</h1>
-          <h2 class="bio-crawl-subtitle">Vancouver born and raised</h2>
+    <section class="bio-page" aria-label="Bio page">
+        <div class="bio-shell">
+            <header class="bio-hero">
+                <p class="bio-kicker"><?php echo esc_html( 'VANCOUVER SIGNAL CHAIN // MUSIC • SYSTEMS • AI' ); ?></p>
+                <h1 class="bio-title"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>
+                <p class="bio-subtitle"><?php echo esc_html( 'Musician. Creative technologist. Senior technical generalist. Builder of strange, useful systems.' ); ?></p>
+                <p class="bio-intro"><?php echo esc_html( 'I’m a Vancouver-born musician and technical systems fixer. I came up through piano lessons, open mics, recording arts, touring vans, bass amps, and studio floors — places where you learn fast, listen harder, and make the thing work even when the room is loud.' ); ?></p>
+                <p class="bio-intro"><?php echo esc_html( 'That same instinct now runs through my technical work: QA automation, IT operations, cloud-connected systems, identity/security, SaaS troubleshooting, APIs, production debugging, and practical AI tools. The through-line is simple: turn chaos into signal, make the useful thing work, and get a little louder when the moment calls for it.' ); ?></p>
+                <div class="bio-status-strip" role="status" aria-label="Current availability"><?php echo esc_html( 'AVAILABLE FOR: senior technical roles • contract builds • QA automation • WordPress/PHP • practical AI prototypes • weird bug triage' ); ?></div>
+                <div class="bio-terminal-strip" aria-label="Operator metadata">
+                    <span><?php echo esc_html( 'LOCATION: VANCOUVER' ); ?></span>
+                    <span><?php echo esc_html( 'MODE: BUILDING' ); ?></span>
+                    <span><?php echo esc_html( 'SIGNAL: ONLINE' ); ?></span>
+                </div>
+                <div class="bio-actions" aria-label="Primary actions">
+                    <?php foreach ( $hero_actions as $action ) : ?>
+                        <a class="bio-button" href="<?php echo esc_url( $action['url'] ); ?>"><?php echo esc_html( $action['label'] ); ?></a>
+                    <?php endforeach; ?>
+                </div>
+            </header>
 
-          <p>Hello. I’m Suzy Easton, a musician and creative technologist. I started with piano lessons, moved into open mics, studied classical music and recording arts, and later played in the psychedelic rock band Seafoam and on bass for The Smokes/Minto. We toured across Canada and recorded in Chicago with Steve Albini.</p>
+            <section class="bio-grid" aria-label="Background and technical profile">
+                <?php foreach ( $main_cards as $card ) : ?>
+                    <article class="bio-card">
+                        <p class="bio-card__label"><?php echo esc_html( $card['label'] ); ?></p>
+                        <h2 class="bio-card__title"><?php echo esc_html( $card['title'] ); ?></h2>
+                        <p class="bio-card__body"><?php echo esc_html( $card['body'] ); ?></p>
+                    </article>
+                <?php endforeach; ?>
+            </section>
 
-          <p>Alongside music, I work in Senior IT Ops with a focus on reliability, automation, and software operations. I like building systems that hold up under pressure, and tools that feel intentional, modern, and fun to use.</p>
+            <section class="bio-proof-panel" aria-labelledby="bio-proof-title">
+                <div class="bio-proof-panel__header">
+                    <h2 id="bio-proof-title"><?php echo esc_html( 'PROOF OF SIGNAL' ); ?></h2>
+                    <p><?php echo esc_html( 'A few receipts from the archive — music, press, radio, and public builds.' ); ?></p>
+                </div>
+                <div class="bio-proof-panel__grid">
+                    <article class="bio-proof-card"><p class="bio-proof-card__label">PRESS CLIPPING</p><h3 class="bio-proof-card__title">Minto finally gets serious</h3><p class="bio-proof-card__body">The Georgia Straight covered Minto’s shift from The Smokes into a harder-working Vancouver rock band, the Steve Albini recording trip in Chicago, and the live-sounding foundation behind Lay It on Me.</p><a class="bio-proof-card__link" href="<?php echo esc_url( 'https://www.straight.com/article-244417/minto-finally-gets-serious' ); ?>" target="_blank" rel="noopener">Read the Georgia Straight article</a></article>
+                    <article class="bio-proof-card"><p class="bio-proof-card__label">LOCAL RADIO</p><h3 class="bio-proof-card__title">CiTR airplay</h3><p class="bio-proof-card__body">“Obsolete” and “A Little Louder” both received airplay on UBC’s CiTR — a local signal boost from the campus/community radio world that helped shape so much Vancouver music culture.</p></article>
+                    <article class="bio-proof-card"><p class="bio-proof-card__label">SELF-RELEASED TRACK</p><h3 class="bio-proof-card__title">A Little Louder</h3><p class="bio-proof-card__body">A short, loud rock signal flare — part confidence anthem, part reminder to take up space.</p><a class="bio-proof-card__link" href="<?php echo esc_url( 'https://suzyeaston.bandcamp.com' ); ?>" target="_blank" rel="noopener">Listen on Bandcamp</a></article>
+                    <article class="bio-proof-card"><p class="bio-proof-card__label">SELF-PRODUCED TRACK</p><h3 class="bio-proof-card__title">Obsolete</h3><p class="bio-proof-card__body">Industrial-tinged glitch pop about feeling obsolete in a digital world — written, performed, recorded, layered, and produced by Suzy.</p><a class="bio-proof-card__link" href="<?php echo esc_url( 'https://suzyeaston.bandcamp.com/album/obsolete' ); ?>" target="_blank" rel="noopener">Listen on Bandcamp</a></article>
+                </div>
+            </section>
 
-          <p>Lately I have been diving deep into AI. I use it for creative workflows, automation, and interactive experiments where art meets infrastructure. I am drawn to work that is practical, innovative, and a little unexpected.</p>
+            <section class="bio-builds" aria-labelledby="bio-builds-title"><div class="bio-builds__header"><h2 id="bio-builds-title">SIGNALS IN ROTATION</h2><p>A few active signals from the lab — music, code, prototypes, and civic-tech weirdness all feeding the same machine.</p></div><div class="bio-builds__grid">
+                <article class="bio-build"><h3 class="bio-build__title">suzyeaston.ca</h3><p class="bio-build__meta">custom WordPress/PHP portfolio + creative-tech sandbox</p><p class="bio-build__body">Retro UI, REST/API workflows, custom templates, AI-assisted prototyping, audio experiments, and interactive web projects.</p><a class="bio-build__link" href="<?php echo esc_url( '/projects/' ); ?>">Open projects hub</a></article>
+                <article class="bio-build"><h3 class="bio-build__title">Gastown Simulator</h3><p class="bio-build__meta">Vancouver browser-world prototype</p><p class="bio-build__body">A first-person Vancouver corridor experiment using civic/open-data flavour, route anchors, weather/time controls, and iterative product design.</p><a class="bio-build__link" href="<?php echo esc_url( '/page-gastown-sim/' ); ?>">Explore prototype</a></article>
+                <article class="bio-build"><h3 class="bio-build__title">VanOps Radar / Lousy Outages</h3><p class="bio-build__meta">local ops + status monitoring concepts</p><p class="bio-build__body">Vancouver-first operational signal tools for outages, transit/road/weather context, provider status weirdness, and business continuity.</p><p><a class="bio-build__link" href="<?php echo esc_url( '/vanops-radar/' ); ?>">VanOps Radar</a> <a class="bio-build__link" href="<?php echo esc_url( '/lousy-outages/' ); ?>">Lousy Outages</a></p></article>
+                <article class="bio-build"><h3 class="bio-build__title">Track Analyzer / ASMR Lab / AI Film Club</h3><p class="bio-build__meta">AI/audio/video experiments</p><p class="bio-build__body">Creative tooling for music feedback, procedural sound, synchronized visuals, storytelling, and the “fine, I’ll build it myself” side of AI.</p><p><a class="bio-build__link" href="<?php echo esc_url( '/suzys-track-analyzer/' ); ?>">Track Analyzer</a> <a class="bio-build__link" href="<?php echo esc_url( '/asmr-lab/' ); ?>">ASMR Lab</a></p></article>
+            </div></section>
 
-          <p>Recent projects include new music, lessons and sessions, and <em>Lousy Outages</em>, an arcade-style outage and status dashboard built for public awareness. It is a playful format for a serious topic, especially in a world where status pages often tell only part of the story.</p>
+            <section class="bio-useful" aria-labelledby="bio-useful-title"><h2 id="bio-useful-title">WHERE I’M USEFUL</h2><div class="bio-useful__grid"><p class="bio-useful__item">Weird bug triage</p><p class="bio-useful__item">QA automation and release confidence</p><p class="bio-useful__item">WordPress/PHP and JavaScript builds</p><p class="bio-useful__item">SaaS, identity, endpoint, and cloud troubleshooting</p><p class="bio-useful__item">Practical AI prototypes with reviewable outputs</p><p class="bio-useful__item">Dashboards, alerts, workflows, and operational cleanup</p><p class="bio-useful__item">Translating between technical and non-technical humans</p><p class="bio-useful__item">Making cursed systems less cursed</p></div></section>
 
-          <p>Coffee for Builders (Vancouver) should get lit one of these days.</p>
-
-          <p>Reach me at <a href="mailto:suzyeaston@icloud.com">suzyeaston@icloud.com</a>.</p>
-
-          <p class="bio-crawl-bandcamp">🎶 <a href="https://suzyeaston.bandcamp.com" target="_blank" rel="noopener">Support on Bandcamp</a></p>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+            <section class="bio-cta-panel" aria-labelledby="bio-cta-title"><h2 class="bio-cta-panel__title" id="bio-cta-title">WORK WITH THE OPERATOR</h2><p class="bio-cta-panel__body">If you need someone who can debug the weird issue, automate the boring thing, test the fragile workflow, clean up the dashboard, explain the system, or make the project feel less cursed, I’m probably your person.</p><div class="bio-cta-panel__actions"><a class="bio-button" href="<?php echo esc_url( 'mailto:suzyeaston@icloud.com?subject=Work%20With%20Suzy' ); ?>">Email Suzy</a><a class="bio-button" href="<?php echo esc_url( '/work-with-suzy/' ); ?>">Work With Suzy</a><a class="bio-button" href="<?php echo esc_url( '/projects/' ); ?>">Projects</a><a class="bio-button" href="<?php echo esc_url( 'https://github.com/suzyeaston' ); ?>" target="_blank" rel="noopener">GitHub</a></div></section>
         </div>
     </section>
 </main>

--- a/style.css
+++ b/style.css
@@ -3568,239 +3568,49 @@ body {
   }
 }
 
-/* Bio crawl: CSS animated opening crawl */
+/* Bio page: Vancouver signal chain */
 body.page-template-page-bio .bio-content,
 body.page-template-page-bio-php .bio-content {
   overflow: visible;
   white-space: normal;
 }
 
-.bio-crawl-wrap {
-  --crawl-duration: 52s;
-  --crawl-start: 62%;
-  --crawl-travel: 1900px;
-  position: relative;
-  overflow: hidden;
-  height: min(84vh, 900px);
-  border-radius: 16px;
-  padding: 0;
-  isolation: isolate;
-  background: radial-gradient(circle at 50% -32%, rgba(26, 26, 26, 0.42), rgba(0, 0, 0, 0.985) 64%);
+.bio-page {
+  --bio-ink: #020711;
+  --bio-dark-blue: #041c2c;
+  --bio-blue: #00205b;
+  --bio-green: #00843d;
+  --bio-neon-green: #38ff8a;
+  --bio-ice: #f4fbff;
+  --bio-gray: #97999b;
+  --bio-panel: rgba(4, 28, 44, 0.86);
+  --bio-border: rgba(244, 251, 255, 0.22);
+  background: radial-gradient(circle at 12% 10%, rgba(0, 132, 61, 0.22), transparent 42%), radial-gradient(circle at 84% 0%, rgba(0, 32, 91, 0.36), transparent 48%), var(--bio-ink);
+  color: var(--bio-ice);
+  padding: clamp(1rem, 2.5vw, 2.5rem) 0 4rem;
+  overflow-x: clip;
 }
-
-.bio-crawl-camera {
-  position: absolute;
-  inset: 0;
-  perspective: 900px;
-  perspective-origin: 50% 24%;
-  overflow: hidden;
-}
-
-.bio-crawl-track {
-  position: absolute;
-  left: 50%;
-  top: 0;
-  width: min(880px, 90vw);
-  margin: 0;
-  transform-origin: 50% 0%;
-  transform: translate3d(-50%, var(--crawl-start), 0);
-  animation: seBioCrawlTrack var(--crawl-duration) linear 1 both;
-  animation-play-state: paused;
-  will-change: transform;
-}
-
-.bio-crawl-wrap.is-crawl-ready .bio-crawl-track {
-  animation-play-state: running;
-}
-
-@keyframes seBioCrawlTrack {
-  from {
-    transform: translate3d(-50%, var(--crawl-start), 0);
-  }
-
-  to {
-    transform: translate3d(-50%, calc(-1 * var(--crawl-travel)), 0);
-  }
-}
-
-.bio-crawl {
-  margin: 0;
-  text-align: left;
-  font-weight: 700;
-  letter-spacing: 0.01em;
-  line-height: 1.58;
-  font-size: clamp(19px, 2.05vw, 31px);
-  color: #f5d24a;
-  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.58);
-  background: transparent;
-  transform-origin: 50% 0%;
-  transform: rotateX(19deg);
-}
-
-.bio-crawl,
-.bio-crawl * {
-  color: #f5d24a !important;
-  white-space: normal;
-  word-spacing: normal;
-  background: transparent !important;
-}
-
-.bio-crawl-title {
-  text-align: center;
-  letter-spacing: 0.12em;
-  margin: 0 0 10px 0;
-  font-size: clamp(40px, 5.2vw, 78px);
-  line-height: 1.1;
-}
-
-.bio-crawl-subtitle {
-  text-align: center;
-  margin: 0 0 34px 0;
-  font-size: clamp(15px, 2vw, 26px);
-  line-height: 1.35;
-}
-
-
-.bio-crawl-content {
-  display: block;
-}
-.bio-crawl p {
-  margin: 0 0 16px 0;
-  text-align: left;
-}
-
-.bio-crawl a {
-  text-decoration: underline;
-  text-underline-offset: 0.14em;
-  transition: color 180ms ease;
-}
-
-.bio-crawl a:hover,
-.bio-crawl a:focus-visible {
-  color: #ffe37a !important;
-}
-
-.bio-crawl-bandcamp {
-  text-align: center;
-  margin-top: 24px;
-}
-
-.bio-crawl-sound-toggle {
-  position: absolute;
-  top: 14px;
-  right: 14px;
-  z-index: 5;
-  border: 1px solid rgba(245, 210, 74, 0.75);
-  border-radius: 999px;
-  padding: 7px 12px;
-  background: rgba(0, 0, 0, 0.72);
-  color: #f5d24a;
-  font-size: 0.62rem;
-  letter-spacing: 0.03em;
-  text-transform: none;
-  cursor: pointer;
-}
-
-.bio-crawl-sound-toggle:focus-visible,
-.bio-crawl-sound-toggle:hover {
-  border-color: #ffe37a;
-  color: #ffe37a;
-}
-
-.bio-crawl-wrap::before,
-.bio-crawl-wrap::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  pointer-events: none;
-  z-index: 4;
-}
-
-.bio-crawl-wrap::before {
-  top: 0;
-  height: 34%;
-  background: linear-gradient(
-    to bottom,
-    rgba(0, 0, 0, 0.96) 0%,
-    rgba(0, 0, 0, 0.78) 10%,
-    rgba(0, 0, 0, 0.46) 28%,
-    rgba(0, 0, 0, 0.2) 52%,
-    rgba(0, 0, 0, 0.06) 76%,
-    rgba(0, 0, 0, 0) 100%
-  );
-}
-
-.bio-crawl-wrap::after {
-  bottom: 0;
-  height: 72px;
-  background: linear-gradient(to top, rgba(0, 0, 0, 0.24), rgba(0, 0, 0, 0));
-}
-
-@media (max-width: 700px) {
-  .bio-crawl-wrap {
-    --crawl-duration: 58s;
-    --crawl-start: 64%;
-    height: min(80vh, 760px);
-  }
-
-  .bio-crawl-track {
-    width: min(700px, 94vw);
-  }
-
-  .bio-crawl {
-    font-size: clamp(16px, 4.05vw, 21px);
-    line-height: 1.54;
-    transform: rotateX(16deg);
-  }
-
-  .bio-crawl-title {
-    font-size: clamp(32px, 9.2vw, 46px);
-  }
-
-  .bio-crawl-subtitle {
-    font-size: clamp(13px, 4.2vw, 18px);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .bio-crawl-wrap {
-    height: auto;
-    overflow: visible;
-    background: transparent;
-    border-radius: 0;
-  }
-
-  .bio-crawl-camera {
-    position: static;
-    perspective: none;
-    transform: none;
-    overflow: visible;
-    width: auto;
-    height: auto;
-  }
-
-  .bio-crawl-track {
-    position: static;
-    width: min(720px, 92%);
-    margin: 0 auto;
-    animation: none;
-    transform: none;
-  }
-
-  .bio-crawl {
-    transform: none;
-    text-align: left;
-    text-shadow: none;
-  }
-
-  .bio-crawl-wrap::before,
-  .bio-crawl-wrap::after {
-    display: none;
-  }
-}
-
-
+.bio-shell{max-width:1100px;margin:0 auto;padding:0 1rem;position:relative}
+.bio-shell:before,.bio-shell:after{content:"";position:absolute;inset:0;pointer-events:none}
+.bio-shell:before{background:repeating-linear-gradient(to bottom, rgba(244,251,255,.04) 0 1px, transparent 1px 4px);opacity:.25}
+.bio-shell:after{background:linear-gradient(90deg,var(--bio-blue) 0 33%,var(--bio-ice) 33% 37%,var(--bio-green) 37% 100%);height:4px;inset:auto 0 -8px;border-radius:999px;box-shadow:0 0 14px rgba(56,255,138,.25)}
+.bio-hero,.bio-card,.bio-proof-panel,.bio-build,.bio-cta-panel,.bio-useful__item{background:var(--bio-panel);border:1px solid var(--bio-border);border-radius:16px;box-shadow:0 8px 30px rgba(0,0,0,.35)}
+.bio-hero{padding:1.25rem}.bio-kicker,.bio-card__label,.bio-proof-card__label{font-family:"Press Start 2P",monospace;font-size:.68rem;letter-spacing:.12em;color:var(--bio-neon-green)}
+.bio-title{font-size:clamp(1.9rem,8vw,3.2rem);line-height:1.06;margin:.55rem 0;color:var(--bio-ice)}
+.bio-subtitle{font-size:1.1rem;color:#d8eaff}.bio-intro,.bio-card__body,.bio-proof-card__body,.bio-build__body{font-family:Inter,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;font-size:1.03rem;line-height:1.72;color:#ebf5ff}
+.bio-status-strip,.bio-terminal-strip{margin-top:1rem;padding:.8rem 1rem;border-radius:10px;background:rgba(2,7,17,.58);border:1px solid rgba(56,255,138,.28)}
+.bio-terminal-strip{display:flex;gap:.8rem;flex-wrap:wrap;font-family:"Press Start 2P",monospace;font-size:.58rem;color:#9cf4cd}
+.bio-actions,.bio-cta-panel__actions{display:flex;gap:.65rem;flex-wrap:wrap;margin-top:1rem}
+.bio-button,.bio-proof-card__link,.bio-build__link{display:inline-block;padding:.56rem .88rem;border-radius:999px;border:1px solid rgba(244,251,255,.35);color:var(--bio-ice);text-decoration:none;background:rgba(0,32,91,.32)}
+.bio-grid,.bio-proof-panel__grid,.bio-builds__grid,.bio-useful__grid{display:grid;grid-template-columns:1fr;gap:1rem;margin-top:1rem}
+.bio-card,.bio-build,.bio-proof-card,.bio-cta-panel{padding:1rem}.bio-card__title,.bio-build__title,.bio-proof-card__title{margin:.5rem 0 .6rem;font-size:1.35rem}
+.bio-proof-panel{margin-top:1.25rem;padding:1rem}.bio-proof-panel__header p,.bio-builds__header p{color:#d2deea}
+.bio-build__meta{font-family:"Press Start 2P",monospace;font-size:.58rem;color:#9cd7ff}.bio-build p{margin:.45rem 0}
+.bio-useful{margin-top:1.2rem}.bio-useful__item{padding:.8rem 1rem;margin:0}.bio-cta-panel{margin-top:1.2rem}
+.bio-button:focus-visible,.bio-proof-card__link:focus-visible,.bio-build__link:focus-visible{outline:2px solid var(--bio-neon-green);outline-offset:2px}
+.bio-button:hover,.bio-proof-card__link:hover,.bio-build__link:hover{background:rgba(56,255,138,.18)}
+@media (min-width:760px){.bio-grid,.bio-proof-panel__grid,.bio-builds__grid{grid-template-columns:repeat(2,minmax(0,1fr))}}
+@media (prefers-reduced-motion: reduce){.bio-shell:before{background:none}.bio-button,.bio-proof-card__link,.bio-build__link{transition:none}}
 .creative-tool-links {
   margin: 28px auto 40px;
   max-width: 860px;


### PR DESCRIPTION
### Motivation
- Replace the old Star Wars-style animated crawl (hard-to-read, cropped, audio toggle) with a static, readable, retro-80s/90s Vancouver profile that communicates musical and technical signal quickly and professionally.
- Keep the page accessible, responsive, and focused on Suzy’s music + systems positioning, press proof, local radio mentions, and active public builds.

### Description
- Rewrote `page-bio.php` to remove the `.bio-crawl-wrap` markup and replace it with semantic, accessible sections: hero (kicker, H1, subtitle, intro, status strip, terminal metadata), primary action buttons, SIDE A–D cards grid, Proof of Signal panel, Signals in Rotation grid, "Where I’m Useful" strip, and final CTA panel; templates use `esc_html()` and `esc_url()` where appropriate.
- Stopped enqueueing the bio-specific audio/script stack on the bio page by removing the `Tone.js` + `js/bio-crawl.js` enqueue block in `functions.php`; `js/bio-crawl.js` remains in the repo but is no longer loaded on `/bio/` (and will not throw errors on that page).
- Replaced the large animated crawl CSS block in `style.css` with a dedicated Bio page style system using the requested deep navy/green/ice palette, panel/card UI, Press Start 2P only for small labels, a readable system font stack for body text, responsive grid, subtle scanline texture, rink-board accent, reduced-motion respect, strong focus states, and no horizontal overflow.
- Kept content requirements: mentions of Minto/The Smokes and Seafoam, Steve Albini recording in Chicago, Georgia Straight press card, CiTR airplay as plain text (no invented link), Bandcamp links, and the requested projects/builds and positioning.

### Testing
- Ran `php -l page-bio.php` and received `No syntax errors detected in page-bio.php`.
- Ran `php -l functions.php` and received `No syntax errors detected in functions.php`.
- Ran `npm test`; the test suite executed but reported overall `67` tests with `52` passing and `15` failing; the failures are in unrelated Gastown / open-data test suites and were not introduced by the bio-page changes (CI output shows unrelated assertions and open-data script errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1733ad2a4832eb51ef37327e4f30b)