### PR TITLE
Add synthetic incident QA flow and modern alert diagnostics

### DIFF
--- a/lousy-outages/README.md
+++ b/lousy-outages/README.md
@@ -33,9 +33,30 @@ To add or remove a provider, edit `includes/Providers.php` or use the checkboxes
 1. (Optional) Sign up for Twilio and obtain your **Account SID**, **Auth Token**, and a verified **From** number to enable SMS alerts.
 2. In wp-admin go to **Settings → Lousy Outages** and enter the SID, token, from number, your destination phone number, and a notification email address.
 3. Choose which providers to monitor and set the polling interval (default 5 minutes).
-4. Click **Send Test Email** to verify delivery; the panel shows the status and the latest subject/recipient recorded.
+4. Click **Send Legacy Test Email** to verify the older basic email path.
+5. Click **Send Synthetic Incident Alert** to verify the modern realtime IncidentAlerts path end-to-end.
+6. Keep **Test configured notification inbox only** enabled by default to avoid notifying public subscribers during QA.
 
 Use the **Poll Now** button in the debug panel to run an immediate poll. The panel also shows the last poll timestamp, each provider’s most recent status, and any fetch errors captured during the run.
+
+## QA and alert health
+
+- Legacy mail test (old path): use **Send Legacy Test Email**.
+- Modern realtime test: use **Send Synthetic Incident Alert**.
+- WP-CLI synthetic test:
+  - `wp lousy:alert-test`
+  - `wp lousy:alert-test --recipient=me@example.com`
+  - `wp lousy:alert-test --dry-run=true`
+  - `wp lousy:alert-test --fixed-id=demo-incident-001`
+- WP-CLI health snapshot:
+  - `wp lousy:alert-health`
+- If delivery fails, inspect:
+  - `lousy_outages_last_alert_delivery_result`
+  - `lousy_outages_last_alert_failure`
+  - `lousy_outages_alert_delivery_failure`
+  - wp-admin Debug panel
+  - `WP_DEBUG` / `error_log`
+  - `lo-mail.log` (if enabled in your environment)
 
 ## Shortcode
 

--- a/lousy-outages/includes/IncidentAlerts.php
+++ b/lousy-outages/includes/IncidentAlerts.php
@@ -45,6 +45,11 @@ class IncidentAlerts {
     private const OPTION_LAST_CHECK        = 'lo_last_status_check';
     private const OPTION_ALERTED_INCIDENTS = 'lousy_outages_alerted_incidents';
     private const OPTION_ALERTED_SUBJECTS  = 'lousy_outages_alerted_subjects';
+    private const OPTION_LAST_ALERT_DELIVERY_RESULT = 'lousy_outages_last_alert_delivery_result';
+    private const OPTION_LAST_ALERT_SUCCESS = 'lousy_outages_last_alert_success';
+    private const OPTION_LAST_ALERT_FAILURE = 'lousy_outages_last_alert_failure';
+    private const OPTION_LAST_SYNTHETIC_ALERT = 'lousy_outages_last_synthetic_alert';
+    private const OPTION_ALERT_DELIVERY_FAILURE = 'lousy_outages_alert_delivery_failure';
 
     private const ALERT_RETENTION_HOURS        = 48;
     private const SUBJECT_ALERT_WINDOW_HOURS   = 12;
@@ -149,16 +154,26 @@ class IncidentAlerts {
         $store->persistIncidents($incidents);
         update_option(self::OPTION_LAST_CHECK, gmdate('c'), false);
 
+        self::process_incidents($incidents, ['mode' => 'real']);
+    }
+
+    public static function process_incidents(array $incidents, array $options = []): array
+    {
+        $store           = $options['store'] ?? new IncidentStore();
+        $dryRun          = !empty($options['dry_run']);
+        $synthetic       = !empty($options['synthetic']);
+        $inboxOnly       = !empty($options['notification_only']);
         $alertedIncidents = self::get_alerted_incidents();
         $alertedSubjects  = self::get_alerted_subjects();
         $activeKeys       = [];
         $nowUtc           = current_time('timestamp', true);
         $subjectWindow    = self::SUBJECT_ALERT_WINDOW_HOURS * HOUR_IN_SECONDS;
-
+        $result = ['total_incidents'=>count($incidents),'considered'=>0,'sent'=>0,'skipped'=>0,'failed'=>0,'recipients'=>[],'failures'=>[],'skipped_reasons'=>[],'synthetic'=>(bool)$synthetic,'dry_run'=>(bool)$dryRun,'mode'=>(string)($options['mode'] ?? 'real')];
         foreach ($incidents as $incident) {
             if (! $incident instanceof Incident) {
                 continue;
             }
+            $result['considered']++;
 
             $incidentKey      = self::make_incident_key($incident);
             $subjectKey       = self::make_subject_key($incident);
@@ -174,10 +189,14 @@ class IncidentAlerts {
             }
 
             if (! $store->canSend($incident)) {
+                $result['skipped']++;
+                $result['skipped_reasons'][] = 'store_can_send_false';
                 continue;
             }
 
             if (! $isAlertableState) {
+                $result['skipped']++;
+                $result['skipped_reasons'][] = 'not_alertable';
                 continue;
             }
 
@@ -189,6 +208,8 @@ class IncidentAlerts {
                     'reason'        => 'stale_incident',
                     'effective_ts'  => $effectiveTs,
                 ]);
+                $result['skipped']++;
+                $result['skipped_reasons'][] = 'stale_incident';
                 continue;
             }
 
@@ -201,6 +222,8 @@ class IncidentAlerts {
                     'status'       => strtolower((string) $incident->status),
                     'impact'       => strtolower((string) ($incident->impact ?? '')),
                 ]);
+                $result['skipped']++;
+                $result['skipped_reasons'][] = 'missing_incident_key';
                 continue;
             }
 
@@ -212,6 +235,8 @@ class IncidentAlerts {
                     'reason'        => 'duplicate',
                     'effective_ts'  => $effectiveTs,
                 ]);
+                $result['skipped']++;
+                $result['skipped_reasons'][] = 'duplicate';
                 continue;
             }
 
@@ -236,12 +261,19 @@ class IncidentAlerts {
                         'last_notified' => $last,
                         'effective_ts'  => $effectiveTs,
                     ]);
+                    $result['skipped']++;
+                    $result['skipped_reasons'][] = 'subject_throttle';
                     continue;
                 }
             }
 
-            if (self::send_incident_alert_email($incident)) {
-                $store->markSent($incident);
+            $sendResult = self::send_incident_alert_email($incident, ['dry_run' => $dryRun, 'notification_only' => $inboxOnly]);
+            $result['recipients'] = array_values(array_unique(array_merge($result['recipients'], $sendResult['recipients'])));
+            if (!empty($sendResult['ok'])) {
+                if (!$dryRun) {
+                    $store->markSent($incident);
+                }
+                $markSentCalled = !$dryRun;
                 $alertedIncidents[$incidentKey] = [
                     'first_notified_at' => $nowUtc,
                     'status'            => strtolower((string) $incident->status),
@@ -265,6 +297,13 @@ class IncidentAlerts {
                     'status'        => strtolower((string) $incident->status),
                     'effective_ts'  => $effectiveTs,
                 ]);
+                $result['sent']++;
+                self::record_alert_delivery(true, $incident, $sendResult['recipients'], '', $markSentCalled, $options);
+            } else {
+                $result['failed']++;
+                $failureReason = (string) ($sendResult['error'] ?? 'send_failed');
+                $result['failures'][] = $failureReason;
+                self::record_alert_delivery(false, $incident, $sendResult['recipients'], $failureReason, false, $options);
             }
         }
 
@@ -272,6 +311,7 @@ class IncidentAlerts {
         $alertedSubjects  = self::prune_alerted_subjects($alertedSubjects, $nowUtc);
         self::set_alerted_incidents($alertedIncidents);
         self::set_alerted_subjects($alertedSubjects);
+        return $result;
     }
 
     public static function send_daily_digest(): void {
@@ -1339,15 +1379,39 @@ class IncidentAlerts {
         return (string) $tokens[$normalized];
     }
 
-    private static function send_incident_alert_email(Incident $incident): bool {
+    public static function make_synthetic_incident(array $overrides = []): Incident
+    {
+        $now = time();
+        $id = isset($overrides['id']) ? (string) $overrides['id'] : ('synthetic-' . wp_generate_uuid4());
+        return new Incident(
+            (string) ($overrides['provider'] ?? 'Lousy Outages QA'),
+            $id,
+            (string) ($overrides['title'] ?? 'Synthetic outage alert test'),
+            (string) ($overrides['status'] ?? 'major_outage'),
+            (string) ($overrides['url'] ?? home_url('/lousy-outages/')),
+            $overrides['component'] ?? null,
+            (string) ($overrides['impact'] ?? 'critical'),
+            (int) ($overrides['detected_at'] ?? $now),
+            $overrides['resolved_at'] ?? null
+        );
+    }
+
+    private static function send_incident_alert_email(Incident $incident, array $options = []): array {
         $subscribers = self::get_subscribers();
         $notificationEmail = sanitize_email((string) get_option('lousy_outages_email', get_option('admin_email')));
+        $notificationOnly = !empty($options['notification_only']);
+        if ($notificationOnly) {
+            $subscribers = [];
+        }
         if ($notificationEmail && is_email($notificationEmail)) {
             $subscribers[] = $notificationEmail;
         }
         $subscribers = array_values(array_unique(array_filter(array_map('sanitize_email', $subscribers))));
         if (empty($subscribers)) {
-            return false;
+            return ['ok'=>false,'recipients'=>[],'error'=>'no_recipients'];
+        }
+        if (!empty($options['dry_run'])) {
+            return ['ok'=>true,'recipients'=>$subscribers,'error'=>''];
         }
 
         $provider      = $incident->provider;
@@ -1387,18 +1451,37 @@ class IncidentAlerts {
 
             if (! $sent) {
                 self::log_error($provider, 'mail send failed for ' . $email);
-                return false;
+                return ['ok'=>false,'recipients'=>$subscribers,'error'=>'mail send failed for ' . $email];
             }
         }
 
-        return true;
+        return ['ok'=>true,'recipients'=>$subscribers,'error'=>''];
     }
 
     /**
      * Backwards compatible alias for sending realtime incident alerts.
      */
     private static function email_incident(Incident $incident): bool {
-        return self::send_incident_alert_email($incident);
+        $result = self::send_incident_alert_email($incident);
+        return !empty($result['ok']);
+    }
+
+    private static function record_alert_delivery(bool $ok, Incident $incident, array $recipients, string $reason, bool $markSentCalled, array $options = []): void
+    {
+        $payload = ['timestamp'=>gmdate('c'),'recipient_count'=>count($recipients),'recipients'=>$recipients,'provider'=>$incident->provider,'incident_id'=>$incident->id,'title'=>$incident->title,'status'=>$incident->status,'mark_sent_called'=>$markSentCalled,'synthetic'=>!empty($options['synthetic']),'mode'=>(string)($options['mode'] ?? 'real'),'reason'=>$reason];
+        update_option(self::OPTION_LAST_ALERT_DELIVERY_RESULT, $payload, false);
+        if ($ok) {
+            update_option(self::OPTION_LAST_ALERT_SUCCESS, $payload, false);
+            if (!empty($options['synthetic'])) {
+                update_option(self::OPTION_LAST_SYNTHETIC_ALERT, $payload, false);
+            }
+        } else {
+            update_option(self::OPTION_LAST_ALERT_FAILURE, $payload, false);
+            update_option(self::OPTION_ALERT_DELIVERY_FAILURE, $payload, false);
+            if (defined('WP_DEBUG') && WP_DEBUG) {
+                error_log('[lousy_outages] alert_delivery_failure ' . wp_json_encode($payload));
+            }
+        }
     }
 
     /**

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -956,7 +956,15 @@ function lousy_outages_settings_page() {
         <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="margin-top: 1rem;">
             <?php wp_nonce_field( 'lousy_outages_test_email' ); ?>
             <input type="hidden" name="action" value="lousy_outages_test_email">
-            <?php submit_button( 'Send Test Email', 'secondary' ); ?>
+            <?php submit_button( 'Send Legacy Test Email', 'secondary' ); ?>
+        </form>
+        <p class="description">Legacy test checks the older basic mail path only.</p>
+
+        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="margin-top: 0.5rem;">
+            <?php wp_nonce_field( 'lousy_outages_synthetic_alert' ); ?>
+            <input type="hidden" name="action" value="lousy_outages_synthetic_alert">
+            <label><input type="checkbox" name="notification_only" value="1" checked> Test configured notification inbox only</label>
+            <?php submit_button( 'Send Synthetic Incident Alert', 'secondary', 'submit', false ); ?>
         </form>
 
         <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="margin-top: 0.5rem;">
@@ -969,6 +977,11 @@ function lousy_outages_settings_page() {
 
         <h2>Debug panel</h2>
         <p><strong>Last poll:</strong> <?php echo esc_html( $last_poll_text ); ?></p>
+        <p><strong>Legacy test email:</strong> <?php echo esc_html( $last_email_text ); ?></p>
+        <p><strong>Modern alert delivery:</strong> <?php echo esc_html( wp_json_encode( get_option( 'lousy_outages_last_alert_delivery_result', [] ) ) ); ?></p>
+        <p><strong>Modern synthetic alert:</strong> <?php echo esc_html( wp_json_encode( get_option( 'lousy_outages_last_synthetic_alert', [] ) ) ); ?></p>
+        <p><strong>Modern real alert success:</strong> <?php echo esc_html( wp_json_encode( get_option( 'lousy_outages_last_alert_success', [] ) ) ); ?></p>
+        <p><strong>Modern real alert failure:</strong> <?php echo esc_html( wp_json_encode( get_option( 'lousy_outages_last_alert_failure', [] ) ) ); ?></p>
         <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="margin-bottom: 1rem;">
             <?php wp_nonce_field( 'lousy_outages_poll_now' ); ?>
             <input type="hidden" name="action" value="lousy_outages_poll_now">
@@ -1067,6 +1080,34 @@ add_action( 'admin_post_lousy_outages_test_sms', function () {
 
     $redirect = add_query_arg( 'page', 'lousy-outages', admin_url( 'options-general.php' ) );
     wp_safe_redirect( $redirect );
+    exit;
+} );
+
+add_action( 'admin_post_lousy_outages_synthetic_alert', function () {
+    if ( ! current_user_can( 'manage_options' ) ) {
+        wp_die( esc_html__( 'Sorry, you are not allowed to access this page.', 'lousy-outages' ) );
+    }
+    check_admin_referer( 'lousy_outages_synthetic_alert' );
+    $notification_only = ! empty( $_POST['notification_only'] );
+    $incident = IncidentAlerts::make_synthetic_incident();
+    $result = IncidentAlerts::process_incidents(
+        [ $incident ],
+        [
+            'synthetic'         => true,
+            'mode'              => 'admin_synthetic',
+            'notification_only' => $notification_only,
+        ]
+    );
+    $ok = (int) ( $result['sent'] ?? 0 ) > 0 && (int) ( $result['failed'] ?? 0 ) === 0;
+    $message = $ok
+        ? sprintf( 'Synthetic incident alert sent to %s at %s.', implode( ', ', (array) ( $result['recipients'] ?? [] ) ), gmdate( 'c' ) )
+        : sprintf( 'Synthetic incident alert failed. Reason: %s. Check Debug panel and logs.', implode( '; ', (array) ( $result['failures'] ?? [] ) ) );
+    set_transient(
+        'lousy_outages_notice',
+        [ 'message' => $message, 'type' => $ok ? 'success' : 'error' ],
+        30
+    );
+    wp_safe_redirect( add_query_arg( 'page', 'lousy-outages', admin_url( 'options-general.php' ) ) );
     exit;
 } );
 

--- a/lousy-outages/wp-cli/class-wp-cli-lousy.php
+++ b/lousy-outages/wp-cli/class-wp-cli-lousy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace SuzyEaston\LousyOutages\CLI;
 
 use SuzyEaston\LousyOutages\Fetcher;
+use SuzyEaston\LousyOutages\IncidentAlerts;
 use SuzyEaston\LousyOutages\Providers;
 use WP_CLI;
 use function WP_CLI\Utils\format_items;
@@ -107,3 +108,44 @@ class RefreshCommand {
 }
 
 WP_CLI::add_command( 'lousy:refresh', RefreshCommand::class );
+
+class AlertTestCommand {
+    public function __invoke( array $args, array $assoc_args ): void {
+        $recipient = isset( $assoc_args['recipient'] ) ? sanitize_email( (string) $assoc_args['recipient'] ) : '';
+        $dry_run   = isset( $assoc_args['dry-run'] ) && in_array( strtolower( (string) $assoc_args['dry-run'] ), [ '1', 'true', 'yes' ], true );
+        $fixed_id  = isset( $assoc_args['fixed-id'] ) ? (string) $assoc_args['fixed-id'] : '';
+        $overrides = [];
+        if ( '' !== $fixed_id ) {
+            $overrides['id'] = $fixed_id;
+        }
+        if ( '' !== $recipient ) {
+            update_option( 'lousy_outages_email', $recipient, false );
+        }
+        $incident = IncidentAlerts::make_synthetic_incident( $overrides );
+        $result = IncidentAlerts::process_incidents( [ $incident ], [ 'synthetic' => true, 'mode' => 'cli_alert_test', 'notification_only' => true, 'dry_run' => $dry_run ] );
+        WP_CLI::line( wp_json_encode( $result ) ?: '{}' );
+        if ( (int) ( $result['failed'] ?? 0 ) > 0 ) {
+            WP_CLI::warning( 'Synthetic alert test had failures.' );
+        } else {
+            WP_CLI::success( 'Synthetic alert test completed.' );
+        }
+    }
+}
+WP_CLI::add_command( 'lousy:alert-test', AlertTestCommand::class );
+
+class AlertHealthCommand {
+    public function __invoke( array $args, array $assoc_args ): void {
+        $subscribers = get_option( 'lo_subscribers', [] );
+        $rows = [
+            [ 'key' => 'configured_notification_email', 'value' => (string) get_option( 'lousy_outages_email', get_option( 'admin_email' ) ) ],
+            [ 'key' => 'subscriber_count', 'value' => is_array( $subscribers ) ? (string) count( $subscribers ) : '0' ],
+            [ 'key' => 'last_modern_success', 'value' => wp_json_encode( get_option( 'lousy_outages_last_alert_success', [] ) ) ?: '{}' ],
+            [ 'key' => 'last_modern_failure', 'value' => wp_json_encode( get_option( 'lousy_outages_last_alert_failure', [] ) ) ?: '{}' ],
+            [ 'key' => 'last_synthetic_test', 'value' => wp_json_encode( get_option( 'lousy_outages_last_synthetic_alert', [] ) ) ?: '{}' ],
+            [ 'key' => 'cron_lo_check_statuses_scheduled', 'value' => wp_next_scheduled( 'lo_check_statuses' ) ? 'yes' : 'no' ],
+            [ 'key' => 'recent_failure_exists', 'value' => get_option( 'lousy_outages_alert_delivery_failure' ) ? 'yes' : 'no' ],
+        ];
+        format_items( 'table', $rows, [ 'key', 'value' ] );
+    }
+}
+WP_CLI::add_command( 'lousy:alert-health', AlertHealthCommand::class );

--- a/tests/IncidentAlertDeliveryTest.php
+++ b/tests/IncidentAlertDeliveryTest.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+namespace {
+if (!defined('MINUTE_IN_SECONDS')) define('MINUTE_IN_SECONDS',60);
+if (!defined('HOUR_IN_SECONDS')) define('HOUR_IN_SECONDS',3600);
+if (!function_exists('sanitize_key')) { function sanitize_key($k){ return strtolower(preg_replace('/[^a-z0-9_]/','',(string)$k) ?? ''); } }
+if (!function_exists('sanitize_title_with_dashes')) { function sanitize_title_with_dashes($t){ $t=strtolower((string)$t); $t=preg_replace('/[^a-z0-9\-]+/','-',$t)??''; return trim($t,'-'); } }
+if (!function_exists('sanitize_email')) { function sanitize_email($e){ return (string)$e; } }
+if (!function_exists('is_email')) { function is_email($e){ return false!==strpos((string)$e,'@'); } }
+if (!function_exists('get_option')) { function get_option($k,$d=null){ return \LousyOutages\Tests\Opt::get((string)$k,$d);} }
+if (!function_exists('update_option')) { function update_option($k,$v,$a=false){ \LousyOutages\Tests\Opt::set((string)$k,$v); return true; } }
+if (!function_exists('home_url')) { function home_url($p='/'){ return 'https://example.com'.$p; } }
+if (!function_exists('add_query_arg')) { function add_query_arg($a,$u){ return (string)$u; } }
+if (!function_exists('current_time')) { function current_time($type,$gmt=false){ return 1700000000; } }
+if (!function_exists('do_action')) { function do_action($h,...$a): void {} }
+if (!function_exists('wp_json_encode')) { function wp_json_encode($v){ return json_encode($v); } }
+if (!function_exists('wp_generate_uuid4')) { function wp_generate_uuid4(){ return 'uuid-1234'; } }
+if (!function_exists('send_lo_outage_alert_email')) { function send_lo_outage_alert_email($email,$payload){ return \LousyOutages\Tests\Mail::$ok; } }
+}
+
+namespace LousyOutages\Tests { class Opt { public static array $o=[]; static function get(string $k,$d=null){ return self::$o[$k]??$d;} static function set(string $k,$v): void {self::$o[$k]=$v;} static function reset(): void {self::$o=[];} } class Mail { public static bool $ok=true; }}
+
+namespace {
+require_once __DIR__ . '/../lousy-outages/includes/Model/Incident.php';
+require_once __DIR__ . '/../lousy-outages/includes/Storage/IncidentStore.php';
+require_once __DIR__ . '/../lousy-outages/includes/IncidentAlerts.php';
+
+use PHPUnit\Framework\TestCase;
+use SuzyEaston\LousyOutages\IncidentAlerts;
+use SuzyEaston\LousyOutages\Storage\IncidentStore;
+
+final class IncidentAlertDeliveryTest extends TestCase {
+    protected function setUp(): void { \LousyOutages\Tests\Opt::reset(); \LousyOutages\Tests\Mail::$ok=true; }
+
+    public function testSyntheticIncidentDefaults(): void {
+        $incident = IncidentAlerts::make_synthetic_incident();
+        $this->assertSame('major_outage', $incident->status);
+    }
+
+    public function testCanSendDoesNotMutateButMarkSentSuppresses(): void {
+        $store = new IncidentStore();
+        $i = IncidentAlerts::make_synthetic_incident(['id'=>'fixed-1']);
+        $this->assertTrue($store->canSend($i));
+        $this->assertSame('', get_option('lousy_outages_last_guid_lousyoutagesqa', ''));
+        $store->markSent($i);
+        $this->assertFalse($store->canSend($i));
+    }
+
+    public function testProcessIncidentsFailureWritesDiagnostics(): void {
+        update_option('lousy_outages_email','qa@example.com',false);
+        \LousyOutages\Tests\Mail::$ok=false;
+        $result = IncidentAlerts::process_incidents([IncidentAlerts::make_synthetic_incident(['id'=>'fixed-2'])], ['synthetic'=>true,'notification_only'=>true]);
+        $this->assertSame(1, $result['failed']);
+        $this->assertNotEmpty(get_option('lousy_outages_alert_delivery_failure', []));
+    }
+}
+}


### PR DESCRIPTION
### Motivation
- The existing admin "Send Test Email" exercised an older legacy mail path and did not validate the modern real-time IncidentAlerts delivery flow end-to-end.
- We need a safe, demo-friendly way to prove the modern path works (without alerting public subscribers) and durable diagnostics when delivery fails.
- CLI and automated tests are required so QA and on-call can reproduce and triage delivery issues reliably.

### Description
- Extracted the incident-processing loop into `IncidentAlerts::process_incidents(array $incidents, array $options = []): array` while keeping `run()` as the production entry point and returning a structured result (total_incidents, considered, sent, skipped, failed, recipients, failures, skipped_reasons, synthetic/dry_run/mode flags). (files: `includes/IncidentAlerts.php`)
- Added synthetic incident generation via `IncidentAlerts::make_synthetic_incident(array $overrides = []): Incident` with safe defaults and unique default IDs, and extended `send_incident_alert_email()` to return structured send results and support `dry_run` and `notification_only` options. (files: `includes/IncidentAlerts.php`)
- Implemented durable alert delivery diagnostics and a failure watchdog storing options such as `lousy_outages_last_alert_delivery_result`, `lousy_outages_last_alert_success`, `lousy_outages_last_alert_failure`, `lousy_outages_last_synthetic_alert`, and `lousy_outages_alert_delivery_failure` and added `record_alert_delivery()` for centralized recording and optional `WP_DEBUG` logging. (files: `includes/IncidentAlerts.php`)
- Admin UI changes include renaming the old button to **Send Legacy Test Email**, adding a **Send Synthetic Incident Alert** flow (default: configured notification inbox only) with an admin notice, and surfacing modern delivery diagnostics in the Debug panel. (file: `lousy-outages.php`)
- Added WP-CLI QA/demo commands `wp lousy:alert-test` (with `--recipient`, `--dry-run`, `--fixed-id`) and `wp lousy:alert-health` to inspect configured inbox, subscriber count, last modern successes/failures, synthetic tests and cron health. (file: `wp-cli/class-wp-cli-lousy.php`)
- Updated `README.md` with a QA and alert health section documenting legacy vs modern tests and CLI usage, and added a lightweight PHPUnit test `tests/IncidentAlertDeliveryTest.php` covering synthetic defaults, `canSend()`/`markSent()` semantics, and failure diagnostics writes. (files: `README.md`, `tests/IncidentAlertDeliveryTest.php`)

### Testing
- Static syntax checks: `php -l` was run for modified PHP files and reported no syntax errors. 
- Unit tests: a lightweight PHPUnit test file `tests/IncidentAlertDeliveryTest.php` was added to assert synthetic incident defaults, `canSend()` vs `markSent()` behavior, and that failed sends write the delivery failure diagnostic option. 
- Automated test run: `phpunit` was not available in this environment so the PHPUnit suite could not be executed here (no run performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f665b5c084832ebb9e3df10345ac8b)