### PR TITLE
Add MVP multi-source early-warning signal collection and fusion

### DIFF
--- a/lousy-outages/includes/ExternalSignals.php
+++ b/lousy-outages/includes/ExternalSignals.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+class ExternalSignals {
+    public static function table_name(): string { global $wpdb; return $wpdb->prefix . 'lo_external_signals'; }
+
+    public static function install(): void {
+        global $wpdb;
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        $table = self::table_name();
+        $charset = $wpdb->get_charset_collate();
+        $sql = "CREATE TABLE {$table} (
+            id BIGINT unsigned NOT NULL AUTO_INCREMENT,
+            source VARCHAR(80) NOT NULL,
+            provider_id VARCHAR(80) NOT NULL DEFAULT '',
+            provider_name VARCHAR(160) NOT NULL DEFAULT '',
+            category VARCHAR(80) NOT NULL DEFAULT '',
+            region VARCHAR(80) NOT NULL DEFAULT '',
+            signal_type VARCHAR(80) NOT NULL DEFAULT '',
+            severity VARCHAR(40) NOT NULL DEFAULT 'unknown',
+            confidence TINYINT unsigned NOT NULL DEFAULT 0,
+            title VARCHAR(255) NOT NULL DEFAULT '',
+            message TEXT NULL,
+            url TEXT NULL,
+            observed_at DATETIME NOT NULL,
+            expires_at DATETIME NULL,
+            raw_hash VARCHAR(128) NULL,
+            created_at DATETIME NOT NULL,
+            PRIMARY KEY (id),
+            KEY source (source), KEY provider_id (provider_id), KEY category (category), KEY region (region), KEY observed_at (observed_at), KEY expires_at (expires_at)
+        ) {$charset};";
+        dbDelta($sql);
+    }
+
+    public static function normalize_signal(array $signal): array {
+        $observed = sanitize_text_field((string)($signal['observed_at'] ?? gmdate('Y-m-d H:i:s')));
+        $expires = isset($signal['expires_at']) ? sanitize_text_field((string)$signal['expires_at']) : null;
+        return [
+            'source' => substr(sanitize_key((string)($signal['source'] ?? 'unknown_external')), 0, 80),
+            'provider_id' => substr(sanitize_key((string)($signal['provider_id'] ?? '')), 0, 80),
+            'provider_name' => substr(sanitize_text_field((string)($signal['provider_name'] ?? '')), 0, 160),
+            'category' => substr(sanitize_key((string)($signal['category'] ?? 'general')), 0, 80),
+            'region' => substr(sanitize_text_field((string)($signal['region'] ?? 'global')), 0, 80),
+            'signal_type' => substr(sanitize_key((string)($signal['signal_type'] ?? 'unknown')), 0, 80),
+            'severity' => substr(sanitize_key((string)($signal['severity'] ?? 'unknown')), 0, 40),
+            'confidence' => max(0, min(100, (int)($signal['confidence'] ?? 0))),
+            'title' => substr(sanitize_text_field((string)($signal['title'] ?? 'External signal observed')), 0, 255),
+            'message' => substr(sanitize_textarea_field((string)($signal['message'] ?? '')), 0, 1000),
+            'url' => substr(esc_url_raw((string)($signal['url'] ?? '')), 0, 1000),
+            'observed_at' => $observed,
+            'expires_at' => $expires ?: null,
+            'raw_hash' => isset($signal['raw_hash']) ? substr(sanitize_text_field((string)$signal['raw_hash']),0,128) : hash('sha256', wp_json_encode($signal)),
+        ];
+    }
+
+    public static function record_signal(array $signal): array {
+        global $wpdb; $s=self::normalize_signal($signal);
+        if (!empty($s['raw_hash'])) {
+            $exists = $wpdb->get_var($wpdb->prepare('SELECT id FROM '.self::table_name().' WHERE raw_hash=%s LIMIT 1', $s['raw_hash']));
+            if ($exists) return ['inserted'=>false,'id'=>(int)$exists,'signal'=>$s];
+        }
+        $wpdb->insert(self::table_name(), array_merge($s,['created_at'=>gmdate('Y-m-d H:i:s')]));
+        return ['inserted'=>true,'id'=>(int)$wpdb->insert_id,'signal'=>$s];
+    }
+    public static function record_many(array $signals): array { $out=['inserted'=>0,'skipped'=>0,'rows'=>[]]; foreach($signals as $sig){$r=self::record_signal((array)$sig);$out['rows'][]=$r; $out[$r['inserted']?'inserted':'skipped']++;} return $out; }
+    public static function get_recent_signals(array $args=[]): array { global $wpdb; $limit=max(1,min(200,(int)($args['limit']??50))); return $wpdb->get_results($wpdb->prepare('SELECT * FROM '.self::table_name().' WHERE observed_at >= %s ORDER BY observed_at DESC LIMIT %d', gmdate('Y-m-d H:i:s', time()-((int)($args['windowMinutes']??60))*60), $limit), ARRAY_A) ?: []; }
+    public static function get_recent_counts(int $windowMinutes=60): array { global $wpdb; $rows=$wpdb->get_results($wpdb->prepare('SELECT source, COUNT(*) as signal_count FROM '.self::table_name().' WHERE observed_at >= %s GROUP BY source', gmdate('Y-m-d H:i:s', time()-$windowMinutes*60)), ARRAY_A) ?: []; return $rows; }
+    public static function clear_expired(): int { global $wpdb; $wpdb->query($wpdb->prepare('DELETE FROM '.self::table_name().' WHERE expires_at IS NOT NULL AND expires_at < %s', gmdate('Y-m-d H:i:s'))); return (int)$wpdb->rows_affected; }
+    public static function clear_demo_signals(): int { global $wpdb; $wpdb->query($wpdb->prepare('DELETE FROM '.self::table_name().' WHERE source = %s', 'demo_external')); return (int)$wpdb->rows_affected; }
+    public static function seed_demo_signals(array $options=[]): array {
+        $now=gmdate('Y-m-d H:i:s');
+        $demo=[[ 'source'=>'demo_external','provider_id'=>'cloudflare','provider_name'=>'Cloudflare','category'=>'internet_health','region'=>'us','signal_type'=>'traffic_anomaly','severity'=>'degraded','confidence'=>68,'title'=>'Internet-health anomaly detected','message'=>'Possible emerging issue from demo telemetry. Official incident not yet confirmed.','observed_at'=>$now ],[ 'source'=>'demo_external','provider_id'=>'local_isp','provider_name'=>'Local ISP','category'=>'isp','region'=>'vancouver','signal_type'=>'internet_outage','severity'=>'major','confidence'=>74,'title'=>'Unconfirmed external signal','message'=>'We are watching this provider due to demo external signal.','observed_at'=>$now ]];
+        return self::record_many($demo);
+    }
+}

--- a/lousy-outages/includes/SignalCollector.php
+++ b/lousy-outages/includes/SignalCollector.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+use SuzyEaston\LousyOutages\Sources\CloudflareRadarSource;
+use SuzyEaston\LousyOutages\Sources\SyntheticCanarySource;
+
+class SignalCollector {
+    public static function sources(): array { return [new CloudflareRadarSource(), new SyntheticCanarySource()]; }
+    public static function collect(array $options=[]): array {
+        $result=['started_at'=>gmdate('c'),'finished_at'=>'','sources'=>[],'total_collected'=>0,'total_stored'=>0];
+        foreach(self::sources() as $source){ $r=self::collect_source($source->id(),$options); $result['sources'][]=$r; $result['total_collected']+=(int)$r['collected_count']; $result['total_stored']+=(int)$r['stored_count']; }
+        $result['finished_at']=gmdate('c'); self::mark_last_collection_result($result); return $result;
+    }
+    public static function collect_source(string $sourceId, array $options=[]): array {
+        foreach(self::sources() as $source){ if($source->id()!==$sourceId) continue; $configured=$source->is_configured(); if(!$configured) return ['source'=>$source->id(),'configured'=>false,'attempted'=>false,'collected_count'=>0,'stored_count'=>0,'errors'=>[]]; $signals=$source->collect($options); $stored=ExternalSignals::record_many($signals); return ['source'=>$source->id(),'configured'=>true,'attempted'=>true,'collected_count'=>count($signals),'stored_count'=>(int)($stored['inserted']??0),'errors'=>[]]; }
+        return ['source'=>$sourceId,'configured'=>false,'attempted'=>false,'collected_count'=>0,'stored_count'=>0,'errors'=>['unknown source']];
+    }
+    public static function get_last_collection_result(): array { $r=get_option('lousy_outages_last_external_collection',[]); return is_array($r)?$r:[]; }
+    public static function mark_last_collection_result(array $result): void { update_option('lousy_outages_last_external_collection',$result,false); }
+}

--- a/lousy-outages/includes/SignalEngine.php
+++ b/lousy-outages/includes/SignalEngine.php
@@ -61,4 +61,32 @@ class SignalEngine {
         usort($signals, static fn($a,$b)=>($b['report_count']<=>$a['report_count']));
         return $signals;
     }
+
+    public static function summarize_fused_signals(int $windowMinutes = 60): array {
+        $community = self::summarize_recent_signals($windowMinutes);
+        $external = class_exists('\SuzyEaston\LousyOutages\ExternalSignals') ? ExternalSignals::get_recent_signals(['windowMinutes'=>$windowMinutes,'limit'=>200]) : [];
+        $buckets = [];
+        foreach ($community as $row) {
+            $key = ($row['provider_id'] ?? '') . '|' . ($row['category'] ?? '') . '|' . ($row['region'] ?? '');
+            $buckets[$key] = ['provider_id'=>(string)$row['provider_id'],'provider_name'=>(string)$row['provider_name'],'category'=>(string)($row['category']??'community'),'region'=>(string)($row['region']??''),'report_count'=>(int)$row['report_count'],'external_signal_count'=>0,'synthetic_failure_count'=>0,'sources'=>['community_reports'],'official_status_known'=>false,'confirmed'=>false,'last_observed_at'=>(string)($row['last_reported_at']??''),'base_confidence'=> self::class_confidence((string)$row['classification']) ];
+        }
+        foreach ($external as $row) {
+            $key = ($row['provider_id'] ?? '') . '|' . ($row['category'] ?? '') . '|' . ($row['region'] ?? '');
+            if (!isset($buckets[$key])) { $buckets[$key]=['provider_id'=>(string)($row['provider_id']??''),'provider_name'=>(string)($row['provider_name']??'Unknown'),'category'=>(string)($row['category']??''),'region'=>(string)($row['region']??''),'report_count'=>0,'external_signal_count'=>0,'synthetic_failure_count'=>0,'sources'=>[],'official_status_known'=>false,'confirmed'=>false,'last_observed_at'=>(string)($row['observed_at']??''),'base_confidence'=>0]; }
+            $buckets[$key]['external_signal_count']++;
+            $src=(string)($row['source']??'external'); if(!in_array($src,$buckets[$key]['sources'],true)) $buckets[$key]['sources'][]=$src;
+            if (($row['source']??'')==='synthetic_canary') $buckets[$key]['synthetic_failure_count']++;
+            $buckets[$key]['base_confidence'] = max((int)$buckets[$key]['base_confidence'], (int)($row['confidence'] ?? 0));
+            if ((string)($row['observed_at']??'') > (string)$buckets[$key]['last_observed_at']) $buckets[$key]['last_observed_at']=(string)$row['observed_at'];
+        }
+        $signals=[];
+        foreach($buckets as $b){ $conf=(int)$b['base_confidence']; if(count($b['sources'])>=2) $conf += 15; if(!$b['confirmed']) $conf=min($conf,95); $class=$conf>=70?'hot':($conf>=45?'trending':($conf>=25?'watch':'quiet')); $msg='Community reports are trending for this provider. Official incident not confirmed.'; if($b['report_count']>0 && $b['external_signal_count']>0){$msg='External internet-health signals and community reports both suggest a possible issue.';} elseif($b['external_signal_count']>0 && $b['synthetic_failure_count']===0 && $b['report_count']===0){$msg='External internet-health telemetry suggests a possible issue. Official incident not confirmed.';} elseif($b['synthetic_failure_count']>0 && $b['report_count']===0){$msg='A lightweight public canary check failed. This is an unconfirmed signal.';}
+            $signals[]=$b + ['confidence'=>$conf,'classification'=>$class,'message'=>$msg,'id'=>md5($b['provider_id'].'|'.$b['category'].'|'.$b['region'])];
+        }
+        usort($signals, static fn($a,$b)=>($b['confidence']<=>$a['confidence']));
+        return $signals;
+    }
+
+    private static function class_confidence(string $class): int { if($class==='watch') return 20; if($class==='trending') return 45; if($class==='hot') return 65; return 0; }
+
 }

--- a/lousy-outages/includes/SignalSourceInterface.php
+++ b/lousy-outages/includes/SignalSourceInterface.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+interface SignalSourceInterface {
+    public function id(): string;
+    public function label(): string;
+    public function is_configured(): bool;
+    /** @return array<int,array<string,mixed>> */
+    public function collect(array $options = []): array;
+}

--- a/lousy-outages/includes/Sources/CloudflareRadarSource.php
+++ b/lousy-outages/includes/Sources/CloudflareRadarSource.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages\Sources;
+
+use SuzyEaston\LousyOutages\SignalSourceInterface;
+
+class CloudflareRadarSource implements SignalSourceInterface {
+    private function token(): string { if (defined('LOUSY_OUTAGES_CLOUDFLARE_RADAR_TOKEN')) return (string) LOUSY_OUTAGES_CLOUDFLARE_RADAR_TOKEN; $env=getenv('LOUSY_OUTAGES_CLOUDFLARE_RADAR_TOKEN'); if($env) return (string)$env; return (string)get_option('lousy_outages_cloudflare_radar_token',''); }
+    public function id(): string { return 'cloudflare_radar'; }
+    public function label(): string { return 'Cloudflare Radar'; }
+    public function is_configured(): bool { return '' !== trim($this->token()); }
+    public function collect(array $options = []): array {
+        if (!$this->is_configured()) return [];
+        $endpoints = [
+            'internet_outage' => 'https://api.cloudflare.com/client/v4/radar/outages',
+            'traffic_anomaly' => 'https://api.cloudflare.com/client/v4/radar/anomalies'
+        ];
+        $out=[];
+        foreach($endpoints as $type=>$url){
+            $res = wp_remote_get($url,['timeout'=>8,'headers'=>['Authorization'=>'Bearer '.$this->token(),'User-Agent'=>'LousyOutages/'.(defined('LOUSY_OUTAGES_VERSION')?LOUSY_OUTAGES_VERSION:'0.1.0')]]);
+            if (is_wp_error($res)) continue;
+            if ((int)wp_remote_retrieve_response_code($res)!==200) continue;
+            $body=json_decode((string)wp_remote_retrieve_body($res),true);
+            $items=(array)($body['result'] ?? []);
+            foreach(array_slice($items,0,10) as $item){
+                $out[]=[ 'source'=>'cloudflare_radar','provider_id'=>sanitize_key((string)($item['asn'] ?? '')),'provider_name'=>sanitize_text_field((string)($item['name'] ?? $item['asn_name'] ?? 'Internet Health')),'category'=>'internet_health','region'=>sanitize_text_field((string)($item['location'] ?? $item['country'] ?? 'global')),'signal_type'=>$type,'severity'=>'degraded','confidence'=>70,'title'=>sanitize_text_field((string)($item['title'] ?? 'Internet-health anomaly detected')),'message'=>sanitize_text_field((string)($item['description'] ?? 'Unconfirmed external signal from internet-health telemetry.')),'url'=>esc_url_raw((string)($item['url'] ?? 'https://radar.cloudflare.com')),'observed_at'=>sanitize_text_field((string)($item['time'] ?? gmdate('Y-m-d H:i:s'))) ];
+            }
+        }
+        return $out;
+    }
+}

--- a/lousy-outages/includes/Sources/SyntheticCanarySource.php
+++ b/lousy-outages/includes/Sources/SyntheticCanarySource.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages\Sources;
+
+use SuzyEaston\LousyOutages\SignalSourceInterface;
+
+class SyntheticCanarySource implements SignalSourceInterface {
+    public function id(): string { return 'synthetic_canary'; }
+    public function label(): string { return 'Synthetic Canary'; }
+    public function is_configured(): bool { return (bool) apply_filters('lo_synthetic_canary_enabled', true); }
+    public function collect(array $options = []): array {
+        if (!$this->is_configured()) return [];
+        $targets = apply_filters('lo_synthetic_canary_targets', [[ 'id'=>'site_home','label'=>'Site Home','url'=>home_url('/'),'provider_id'=>'site','category'=>'site','region'=>'local','method'=>'HEAD','expected_statuses'=>[200,204,301,302],'timeout_seconds'=>5 ]]);
+        $max=max(1,min(10,(int)apply_filters('lo_synthetic_canary_max_targets',5)));
+        $out=[];
+        foreach(array_slice((array)$targets,0,$max) as $t){
+            $method=strtoupper((string)($t['method']??'HEAD')); $timeout=max(1,min(5,(int)($t['timeout_seconds']??5))); $url=esc_url_raw((string)($t['url']??'')); if(!$url) continue;
+            $start=microtime(true);
+            $res = $method==='GET' ? wp_remote_get($url,['timeout'=>$timeout,'redirection'=>2]) : wp_remote_head($url,['timeout'=>$timeout,'redirection'=>2]);
+            $elapsed=(microtime(true)-$start)*1000;
+            $expected=array_map('intval',(array)($t['expected_statuses']??[200,204,301,302]));
+            if (is_wp_error($res)) { $out[]=$this->failure($t,'http_check_failed','major','Synthetic check failed for '.($t['label']??$url),'A lightweight public canary check failed. This is an unconfirmed signal, not proof of a provider outage.'); continue; }
+            $code=(int)wp_remote_retrieve_response_code($res);
+            if (!in_array($code,$expected,true)) { $out[]=$this->failure($t,'http_check_failed','degraded','Synthetic check failed for '.($t['label']??$url),'Synthetic check failures observed. Official incident not yet confirmed.'); continue; }
+            $th=(float)apply_filters('lo_synthetic_canary_latency_ms',2500);
+            if ($elapsed > $th) { $out[]=$this->failure($t,'http_latency_high','degraded','Synthetic latency high for '.($t['label']??$url),'A lightweight public canary check failed. This is an unconfirmed signal.'); }
+        }
+        return $out;
+    }
+    private function failure(array $t,string $type,string $severity,string $title,string $msg): array { return ['source'=>'synthetic_canary','provider_id'=>sanitize_key((string)($t['provider_id']??$t['id']??'')),'provider_name'=>sanitize_text_field((string)($t['label']??'Synthetic Canary')),'category'=>sanitize_key((string)($t['category']??'synthetic')),'region'=>sanitize_text_field((string)($t['region']??'global')),'signal_type'=>$type,'severity'=>$severity,'confidence'=>40,'title'=>$title,'message'=>$msg,'url'=>esc_url_raw((string)($t['url']??'')),'observed_at'=>gmdate('Y-m-d H:i:s')]; }
+}

--- a/lousy-outages/includes/Subscribe.php
+++ b/lousy-outages/includes/Subscribe.php
@@ -89,7 +89,7 @@ class Lousy_Outages_Subscribe {
     public static function get_signals(\WP_REST_Request $request) {
         $window = max(1, (int)$request->get_param('window_minutes'));
         if ($window <= 1) { $window = 60; }
-        $signals = SignalEngine::summarize_recent_signals($window);
+        $signals = SignalEngine::summarize_fused_signals($window);
         $safeSignals = [];
         foreach ($signals as $signal) {
             $safeSignals[] = [
@@ -97,12 +97,16 @@ class Lousy_Outages_Subscribe {
                 'provider_name' => (string)($signal['provider_name'] ?? ''),
                 'classification' => (string)($signal['classification'] ?? 'quiet'),
                 'report_count' => (int)($signal['report_count'] ?? 0),
-                'unique_reporter_count' => (int)($signal['unique_reporter_count'] ?? 0),
-                'top_symptom' => (string)($signal['top_symptom'] ?? 'other'),
-                'severity' => (string)($signal['severity'] ?? 'unknown'),
-                'region' => (string)($signal['region'] ?? ''),
+                                'region' => (string)($signal['region'] ?? ''),
                 'message' => (string)($signal['message'] ?? ''),
-                'last_reported_at' => (string)($signal['last_reported_at'] ?? ''),
+                'category' => (string)($signal['category'] ?? ''),
+                'region' => (string)($signal['region'] ?? ''),
+                'confidence' => (int)($signal['confidence'] ?? 0),
+                'external_signal_count' => (int)($signal['external_signal_count'] ?? 0),
+                'synthetic_failure_count' => (int)($signal['synthetic_failure_count'] ?? 0),
+                'sources' => array_values(array_map('strval', (array)($signal['sources'] ?? []))),
+                'confirmed' => !empty($signal['confirmed']),
+                'last_observed_at' => (string)($signal['last_observed_at'] ?? ''),
                 'official_status_known' => !empty($signal['official_status_known']),
             ];
         }

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -52,6 +52,11 @@ require_once LOUSY_OUTAGES_PATH . 'includes/Email/Composer.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Sources/Sources.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Sources/index.php';
 require_once LOUSY_OUTAGES_PATH . 'includes/Cron/Refresh.php';
+require_once LOUSY_OUTAGES_PATH . 'includes/Sources/SyntheticCanarySource.php';
+require_once LOUSY_OUTAGES_PATH . 'includes/Sources/CloudflareRadarSource.php';
+require_once LOUSY_OUTAGES_PATH . 'includes/SignalCollector.php';
+require_once LOUSY_OUTAGES_PATH . 'includes/ExternalSignals.php';
+require_once LOUSY_OUTAGES_PATH . 'includes/SignalSourceInterface.php';
 require_once LOUSY_OUTAGES_PATH . 'public/shortcode.php';
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
@@ -72,6 +77,8 @@ use SuzyEaston\LousyOutages\Api;
 use SuzyEaston\LousyOutages\Feeds;
 use SuzyEaston\LousyOutages\MailTransport;
 use SuzyEaston\LousyOutages\IncidentAlerts;
+use SuzyEaston\LousyOutages\ExternalSignals;
+use SuzyEaston\LousyOutages\SignalCollector;
 use SuzyEaston\LousyOutages\Cron\Refresh as RefreshCron;
 
 Api::bootstrap();
@@ -109,12 +116,18 @@ function lousy_outages_activate() {
     if ( ! wp_next_scheduled( 'lo_check_statuses' ) ) {
         wp_schedule_event( time() + 60, 'lo_five_minutes', 'lo_check_statuses' );
     }
+    if ( ! wp_next_scheduled( 'lousy_outages_collect_external_signals' ) ) {
+        $schedule = wp_get_schedules();
+        $key = isset($schedule['lousy_outages_15min']) ? 'lousy_outages_15min' : 'hourly';
+        wp_schedule_event( time() + 120, $key, 'lousy_outages_collect_external_signals' );
+    }
     if ( function_exists( 'lo_cron_activate' ) ) {
         lo_cron_activate();
     }
     lousy_outages_create_page();
     Subscriptions::create_table();
     UserReports::install();
+    ExternalSignals::install();
     Subscriptions::schedule_purge();
     $default_email = 'suzyeaston@gmail.com';
     $stored_email  = get_option( 'lousy_outages_email' );
@@ -134,6 +147,7 @@ function lousy_outages_deactivate() {
     wp_clear_scheduled_hook( 'lousy_outages_poll' );
     wp_clear_scheduled_hook( 'lousy_outages_cron_refresh' );
     wp_clear_scheduled_hook( 'lo_check_statuses' );
+    wp_clear_scheduled_hook( 'lousy_outages_collect_external_signals' );
     Subscriptions::clear_schedule();
     if ( function_exists( 'lo_cron_deactivate' ) ) {
         lo_cron_deactivate();
@@ -1032,6 +1046,14 @@ function lousy_outages_settings_page() {
         <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="display:inline-block;">
             <?php wp_nonce_field('lousy_outages_clear_demo_reports'); ?><input type="hidden" name="action" value="lousy_outages_clear_demo_reports"><?php submit_button('Clear Demo Community Reports', 'delete', 'submit', false); ?>
         </form>
+        <?php $external = ExternalSignals::get_recent_signals(['windowMinutes'=>60,'limit'=>8]); $fused = SignalEngine::summarize_fused_signals(60); $collector = SignalCollector::get_last_collection_result(); ?>
+        <h2>External Signal Diagnostics</h2>
+        <p><strong>Last external collection:</strong> <?php echo esc_html((string)($collector['finished_at'] ?? 'Never')); ?></p>
+        <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="display:inline-block;margin-right:8px;"><?php wp_nonce_field('lousy_outages_collect_signals_now'); ?><input type="hidden" name="action" value="lousy_outages_collect_signals_now"><?php submit_button('Collect External Signals Now','secondary','submit',false); ?></form>
+        <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="display:inline-block;margin-right:8px;"><?php wp_nonce_field('lousy_outages_seed_demo_external_signals'); ?><input type="hidden" name="action" value="lousy_outages_seed_demo_external_signals"><?php submit_button('Seed Demo External Signals','secondary','submit',false); ?></form>
+        <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="display:inline-block;"><?php wp_nonce_field('lousy_outages_clear_demo_external_signals'); ?><input type="hidden" name="action" value="lousy_outages_clear_demo_external_signals"><?php submit_button('Clear Demo External Signals','delete','submit',false); ?></form>
+        <h3>Fused signals (community + external signals)</h3><ul><?php foreach (array_slice((array)$fused,0,8) as $row) : ?><li><?php echo esc_html((string)($row['provider_name'] ?? $row['provider_id'])); ?> — <?php echo esc_html((string)($row['classification'] ?? 'quiet')); ?> (<?php echo esc_html((string)($row['confidence'] ?? 0)); ?>) — <?php echo esc_html((string)($row['message'] ?? '')); ?></li><?php endforeach; ?></ul>
+        <h3>Recent external signals</h3><ul><?php foreach((array)$external as $row) : ?><li><?php echo esc_html((string)($row['observed_at'] ?? '')); ?> · <?php echo esc_html((string)($row['source'] ?? '')); ?> · <?php echo esc_html((string)($row['provider_name'] ?? $row['provider_id'] ?? '')); ?> · <?php echo esc_html((string)($row['signal_type'] ?? '')); ?> · <?php echo esc_html((string)($row['title'] ?? '')); ?></li><?php endforeach; ?></ul>
         <h3>Top providers by report count</h3>
         <ul><?php foreach ((array)($diag['provider_counts'] ?? []) as $row) : ?><li><?php echo esc_html((string)($row['provider_id'] ?? 'unknown')); ?>: <?php echo esc_html((string)($row['report_count'] ?? 0)); ?></li><?php endforeach; ?></ul>
     </div>
@@ -1387,3 +1409,9 @@ add_action( 'rest_api_init', function () {
         },
     ] );
 } );
+
+add_action( 'lousy_outages_collect_external_signals', static function () { SignalCollector::collect(); } );
+
+add_action( 'admin_post_lousy_outages_collect_signals_now', function () { if(!current_user_can('manage_options')){wp_die(esc_html__('Sorry, you are not allowed to access this page.','lousy-outages'));} check_admin_referer('lousy_outages_collect_signals_now'); $r=SignalCollector::collect(); set_transient('lousy_outages_notice',['message'=>sprintf('External signal collection finished. Stored %d signals.',(int)($r['total_stored']??0)),'type'=>'success'],30); wp_safe_redirect(add_query_arg('page','lousy-outages',admin_url('options-general.php'))); exit; } );
+add_action( 'admin_post_lousy_outages_seed_demo_external_signals', function () { if(!current_user_can('manage_options')){wp_die(esc_html__('Sorry, you are not allowed to access this page.','lousy-outages'));} check_admin_referer('lousy_outages_seed_demo_external_signals'); $r=ExternalSignals::seed_demo_signals(); set_transient('lousy_outages_notice',['message'=>sprintf('Seeded %d demo external signals.',(int)($r['inserted']??0)),'type'=>'success'],30); wp_safe_redirect(add_query_arg('page','lousy-outages',admin_url('options-general.php'))); exit; } );
+add_action( 'admin_post_lousy_outages_clear_demo_external_signals', function () { if(!current_user_can('manage_options')){wp_die(esc_html__('Sorry, you are not allowed to access this page.','lousy-outages'));} check_admin_referer('lousy_outages_clear_demo_external_signals'); $c=ExternalSignals::clear_demo_signals(); set_transient('lousy_outages_notice',['message'=>sprintf('Cleared %d demo external signals.',(int)$c),'type'=>'success'],30); wp_safe_redirect(add_query_arg('page','lousy-outages',admin_url('options-general.php'))); exit; } );

--- a/tests/ExternalSignalsTest.php
+++ b/tests/ExternalSignalsTest.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/bootstrap.php';
+require_once __DIR__ . '/../lousy-outages/includes/ExternalSignals.php';
+use SuzyEaston\LousyOutages\ExternalSignals;
+$tests=[];
+$tests['normalize_clamps_and_sanitizes']=function(){ $s=ExternalSignals::normalize_signal(['source'=>'Cloud Flare!','confidence'=>999,'title'=>str_repeat('a',500),'provider_id'=>'','category'=>'Internet Health']); if($s['confidence']!==100) throw new RuntimeException('confidence clamp failed'); if(strlen($s['title'])>255) throw new RuntimeException('title limit failed'); if($s['provider_id']!=='') throw new RuntimeException('provider optional failed');};
+$tests['seed_clear_demo']=function(){ global $wpdb; if(!method_exists($wpdb,'insert')) return; ExternalSignals::seed_demo_signals(); $cleared=ExternalSignals::clear_demo_signals(); if($cleared<0) throw new RuntimeException('clear failed');};
+foreach($tests as $name=>$fn){$fn(); echo "PASS: $name\n";}

--- a/tests/FusedSignalsTest.php
+++ b/tests/FusedSignalsTest.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/bootstrap.php';
+require_once __DIR__ . '/../lousy-outages/includes/Providers.php';
+require_once __DIR__ . '/../lousy-outages/includes/UserReports.php';
+require_once __DIR__ . '/../lousy-outages/includes/ExternalSignals.php';
+require_once __DIR__ . '/../lousy-outages/includes/SignalEngine.php';
+use SuzyEaston\LousyOutages\SignalEngine;
+$r=SignalEngine::summarize_fused_signals(60);
+if(!is_array($r)) throw new RuntimeException('not array');
+echo "PASS: fused signals shape\n";

--- a/tests/SyntheticCanarySourceTest.php
+++ b/tests/SyntheticCanarySourceTest.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/bootstrap.php';
+require_once __DIR__ . '/../lousy-outages/includes/SignalSourceInterface.php';
+require_once __DIR__ . '/../lousy-outages/includes/Sources/SyntheticCanarySource.php';
+use SuzyEaston\LousyOutages\Sources\SyntheticCanarySource;
+$src=new SyntheticCanarySource();
+$signals=$src->collect();
+if(!is_array($signals)) throw new RuntimeException('collect not array');
+echo "PASS: synthetic collect shape\n";


### PR DESCRIPTION
### Motivation
- Provide an MVP early-warning architecture that combines official status pages, community reports, external internet-health feeds, and lightweight synthetic canaries into cautious, demoable early-warning signals. 
- Avoid claiming confirmed outages unless an official source verifies them and keep probes safe, lightweight, and privacy-preserving.

### Description
- Added a normalized external signal store `SuzyEaston\LousyOutages\ExternalSignals` with a `{$wpdb->prefix}lo_external_signals` table, normalization/sanitization, `raw_hash` dedupe, `install()`, querying, expiry cleanup, and demo seed/clear helpers (`seed_demo_signals`, `clear_demo_signals`).
- Introduced a source adapter contract `SuzyEaston\LousyOutages\SignalSourceInterface` and two adapters: `Sources\CloudflareRadarSource` (token-gated, graceful `wp_remote_get` parsing for `internet_outage` / `traffic_anomaly`) and `Sources\SyntheticCanarySource` (polite HEAD/GET checks driven by `lo_synthetic_canary_targets` and bounded timeouts/limits).
- Implemented `SuzyEaston\LousyOutages\SignalCollector` to register sources, run collections, persist normalized signals via `ExternalSignals::record_many`, and store last-run diagnostics.
- Wired pieces into plugin bootstrap: require/load new files, call `ExternalSignals::install()` on activation, add scheduled hook `lousy_outages_collect_external_signals`, add admin-post actions and admin UI controls/buttons for "Collect External Signals Now", "Seed Demo External Signals", and "Clear Demo External Signals", and render recent external signals + fused diagnostics in the existing debug/settings page.
- Extended `SignalEngine` with `summarize_fused_signals()` that fuses community reports + external/synthetic signals into a cautious confidence score and classification, and updated `Subscribe::get_signals` to return fused fields (`confidence`, `external_signal_count`, `synthetic_failure_count`, `sources`, `confirmed`, etc.).
- Added small unit-style scripts: `tests/ExternalSignalsTest.php`, `tests/SyntheticCanarySourceTest.php`, and `tests/FusedSignalsTest.php` to validate normalization, synthetic collect shape, and fused summary shape in the local test harness.

### Testing
- Syntax lint: `php -l` checks for modified files (`ExternalSignals.php`, `SignalSourceInterface.php`, `SignalCollector.php`, `CloudflareRadarSource.php`, `SyntheticCanarySource.php`, `SignalEngine.php`, `Subscribe.php`, `lousy-outages.php`) all passed.
- Existing plugin tests run directly and passed: `tests/SignalEngineTest.php`, `tests/UserReportsTest.php`, `tests/SubscriptionsTest.php`, and `tests/IncidentStoreCloudflareSuppressionTest.php` (these are unchanged behavioral tests and succeeded in this environment).
- New tests executed in the lightweight harness failed due to missing WordPress runtime helpers or DB stubs (environment issues): `tests/ExternalSignalsTest.php` failed because `sanitize_textarea_field` and other WP helpers are not present; `tests/SyntheticCanarySourceTest.php` failed due to missing `esc_url_raw`; `tests/FusedSignalsTest.php` failed because `$wpdb` / UserReports DB stubs are not available. These are environment/test-bootstrap gaps rather than syntax issues.
- Next step: add small WP helper stubs / richer test bootstrap so new tests can run in this environment; live Cloudflare parsing can be tightened once token-backed fixtures are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f5b4f67c832ead2cb8a0512da0f8)