### PR TITLE
Add public subscriber preferences for provider-scoped alerts and delivery consent

### DIFF
--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -1658,3 +1658,9 @@
     display: none !important;
   }
 }
+
+.lo-subscribe__fieldset{border:1px solid var(--lo-border);padding:12px;border-radius:12px;margin:12px 0;background:rgba(10,16,32,.45)}
+.lo-subscribe__legend{padding:0 6px;color:var(--lo-accent);font-size:.8rem;text-transform:uppercase;letter-spacing:.08em}
+.lo-subscribe__provider-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:8px}
+.lo-subscribe__checkbox{display:flex;align-items:center;gap:8px;font-size:.85rem}
+.lo-subscribe__prefs{display:grid;gap:8px}

--- a/lousy-outages/assets/lousy-outages.js
+++ b/lousy-outages/assets/lousy-outages.js
@@ -3058,6 +3058,10 @@
     var honeypot = form.querySelector('input[name="website"]');
     var nonceInput = form.querySelector('input[name="_wpnonce"]');
     var challengeInput = form.querySelector('input[name="challenge_response"]');
+    var providerInputs = form.querySelectorAll('input[name="providers[]"]:checked');
+    var realtimeInput = form.querySelector('input[name="realtime_alerts"]');
+    var digestInput = form.querySelector('input[name="daily_digest"]');
+    var newsletterInput = form.querySelector('input[name="newsletter"]');
     var endpoint = form.getAttribute('action') || state.subscribeEndpoint;
     if (!endpoint || !state.fetchImpl) {
       return;
@@ -3083,7 +3087,11 @@
       email: email,
       website: honeypot ? honeypot.value : '',
       _wpnonce: nonceInput ? nonceInput.value : '',
-      challenge_response: challengeInput ? challengeInput.value.trim() : ''
+      challenge_response: challengeInput ? challengeInput.value.trim() : '',
+      providers: Array.prototype.map.call(providerInputs || [], function (input) { return input.value; }),
+      realtime_alerts: !!(realtimeInput && realtimeInput.checked),
+      daily_digest: !!(digestInput && digestInput.checked),
+      newsletter: !!(newsletterInput && newsletterInput.checked)
     };
 
     state.fetchImpl(endpoint, {

--- a/lousy-outages/includes/IncidentAlerts.php
+++ b/lousy-outages/includes/IncidentAlerts.php
@@ -419,7 +419,9 @@ class IncidentAlerts {
             return;
         }
 
-        $subscribers = self::get_subscribers();
+        $subscribers = array_values(array_filter(self::get_subscribers(), static function (string $email): bool {
+            return Subscriptions::subscriber_wants_digest($email);
+        }));
         if (empty($subscribers)) {
             return;
         }
@@ -1397,7 +1399,11 @@ class IncidentAlerts {
     }
 
     private static function send_incident_alert_email(Incident $incident, array $options = []): array {
-        $subscribers = self::get_subscribers();
+        $providerId = sanitize_key((string) $incident->provider);
+        $subscribers = array_values(array_filter(self::get_subscribers(), static function (string $email) use ($providerId): bool {
+            return Subscriptions::subscriber_wants_realtime($email)
+                && Subscriptions::subscriber_wants_provider($email, $providerId);
+        }));
         $notificationEmail = sanitize_email((string) get_option('lousy_outages_email', get_option('admin_email')));
         $notificationOnly = !empty($options['notification_only']);
         if ($notificationOnly) {

--- a/lousy-outages/includes/Subscribe.php
+++ b/lousy-outages/includes/Subscribe.php
@@ -325,11 +325,22 @@ function lo_handle_subscribe(\WP_REST_Request $request) {
     }
 
     $email = strtolower($email);
+    $providers = $request->get_param('providers');
+    if (!is_array($providers)) {
+        $providers = [];
+    }
+    $preferences = Subscriptions::normalize_preferences([
+        'providers' => $providers,
+        'realtime_alerts' => $request->get_param('realtime_alerts'),
+        'daily_digest' => $request->get_param('daily_digest'),
+        'newsletter' => $request->get_param('newsletter'),
+    ]);
+
     $subscribers = get_option('suzy_newsletter', []);
     if (!is_array($subscribers)) {
         $subscribers = [];
     }
-    if (!in_array($email, $subscribers, true)) {
+    if (!empty($preferences['newsletter']) && !in_array($email, $subscribers, true)) {
         $subscribers[] = $email;
         update_option('suzy_newsletter', array_values(array_unique($subscribers)), false);
     }
@@ -337,7 +348,7 @@ function lo_handle_subscribe(\WP_REST_Request $request) {
     $token   = lo_generate_subscribe_token($email);
     $ip      = lo_detect_subscribe_ip($request);
     $ip_hash = lo_hash_subscriber_ip($ip);
-    Subscriptions::save_pending($email, $token, $ip_hash, 'form');
+    Subscriptions::save_pending_with_preferences($email, $token, $ip_hash, 'form', $preferences);
 
     $domain = wp_parse_url(home_url(), PHP_URL_HOST);
     if (!is_string($domain) || '' === $domain) {
@@ -376,7 +387,7 @@ function lo_handle_subscribe(\WP_REST_Request $request) {
         $confirm_url_filter = $default_confirm_url;
     }
 
-    $sent = lo_send_confirmation($email, $confirm_url_filter);
+    $sent = lo_send_confirmation($email, $confirm_url_filter, $preferences);
 
     $admin_email = apply_filters('lo_admin_notification_email', 'admin@suzyeaston.ca', $email, $request);
     $ok_admin    = false;

--- a/lousy-outages/includes/Subscriptions.php
+++ b/lousy-outages/includes/Subscriptions.php
@@ -33,7 +33,7 @@ class Subscriptions {
             }
 
             $columns = array_map('strtolower', $columns);
-            foreach (['email', 'status', 'token', 'created_at', 'updated_at', 'ip_hash', 'consent_source'] as $required) {
+            foreach (['email', 'status', 'token', 'created_at', 'updated_at', 'ip_hash', 'consent_source', 'providers', 'realtime_alerts', 'daily_digest', 'newsletter', 'consent_version', 'confirmed_at'] as $required) {
                 if (!in_array($required, $columns, true)) {
                     $needs_upgrade = true;
                     break;
@@ -69,6 +69,12 @@ class Subscriptions {
             updated_at DATETIME NOT NULL,
             ip_hash CHAR(64) NOT NULL,
             consent_source VARCHAR(50) NOT NULL DEFAULT '',
+            providers LONGTEXT NULL,
+            realtime_alerts TINYINT(1) NOT NULL DEFAULT 1,
+            daily_digest TINYINT(1) NOT NULL DEFAULT 0,
+            newsletter TINYINT(1) NOT NULL DEFAULT 0,
+            consent_version VARCHAR(30) NOT NULL DEFAULT '2026-05',
+            confirmed_at DATETIME NULL,
             PRIMARY KEY  (id),
             UNIQUE KEY email (email),
             UNIQUE KEY token (token)
@@ -95,47 +101,129 @@ class Subscriptions {
     }
 
     public static function save_pending(string $email, string $token, string $ip_hash, string $source = 'form'): void {
-        global $wpdb;
-
-        self::ensure_schema();
-
-        $table  = self::table_name();
-        $now    = gmdate('Y-m-d H:i:s');
-
-        $existing = $wpdb->get_row($wpdb->prepare("SELECT id, status FROM {$table} WHERE email = %s", $email));
-
-        if ($existing) {
-            $wpdb->update(
-                $table,
-                [
-                    'status'         => self::STATUS_PENDING,
-                    'token'          => $token,
-                    'created_at'     => $now,
-                    'updated_at'     => $now,
-                    'ip_hash'        => $ip_hash,
-                    'consent_source' => $source,
-                ],
-                ['id' => (int) $existing->id],
-                ['%s', '%s', '%s', '%s', '%s', '%s'],
-                ['%d']
-            );
-        } else {
-            $wpdb->insert(
-                $table,
-                [
-                    'email'          => $email,
-                    'status'         => self::STATUS_PENDING,
-                    'token'          => $token,
-                    'created_at'     => $now,
-                    'updated_at'     => $now,
-                    'ip_hash'        => $ip_hash,
-                    'consent_source' => $source,
-                ],
-                ['%s', '%s', '%s', '%s', '%s', '%s', '%s']
-            );
-        }
+        self::save_pending_with_preferences($email, $token, $ip_hash, $source, []);
     }
 
+
+    public static function normalize_provider_ids(array $ids): array {
+        $providers = Providers::list();
+        $allowed = array_fill_keys(array_keys($providers), true);
+        $normalized = [];
+
+        foreach ($ids as $id) {
+            $key = sanitize_key((string) $id);
+            if ('' === $key || !isset($allowed[$key])) {
+                continue;
+            }
+            $normalized[$key] = $key;
+        }
+
+        return array_values($normalized);
+    }
+
+    public static function normalize_preferences(array $input): array {
+        $providers = [];
+        if (isset($input['providers']) && is_array($input['providers'])) {
+            $providers = self::normalize_provider_ids($input['providers']);
+        }
+
+        $toBool = static function ($value, bool $default = false): bool {
+            if (is_bool($value)) {
+                return $value;
+            }
+            if (null === $value) {
+                return $default;
+            }
+            if (is_string($value)) {
+                $v = strtolower(trim($value));
+                if (in_array($v, ['1', 'true', 'yes', 'on'], true)) {
+                    return true;
+                }
+                if (in_array($v, ['0', 'false', 'no', 'off', ''], true)) {
+                    return false;
+                }
+            }
+
+            return !empty($value);
+        };
+
+        return [
+            'providers' => $providers,
+            'realtime_alerts' => $toBool($input['realtime_alerts'] ?? true, true),
+            'daily_digest' => $toBool($input['daily_digest'] ?? false, false),
+            'newsletter' => $toBool($input['newsletter'] ?? false, false),
+        ];
+    }
+
+    public static function save_pending_with_preferences(string $email, string $token, string $ip_hash, string $source, array $preferences): void {
+        global $wpdb;
+        self::ensure_schema();
+        $table = self::table_name();
+        $now = gmdate('Y-m-d H:i:s');
+        $prefs = self::normalize_preferences($preferences);
+
+        $data = [
+            'status' => self::STATUS_PENDING,
+            'token' => $token,
+            'created_at' => $now,
+            'updated_at' => $now,
+            'ip_hash' => $ip_hash,
+            'consent_source' => $source,
+            'providers' => wp_json_encode($prefs['providers']),
+            'realtime_alerts' => $prefs['realtime_alerts'] ? 1 : 0,
+            'daily_digest' => $prefs['daily_digest'] ? 1 : 0,
+            'newsletter' => $prefs['newsletter'] ? 1 : 0,
+            'consent_version' => '2026-05',
+        ];
+
+        $existing = $wpdb->get_row($wpdb->prepare("SELECT id FROM {$table} WHERE email = %s", $email));
+        if ($existing) {
+            $wpdb->update($table, $data, ['id' => (int) $existing->id]);
+            return;
+        }
+
+        $data['email'] = $email;
+        $wpdb->insert($table, $data);
+    }
+
+    public static function get_preferences_for_email(string $email): array {
+        global $wpdb;
+        self::ensure_schema();
+
+        $defaults = ['providers'=>[], 'realtime_alerts'=>true, 'daily_digest'=>false, 'newsletter'=>false];
+        $table = self::table_name();
+        $row = $wpdb->get_row($wpdb->prepare("SELECT providers,realtime_alerts,daily_digest,newsletter FROM {$table} WHERE email = %s", $email), ARRAY_A);
+        if (!is_array($row)) {
+            return $defaults;
+        }
+
+        $providers = [];
+        if (isset($row['providers']) && is_string($row['providers']) && '' !== trim($row['providers'])) {
+            $decoded = json_decode($row['providers'], true);
+            if (is_array($decoded)) {
+                $providers = self::normalize_provider_ids($decoded);
+            }
+        }
+
+        return [
+            'providers' => $providers,
+            'realtime_alerts' => !isset($row['realtime_alerts']) ? true : (int)$row['realtime_alerts'] === 1,
+            'daily_digest' => isset($row['daily_digest']) && (int)$row['daily_digest'] === 1,
+            'newsletter' => isset($row['newsletter']) && (int)$row['newsletter'] === 1,
+        ];
+    }
+
+    public static function subscriber_wants_provider(string $email, string $provider_id): bool {
+        $prefs = self::get_preferences_for_email($email);
+        if (empty($prefs['providers'])) {
+            return true;
+        }
+        return in_array(sanitize_key($provider_id), $prefs['providers'], true);
+    }
+
+    public static function subscriber_wants_realtime(string $email): bool { return (bool) self::get_preferences_for_email($email)['realtime_alerts']; }
+    public static function subscriber_wants_digest(string $email): bool { return (bool) self::get_preferences_for_email($email)['daily_digest']; }
+    public static function subscriber_wants_newsletter(string $email): bool { return (bool) self::get_preferences_for_email($email)['newsletter']; }
     public static function find_by_token(string $token): ?array {
         global $wpdb;
 
@@ -152,15 +240,18 @@ class Subscriptions {
         self::ensure_schema();
 
         $table = self::table_name();
+        $data = [
+            'status'     => $status,
+            'updated_at' => gmdate('Y-m-d H:i:s'),
+        ];
+        if (self::STATUS_SUBSCRIBED === $status) {
+            $data['confirmed_at'] = gmdate('Y-m-d H:i:s');
+        }
+
         $updated = $wpdb->update(
             $table,
-            [
-                'status'     => $status,
-                'updated_at' => gmdate('Y-m-d H:i:s'),
-            ],
-            ['token' => $token],
-            ['%s', '%s'],
-            ['%s']
+            $data,
+            ['token' => $token]
         );
 
         return false !== $updated && $updated > 0;

--- a/lousy-outages/includes/email-templates.php
+++ b/lousy-outages/includes/email-templates.php
@@ -30,7 +30,7 @@ if (!function_exists('lo_unsubscribe_url_for')) {
 }
 
 if (!function_exists('lo_send_confirmation')) {
-    function lo_send_confirmation(string $email, ?string $confirm_url = null): bool {
+    function lo_send_confirmation(string $email, ?string $confirm_url = null, array $preferences = []): bool {
         $unsubscribe_url = lo_unsubscribe_url_for($email);
 
         do_action('lousy_outages_log', 'confirm_email_unsub_url', [
@@ -38,7 +38,7 @@ if (!function_exists('lo_send_confirmation')) {
             'unsub' => $unsubscribe_url,
         ]);
 
-        return send_lo_confirmation_email($email, $unsubscribe_url, $confirm_url);
+        return send_lo_confirmation_email($email, $unsubscribe_url, $confirm_url, $preferences);
     }
 }
 
@@ -46,7 +46,7 @@ if (!function_exists('send_lo_confirmation_email')) {
     /**
      * Sends the Lousy Outages confirmation email.
      */
-    function send_lo_confirmation_email(string $email, string $unsubscribe_url, ?string $confirm_url = null): bool {
+    function send_lo_confirmation_email(string $email, string $unsubscribe_url, ?string $confirm_url = null, array $preferences = []): bool {
         $email = sanitize_email($email);
         if (!$email || !is_email($email)) {
             error_log('[lousy_outages] confirmation_email invalid recipient');
@@ -72,6 +72,24 @@ if (!function_exists('send_lo_confirmation_email')) {
         $confirm_raw  = esc_url_raw($confirm_url);
         $confirm_html = esc_url($confirm_url);
 
+
+        $prefs = class_exists('SuzyEaston\LousyOutages\Subscriptions')
+            ? \SuzyEaston\LousyOutages\Subscriptions::normalize_preferences($preferences)
+            : ['providers'=>[], 'realtime_alerts'=>true, 'daily_digest'=>false, 'newsletter'=>false];
+        $providerNames = [];
+        if (class_exists('SuzyEaston\LousyOutages\Providers')) {
+            $providerMap = \SuzyEaston\LousyOutages\Providers::list();
+            foreach ((array) ($prefs['providers'] ?? []) as $providerId) {
+                $providerId = sanitize_key((string) $providerId);
+                if (isset($providerMap[$providerId]['name'])) {
+                    $providerNames[] = (string) $providerMap[$providerId]['name'];
+                }
+            }
+        }
+        $providerSummary = empty($providerNames) ? 'All monitored providers' : implode(', ', $providerNames);
+        $realtimeSummary = !empty($prefs['realtime_alerts']) ? 'on' : 'off';
+        $digestSummary = !empty($prefs['daily_digest']) ? 'on' : 'off';
+
         $subject = '🔔 Please confirm your subscription to Lousy Outages';
 
         $text_body_lines = [
@@ -81,6 +99,10 @@ if (!function_exists('send_lo_confirmation_email')) {
             $confirm_raw,
             '',
             'Dashboard anytime: ' . home_url('/lousy-outages/'),
+            '',
+            'You’re set for real-time alerts: ' . $realtimeSummary,
+            'Daily digest: ' . $digestSummary,
+            'Providers: ' . $providerSummary,
             '',
             'Unsubscribe instantly if this wasn’t you:',
             $unsubscribe_raw,

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -867,6 +867,10 @@ function render_subscribe_shortcode(): string {
     $email_id  = $form_uid . '-email';
     $challenge_id = $form_uid . '-challenge';
     $challenge_hint_id = $challenge_id . '-hint';
+    $providers = Providers::enabled();
+    if (empty($providers)) {
+        $providers = Providers::list();
+    }
 
     ob_start();
     ?>
@@ -886,6 +890,25 @@ function render_subscribe_shortcode(): string {
                     autocomplete="email"
                 />
             </label>
+            <fieldset class="lo-subscribe__fieldset">
+                <legend class="lo-subscribe__legend">Choose your outage alerts</legend>
+                <p class="lo-subscribe__note">Pick the services you care about. Leave everything checked if you want the full chaos feed.</p>
+                <div class="lo-subscribe__provider-grid">
+                    <?php foreach ($providers as $provider) : $provider_id = sanitize_key((string) ($provider['id'] ?? '')); if ('' === $provider_id) { continue; } ?>
+                        <label class="lo-subscribe__checkbox">
+                            <input type="checkbox" name="providers[]" value="<?php echo esc_attr($provider_id); ?>" checked />
+                            <span><?php echo esc_html((string) ($provider['name'] ?? $provider_id)); ?></span>
+                        </label>
+                    <?php endforeach; ?>
+                </div>
+            </fieldset>
+            <fieldset class="lo-subscribe__fieldset lo-subscribe__prefs">
+                <legend class="lo-subscribe__legend">Delivery preferences</legend>
+                <label class="lo-subscribe__checkbox"><input type="checkbox" name="realtime_alerts" value="1" checked /> <span>Real-time incident alerts</span></label>
+                <label class="lo-subscribe__checkbox"><input type="checkbox" name="daily_digest" value="1" /> <span>Daily digest</span></label>
+                <label class="lo-subscribe__checkbox"><input type="checkbox" name="newsletter" value="1" /> <span>Product updates / newsletter</span></label>
+                <p class="lo-subscribe__note">We’ll only use this to send the outage updates you request. You can unsubscribe anytime.</p>
+            </fieldset>
             <div class="lo-subscribe__label lo-subscribe__challenge">
                 <p class="lo-subscribe__prompt">Type the Steve Jobs line shown below to prove you&rsquo;re not a bot.</p>
                 <?php if ($challenge_phrase) : ?>

--- a/tests/SubscriptionsTest.php
+++ b/tests/SubscriptionsTest.php
@@ -77,10 +77,7 @@ namespace {
             if ('email' === $prepared['type']) {
                 foreach ($this->rows as $row) {
                     if ($row['email'] === $prepared['value']) {
-                        $result = [
-                            'id'     => $row['id'],
-                            'status' => $row['status'],
-                        ];
+                        $result = $row;
                         return $output === ARRAY_A ? $result : (object) $result;
                     }
                 }
@@ -196,6 +193,7 @@ namespace LousyOutages\Tests {
             throw new \RuntimeException('Expected find_by_token to return updated timestamps.');
         }
     };
+
 
     $failed = false;
     foreach ($tests as $name => $callback) {


### PR DESCRIPTION
### Motivation
- Let public visitors choose which providers they care about and whether they want real-time alerts, a daily digest, and/or product newsletter, so subscribers can avoid alert fatigue.
- Keep existing confirmation/unsubscribe flow and backward compatibility for legacy subscribers while plumbing preferences through the public subscribe experience and delivery paths.

### Description
- Extend subscription storage and schema handling in `Subscriptions` to include `providers` (JSON), `realtime_alerts`, `daily_digest`, `newsletter`, `consent_version`, and `confirmed_at`, and add helpers: `normalize_provider_ids`, `normalize_preferences`, `save_pending_with_preferences`, `get_preferences_for_email`, `subscriber_wants_provider`, `subscriber_wants_realtime`, `subscriber_wants_digest`, and `subscriber_wants_newsletter`.
- Update the public subscribe form (`public/shortcode.php`) to render a provider checklist plus delivery preference checkboxes and add minimal neon-style CSS for the new controls (`assets/lousy-outages.css`).
- Send preferences from front-end submit (`assets/lousy-outages.js`) and persist them via the subscribe endpoint (`lo_handle_subscribe`) which now calls `save_pending_with_preferences` and only adds to `suzy_newsletter` when newsletter is explicitly opted-in.
- Filter recipients during delivery: `IncidentAlerts::send_incident_alert_email` now limits public realtime recipients to confirmed subscribers who opted into realtime alerts and whose provider selection matches the incident, while still always including the configured notification inbox; `send_daily_digest` filters recipients to subscribers who opted into daily digest.
- Update confirmation email helpers to accept preferences and include a brief summary of chosen preferences/providers in the confirmation copy.
- Minor test harness adjustment to make the fake DB row shape return full rows for email lookups to align with the expanded subscription row usage.

### Testing
- Ran `php -l` on modified PHP files (`includes/Subscriptions.php`, `includes/Subscribe.php`, `includes/IncidentAlerts.php`, `includes/email-templates.php`, `public/shortcode.php`) — no syntax errors reported.
- Ran the existing ad-hoc test script `php tests/SubscriptionsTest.php` — test run failed with a namespacing/bootstrap error: `Class "LousyOutages\Subscriptions" not found`, which appears to be a pre-existing test-harness mismatch (the repository contains ad-hoc PHP test runners that assume different bootstrapping); this prevented the bundled script from completing successfully.
- Note: I did not add integration tests requiring DB migrations in this pass; recipient-filtering and digest-item filtering unit tests are TODOs because the current lightweight test harness requires namespace/bootstrap fixes to run new PHPUnit-style tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e9dc9bbc832e9290e1ef49f607a7)