### PR TITLE
Fix outage alert delivery and sent-state handling

### DIFF
--- a/lousy-outages/includes/IncidentAlerts.php
+++ b/lousy-outages/includes/IncidentAlerts.php
@@ -173,7 +173,7 @@ class IncidentAlerts {
                 continue;
             }
 
-            if (! $store->shouldSend($incident)) {
+            if (! $store->canSend($incident)) {
                 continue;
             }
 
@@ -241,6 +241,7 @@ class IncidentAlerts {
             }
 
             if (self::send_incident_alert_email($incident)) {
+                $store->markSent($incident);
                 $alertedIncidents[$incidentKey] = [
                     'first_notified_at' => $nowUtc,
                     'status'            => strtolower((string) $incident->status),
@@ -1340,6 +1341,11 @@ class IncidentAlerts {
 
     private static function send_incident_alert_email(Incident $incident): bool {
         $subscribers = self::get_subscribers();
+        $notificationEmail = sanitize_email((string) get_option('lousy_outages_email', get_option('admin_email')));
+        if ($notificationEmail && is_email($notificationEmail)) {
+            $subscribers[] = $notificationEmail;
+        }
+        $subscribers = array_values(array_unique(array_filter(array_map('sanitize_email', $subscribers))));
         if (empty($subscribers)) {
             return false;
         }
@@ -1689,4 +1695,3 @@ class IncidentAlerts {
 }
 
 add_action('lo_check_statuses', [IncidentAlerts::class, 'run']);
-

--- a/lousy-outages/includes/Storage/IncidentStore.php
+++ b/lousy-outages/includes/Storage/IncidentStore.php
@@ -21,6 +21,20 @@ class IncidentStore
      */
     public function shouldSend(Incident $incident): bool
     {
+        if (! $this->canSend($incident)) {
+            return false;
+        }
+
+        $this->markSent($incident);
+
+        return true;
+    }
+
+    /**
+     * Determine whether an alert email should fire for the incident without mutating send markers.
+     */
+    public function canSend(Incident $incident): bool
+    {
         $providerKey = $this->providerKey($incident);
         $guid        = $this->incidentGuid($incident);
         $status      = $this->normalizeStatus($incident->status);
@@ -56,11 +70,22 @@ class IncidentStore
             return false;
         }
 
+        return true;
+    }
+
+    /**
+     * Persist last-send markers for an incident after successful delivery.
+     */
+    public function markSent(Incident $incident): void
+    {
+        $providerKey = $this->providerKey($incident);
+        $guid        = $this->incidentGuid($incident);
+        $status      = $this->normalizeStatus($incident->status);
+        $now         = time();
+
         update_option($this->lastGuidOption($providerKey), $guid, false);
         update_option($this->lastAlertOption($providerKey), $now, false);
         update_option($this->lastStatusOption($providerKey), $status, false);
-
-        return true;
     }
 
     /**


### PR DESCRIPTION
### Motivation
- The incident alerter could mark incidents as "sent" before email delivery, suppressing later retries and causing missing notifications. 
- The newer incident runner only used the public `lo_subscribers` list and ignored the configured notification inbox (`lousy_outages_email`), which could result in alerts being sent to nobody.

### Description
- Added a non-mutating gate `canSend()` and a `markSent()` method to `lousy-outages/includes/Storage/IncidentStore.php`, and kept `shouldSend()` as a compatibility wrapper that delegates to the new methods.  
- Updated the alert runner in `lousy-outages/includes/IncidentAlerts.php` to call `canSend()` before attempting delivery and to call `markSent()` only after `send_incident_alert_email()` returns true.  
- Modified `send_incident_alert_email()` to always include the configured notification email (`lousy_outages_email` with fallback to `admin_email`) alongside `lo_subscribers`, with sanitization, validation, and de-duplication.  
- Files changed: `lousy-outages/includes/Storage/IncidentStore.php` and `lousy-outages/includes/IncidentAlerts.php`.

### Testing
- Ran PHP syntax checks with `php -l lousy-outages/includes/Storage/IncidentStore.php` and `php -l lousy-outages/includes/IncidentAlerts.php`, and both reported no syntax errors.  
- Verified changes were staged and committed successfully with `git commit` (commit message: "Fix outage alert delivery and sent-state handling").  
- No automated unit tests exist in the repository, so validation was limited to syntax checks and a successful commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f65ec4e604832eb3eb98c1b8c13358)