### PR TITLE
Add community signal diagnostics, demo seed/clear controls, public signals endpoint, and client refresh

### DIFF
--- a/lousy-outages/assets/lousy-outages.js
+++ b/lousy-outages/assets/lousy-outages.js
@@ -125,6 +125,8 @@
     reportCaptchaToken: null,
     reportCaptchaRefresh: null,
     reportPhraseEndpoint: '',
+    signalsEndpoint: '',
+    signalsContainer: null,
     reportCaptchaTokenValue: '',
     reportProvidersInitialized: false,
     debug: false,
@@ -3347,9 +3349,8 @@
             state.reportContact.value = '';
           }
           setReportStatus(message || 'Thanks — we logged your unconfirmed community report and we’re watching this.', 'success');
-          fetchHistoryData().catch(function () {
-            // Ignore history refresh errors after submit.
-          });
+          fetchHistoryData().catch(function () {});
+          fetchCommunitySignals();
         } else {
           setReportStatus(message || 'Could not submit report right now, please try again later.', 'error');
         }
@@ -3380,6 +3381,8 @@
     state.reportCaptchaToken = state.reportForm ? state.reportForm.querySelector('[data-lo-report-captcha-token]') : null;
     state.reportCaptchaRefresh = state.reportForm ? state.reportForm.querySelector('[data-lo-report-captcha-refresh]') : null;
     state.reportPhraseEndpoint = state.reportForm ? String(state.reportForm.dataset.loReportPhraseEndpoint || '') : '';
+    state.signalsContainer = state.doc.querySelector('[data-lo-signals]');
+    state.signalsEndpoint = state.signalsContainer ? String(state.signalsContainer.getAttribute('data-lo-signals-endpoint') || '') : '';
 
     if (state.reportForm && !state.reportForm.dataset.loReportEnhanced) {
       state.reportForm.dataset.loReportEnhanced = '1';
@@ -3396,12 +3399,43 @@
     if (state.reportCaptchaRefresh) {
       state.reportCaptchaRefresh.addEventListener('click', function () {
         requestReportPhrase();
+    fetchCommunitySignals();
       });
     }
 
     requestReportPhrase();
+    fetchCommunitySignals();
   }
 
+
+  function renderCommunitySignals(signals) {
+    if (!state.signalsContainer) return;
+    var list = state.signalsContainer.querySelector('[data-lo-signals-list]');
+    var empty = state.signalsContainer.querySelector('[data-lo-signals-empty]');
+    if (!list || !empty) return;
+    var rows = Array.isArray(signals) ? signals.filter(function (s) {
+      var c = String((s && s.classification) || '').toLowerCase();
+      return c === 'watch' || c === 'trending' || c === 'hot';
+    }) : [];
+    list.innerHTML = '';
+    if (!rows.length) { empty.hidden = false; return; }
+    empty.hidden = true;
+    rows.slice(0,5).forEach(function (signal) {
+      var row = state.doc.createElement('div');
+      row.className = 'lo-signal lo-signal--' + String(signal.classification || 'watch');
+      row.innerHTML = '<span class="lo-signal__badge">' + String(signal.classification || '').charAt(0).toUpperCase() + String(signal.classification || '').slice(1) + '</span>' +
+        '<strong>' + String(signal.provider_name || signal.provider_id || 'Provider') + '</strong>' +
+        '<span>' + String(signal.message || 'Unconfirmed community signal. We are watching this.') + '</span>';
+      list.appendChild(row);
+    });
+  }
+
+  function fetchCommunitySignals() {
+    if (!state.fetchImpl || !state.signalsEndpoint) return Promise.resolve();
+    return state.fetchImpl(state.signalsEndpoint, { method: 'GET' }).then(function (res) { return res.json(); }).then(function (data) {
+      if (data && data.success && Array.isArray(data.signals)) renderCommunitySignals(data.signals);
+    }).catch(function () {});
+  }
   function isDocumentVisible() {
     if (!state.doc || typeof state.doc.visibilityState !== 'string') {
       return true;

--- a/lousy-outages/includes/Subscribe.php
+++ b/lousy-outages/includes/Subscribe.php
@@ -43,6 +43,11 @@ class Lousy_Outages_Subscribe {
             'callback' => [self::class, 'report_issue'],
             'permission_callback' => '__return_true',
         ]);
+        register_rest_route('lousy-outages/v1', '/signals', [
+            'methods' => 'GET',
+            'callback' => [self::class, 'get_signals'],
+            'permission_callback' => '__return_true',
+        ]);
 
     }
 
@@ -79,6 +84,36 @@ class Lousy_Outages_Subscribe {
         ], 200);
     }
 
+
+
+    public static function get_signals(\WP_REST_Request $request) {
+        $window = max(1, (int)$request->get_param('window_minutes'));
+        if ($window <= 1) { $window = 60; }
+        $signals = SignalEngine::summarize_recent_signals($window);
+        $safeSignals = [];
+        foreach ($signals as $signal) {
+            $safeSignals[] = [
+                'provider_id' => (string)($signal['provider_id'] ?? ''),
+                'provider_name' => (string)($signal['provider_name'] ?? ''),
+                'classification' => (string)($signal['classification'] ?? 'quiet'),
+                'report_count' => (int)($signal['report_count'] ?? 0),
+                'unique_reporter_count' => (int)($signal['unique_reporter_count'] ?? 0),
+                'top_symptom' => (string)($signal['top_symptom'] ?? 'other'),
+                'severity' => (string)($signal['severity'] ?? 'unknown'),
+                'region' => (string)($signal['region'] ?? ''),
+                'message' => (string)($signal['message'] ?? ''),
+                'last_reported_at' => (string)($signal['last_reported_at'] ?? ''),
+                'official_status_known' => !empty($signal['official_status_known']),
+            ];
+        }
+
+        return new \WP_REST_Response([
+            'success' => true,
+            'window_minutes' => $window,
+            'signals' => $safeSignals,
+            'generated_at' => gmdate('c'),
+        ], 200);
+    }
     public static function confirm(\WP_REST_Request $request) {
         $token = sanitize_text_field((string) $request->get_param('token'));
         if ('' === $token) {

--- a/lousy-outages/includes/UserReports.php
+++ b/lousy-outages/includes/UserReports.php
@@ -37,69 +37,65 @@ class UserReports {
         dbDelta($sql);
     }
 
-    public static function hash_value(string $raw): string {
-        return hash('sha256', wp_salt('auth') . '|' . trim($raw));
-    }
+    public static function hash_value(string $raw): string { return hash('sha256', wp_salt('auth') . '|' . trim($raw)); }
 
     public static function normalize_input(array $input): array {
         $provider = sanitize_key((string)($input['provider_id'] ?? ''));
         $providers = Providers::list();
-        if (!isset($providers[$provider])) {
-            return ['ok'=>false,'error'=>'invalid_provider'];
-        }
+        if (!isset($providers[$provider])) return ['ok'=>false,'error'=>'invalid_provider'];
         $symptom = sanitize_key((string)($input['symptom'] ?? 'other'));
-        if (!in_array($symptom, self::ALLOWED_SYMPTOMS, true)) { $symptom = 'other'; }
+        if (!in_array($symptom, self::ALLOWED_SYMPTOMS, true)) $symptom = 'other';
         $severity = sanitize_key((string)($input['severity'] ?? 'unknown'));
-        if (!in_array($severity, self::ALLOWED_SEVERITY, true)) { $severity = 'unknown'; }
+        if (!in_array($severity, self::ALLOWED_SEVERITY, true)) $severity = 'unknown';
         $region = substr(sanitize_text_field((string)($input['region'] ?? '')), 0, 80);
         $details = substr(sanitize_text_field((string)($input['details'] ?? '')), 0, 500);
         $email = sanitize_email((string)($input['email'] ?? ''));
         $email_hash = ($email && is_email($email)) ? self::hash_value(strtolower($email)) : null;
         $ip = (string)($input['ip'] ?? ($_SERVER['REMOTE_ADDR'] ?? ''));
         $ua = (string)($input['user_agent'] ?? ($_SERVER['HTTP_USER_AGENT'] ?? ''));
-        return [
-            'ok'=>true,
-            'provider_id'=>$provider,'symptom'=>$symptom,'severity'=>$severity,'region'=>$region,
-            'details'=>$details,'email_hash'=>$email_hash,
-            'ip_hash'=>self::hash_value($ip),'user_agent_hash'=>self::hash_value($ua),
-            'source'=>'public_form','status'=>'new',
-        ];
+        return ['ok'=>true,'provider_id'=>$provider,'symptom'=>$symptom,'severity'=>$severity,'region'=>$region,'details'=>$details,'email_hash'=>$email_hash,'ip_hash'=>self::hash_value($ip),'user_agent_hash'=>self::hash_value($ua),'source'=>'public_form','status'=>'new'];
     }
 
     public static function is_rate_limited(string $ipHash, string $provider_id): bool {
         global $wpdb;
-        $table = self::table_name();
         $cutoff = gmdate('Y-m-d H:i:s', time() - 5 * MINUTE_IN_SECONDS);
-        $count = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$table} WHERE ip_hash = %s AND provider_id = %s AND created_at >= %s", $ipHash, $provider_id, $cutoff));
+        $count = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM " . self::table_name() . " WHERE ip_hash = %s AND provider_id = %s AND created_at >= %s", $ipHash, $provider_id, $cutoff));
         return $count > 0;
     }
 
     public static function record_report(array $input): array {
         global $wpdb;
         $normalized = self::normalize_input($input);
-        if (empty($normalized['ok'])) { return ['success'=>false,'error'=>'invalid_provider']; }
-        if (self::is_rate_limited((string)$normalized['ip_hash'], (string)$normalized['provider_id'])) {
-            return ['success'=>false,'rate_limited'=>true,'message'=>'Thanks, we already logged a recent report for this provider. We’re watching it.'];
-        }
+        if (empty($normalized['ok'])) return ['success'=>false,'error'=>'invalid_provider'];
+        if (self::is_rate_limited((string)$normalized['ip_hash'], (string)$normalized['provider_id'])) return ['success'=>false,'rate_limited'=>true,'message'=>'Thanks, we already logged a recent report for this provider. We’re watching it.'];
         $now = gmdate('Y-m-d H:i:s');
-        $data = $normalized;
-        unset($data['ok']);
-        $data['created_at'] = $now;
+        $data = $normalized; unset($data['ok']); $data['created_at'] = $now;
         $wpdb->insert(self::table_name(), $data);
         return ['success'=>true,'provider_id'=>$data['provider_id'],'created_at'=>$now];
     }
 
     public static function get_recent_reports(array $args = []): array {
         global $wpdb;
-        $window = (int)($args['windowMinutes'] ?? 60);
-        $limit = (int)($args['limit'] ?? 50);
+        $window = max(1, (int)($args['windowMinutes'] ?? 60));
+        $limit = max(1, (int)($args['limit'] ?? 50));
         $provider = sanitize_key((string)($args['provider_id'] ?? ''));
-        $cutoff = gmdate('Y-m-d H:i:s', time() - max(1,$window) * MINUTE_IN_SECONDS);
-        $table = self::table_name();
-        if ($provider) {
-            return (array)$wpdb->get_results($wpdb->prepare("SELECT * FROM {$table} WHERE provider_id = %s AND created_at >= %s ORDER BY created_at DESC LIMIT %d", $provider,$cutoff,$limit), ARRAY_A);
-        }
-        return (array)$wpdb->get_results($wpdb->prepare("SELECT * FROM {$table} WHERE created_at >= %s ORDER BY created_at DESC LIMIT %d", $cutoff,$limit), ARRAY_A);
+        $source = sanitize_key((string)($args['source'] ?? ''));
+        $status = sanitize_key((string)($args['status'] ?? ''));
+        $cutoff = gmdate('Y-m-d H:i:s', time() - $window * MINUTE_IN_SECONDS);
+        $sql = 'SELECT * FROM ' . self::table_name() . ' WHERE created_at >= %s';
+        $params = [$cutoff];
+        if ($provider) { $sql .= ' AND provider_id = %s'; $params[] = $provider; }
+        if ($source) { $sql .= ' AND source = %s'; $params[] = $source; }
+        if ($status) { $sql .= ' AND status = %s'; $params[] = $status; }
+        $sql .= ' ORDER BY created_at DESC LIMIT %d';
+        $params[] = $limit;
+        return (array)$wpdb->get_results($wpdb->prepare($sql, ...$params), ARRAY_A);
+    }
+
+    public static function get_recent_report_count(int $windowMinutes = 60): int {
+        global $wpdb;
+        $cutoff = gmdate('Y-m-d H:i:s', time() - max(1, $windowMinutes) * MINUTE_IN_SECONDS);
+        return (int)$wpdb->get_var($wpdb->prepare('SELECT COUNT(*) FROM ' . self::table_name() . ' WHERE created_at >= %s', $cutoff));
     }
 
     public static function count_recent_reports(string $provider_id, int $windowMinutes = 60): int {
@@ -112,5 +108,41 @@ class UserReports {
         global $wpdb;
         $cutoff = gmdate('Y-m-d H:i:s', time() - max(1,$windowMinutes) * MINUTE_IN_SECONDS);
         return (array)$wpdb->get_results($wpdb->prepare('SELECT provider_id, COUNT(*) AS report_count FROM ' . self::table_name() . ' WHERE created_at >= %s GROUP BY provider_id ORDER BY report_count DESC', $cutoff), ARRAY_A);
+    }
+
+    public static function get_admin_diagnostics(int $windowMinutes = 60): array {
+        return [
+            'window_minutes' => max(1, $windowMinutes),
+            'total_reports' => self::get_recent_report_count($windowMinutes),
+            'provider_counts' => self::get_recent_provider_counts($windowMinutes),
+            'signals' => SignalEngine::summarize_recent_signals($windowMinutes),
+            'recent_reports' => self::get_recent_reports(['windowMinutes' => $windowMinutes, 'limit' => 25]),
+        ];
+    }
+
+    public static function seed_demo_reports(array $options = []): array {
+        global $wpdb;
+        $providers = Providers::enabled();
+        if (empty($providers)) $providers = Providers::list();
+        $ids = array_values(array_keys($providers));
+        if (count($ids) < 3) return ['inserted' => 0, 'provider_ids' => []];
+        $plan = [[$ids[0], 5, 'api', 'major', 'us-east', 'Demo report: API timeout'],[$ids[1], 3, 'login', 'degraded', 'us-west', 'Demo report: login errors'],[$ids[2], 2, 'checkout', 'minor', 'ca-central', 'Demo report: checkout failures']];
+        $inserted = 0;
+        foreach ($plan as $idx => $rowPlan) {
+            [$providerId, $count, $symptom, $severity, $region, $details] = $rowPlan;
+            for ($i = 0; $i < $count; $i++) {
+                $now = gmdate('Y-m-d H:i:s', time() - (($idx * 2 + $i) * 60));
+                $seed = $providerId . '|' . $idx . '|' . $i;
+                $wpdb->insert(self::table_name(), ['provider_id' => sanitize_key((string)$providerId), 'symptom' => $symptom, 'severity' => $severity, 'region' => $region, 'source' => 'demo_seed', 'details' => $details, 'email_hash' => self::hash_value('demo-email-' . $seed), 'ip_hash' => self::hash_value('demo-ip-' . $seed), 'user_agent_hash' => self::hash_value('demo-ua-' . $seed), 'created_at' => $now, 'status' => 'new']);
+                $inserted++;
+            }
+        }
+        return ['inserted' => $inserted, 'provider_ids' => [$ids[0], $ids[1], $ids[2]]];
+    }
+
+    public static function clear_demo_reports(): int {
+        global $wpdb;
+        $sql = $wpdb->prepare('DELETE FROM ' . self::table_name() . ' WHERE source = %s', 'demo_seed');
+        return (int)$wpdb->query($sql);
     }
 }

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -67,6 +67,7 @@ use SuzyEaston\LousyOutages\Email;
 use SuzyEaston\LousyOutages\Precursor;
 use SuzyEaston\LousyOutages\Subscriptions;
 use SuzyEaston\LousyOutages\UserReports;
+use SuzyEaston\LousyOutages\SignalEngine;
 use SuzyEaston\LousyOutages\Api;
 use SuzyEaston\LousyOutages\Feeds;
 use SuzyEaston\LousyOutages\MailTransport;
@@ -1019,6 +1020,20 @@ function lousy_outages_settings_page() {
                 <?php endforeach; ?>
             </tbody>
         </table>
+
+        <?php $diag = UserReports::get_admin_diagnostics(60); $topSignal = !empty($diag['signals'][0]['classification']) ? (string)$diag['signals'][0]['classification'] : 'quiet'; ?>
+        <h2>Community Signal Diagnostics</h2>
+        <p><strong>Total community reports in last hour:</strong> <?php echo esc_html((string)($diag['total_reports'] ?? 0)); ?></p>
+        <p><strong>Providers with reports:</strong> <?php echo esc_html((string)count((array)($diag['provider_counts'] ?? []))); ?></p>
+        <p><strong>Top signal classification:</strong> <?php echo esc_html(ucfirst($topSignal)); ?> (unconfirmed community signal)</p>
+        <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="display:inline-block;margin-right:8px;">
+            <?php wp_nonce_field('lousy_outages_seed_demo_reports'); ?><input type="hidden" name="action" value="lousy_outages_seed_demo_reports"><?php submit_button('Seed Demo Community Reports', 'secondary', 'submit', false); ?>
+        </form>
+        <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="display:inline-block;">
+            <?php wp_nonce_field('lousy_outages_clear_demo_reports'); ?><input type="hidden" name="action" value="lousy_outages_clear_demo_reports"><?php submit_button('Clear Demo Community Reports', 'delete', 'submit', false); ?>
+        </form>
+        <h3>Top providers by report count</h3>
+        <ul><?php foreach ((array)($diag['provider_counts'] ?? []) as $row) : ?><li><?php echo esc_html((string)($row['provider_id'] ?? 'unknown')); ?>: <?php echo esc_html((string)($row['report_count'] ?? 0)); ?></li><?php endforeach; ?></ul>
     </div>
     <?php
 }
@@ -1136,6 +1151,23 @@ add_action( 'admin_post_lousy_outages_poll_now', function () {
     $redirect = add_query_arg( 'page', 'lousy-outages', admin_url( 'options-general.php' ) );
     wp_safe_redirect( $redirect );
     exit;
+} );
+
+
+add_action( 'admin_post_lousy_outages_seed_demo_reports', function () {
+    if ( ! current_user_can( 'manage_options' ) ) { wp_die( esc_html__( 'Sorry, you are not allowed to access this page.', 'lousy-outages' ) ); }
+    check_admin_referer( 'lousy_outages_seed_demo_reports' );
+    $result = UserReports::seed_demo_reports();
+    set_transient('lousy_outages_notice',['message'=>sprintf('Seeded %d demo community reports.', (int)($result['inserted'] ?? 0)),'type'=>'success'],30);
+    wp_safe_redirect( add_query_arg( 'page', 'lousy-outages', admin_url( 'options-general.php' ) ) ); exit;
+} );
+
+add_action( 'admin_post_lousy_outages_clear_demo_reports', function () {
+    if ( ! current_user_can( 'manage_options' ) ) { wp_die( esc_html__( 'Sorry, you are not allowed to access this page.', 'lousy-outages' ) ); }
+    check_admin_referer( 'lousy_outages_clear_demo_reports' );
+    $count = UserReports::clear_demo_reports();
+    set_transient('lousy_outages_notice',['message'=>sprintf('Cleared %d demo community reports.', (int)$count),'type'=>'success'],30);
+    wp_safe_redirect( add_query_arg( 'page', 'lousy-outages', admin_url( 'options-general.php' ) ) ); exit;
 } );
 
 function lousy_outages_build_provider_payload( string $id, array $state, string $fetched_at ): array {

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -872,6 +872,7 @@ function render_subscribe_shortcode(): string {
         $providers = Providers::list();
     }
     $report_endpoint = esc_url_raw(rest_url('lousy-outages/v1/report'));
+    $signals_endpoint = esc_url_raw(rest_url('lousy-outages/v1/signals'));
     $signals = class_exists('\\SuzyEaston\\LousyOutages\\SignalEngine') ? SignalEngine::summarize_recent_signals(60) : [];
 
     ob_start();
@@ -966,8 +967,9 @@ function render_subscribe_shortcode(): string {
             <button type="submit" class="lo-subscribe__button" data-lo-report-submit>Report issue</button>
             <p class="lo-report__status" data-lo-report-status aria-live="polite"></p>
         </form>
-        <div class="lo-signals" data-lo-signals>
+        <div class="lo-signals" data-lo-signals data-lo-signals-endpoint="<?php echo esc_url($signals_endpoint); ?>">
             <h4>Community signals</h4>
+            <div data-lo-signals-list>
             <?php foreach (array_slice($signals, 0, 5) as $signal) : $class = (string)($signal['classification'] ?? 'quiet'); if ($class === 'quiet') { continue; } ?>
                 <div class="lo-signal lo-signal--<?php echo esc_attr($class); ?>">
                     <span class="lo-signal__badge"><?php echo esc_html(ucfirst($class)); ?></span>
@@ -975,6 +977,8 @@ function render_subscribe_shortcode(): string {
                     <span><?php echo esc_html((string)($signal['message'] ?? 'Unconfirmed community signal.')); ?></span>
                 </div>
             <?php endforeach; ?>
+            </div>
+            <p data-lo-signals-empty<?php echo !empty($signals) ? " hidden" : ""; ?>>No unusual community reports.</p>
         </div>
     </section>
     <?php

--- a/tests/UserReportsTest.php
+++ b/tests/UserReportsTest.php
@@ -1,10 +1,26 @@
 <?php
 declare(strict_types=1);
 require_once __DIR__.'/bootstrap.php';
+if (!function_exists('get_option')) { function get_option($k,$d=null){ return $d; } }
+if (!function_exists('update_option')) { function update_option($k,$v,$a=null){ return true; } }
 require_once __DIR__.'/../lousy-outages/includes/Providers.php';
+require_once __DIR__.'/../lousy-outages/includes/SignalEngine.php';
 require_once __DIR__.'/../lousy-outages/includes/UserReports.php';
 use SuzyEaston\LousyOutages\UserReports;
-$r=UserReports::normalize_input(['provider_id'=>'notreal']); if(!empty($r['ok'])){ echo "not ok - invalid provider\n"; exit(1);} 
-$ok=UserReports::normalize_input(['provider_id'=>'cloudflare','symptom'=>'nope','details'=>str_repeat('a',600),'ip'=>'1.2.3.4']);
-if($ok['symptom']!=='other'){ echo "not ok - symptom normalize\n"; exit(1);} if(strlen($ok['details'])!==500){ echo "not ok - details len\n"; exit(1);} if(($ok['ip_hash']??'')==='1.2.3.4'){ echo "not ok - raw ip stored\n"; exit(1);} 
-echo "ok - user report normalization\nAll tests passed\n";
+
+class FakeWpdbUserReports {
+    public string $prefix='wp_'; public array $rows=[];
+    public function prepare($q,...$args){ return ['q'=>$q,'args'=>$args]; }
+    public function insert($t,$d){ $this->rows[]=$d; return 1; }
+    public function get_var($p){ $q=strtolower($p['q']); $a=$p['args']; if(str_contains($q,'provider_id = %s')){ $pid=$a[0]; $cut=$a[1]; return count(array_filter($this->rows,fn($r)=>$r['provider_id']===$pid&&$r['created_at']>=$cut)); } $cut=$a[0]??''; return count(array_filter($this->rows,fn($r)=>$r['created_at']>=$cut)); }
+    public function get_results($p,$o){ $q=strtolower($p['q']); if(str_contains($q,'group by provider_id')){ $cut=$p['args'][0]; $counts=[]; foreach($this->rows as $r){ if($r['created_at']<$cut) continue; $counts[$r['provider_id']]=($counts[$r['provider_id']]??0)+1; } $out=[]; foreach($counts as $k=>$v){$out[]=['provider_id'=>$k,'report_count'=>$v];} return $out; } return array_slice(array_reverse($this->rows),0,25); }
+    public function query($prepared){ $before=count($this->rows); $this->rows=array_values(array_filter($this->rows,fn($r)=>($r['source']??'')!=='demo_seed')); return $before-count($this->rows); }
+}
+
+$tests=[];
+$tests['normalize_input']=function(){ $r=UserReports::normalize_input(['provider_id'=>'notreal']); if(!empty($r['ok'])) throw new RuntimeException('invalid provider'); $ok=UserReports::normalize_input(['provider_id'=>'cloudflare','symptom'=>'nope','details'=>str_repeat('a',600),'ip'=>'1.2.3.4']); if($ok['symptom']!=='other'||strlen($ok['details'])!==500||$ok['ip_hash']==='1.2.3.4') throw new RuntimeException('normalize'); };
+$tests['seed_and_clear_demo_reports']=function(){ global $wpdb; $wpdb=new FakeWpdbUserReports(); $seed=UserReports::seed_demo_reports(); if(($seed['inserted']??0)<=0) throw new RuntimeException('no seed'); foreach($wpdb->rows as $r){ if(($r['source']??'')!=='demo_seed') throw new RuntimeException('wrong source'); } $wpdb->rows[]=['provider_id'=>'cloudflare','source'=>'public_form','created_at'=>gmdate('Y-m-d H:i:s')]; $deleted=UserReports::clear_demo_reports(); if($deleted<=0) throw new RuntimeException('not deleted'); if(count($wpdb->rows)!==1||$wpdb->rows[0]['source']!=='public_form') throw new RuntimeException('deleted non-demo'); };
+$tests['diagnostics_shape']=function(){ global $wpdb; $wpdb=new FakeWpdbUserReports(); UserReports::seed_demo_reports(); $diag=UserReports::get_admin_diagnostics(60); foreach(['total_reports','provider_counts','signals','recent_reports','window_minutes'] as $k){ if(!array_key_exists($k,$diag)) throw new RuntimeException('missing '.$k); } };
+
+$f=false; foreach($tests as $n=>$cb){ try{$cb(); echo "ok - $n\n";}catch(Throwable $e){$f=true; echo "not ok - $n: {$e->getMessage()}\n";}}
+if($f) exit(1); echo "All tests passed\n";


### PR DESCRIPTION
### Motivation
- Provide an admin-facing diagnostics / demo control surface so the community-signal system is demoable without exposing raw PII. 
- Make the public signal panel refreshable from a read-only aggregate endpoint to show live, unconfirmed community signals in the demo.
- Keep privacy and legal language intact: only aggregate signals are public and demo cleanup touches only demo rows.

### Description
- Added diagnostics and demo helpers to `UserReports`: `get_recent_report_count`, extended `get_recent_reports` (filters for `provider_id`, `source`, `status`, `limit`), `get_recent_provider_counts`, `get_admin_diagnostics`, `seed_demo_reports` (inserts deterministic `source='demo_seed'` rows), and `clear_demo_reports` (deletes only `source='demo_seed'`). (edited: `lousy-outages/includes/UserReports.php`)
- Registered a new read-only REST route `GET /wp-json/lousy-outages/v1/signals` that returns aggregate, sanitized signal objects (no raw IP/email/UA/hashes/details). (edited: `lousy-outages/includes/Subscribe.php`)
- Extended the existing settings page (`lousy_outages_settings_page`) with a “Community Signal Diagnostics” section that displays totals, top providers, top classification, and provides two admin actions (seed/clear demo reports) protected by `manage_options` and `check_admin_referer`. Backend admin-post handlers set transients and `wp_safe_redirect` back to the settings page. (edited: `lousy-outages/lousy-outages.php`)
- Updated the public shortcode markup to include stable JS hooks and the new endpoint: added `data-lo-signals`, `data-lo-signals-list`, `data-lo-signals-empty`, and a `data-lo-signals-endpoint` attribute while preserving server-rendered fallback. (edited: `lousy-outages/public/shortcode.php`)
- Front-end JS now fetches the aggregate `signals` endpoint once on load and again after a successful report submit and renders only `watch`/`trending`/`hot` signals without changing existing submit behavior. No aggressive polling added. (edited: `lousy-outages/assets/lousy-outages.js`)
- Added lightweight tests for `UserReports`: normalization, demo seed/clear safety, and `get_admin_diagnostics` shape using a small fake `$wpdb` double. (edited: `tests/UserReportsTest.php`)

### Testing
- Ran PHP syntax checks: `php -l` for `includes/UserReports.php`, `includes/SignalEngine.php`, `includes/Subscribe.php`, `lousy-outages.php`, and `public/shortcode.php` — all reported no syntax errors.
- Ran unit-style test scripts: `php tests/SignalEngineTest.php` (passed), `php tests/UserReportsTest.php` (passed after adding lightweight WP option stubs inside the test harness), `php tests/SubscriptionsTest.php` (passed), and `php tests/IncidentStoreCloudflareSuppressionTest.php` (passed).
- Note: `IncidentAlertDeliveryTest.php` was not executed because it is a PHPUnit-structured test and not directly runnable via plain `php` in the ad-hoc harness; it remains unchanged and was intentionally not marked as passed.
- All modified code paths exercised by the new tests behaved as expected; demo seeding creates `source='demo_seed'` rows and `clear_demo_reports()` deletes only those demo rows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f0a851ec832e989283b4cdd8259a)