### PR TITLE
Scaffold standalone Lousy Outages plugin package with migration-safe loader

### DIFF
--- a/plugins/lousy-outages/README.md
+++ b/plugins/lousy-outages/README.md
@@ -1,0 +1,85 @@
+# Lousy Outages
+
+Monitor third‑party service status and get SMS and email alerts when things break.
+
+## Providers
+
+| ID | Name | Endpoint |
+|----|------|----------|
+| github | GitHub | https://www.githubstatus.com/api/v2/summary.json |
+| cloudflare | Cloudflare | https://www.cloudflarestatus.com/api/v2/summary.json |
+| openai | OpenAI | https://status.openai.com/api/v2/summary.json |
+| atlassian | Atlassian | https://status.atlassian.com/api/v2/summary.json |
+| digitalocean | DigitalOcean | https://status.digitalocean.com/api/v2/summary.json |
+| netlify | Netlify | https://www.netlifystatus.com/api/v2/summary.json |
+| vercel | Vercel | https://www.vercel-status.com/api/v2/summary.json |
+| zoom | Zoom | https://status.zoom.us/api/v2/summary.json |
+| zscaler | Zscaler | https://trust.zscaler.com/rss-feed |
+| slack | Slack | https://slack-status.com/feed/rss |
+| teamviewer | TeamViewer | https://status.teamviewer.com/api/v2/summary.json |
+| linear | Linear | https://status.linear.app/api/v2/summary.json |
+| sentry | Sentry | https://status.sentry.io/api/v2/summary.json |
+| aws | AWS | https://status.aws.amazon.com/rss/all.rss |
+| azure | Azure | https://azurestatuscdn.azureedge.net/en-us/status/feed/ |
+| gcp | Google Cloud | https://www.google.com/appsstatus/dashboard/en-CA/feed.atom |
+
+Zscaler is queried from `https://trust.zscaler.com` to dodge intermittent DNS failures. New default providers include TeamViewer, Linear, and Sentry—toggle any of them from **Settings → Lousy Outages**.
+
+
+To add or remove a provider, edit `includes/Providers.php` or use the checkboxes under **Settings → Lousy Outages** in wp-admin.
+
+## Notifications
+
+1. (Optional) Sign up for Twilio and obtain your **Account SID**, **Auth Token**, and a verified **From** number to enable SMS alerts.
+2. In wp-admin go to **Settings → Lousy Outages** and enter the SID, token, from number, your destination phone number, and a notification email address.
+3. Choose which providers to monitor and set the polling interval (default 5 minutes).
+4. Click **Send Legacy Test Email** to verify the older basic email path.
+5. Click **Send Synthetic Incident Alert** to verify the modern realtime IncidentAlerts path end-to-end.
+6. Keep **Test configured notification inbox only** enabled by default to avoid notifying public subscribers during QA.
+
+Use the **Poll Now** button in the debug panel to run an immediate poll. The panel also shows the last poll timestamp, each provider’s most recent status, and any fetch errors captured during the run.
+
+## QA and alert health
+
+- Legacy mail test (old path): use **Send Legacy Test Email**.
+- Modern realtime test: use **Send Synthetic Incident Alert**.
+- WP-CLI synthetic test:
+  - `wp lousy:alert-test`
+  - `wp lousy:alert-test --recipient=me@example.com`
+  - `wp lousy:alert-test --dry-run=true`
+  - `wp lousy:alert-test --fixed-id=demo-incident-001`
+- WP-CLI health snapshot:
+  - `wp lousy:alert-health`
+- If delivery fails, inspect:
+  - `lousy_outages_last_alert_delivery_result`
+  - `lousy_outages_last_alert_failure`
+  - `lousy_outages_alert_delivery_failure`
+  - wp-admin Debug panel
+  - `WP_DEBUG` / `error_log`
+  - `lo-mail.log` (if enabled in your environment)
+
+## Shortcode
+
+Place `[lousy_outages]` in any page or post to render the status table. A page titled *Lousy Outages* is created automatically on activation.
+
+
+## Deliverability checklist
+
+- DMARC passes when either DKIM passes with alignment **or** SPF passes with an envelope-from (Return-Path / MAIL FROM) aligned to the visible From domain.
+- Lousy Outages mail now sets PHPMailer `Sender` and sendmail `-f` to align envelope-from with the `suzyeaston.ca` From domain.
+- In Gmail, open an alert email, choose **Show original**, and verify `dmarc=pass` in Authentication-Results.
+- DNS still matters: SPF, DKIM, and DMARC records must be correctly configured for full deliverability.
+
+## Filters & Actions
+
+- `lousy_outages_providers` – filter the provider array before polling.
+- `lousy_outages_status` – filter normalized status before storage.
+
+## Development
+
+Polling runs via WP-Cron (`lousy_outages_poll`). A separate background refresh (`lousy_outages_cron_refresh`) updates the snapshot and "Last fetched" timestamp every 15 minutes; on low-traffic sites, point a system cron at `wp-cron.php` to keep it firing. Results are stored in an option and also exposed at `/wp-json/lousy-outages/v1/status`.
+
+## How to subscribe to RSS
+
+- RSS reader: add `https://suzyeaston.ca/lousy-outages/feed/status/` (or `https://suzyeaston.ca/feed/lousy-outages-status/`) to NetNewsWire, Feedly, or your preferred client to receive incident alerts.
+- Slack or email: point an automation tool such as IFTTT or Zapier at the same feed (trigger: “New RSS item”) and forward the payload to a Slack webhook, email address, or other notification channel.

--- a/plugins/lousy-outages/assets/hud.css
+++ b/plugins/lousy-outages/assets/hud.css
@@ -1,0 +1,42 @@
+.lo-hud {
+  position: relative;
+}
+
+.lo-hud-spinner {
+  display: none;
+  margin-left: 0.75rem;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: #8f80ff;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.lo-hud-spinner::before {
+  content: '';
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  animation: lo-hud-spin 0.9s linear infinite;
+}
+
+.lo-hud--dialing .lo-hud-spinner {
+  display: inline-flex;
+}
+
+@keyframes lo-hud-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.lo-hud [data-lo-degraded] {
+  transition: opacity 0.25s ease;
+}

--- a/plugins/lousy-outages/assets/hud.js
+++ b/plugins/lousy-outages/assets/hud.js
@@ -1,0 +1,400 @@
+(function (root) {
+  'use strict';
+
+  if (!root || !root.document) {
+    return;
+  }
+
+  var doc = root.document;
+
+  var STATUS_CLASS_MAP = {
+    operational: 'status--operational',
+    degraded: 'status--degraded',
+    outage: 'status--outage',
+    maintenance: 'status--maintenance',
+    unknown: 'status--unknown'
+  };
+
+  function normalizeService(service) {
+    if (!service || typeof service !== 'object') {
+      return null;
+    }
+    var status = String(service.status || service.stateCode || service.state || 'unknown').toLowerCase();
+    if (status === 'major_outage' || status === 'critical') {
+      status = 'outage';
+    } else if (status === 'minor_outage' || status === 'degraded_performance' || status === 'partial_outage') {
+      status = 'degraded';
+    }
+    var statusText = String(service.status_text || service.state || service.status_label || '').trim();
+    if (!statusText) {
+      statusText = status.replace(/_/g, ' ');
+      statusText = statusText.charAt(0).toUpperCase() + statusText.slice(1);
+    }
+    return {
+      id: String(service.id || service.provider || ''),
+      name: String(service.name || service.provider || ''),
+      status: status || 'unknown',
+      status_text: statusText,
+      summary: String(service.summary || service.message || ''),
+      url: String(service.url || ''),
+      updated_at: String(service.updated_at || service.updatedAt || ''),
+      risk: parseInt(service.risk, 10) || 0
+    };
+  }
+
+  function normalizeSnapshot(payload, fallbackTtl) {
+    var ttl = parseInt(payload && payload.ttl_seconds, 10);
+    if (!Number.isFinite(ttl) || ttl <= 0) {
+      ttl = Math.max(30, Math.round((fallbackTtl || 60000) / 1000));
+    }
+    var services = Array.isArray(payload && payload.services) ? payload.services.map(normalizeService).filter(Boolean) : [];
+    return {
+      updated_at: (payload && payload.updated_at) ? String(payload.updated_at) : new Date().toISOString(),
+      ttl_seconds: ttl,
+      services: services,
+      stale: !!(payload && payload.stale)
+    };
+  }
+
+  function formatDate(value) {
+    if (!value) {
+      return '';
+    }
+    var d = new Date(value);
+    if (Number.isNaN(d.getTime())) {
+      return value;
+    }
+    try {
+      return new Intl.DateTimeFormat(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit'
+      }).format(d);
+    } catch (err) {
+      return d.toISOString();
+    }
+  }
+
+  function escapeId(value) {
+    if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+      return CSS.escape(value);
+    }
+    return String(value).replace(/[^a-zA-Z0-9_-]/g, '\\$&');
+  }
+
+  function applyStatusClass(el, status) {
+    if (!el || !el.classList) {
+      return;
+    }
+    var classes = Object.values(STATUS_CLASS_MAP);
+    classes.forEach(function (cls) { el.classList.remove(cls); });
+    var mapped = STATUS_CLASS_MAP[status] || STATUS_CLASS_MAP.unknown;
+    el.classList.add(mapped);
+  }
+
+  function setupHud(container, config) {
+    if (!container) {
+      return;
+    }
+    container.classList.add('lo-hud');
+
+    var refreshBtn = container.querySelector('[data-lo-refresh]');
+    var countdownEl = container.querySelector('[data-lo-countdown]');
+    var fetchedEl = container.querySelector('[data-lo-fetched]');
+    var fetchedLabelEl = container.querySelector('[data-lo-fetched-label]');
+    var degradedEl = container.querySelector('[data-lo-degraded]');
+    var gridEl = container.querySelector('[data-lo-grid]');
+    var baseCountdown = countdownEl ? countdownEl.textContent : 'Auto-refresh ready';
+    var snapshotEndpoint = container.getAttribute('data-lo-snapshot') || config.snapshotEndpoint || '';
+    var refreshInterval = parseInt(container.getAttribute('data-lo-refresh-interval'), 10);
+    if (!Number.isFinite(refreshInterval) || refreshInterval <= 0) {
+      refreshInterval = parseInt(config.pollInterval, 10);
+    }
+    if (!Number.isFinite(refreshInterval) || refreshInterval <= 0) {
+      refreshInterval = 60000;
+    }
+    var manualRetryDelay = 1500;
+    var manualRetryAttempts = 4;
+
+    var spinnerEl = doc.createElement('span');
+    spinnerEl.className = 'lo-hud-spinner';
+    spinnerEl.setAttribute('aria-hidden', 'true');
+    spinnerEl.textContent = 'Dialing…';
+    if (refreshBtn && refreshBtn.parentNode) {
+      refreshBtn.parentNode.insertBefore(spinnerEl, refreshBtn.nextSibling);
+    } else {
+      container.appendChild(spinnerEl);
+    }
+
+    var state = {
+      fetchInFlight: false,
+      refreshTimer: null,
+      countdownTimer: null,
+      nextRefreshAt: null,
+      lastSnapshot: null
+    };
+
+    function setSpinner(active) {
+      if (active) {
+        container.classList.add('lo-hud--dialing');
+      } else {
+        container.classList.remove('lo-hud--dialing');
+      }
+    }
+
+    function setRefreshing(active) {
+      if (!refreshBtn) {
+        return;
+      }
+      refreshBtn.disabled = !!active;
+      refreshBtn.setAttribute('aria-busy', active ? 'true' : 'false');
+      refreshBtn.textContent = active ? 'Refreshing…' : 'Refresh now';
+    }
+
+    function setDegraded(active, message) {
+      if (!degradedEl) {
+        return;
+      }
+      if (active) {
+        degradedEl.textContent = message || 'Auto-refresh degraded';
+        degradedEl.removeAttribute('hidden');
+      } else {
+        degradedEl.textContent = '';
+        degradedEl.setAttribute('hidden', 'hidden');
+      }
+    }
+
+    function clearTimers() {
+      if (state.refreshTimer) {
+        root.clearTimeout(state.refreshTimer);
+        state.refreshTimer = null;
+      }
+      if (state.countdownTimer) {
+        root.clearInterval(state.countdownTimer);
+        state.countdownTimer = null;
+      }
+      state.nextRefreshAt = null;
+    }
+
+    function updateCountdown() {
+      if (!countdownEl) {
+        return;
+      }
+      if (!state.nextRefreshAt) {
+        countdownEl.textContent = doc.hidden ? 'Auto-refresh paused' : baseCountdown;
+        return;
+      }
+      var diff = state.nextRefreshAt - Date.now();
+      if (diff <= 0) {
+        countdownEl.textContent = 'Refreshing…';
+        return;
+      }
+      countdownEl.textContent = '';
+    }
+
+    function startCountdown() {
+      if (state.countdownTimer) {
+        root.clearInterval(state.countdownTimer);
+      }
+      updateCountdown();
+      state.countdownTimer = root.setInterval(updateCountdown, 1000);
+    }
+
+    function scheduleRefresh(delay) {
+      if (doc.hidden) {
+        clearTimers();
+        updateCountdown();
+        return;
+      }
+      if (!Number.isFinite(delay) || delay <= 0) {
+        delay = refreshInterval;
+      }
+      if (state.refreshTimer) {
+        root.clearTimeout(state.refreshTimer);
+      }
+      state.nextRefreshAt = Date.now() + delay;
+      startCountdown();
+      state.refreshTimer = root.setTimeout(function () {
+        state.refreshTimer = null;
+        fetchSnapshot(false);
+      }, delay);
+    }
+
+    function updateFetchedLabel() {
+      if (!fetchedEl || !state.lastSnapshot) {
+        return;
+      }
+      fetchedEl.textContent = formatDate(state.lastSnapshot.updated_at);
+      if (fetchedLabelEl) {
+        fetchedLabelEl.textContent = state.lastSnapshot.stale ? 'Last fetched (stale)' : 'Last fetched';
+      }
+    }
+
+    function updateCards(services) {
+      if (!Array.isArray(services)) {
+        return;
+      }
+      services.forEach(function (service) {
+        if (!service || !service.id) {
+          return;
+        }
+        var selector = '[data-provider-id="' + escapeId(service.id) + '"]';
+        var card = gridEl ? gridEl.querySelector(selector) : null;
+        if (!card) {
+          card = container.querySelector(selector);
+        }
+        if (!card) {
+          return;
+        }
+        var badge = card.querySelector('[data-lo-badge]') || card.querySelector('.status-badge');
+        if (badge) {
+          badge.textContent = service.status_text;
+          applyStatusClass(badge, service.status);
+          badge.setAttribute('data-status', service.status);
+        }
+        var summary = card.querySelector('[data-lo-summary]') || card.querySelector('.provider-card__summary');
+        if (summary) {
+          summary.textContent = service.summary || '';
+        }
+        var link = card.querySelector('[data-lo-status-url]') || card.querySelector('.provider-link');
+        if (link && service.url) {
+          link.setAttribute('href', service.url);
+        }
+      });
+    }
+
+    function applySnapshot(snapshot) {
+      state.lastSnapshot = snapshot;
+      updateFetchedLabel();
+      updateCards(snapshot.services);
+      if (snapshot.stale) {
+        setDegraded(true, 'Showing cached data – refreshing soon');
+      } else {
+        setDegraded(false);
+      }
+    }
+
+    function delay(ms) {
+      return new Promise(function (resolve) {
+        if (root && typeof root.setTimeout === 'function') {
+          root.setTimeout(resolve, ms);
+        } else {
+          setTimeout(resolve, ms);
+        }
+      });
+    }
+
+    function fetchSnapshot(manual, attempt, baselineTimestamp) {
+      if (!snapshotEndpoint || state.fetchInFlight) {
+        return;
+      }
+      var keepActive = false;
+      var currentAttempt = typeof attempt === 'number' ? attempt : 0;
+      var baseline = baselineTimestamp;
+      if (manual && currentAttempt === 0) {
+        baseline = state.lastSnapshot && state.lastSnapshot.updated_at ? state.lastSnapshot.updated_at : null;
+      }
+      state.fetchInFlight = true;
+      setRefreshing(true);
+      setSpinner(true);
+
+      root.fetch(snapshotEndpoint, {
+        method: 'GET',
+        credentials: 'same-origin',
+        headers: { Accept: 'application/json' }
+      }).then(function (response) {
+        if (!response || typeof response.json !== 'function') {
+          throw new Error('invalid response');
+        }
+        return response.json();
+      }).then(function (payload) {
+        var snapshot = normalizeSnapshot(payload, refreshInterval);
+        if (snapshot) {
+          applySnapshot(snapshot);
+          var updatedAt = snapshot.updated_at;
+          if (manual && baseline && updatedAt === baseline && currentAttempt < manualRetryAttempts) {
+            keepActive = true;
+            state.fetchInFlight = false;
+            return delay(manualRetryDelay).then(function () {
+              fetchSnapshot(true, currentAttempt + 1, baseline);
+            });
+          }
+        }
+        scheduleRefresh(refreshInterval);
+      }).catch(function () {
+        setDegraded(true, 'Auto-refresh unavailable – retrying');
+        scheduleRefresh(Math.min(refreshInterval, 30000));
+      }).finally(function () {
+        if (keepActive) {
+          return;
+        }
+        state.fetchInFlight = false;
+        setRefreshing(false);
+        setSpinner(false);
+      });
+    }
+
+    if (refreshBtn) {
+      refreshBtn.addEventListener('click', function (event) {
+        event.preventDefault();
+        if (state.fetchInFlight) {
+          return;
+        }
+        fetchSnapshot(true);
+      });
+    }
+
+    doc.addEventListener('visibilitychange', function () {
+      if (doc.hidden) {
+        clearTimers();
+        updateCountdown();
+      } else {
+        if (state.fetchInFlight) {
+          return;
+        }
+        if (state.lastSnapshot && state.lastSnapshot.stale) {
+          fetchSnapshot(false);
+        } else {
+          scheduleRefresh(Math.min(5000, refreshInterval));
+        }
+      }
+    });
+
+    var initialSnapshot = null;
+    var configInitial = config && config.initial ? config.initial : null;
+    if (configInitial && Array.isArray(configInitial.providers)) {
+      initialSnapshot = normalizeSnapshot({
+        updated_at: configInitial.fetched_at || configInitial.fetchedAt,
+        services: configInitial.providers,
+        stale: false,
+        ttl_seconds: Math.round(refreshInterval / 1000)
+      }, refreshInterval);
+    }
+
+    if (initialSnapshot) {
+      applySnapshot(initialSnapshot);
+    }
+
+    scheduleRefresh(refreshInterval);
+  }
+
+  function init() {
+    var config = root.LousyOutagesConfig || {};
+    var containers = doc.querySelectorAll('.lousy-outages');
+    if (!containers || !containers.length) {
+      return;
+    }
+    Array.prototype.forEach.call(containers, function (container) {
+      setupHud(container, config);
+    });
+  }
+
+  if (doc.readyState === 'loading') {
+    doc.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})(typeof window !== 'undefined' ? window : this);

--- a/plugins/lousy-outages/assets/js/outages.js
+++ b/plugins/lousy-outages/assets/js/outages.js
@@ -1,0 +1,8 @@
+(function () {
+    if ('undefined' === typeof window) {
+        return;
+    }
+    window.setInterval(function () {
+        window.location.reload();
+    }, 300000);
+})();

--- a/plugins/lousy-outages/assets/lousy-outages.css
+++ b/plugins/lousy-outages/assets/lousy-outages.css
@@ -1,0 +1,1677 @@
+.lousy-outages-root,
+.lousy-outages {
+  --lo-bg: radial-gradient(circle at 12% 20%, rgba(96, 255, 214, 0.08), transparent 28%),
+    radial-gradient(circle at 80% 10%, rgba(255, 168, 255, 0.12), transparent 32%),
+    #0b1021;
+  --lo-surface: #121c33;
+  --lo-surface-strong: #18274a;
+  --lo-text: #e8f3ff;
+  --lo-muted: rgba(232, 243, 255, 0.76);
+  --lo-accent: #8af7e4;
+  --lo-pop: #f49ae5;
+  --lo-border: rgba(138, 247, 228, 0.42);
+  --lo-contrast: #04070f;
+  font-family: 'IBM Plex Mono', 'Courier New', monospace;
+  color: var(--lo-text);
+}
+
+.lousy-outages-root {
+  background: var(--lo-bg);
+}
+
+.lousy-outages {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 8px 16px;
+  background: var(--lo-bg);
+  min-height: 60vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.lousy-outages::before,
+.lousy-outages::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.lousy-outages::before {
+  background-image: linear-gradient(rgba(138, 247, 228, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(138, 247, 228, 0.05) 1px, transparent 1px);
+  background-size: 28px 28px;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.8), transparent 60%, rgba(0, 0, 0, 0.8));
+  animation: lo-grid-pan 24s linear infinite;
+}
+
+.lousy-outages::after {
+  background: linear-gradient(
+      rgba(255, 255, 255, 0.04),
+      rgba(255, 255, 255, 0.01)
+    ),
+    repeating-linear-gradient(
+      0deg,
+      rgba(0, 0, 0, 0) 0,
+      rgba(0, 0, 0, 0) 2px,
+      rgba(0, 0, 0, 0.15) 3px,
+      rgba(0, 0, 0, 0.1) 4px
+    );
+  mix-blend-mode: screen;
+  opacity: 0.4;
+  animation: lo-scan 9s linear infinite;
+}
+
+@keyframes lo-grid-pan {
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+  to {
+    transform: translate3d(-28px, -28px, 0);
+  }
+}
+
+@keyframes lo-scan {
+  0% {
+    opacity: 0.6;
+  }
+  40% {
+    opacity: 0.2;
+  }
+  50% {
+    opacity: 0.7;
+  }
+  100% {
+    opacity: 0.4;
+  }
+}
+
+.lousy-outages a {
+  color: var(--lo-accent);
+}
+
+.lousy-outages > * {
+  position: relative;
+  z-index: 1;
+}
+
+
+.lo-header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 14px;
+  min-height: 56px;
+}
+
+.lo-mode-toggle {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.lo-mode-toggle__button {
+  border: 1px solid var(--lo-border);
+  background: rgba(18, 28, 51, 0.7);
+  color: var(--lo-text);
+  padding: 8px 16px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.lo-mode-toggle__button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(10, 20, 40, 0.35);
+}
+
+.lo-mode-toggle__button.is-active {
+  background: linear-gradient(135deg, rgba(138, 247, 228, 0.9), rgba(109, 255, 199, 0.7));
+  color: var(--lo-contrast);
+  border-color: rgba(138, 247, 228, 0.8);
+  box-shadow: 0 0 0 2px rgba(138, 247, 228, 0.2);
+}
+
+.lo-hero {
+  margin-bottom: 16px;
+}
+
+.lo-card--hero {
+  border: 2px solid rgba(138, 247, 228, 0.9);
+  background: linear-gradient(135deg, rgba(18, 28, 51, 0.95), rgba(10, 16, 32, 0.9));
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.4);
+}
+
+.lo-card--hero .lo-title {
+  color: var(--lo-accent);
+}
+
+.lo-incidents {
+  display: block;
+  margin-bottom: 18px;
+}
+
+.lo-section {
+  margin: 18px 0;
+}
+
+.lo-section__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.lo-section__toggle {
+  border: 1px solid var(--lo-border);
+  background: rgba(9, 14, 28, 0.7);
+  color: var(--lo-muted);
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.lo-section__toggle[aria-expanded='true'] {
+  background: rgba(138, 247, 228, 0.12);
+  color: var(--lo-text);
+}
+
+.lo-grid--section[hidden] {
+  display: none;
+}
+
+.lo-all[hidden],
+.lo-incidents[hidden],
+.lo-hero[hidden] {
+  display: none;
+}
+
+.lo-status-board {
+  margin: 18px auto 10px;
+  max-width: 1080px;
+}
+
+.lo-status-board__frame {
+  border: 3px solid rgba(255, 184, 28, 0.9);
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(18, 28, 51, 0.92), rgba(5, 9, 19, 0.96));
+  box-shadow:
+    0 20px 38px rgba(0, 0, 0, 0.55),
+    inset 0 0 0 2px rgba(255, 233, 196, 0.12);
+  overflow: hidden;
+  position: relative;
+}
+
+.lo-status-board__header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 16px 10px;
+  background: linear-gradient(90deg, rgba(255, 184, 28, 0.12), rgba(138, 247, 228, 0.08));
+  border-bottom: 2px solid rgba(255, 184, 28, 0.4);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.lo-status-board__titles {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+
+.lo-status-board__eyebrow {
+  margin: 0;
+  color: rgba(255, 233, 196, 0.75);
+  font-size: 0.7rem;
+  letter-spacing: 0.15em;
+}
+
+.lo-status-board__title {
+  margin: 0;
+  color: var(--lo-accent, #8af7e4);
+  font-size: 1.1rem;
+  text-shadow: 0 0 8px rgba(138, 247, 228, 0.35);
+}
+
+.lo-status-board__badge {
+  border: 1px dashed rgba(255, 184, 28, 0.7);
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-size: 0.7rem;
+  color: #ffecc7;
+  background: rgba(10, 10, 10, 0.65);
+  text-transform: uppercase;
+}
+
+.lo-status-board__lights {
+  display: inline-flex;
+  gap: 6px;
+}
+
+.lo-led {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  display: inline-block;
+  box-shadow: 0 0 12px currentColor;
+  animation: lo-led-pulse 1.8s ease-in-out infinite;
+}
+
+.lo-led--green {
+  color: #5eff8f;
+}
+.lo-led--amber {
+  color: #ffcf5c;
+  animation-delay: 0.2s;
+}
+.lo-led--red {
+  color: #ff7b7b;
+  animation-delay: 0.4s;
+}
+
+.lo-status-board__body {
+  position: relative;
+  padding: 12px;
+  background: radial-gradient(circle at 40% 10%, rgba(255, 184, 28, 0.05), transparent 40%),
+    radial-gradient(circle at 80% 0%, rgba(138, 247, 228, 0.1), transparent 40%),
+    linear-gradient(135deg, rgba(0, 0, 0, 0.92), rgba(10, 10, 18, 0.88));
+}
+
+.lo-status-board__body .lousy-outages {
+  margin: 0;
+  border: 2px solid rgba(255, 184, 28, 0.5);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 233, 196, 0.14),
+    0 10px 28px rgba(0, 0, 0, 0.45);
+}
+
+.lo-scanline {
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+      0deg,
+      rgba(255, 255, 255, 0.04) 0,
+      rgba(255, 255, 255, 0.04) 1px,
+      rgba(0, 0, 0, 0) 3px,
+      rgba(0, 0, 0, 0) 6px
+    ),
+    linear-gradient(90deg, rgba(255, 184, 28, 0.06), rgba(138, 247, 228, 0.06));
+  opacity: 0.35;
+  mix-blend-mode: screen;
+  pointer-events: none;
+  animation: lo-scanline-move 8s linear infinite;
+}
+
+.lo-atmosphere {
+  text-align: center;
+  margin: 16px auto 10px;
+  max-width: 960px;
+  position: relative;
+}
+
+.lo-atmosphere::after {
+  content: '_';
+  display: inline-block;
+  margin-left: 6px;
+  color: var(--lo-pop, #f49ae5);
+  animation: lo-cursor 1.1s steps(2, end) infinite;
+}
+
+.lo-atmosphere__lede {
+  margin: 8px 0 0;
+  color: var(--lo-muted, #9ab6cc);
+  font-size: 0.95rem;
+  letter-spacing: 0.06em;
+}
+
+.lo-block-title {
+  margin: 0 0 8px;
+  font-size: 1rem;
+  color: var(--lo-accent);
+}
+
+.lo-meta {
+  color: var(--lo-muted);
+  font-size: 0.95rem;
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.lo-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin: 10px 0 16px;
+}
+
+.lo-trending {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: rgba(244, 154, 229, 0.18);
+  border: 2px solid rgba(244, 154, 229, 0.85);
+  border-radius: 14px;
+  padding: 10px 14px;
+  margin-bottom: 18px;
+  color: var(--lo-accent);
+  font-weight: 600;
+}
+
+.lo-trending__icon {
+  font-size: 1.4rem;
+  line-height: 1;
+}
+
+.lo-trending__body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.lo-trending__reasons {
+  font-size: 0.85rem;
+  color: var(--lo-muted);
+}
+
+.lo-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 2px solid var(--lo-accent);
+  color: var(--lo-accent);
+  background: transparent;
+  padding: 6px 12px;
+  border-radius: 10px;
+  text-decoration: none;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.lo-link:hover,
+.lo-link:focus {
+  text-decoration: underline;
+  transform: translateY(-1px) scale(1.02);
+  box-shadow: 0 6px 16px rgba(138, 247, 228, 0.2);
+}
+
+.lo-link[disabled] {
+  opacity: 0.5;
+  cursor: progress;
+}
+
+.lo-history {
+  background: var(--lo-surface);
+  border: 2px solid var(--lo-border);
+  border-radius: 12px;
+  padding: 12px;
+  margin-bottom: 16px;
+}
+
+.lo-history__heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.lo-history__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  margin: 4px 0 12px;
+}
+
+.lo-history__controls label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+}
+
+.lo-history__controls select {
+  background: #0e1117;
+  color: #f8f8f2;
+  border: 1px solid #353535;
+  padding: 4px 8px;
+  font-family: inherit;
+  font-size: 13px;
+}
+
+.lo-history__charts {
+  margin: 10px 0 16px;
+  padding: 8px 10px;
+  border: 2px solid #222;
+  background: #0c0c0c;
+}
+
+.lo-history__report {
+  margin-bottom: 12px;
+  padding: 12px;
+  border: 1px solid rgba(138, 247, 228, 0.4);
+  background: linear-gradient(135deg, rgba(18, 28, 51, 0.85), rgba(10, 16, 32, 0.9));
+  box-shadow: inset 0 0 0 1px rgba(244, 154, 229, 0.2);
+}
+
+.lo-history__report-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.lo-history__report-stat {
+  border: 1px solid rgba(138, 247, 228, 0.4);
+  background: rgba(8, 12, 24, 0.75);
+  padding: 10px;
+  border-radius: 8px;
+}
+
+.lo-history__report-label {
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(138, 247, 228, 0.9);
+  margin-bottom: 4px;
+}
+
+.lo-history__report-value {
+  font-size: 14px;
+  font-weight: 700;
+  color: #fefefe;
+}
+
+.lo-history__report-sub {
+  margin-top: 4px;
+  font-size: 11px;
+  color: #f6ff8f;
+}
+
+.lo-history__report-table-wrap {
+  border-top: 1px dashed rgba(138, 247, 228, 0.4);
+  padding-top: 10px;
+}
+
+.lo-history__report-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.lo-history__report-table th,
+.lo-history__report-table td {
+  border: 1px solid rgba(138, 247, 228, 0.2);
+  padding: 6px 8px;
+  text-align: left;
+}
+
+.lo-history__report-table th {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(232, 243, 255, 0.8);
+  font-size: 10px;
+}
+
+.lo-history__chart {
+  margin-bottom: 12px;
+}
+
+.lo-history__chart:last-child {
+  margin-bottom: 0;
+}
+
+.lo-history__chart-content {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.lo-history__view-toggle {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 6px 0 8px;
+}
+
+.lo-history__view-button {
+  border: 1px solid rgba(138, 247, 228, 0.6);
+  background: rgba(8, 12, 24, 0.8);
+  color: var(--lo-text);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 6px 10px;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.lo-history__view-button.is-active {
+  background: linear-gradient(135deg, rgba(244, 154, 229, 0.9), rgba(138, 247, 228, 0.9));
+  color: #050510;
+}
+
+.lo-history__chart-title {
+  font-size: 12px;
+  margin-bottom: 4px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+.lo-history__chart svg {
+  width: 100%;
+  height: auto;
+  border: 1px solid #222;
+  background: repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.03) 0, rgba(255, 255, 255, 0.03) 4px, transparent 4px, transparent 8px);
+}
+
+.lo-history__chart-bar {
+  fill: #6df28c;
+  stroke: #0c0c0c;
+  stroke-width: 1;
+}
+
+.lo-history__chart-bar--thin {
+  fill: #ffb347;
+}
+
+.lo-history__chart-bar--active {
+  fill: #ffda7a;
+  stroke: #fff4c2;
+  stroke-width: 1.4;
+}
+
+.lo-history__chart-text {
+  font-size: 10px;
+  fill: #fefefe;
+}
+
+.lo-heatmap__cell {
+  stroke: rgba(0, 0, 0, 0.6);
+  stroke-width: 1;
+}
+
+.lo-heatmap__cell--level-0 {
+  fill: rgba(255, 255, 255, 0.08);
+}
+
+.lo-heatmap__cell--level-1 {
+  fill: rgba(109, 255, 199, 0.35);
+}
+
+.lo-heatmap__cell--level-2 {
+  fill: rgba(109, 255, 199, 0.6);
+}
+
+.lo-heatmap__cell--level-3 {
+  fill: rgba(244, 154, 229, 0.6);
+}
+
+.lo-heatmap__cell--level-4 {
+  fill: rgba(244, 154, 229, 0.9);
+}
+
+.lo-heatmap__cell--active {
+  stroke: #f6ff8f;
+  stroke-width: 2;
+}
+
+.lo-heatmap__legend {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--lo-muted);
+}
+
+.lo-heatmap__legend-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.lo-heatmap__swatch {
+  width: 12px;
+  height: 12px;
+  border: 1px solid rgba(0, 0, 0, 0.8);
+  display: inline-block;
+}
+
+.lo-heatmap__peak {
+  margin-top: 6px;
+}
+
+.lo-trend__line {
+  fill: none;
+  stroke: #f49ae5;
+  stroke-width: 2;
+  filter: drop-shadow(0 0 6px rgba(244, 154, 229, 0.45));
+}
+
+.lo-trend__point {
+  fill: #6df28c;
+  stroke: #0c0c0c;
+  stroke-width: 1;
+}
+
+.lo-trend__point--active {
+  fill: #f6ff8f;
+  stroke: #fff4c2;
+}
+
+.lo-history__meta {
+  margin: 0;
+  color: var(--lo-muted);
+  font-size: 0.9rem;
+}
+
+.lo-history__chart-tooltip {
+  margin: 6px 0 10px;
+  padding: 6px 8px;
+  font-size: 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(0, 0, 0, 0.35);
+  color: #f9f9f9;
+  border-radius: 6px;
+}
+
+.lo-history__body {
+  margin-top: 12px;
+  max-height: none;
+  overflow: visible;
+  padding-right: 0;
+}
+
+.lo-history__list {
+  list-style: decimal;
+  list-style-position: inside;
+  margin: 0;
+  padding-left: 8px;
+}
+
+.lo-history__item + .lo-history__item {
+  margin-top: 10px;
+}
+
+.lo-history__item {
+  background: rgba(244, 154, 229, 0.12);
+  border: 1px solid var(--lo-border);
+  border-radius: 10px;
+  padding: 10px 12px;
+  color: var(--lo-text);
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 8px;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.2s ease;
+}
+
+.lo-history__item:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(244, 154, 229, 0.2);
+}
+
+.lo-history__item--placeholder {
+  font-style: italic;
+  color: var(--lo-muted);
+}
+
+.lo-history__time {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.lo-history__time time {
+  font-weight: 700;
+  color: var(--lo-accent);
+}
+
+.lo-history__time-range {
+  color: #b4b4be;
+  font-size: 0.8rem;
+}
+
+.lo-history__details {
+  font-size: 0.95rem;
+  line-height: 1.35;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
+.lo-history__summary {
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
+.lo-history__count {
+  font-size: 0.85rem;
+  color: var(--lo-muted);
+}
+
+.lo-history__badge {
+  justify-self: end;
+}
+
+.lo-history__empty,
+.lo-history__error {
+  margin: 10px 0 0;
+  font-size: 0.9rem;
+  color: var(--lo-muted);
+}
+
+.lo-history__error {
+  color: #ff6b6b;
+}
+
+.lo-history__toggle {
+  margin-top: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.lo-icon {
+  width: 16px;
+  height: 16px;
+  display: inline-block;
+}
+
+.lousy-outages [hidden] {
+  display: none !important;
+}
+
+.lo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
+  min-height: 320px;
+}
+
+.lo-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 32px 16px;
+  color: var(--lo-accent);
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.lo-loading__spinner {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 3px solid rgba(255, 184, 28, 0.25);
+  border-top-color: var(--lo-accent);
+  animation: lo-spin 1.1s linear infinite;
+}
+
+.lo-loading__text {
+  font-family: 'Courier New', 'Lucida Console', monospace;
+}
+
+@keyframes lo-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes lo-led-pulse {
+  0%,
+  100% {
+    filter: drop-shadow(0 0 6px currentColor);
+    opacity: 0.8;
+  }
+  50% {
+    filter: drop-shadow(0 0 12px currentColor);
+    opacity: 1;
+  }
+}
+
+@keyframes lo-scanline-move {
+  from {
+    transform: translateY(-6px);
+  }
+  to {
+    transform: translateY(6px);
+  }
+}
+
+@keyframes lo-cursor {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+.lo-card {
+  background: #080808;
+  border: 2px solid rgba(255, 184, 28, 0.85);
+  border-radius: 14px;
+  padding: 12px;
+  box-shadow: 0 0 14px rgba(244, 154, 229, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 220px;
+}
+
+.lo-card--hidden {
+  display: none;
+}
+
+.lo-card--external .lo-summary {
+  margin-bottom: 4px;
+}
+
+.lo-links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.lo-links li {
+  margin: 0;
+}
+
+.lo-title {
+  color: var(--lo-accent);
+  font-weight: 700;
+  margin: 0 0 6px;
+  font-size: 1.05rem;
+}
+
+.lo-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.lo-pill {
+  display: inline-block;
+  padding: 2px 8px 2px 18px;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.06);
+}
+
+.lo-pill::before {
+  content: '';
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  left: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.25),
+    0 0 8px currentColor;
+}
+
+
+.lo-pill.operational {
+  color: var(--lo-accent);
+}
+.lo-pill.operational::before {
+  background: #5eff8f;
+}
+
+.lo-pill.degraded {
+  color: #f5a300;
+}
+.lo-pill.degraded::before {
+  background: #f5a300;
+}
+
+.lo-pill.outage {
+  color: var(--lo-pop);
+}
+.lo-pill.outage::before {
+  background: #f86be6;
+  animation: lo-led-pulse 1.4s ease-in-out infinite;
+}
+
+.lo-pill.unknown,
+.lo-pill.maintenance {
+  color: #aaa;
+}
+.lo-pill.unknown::before,
+.lo-pill.maintenance::before {
+  background: #aaa;
+}
+.lo-pill.risk {
+  color: #ffb347;
+  border-color: #ffb347;
+}
+.lo-pill.risk::before {
+  background: #ffb347;
+}
+
+.lo-message {
+  margin: 0 0 6px;
+  color: var(--lo-text);
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.lo-summary,
+.lo-snark {
+  margin: 0;
+  color: var(--lo-muted);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.lo-card-meta-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.lo-card-meta {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--lo-muted);
+  line-height: 1.3;
+}
+
+.lo-card-meta--hint {
+  color: rgba(232, 243, 255, 0.6);
+}
+
+.lo-card-debug {
+  margin: 0;
+  font-size: 0.75rem;
+  font-family: 'IBM Plex Mono', 'Courier New', monospace;
+  color: #ffd9a0;
+}
+
+.lo-snark {
+  color: var(--lo-accent);
+  font-style: italic;
+}
+
+.lo-status-link {
+  margin-top: auto;
+  font-weight: 700;
+  text-decoration: none;
+  color: var(--lo-pop);
+}
+
+.lo-status-link:hover,
+.lo-status-link:focus {
+  text-decoration: underline;
+}
+.lo-prealert {
+  background: rgba(244, 154, 229, 0.15);
+  border: 1px solid rgba(244, 154, 229, 0.45);
+  border-radius: 10px;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--lo-muted);
+}
+.lo-prealert strong {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--lo-accent);
+}
+.lo-prealert-summary {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #fff2d6;
+}
+.lo-prealert-metrics {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #ffd9a0;
+}
+
+.lo-inc {
+  margin-top: 8px;
+  font-size: 0.9rem;
+  line-height: 1.3;
+  color: #defcce;
+}
+
+.lo-inc-list {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.lo-inc-item {
+  background: rgba(244, 154, 229, 0.12);
+  border-left: 3px solid var(--lo-border);
+  padding: 6px 8px;
+  border-radius: 6px;
+}
+
+.lo-inc-title {
+  font-weight: 600;
+  margin: 0 0 4px;
+  color: var(--lo-accent);
+}
+
+.lo-inc-meta {
+  font-size: 0.8rem;
+  color: var(--lo-muted);
+  margin: 0;
+}
+
+.lo-empty {
+  font-size: 0.85rem;
+  color: rgba(255, 233, 196, 0.7);
+}
+
+.lo-error {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: #ff6b6b;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+}
+
+@media (max-width: 480px) {
+  .lo-meta {
+    font-size: 0.85rem;
+  }
+
+  .lo-link {
+    width: 100%;
+    text-align: center;
+  }
+}
+
+.lo-pill--degraded {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #f5a300;
+  border-color: #f5a300;
+  background: rgba(245, 163, 0, 0.15);
+}
+
+.lo-components {
+  margin-top: 8px;
+}
+
+.lo-components__title {
+  margin: 0 0 4px;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #ffecc7;
+}
+
+.lo-components__list {
+  list-style: disc;
+  margin: 0;
+  padding-left: 18px;
+  color: #fff1d8;
+  font-size: 0.85rem;
+}
+
+.lo-component-name {
+  font-weight: 600;
+}
+
+.lo-component-status {
+  margin-left: 6px;
+  color: #f5a300;
+}
+
+.lo-inc-summary {
+  margin: 4px 0 0;
+  font-size: 0.85rem;
+  color: var(--lo-muted);
+}
+
+
+.lo-subscribe {
+  margin: 16px auto;
+  padding: 14px 16px;
+  max-width: 400px;
+  border: 2px solid rgba(255, 184, 28, 0.8);
+  border-radius: 12px;
+  background: linear-gradient(160deg, rgba(244, 154, 229, 0.2), rgba(12, 12, 12, 0.92));
+  color: rgba(255, 233, 196, 0.95);
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.32);
+  backdrop-filter: blur(3px);
+}
+
+.lo-subscribe__title {
+  margin: 0 0 4px;
+  font-size: 1rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--lo-accent);
+}
+
+.lo-subscribe__intro {
+  margin: 0 0 10px;
+  font-size: 0.88rem;
+  line-height: 1.4;
+  color: rgba(255, 233, 196, 0.88);
+}
+
+.lo-subscribe__form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: stretch;
+}
+
+.lo-subscribe__label {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 200px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(255, 233, 196, 0.88);
+}
+
+.lo-subscribe__label span {
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.lo-subscribe__input {
+  margin-top: 6px;
+  padding: 9px 11px;
+  border-radius: 11px;
+  border: 2px solid rgba(255, 184, 28, 0.85);
+  background: var(--lo-text);
+  color: #050505;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.14);
+  transition: box-shadow 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+}
+
+.lo-subscribe__input:focus {
+  outline: none;
+  border-color: #ffcf5c;
+  box-shadow: 0 0 0 3px var(--lo-border);
+}
+
+.lo-subscribe__input::placeholder {
+  color: rgba(5, 5, 5, 0.55);
+}
+
+.lo-subscribe__challenge {
+  flex-basis: 100%;
+}
+
+.lo-subscribe__prompt {
+  margin: 0 0 6px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--lo-muted);
+}
+
+.lo-subscribe__challenge-quote {
+  margin: 0 0 8px;
+  padding: 9px 11px;
+  border-left: 3px solid var(--lo-border);
+  border-radius: 9px;
+  background: linear-gradient(120deg, rgba(255, 184, 28, 0.12), rgba(255, 72, 164, 0.12));
+  font-size: 0.88rem;
+  font-weight: 700;
+  line-height: 1.4;
+  color: rgba(255, 233, 196, 0.94);
+}
+
+.lo-subscribe__note {
+  margin: 6px 0 0;
+  font-size: 0.78rem;
+  color: var(--lo-muted);
+}
+
+.lo-subscribe__button {
+  background: var(--lo-pop);
+  color: #050505;
+  border: 2px solid var(--lo-accent);
+  border-radius: 999px;
+  padding: 9px 18px;
+  font-weight: 800;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.lo-subscribe__button:hover,
+.lo-subscribe__button:focus {
+  background: #ff6a3a;
+  transform: translateY(-1px);
+  box-shadow: 0 6px 14px rgba(244, 154, 229, 0.35);
+}
+
+.lo-subscribe__status {
+  flex-basis: 100%;
+  margin: 4px 0 0;
+  min-height: 1.4em;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(255, 233, 196, 0.92);
+}
+
+.lo-panel {
+  margin: 0 auto 18px;
+  padding: 14px 16px;
+  border: 2px solid rgba(255, 184, 28, 0.8);
+  border-radius: 12px;
+  background: linear-gradient(160deg, rgba(244, 154, 229, 0.12), rgba(12, 12, 12, 0.92));
+  color: rgba(255, 233, 196, 0.95);
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.32);
+  text-align: left;
+}
+
+.lo-panel--report {
+  max-width: 760px;
+}
+
+.lo-panel__header {
+  margin-bottom: 10px;
+}
+
+.lo-panel__title {
+  margin: 0 0 4px;
+  font-size: 1.05rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--lo-accent);
+}
+
+.lo-panel__subtitle {
+  margin: 0;
+  color: var(--lo-muted);
+  font-size: 0.9rem;
+}
+
+.lo-report__form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.lo-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.lo-label {
+  font-size: 0.85rem;
+  color: rgba(255, 233, 196, 0.9);
+  letter-spacing: 0.04em;
+}
+
+.lo-input {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--lo-border);
+  background: rgba(0, 0, 0, 0.35);
+  color: var(--lo-text);
+  font-size: 0.95rem;
+  font-family: inherit;
+}
+
+.lo-input:focus {
+  outline: 2px solid var(--lo-accent);
+  outline-offset: 2px;
+}
+
+.lo-input--textarea {
+  min-height: 110px;
+  resize: vertical;
+}
+
+.lo-report__prompt {
+  margin: 0;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--lo-muted);
+}
+
+.lo-report__help {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--lo-muted);
+}
+
+.lo-report__captcha-display {
+  margin: 6px 0;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--lo-border);
+  background: rgba(0, 0, 0, 0.45);
+  color: #f6ff8f;
+  font-family: "IBM Plex Mono", "VT323", monospace;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+}
+
+.lo-report__captcha-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.lo-report__captcha-refresh {
+  align-self: flex-start;
+  border: none;
+  background: none;
+  color: var(--lo-accent);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  padding: 0;
+}
+
+.lo-report__captcha-refresh:hover,
+.lo-report__captcha-refresh:focus {
+  color: #ff6a3a;
+  text-decoration: underline;
+}
+
+.lo-report__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.lo-report-submit {
+  position: relative;
+  z-index: 2;
+}
+
+.lo-button {
+  background: var(--lo-pop);
+  color: #050505;
+  border: 2px solid var(--lo-accent);
+  border-radius: 999px;
+  padding: 10px 16px;
+  font-weight: 800;
+  font-size: 0.9rem;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.lo-button:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.lo-button:hover,
+.lo-button:focus {
+  background: #ff6a3a;
+  transform: translateY(-1px);
+  box-shadow: 0 6px 14px rgba(244, 154, 229, 0.35);
+}
+
+.lo-report__status {
+  margin: 0;
+  min-height: 1.4em;
+  font-size: 0.9rem;
+  color: var(--lo-muted);
+}
+
+.lo-report__status--success {
+  color: #6effba;
+}
+
+.lo-report__status--error {
+  color: #ff7b7b;
+}
+
+.lo-subscribe__status--error {
+  color: #ff6b6b;
+}
+
+.lo-subscribe__help {
+  margin: 12px 0 0;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: var(--lo-muted);
+}
+
+.lo-banner {
+  margin: 24px 0;
+  padding: 16px 20px;
+  border-radius: 14px;
+  background: rgba(32, 16, 0, 0.88);
+  border: 2px solid var(--lo-border);
+  color: var(--lo-text);
+  box-shadow: 0 20px 36px rgba(0, 0, 0, 0.4);
+}
+
+.lo-banner p {
+  margin: 0;
+}
+
+.lo-banner--success {
+  border-color: rgba(255, 184, 28, 0.7);
+  color: #ffecc7;
+}
+
+.lo-banner--info {
+  border-color: rgba(255, 124, 67, 0.6);
+  color: #ffe3cc;
+}
+
+.lo-banner--warning {
+  border-color: rgba(245, 163, 0, 0.7);
+  color: var(--lo-text);
+}
+
+.lo-banner--error {
+  border-color: rgba(244, 154, 229, 0.7);
+  color: #ffd7ca;
+}
+
+@media (max-width: 600px) {
+  .lo-status-board__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .lo-status-board__badge {
+    align-self: flex-end;
+  }
+
+  .lo-subscribe__form {
+    flex-direction: column;
+  }
+
+  .lo-subscribe__challenge {
+    flex-basis: auto;
+  }
+
+  .lo-subscribe__button {
+    width: 100%;
+  }
+}
+
+.lo-settings {
+  border: 2px dashed var(--lo-border);
+  border-radius: 12px;
+  padding: 12px;
+  margin: 18px 0;
+  background: rgba(10, 10, 10, 0.6);
+}
+
+.lo-settings__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0 0 10px;
+}
+
+.lo-settings__button {
+  appearance: none;
+  border: 1px solid var(--lo-border);
+  background: var(--lo-accent);
+  color: #0b0b0b;
+  font-weight: 700;
+  border-radius: 8px;
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.lo-settings__button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.lo-settings__button--ghost {
+  background: transparent;
+  color: var(--lo-accent);
+}
+
+.lo-settings__hint {
+  margin: 0 0 10px;
+  font-size: 0.95rem;
+  color: var(--lo-muted);
+}
+
+.lo-settings__options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 8px 12px;
+}
+
+.lo-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+  color: var(--lo-accent);
+}
+
+.lo-checkbox input[type='checkbox'] {
+  accent-color: var(--lo-accent);
+}
+
+.lo-support {
+  margin: 24px auto 8px;
+  max-width: 880px;
+  border-top: 2px solid var(--lo-border);
+  padding-top: 14px;
+  color: var(--lo-muted);
+}
+
+.lo-support__lead,
+.lo-support__note {
+  margin: 0 0 10px;
+  font-size: 0.95rem;
+}
+
+.lo-support__links {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.lo-support__obfuscate {
+  letter-spacing: 0.04em;
+}
+
+@media print {
+  body * {
+    visibility: hidden;
+  }
+
+  .lousy-outages-root,
+  .lousy-outages-root *,
+  .lousy-outages,
+  .lousy-outages * {
+    visibility: visible;
+  }
+
+  .lousy-outages-root,
+  .lousy-outages {
+    position: relative;
+    background: #ffffff;
+    color: #000000;
+    box-shadow: none;
+  }
+
+  .lo-link,
+  [data-lo-refresh],
+  [data-lo-export-csv],
+  [data-lo-export-pdf] {
+    display: none !important;
+  }
+}
+
+.lo-subscribe__fieldset{border:1px solid var(--lo-border);padding:12px;border-radius:12px;margin:12px 0;background:rgba(10,16,32,.45)}
+.lo-subscribe__legend{padding:0 6px;color:var(--lo-accent);font-size:.8rem;text-transform:uppercase;letter-spacing:.08em}
+.lo-subscribe__provider-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:8px}
+.lo-subscribe__checkbox{display:flex;align-items:center;gap:8px;font-size:.85rem}
+.lo-subscribe__prefs{display:grid;gap:8px}
+
+.lo-report{margin-top:20px;padding:14px;border:1px solid rgba(255,184,28,.45);background:rgba(8,8,20,.7)}
+.lo-report__form{display:grid;gap:10px}
+.lo-report__field{display:grid;gap:4px;font-size:12px;color:#ffe9c4}
+.lo-report__status{min-height:1.2em;color:#9af3ff}
+.lo-signals{margin-top:12px;display:grid;gap:8px}
+.lo-signal{padding:8px;border:1px solid rgba(255,255,255,.2)}
+.lo-signal--watch{border-color:#9af3ff}
+.lo-signal--trending{border-color:#ffb81c}
+.lo-signal--hot{border-color:#ff5a5a}
+.lo-signal__badge{font-weight:700;margin-right:6px}

--- a/plugins/lousy-outages/assets/lousy-outages.js
+++ b/plugins/lousy-outages/assets/lousy-outages.js
@@ -1,0 +1,3860 @@
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory(root);
+  } else {
+    var api = factory(root);
+    root.LousyOutagesApp = api;
+    if (root && root.document && root.LousyOutagesConfig) {
+      api.init(root.LousyOutagesConfig);
+    }
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : (typeof self !== 'undefined' ? self : this), function (rootRef) {
+  'use strict';
+
+  var globalRoot = rootRef && typeof rootRef.setTimeout === 'function' ? rootRef : (typeof globalThis !== 'undefined' ? globalThis : rootRef);
+
+  var POLL_MS = 10000;
+  var MAX_DELAY = 60000;
+  var STALE_REFRESH_THRESHOLD_MS = 6 * 60 * 1000;
+  var STALE_REFRESH_COOLDOWN_MS = 3 * 60 * 1000;
+  var DEGRADE_THRESHOLD = 0.5;
+  var RECOVER_THRESHOLD = 0.7;
+  var MANUAL_REFRESH_RETRY_DELAY = 1500;
+  var MANUAL_REFRESH_MAX_ATTEMPTS = 4;
+  var VISIBILITY_STORAGE_KEY = 'lo-visible-providers';
+  var LAST_OK_STORAGE_PREFIX = 'lo_last_ok_';
+  var HISTORY_CHART_MODE_KEY = 'lo_history_chart_mode';
+  var HISTORY_LIMIT = 80;
+  var HISTORY_RENDER_LIMIT = 12;
+  var HISTORY_DEFAULT_DAYS = 30;
+  var UNKNOWN_MESSAGE = 'Can\u2019t verify status right now.';
+  var UNKNOWN_HINT = 'Provider page may still be operational \u2014 click \u2018View status\u2019.';
+
+  var STATUS_MAP = {
+    operational: { code: 'operational', label: 'Operational', className: 'status--operational' },
+    degraded: { code: 'degraded', label: 'Degraded', className: 'status--degraded' },
+    major: { code: 'major', label: 'Major Outage', className: 'status--outage' },
+    outage: { code: 'outage', label: 'Outage', className: 'status--outage' },
+    maintenance: { code: 'maintenance', label: 'Maintenance', className: 'status--maintenance' },
+    unknown: { code: 'unknown', label: 'Unknown', className: 'status--unknown' }
+  };
+
+  var SNARKS = {
+    aws: [
+      'us-east-1 is a lifestyle choice.',
+      'Somewhere a Lambda forgot to set its alarm.'
+    ],
+    github: ['Push it real good, but maybe later.'],
+    default: ['Hold tight—someone’s jiggling the ethernet cable.']
+  };
+
+  var state = {
+    root: globalRoot,
+    doc: null,
+    fetchImpl: null,
+    endpoint: '',
+    refreshEndpoint: '',
+    refreshNonce: '',
+    subscribeEndpoint: '',
+    baseDelay: POLL_MS,
+    delay: POLL_MS,
+    maxDelay: MAX_DELAY,
+    timer: null,
+    countdownTimer: null,
+    nextRefreshAt: null,
+    etag: null,
+    visibilityPaused: false,
+    container: null,
+    grid: null,
+    fetchedEl: null,
+    fetchedLabelEl: null,
+    fetchedLabel: 'Fetched',
+    countdownEl: null,
+    refreshButton: null,
+    degradedBadge: null,
+    trendingBanner: null,
+    trendingText: null,
+    trendingReasons: null,
+    exportCSVButton: null,
+    exportPDFButton: null,
+    modeToggle: null,
+    modeButtons: {},
+    viewMode: 'incidents',
+    incidentsWrap: null,
+    allProvidersWrap: null,
+    heroWrap: null,
+    heroTime: null,
+    sectionGrids: {},
+    sectionBodies: {},
+    sectionToggles: {},
+    providerToggles: [],
+    mediaQuery: null,
+    loadingEl: null,
+    fetchedAt: null,
+    isRefreshing: false,
+    pendingManual: false,
+    lastFetchStartedAt: null,
+    manualQueued: false,
+    staleRefreshQueued: false,
+    staleRefreshInFlight: false,
+    lastStaleRefreshAttempt: null,
+    degradedDueToStale: false,
+    historyEndpoint: '',
+    historyList: null,
+    historyEmpty: null,
+    historyError: null,
+    historyCharts: null,
+    historyImportantOnly: true,
+    historyWindowDays: HISTORY_DEFAULT_DAYS,
+    historyProviders: [],
+    historyMeta: {},
+    historyIncidents: [],
+    historyExpanded: false,
+    historyToggleButton: null,
+    visibleProviders: {},
+    reportForm: null,
+    reportProvider: null,
+    reportProviderNameWrap: null,
+    reportProviderName: null,
+    reportSummary: null,
+    reportContact: null,
+    reportStatus: null,
+    reportSubmit: null,
+    reportCaptchaPhrase: null,
+    reportCaptchaInput: null,
+    reportCaptchaToken: null,
+    reportCaptchaRefresh: null,
+    reportPhraseEndpoint: '',
+    signalsEndpoint: '',
+    signalsContainer: null,
+    reportCaptchaTokenValue: '',
+    reportProvidersInitialized: false,
+    debug: false,
+    latestProviders: [],
+    incidentsMeta: {},
+    postPaintStarted: false
+  };
+
+  function delay(ms) {
+    return new Promise(function (resolve) {
+      var timerRoot = state.root && typeof state.root.setTimeout === 'function'
+        ? state.root
+        : (globalRoot && typeof globalRoot.setTimeout === 'function' ? globalRoot : null);
+      if (timerRoot) {
+        timerRoot.setTimeout(resolve, ms);
+      } else {
+        setTimeout(resolve, ms);
+      }
+    });
+  }
+
+  function normalizeStatus(code) {
+    var key = String(code || '').toLowerCase();
+
+    switch (key) {
+      case 'none':
+        key = 'operational';
+        break;
+      case 'minor_outage':
+      case 'partial_outage':
+      case 'degraded_performance':
+        key = 'degraded';
+        break;
+      case 'major_outage':
+      case 'critical':
+        key = 'major';
+        break;
+    }
+
+    return STATUS_MAP[key] || STATUS_MAP.unknown;
+  }
+
+  function snarkOutage(provider, status, summary) {
+    var normalized = normalizeStatus(status);
+    if ('operational' === normalized.code || 'maintenance' === normalized.code) {
+      return summary || normalized.label;
+    }
+    var providerKey = String(provider || '').toLowerCase().replace(/[^a-z0-9]+/g, '');
+    var lines = SNARKS[providerKey] || SNARKS.default;
+    if (!lines.length) {
+      return summary || 'Something feels off.';
+    }
+    var index = Math.floor(Math.random() * lines.length);
+    return lines[index] || summary || 'Something feels off.';
+  }
+
+  function escapeSelector(id) {
+    if (typeof id !== 'string') {
+      return '';
+    }
+    if (typeof CSS !== 'undefined' && CSS.escape) {
+      return CSS.escape(id);
+    }
+    return id.replace(/[^a-zA-Z0-9_-]/g, '\\$&');
+  }
+
+  function appendQuery(url, key, value) {
+    var separator = url.indexOf('?') === -1 ? '?' : '&';
+    return url + separator + key + '=' + encodeURIComponent(value);
+  }
+
+  function hasUnavailableCopy(text) {
+    return /temporarily unavailable|can[’']t verify/i.test(String(text || ''));
+  }
+
+  function getProviderId(provider) {
+    if (!provider) {
+      return '';
+    }
+    var id = provider.id || provider.provider || provider.slug || provider.name || '';
+    return String(id || '').toLowerCase();
+  }
+
+  function writeLastKnown(provider, normalized) {
+    if (!state.root || !state.root.localStorage || !provider) {
+      return;
+    }
+    var statusInfo = normalizeStatus(provider.status || provider.stateCode || provider.overall || provider.overall_status || normalized.code);
+    if (statusInfo.code === 'unknown') {
+      return;
+    }
+    var providerId = getProviderId(provider);
+    if (!providerId) {
+      return;
+    }
+    var payload = {
+      status: statusInfo.code,
+      status_label: provider.status_label || statusInfo.label,
+      message: provider.message || '',
+      summary: provider.summary || '',
+      fetched_at: provider.fetched_at || provider.fetchedAt || provider.updated_at || provider.updatedAt || ''
+    };
+    try {
+      state.root.localStorage.setItem(LAST_OK_STORAGE_PREFIX + providerId, JSON.stringify(payload));
+    } catch (err) {
+      // Ignore storage errors.
+    }
+  }
+
+  function readLastKnown(providerId) {
+    if (!state.root || !state.root.localStorage || !providerId) {
+      return null;
+    }
+    try {
+      var raw = state.root.localStorage.getItem(LAST_OK_STORAGE_PREFIX + providerId);
+      if (!raw) {
+        return null;
+      }
+      var parsed = JSON.parse(raw);
+      return parsed && typeof parsed === 'object' ? parsed : null;
+    } catch (err) {
+      return null;
+    }
+  }
+
+
+  function loadVisibleProviders() {
+    if (!state.root || !state.root.localStorage) {
+      return {};
+    }
+    try {
+      var raw = state.root.localStorage.getItem(VISIBILITY_STORAGE_KEY);
+      if (!raw) {
+        return {};
+      }
+      var parsed = JSON.parse(raw);
+      return parsed && typeof parsed === 'object' ? parsed : {};
+    } catch (err) {
+      return {};
+    }
+  }
+
+  function persistVisibleProviders(prefs) {
+    if (!state.root || !state.root.localStorage) {
+      return;
+    }
+    try {
+      state.root.localStorage.setItem(VISIBILITY_STORAGE_KEY, JSON.stringify(prefs || {}));
+    } catch (err) {
+      // Ignore storage errors.
+    }
+  }
+
+  function applyProviderVisibility() {
+    if (!state.container) {
+      return;
+    }
+    var cards = state.container.querySelectorAll('.lo-card');
+    if (!cards || !cards.length) {
+      return;
+    }
+    var prefs = state.visibleProviders || {};
+    var hasPrefs = Object.keys(prefs).length > 0;
+    cards.forEach(function (card) {
+      var slug = card.getAttribute('data-provider-id');
+      var show = true;
+      if (slug) {
+        if (hasPrefs) {
+          show = prefs[slug] !== false;
+        }
+      }
+      if (show) {
+        card.classList.remove('lo-card--hidden');
+        card.removeAttribute('data-lo-hidden');
+        card.setAttribute('aria-hidden', 'false');
+      } else {
+        card.classList.add('lo-card--hidden');
+        card.setAttribute('data-lo-hidden', 'true');
+        card.setAttribute('aria-hidden', 'true');
+      }
+    });
+  }
+
+  function syncProviderToggleUI() {
+    if (!state.providerToggles || !state.providerToggles.length) {
+      return;
+    }
+    var prefs = state.visibleProviders || {};
+    var hasPrefs = Object.keys(prefs).length > 0;
+    state.providerToggles.forEach(function (input) {
+      var slug = input.value;
+      if (!slug) {
+        return;
+      }
+      var checked = hasPrefs ? prefs[slug] !== false : true;
+      input.checked = checked;
+    });
+  }
+
+  function handleProviderToggle(event) {
+    var target = event.target;
+    if (!target || !target.value) {
+      return;
+    }
+    var prefs = state.visibleProviders || {};
+    prefs[target.value] = !!target.checked;
+    state.visibleProviders = prefs;
+    persistVisibleProviders(prefs);
+    applyProviderVisibility();
+  }
+
+  function setAllProvidersVisibility(visible) {
+    if (!state.providerToggles || !state.providerToggles.length) {
+      return;
+    }
+    var prefs = {};
+    state.providerToggles.forEach(function (input) {
+      if (!input || !input.value) {
+        return;
+      }
+      input.checked = visible;
+      if (!visible) {
+        prefs[input.value] = false;
+      }
+    });
+    state.visibleProviders = prefs;
+    persistVisibleProviders(prefs);
+    applyProviderVisibility();
+  }
+
+  function initProviderVisibility() {
+    state.visibleProviders = loadVisibleProviders();
+    var toggles = state.container ? state.container.querySelectorAll('[data-lo-provider-toggle]') : [];
+    state.providerToggles = toggles ? Array.prototype.slice.call(toggles) : [];
+    if (state.providerToggles.length) {
+      state.providerToggles.forEach(function (input) {
+        input.addEventListener('change', handleProviderToggle);
+      });
+      syncProviderToggleUI();
+    }
+
+    var selectAll = state.container ? state.container.querySelector('[data-lo-provider-select="all"]') : null;
+    if (selectAll) {
+      selectAll.addEventListener('click', function (event) {
+        event.preventDefault();
+        setAllProvidersVisibility(true);
+        syncProviderToggleUI();
+      });
+    }
+
+    var selectNone = state.container ? state.container.querySelector('[data-lo-provider-select="none"]') : null;
+    if (selectNone) {
+      selectNone.addEventListener('click', function (event) {
+        event.preventDefault();
+        setAllProvidersVisibility(false);
+        syncProviderToggleUI();
+      });
+    }
+    applyProviderVisibility();
+  }
+
+
+  function getText(target, selector) {
+    if (!target) {
+      return '';
+    }
+    var node = selector ? target.querySelector(selector) : target;
+    if (!node || typeof node.textContent !== 'string') {
+      return '';
+    }
+    return node.textContent.trim();
+  }
+
+  function getHistoryChartData() {
+    var meta = state.historyMeta || {};
+    var providers = state.historyProviders || [];
+
+    var providerCounts = meta && meta.provider_counts && typeof meta.provider_counts === 'object'
+      ? meta.provider_counts
+      : null;
+    var dailyCounts = meta && meta.daily_counts && typeof meta.daily_counts === 'object'
+      ? meta.daily_counts
+      : null;
+    var yoy = meta && meta.year_over_year && typeof meta.year_over_year === 'object'
+      ? meta.year_over_year
+      : null;
+
+    if (!providerCounts) {
+      providerCounts = {};
+      (Array.isArray(providers) ? providers : []).forEach(function (provider) {
+        if (!provider || !Array.isArray(provider.incidents)) {
+          return;
+        }
+        var label = provider.label || provider.name || provider.provider || 'Provider';
+        providerCounts[label] = (providerCounts[label] || 0) + provider.incidents.length;
+      });
+    }
+
+    if (!dailyCounts) {
+      dailyCounts = {};
+      (Array.isArray(providers) ? providers : []).forEach(function (provider) {
+        if (!provider || !Array.isArray(provider.incidents)) {
+          return;
+        }
+        provider.incidents.forEach(function (incident) {
+          var dateStr = incident.first_seen || incident.firstSeen || incident.last_seen || incident.lastSeen || '';
+          if (!dateStr) {
+            return;
+          }
+          var parsed = Date.parse(dateStr);
+          if (!Number.isNaN(parsed)) {
+            var formatted = new Date(parsed).toISOString().slice(0, 10);
+            dailyCounts[formatted] = (dailyCounts[formatted] || 0) + 1;
+          }
+        });
+      });
+    }
+
+    var windowDays = meta && meta.window_days ? parseInt(meta.window_days, 10) : state.historyWindowDays;
+
+    return {
+      providerCounts: providerCounts,
+      dailyCounts: dailyCounts,
+      windowDays: Number.isFinite(windowDays) && windowDays > 0 ? windowDays : HISTORY_DEFAULT_DAYS,
+      yearOverYear: yoy
+    };
+  }
+
+  function downloadCSV() {
+    var incidents = Array.isArray(state.historyIncidents) ? state.historyIncidents : [];
+    if (!incidents.length) {
+      if (state.root && state.root.alert) {
+        state.root.alert('No incidents to export yet. Try refreshing history.');
+      }
+      return;
+    }
+
+    var rows = [
+      ['first_seen', 'last_seen', 'provider', 'severity', 'status', 'summary', 'url']
+    ];
+
+    incidents.forEach(function (entry) {
+      rows.push([
+        entry.first_seen || '',
+        entry.last_seen || '',
+        entry.provider || '',
+        String(entry.severity || '').toUpperCase(),
+        entry.status || '',
+        entry.summary || '',
+        entry.url || ''
+      ]);
+    });
+
+    var csvContent = rows.map(function (row) {
+      return row.map(function (field) {
+        var safe = (field || '').toString().replace(/"/g, '""');
+        return '"' + safe + '"';
+      }).join(',');
+    }).join('\n');
+
+    var blob = new Blob([csvContent], { type: 'text/csv' });
+    var urlCreator = (state.root && state.root.URL) ? state.root.URL : (typeof URL !== 'undefined' ? URL : null);
+    if (!urlCreator || !urlCreator.createObjectURL) {
+      return;
+    }
+    var url = urlCreator.createObjectURL(blob);
+    var link = state.doc.createElement('a');
+    link.href = url;
+    link.download = 'lousy-outages-history.csv';
+    state.doc.body.appendChild(link);
+    link.click();
+    state.doc.body.removeChild(link);
+    if (urlCreator.revokeObjectURL) {
+      urlCreator.revokeObjectURL(url);
+    }
+  }
+
+  function exportPDF() {
+    if (!state.root || !state.historyCharts) {
+      return;
+    }
+
+    var hasCharts = state.historyCharts.querySelector && state.historyCharts.querySelector('svg');
+    if (!hasCharts) {
+      return;
+    }
+
+    var clone = state.historyCharts.cloneNode(true);
+    clone.removeAttribute('hidden');
+
+    var originalCanvases = state.historyCharts.querySelectorAll ? state.historyCharts.querySelectorAll('canvas') : [];
+    var clonedCanvases = clone.querySelectorAll ? clone.querySelectorAll('canvas') : [];
+    if (originalCanvases.length && clonedCanvases.length) {
+      clonedCanvases.forEach(function (canvas, idx) {
+        var original = originalCanvases[idx];
+        if (!original || !original.toDataURL) {
+          return;
+        }
+        try {
+          var dataUrl = original.toDataURL('image/png');
+          var img = state.doc.createElement('img');
+          img.src = dataUrl;
+          img.alt = original.getAttribute('aria-label') || 'Chart image';
+          img.style.width = '100%';
+          img.style.height = 'auto';
+          canvas.parentNode.replaceChild(img, canvas);
+        } catch (err) {
+          // Ignore canvas export errors.
+        }
+      });
+    }
+
+    var printWindow = state.root.open('', '_blank');
+    if (!printWindow || !printWindow.document || typeof printWindow.document.write !== 'function') {
+      return;
+    }
+
+    var styles = [
+      "@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&display=swap');",
+      'body { margin: 0; padding: 24px; font-family: \"Press Start 2P\", \"VT323\", \"IBM Plex Mono\", monospace; background: #050510; color: #9af3ff; text-shadow: 0 0 6px rgba(0, 255, 255, 0.35); }',
+      '.lo-history__chart { margin-bottom: 24px; padding: 16px; border: 2px solid #1bf0ff; box-shadow: 0 0 0 2px #ff2fb3 inset, 0 0 18px rgba(27, 240, 255, 0.25); background: linear-gradient(135deg, rgba(0, 255, 170, 0.05) 0%, rgba(255, 47, 179, 0.05) 100%), #0b0b1e; }',
+      '.lo-history__report { margin-bottom: 24px; padding: 16px; border: 2px solid #1bf0ff; box-shadow: 0 0 0 2px #ff2fb3 inset, 0 0 18px rgba(27, 240, 255, 0.25); background: linear-gradient(135deg, rgba(0, 255, 170, 0.05) 0%, rgba(255, 47, 179, 0.05) 100%), #0b0b1e; }',
+      '.lo-history__chart-title { font-size: 12px; font-weight: 700; margin-bottom: 8px; letter-spacing: 1px; text-transform: uppercase; color: #f5f5f5; }',
+      '.lo-history__subtitle { color: #72f3ff; font-size: 10px; letter-spacing: 0.5px; margin-bottom: 8px; }',
+      '.lo-history__chart svg, .lo-history__chart canvas, .lo-history__chart img { width: 100%; height: auto; border: 1px solid #2affd5; background: repeating-linear-gradient(90deg, rgba(42, 255, 213, 0.08) 0, rgba(42, 255, 213, 0.08) 6px, transparent 6px, transparent 12px), #050510; image-rendering: pixelated; }',
+      '.lo-history__chart-bar { fill: #26ffd6; stroke: #000; stroke-width: 1; }',
+      '.lo-history__chart-bar--thin { fill: #ff2fb3; }',
+      '.lo-history__chart-bar--active { filter: drop-shadow(0 0 4px rgba(255, 47, 179, 0.8)); }',
+      '.lo-history__chart-text { font-size: 9px; fill: #e4f7ff; text-shadow: 0 0 4px rgba(0, 255, 255, 0.25); }',
+      '.lo-history__chart text { font-family: \"Press Start 2P\", \"VT323\", \"IBM Plex Mono\", monospace; }',
+      '.lo-history__chart-tooltip { margin-top: 6px; font-size: 10px; color: #f6ff8f; }',
+      '.lo-retro-legend { display: flex; gap: 10px; align-items: center; margin-top: 10px; font-size: 9px; color: #fefefe; }',
+      '.lo-retro-legend__swatch { width: 14px; height: 14px; border: 2px solid #0b0b1e; box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.2); display: inline-block; margin-right: 6px; }',
+      '.lo-history__report-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 10px; margin-bottom: 12px; }',
+      '.lo-history__report-stat { padding: 10px; border: 1px solid rgba(42, 255, 213, 0.5); background: rgba(5, 5, 16, 0.6); }',
+      '.lo-history__report-label { font-size: 9px; text-transform: uppercase; letter-spacing: 1px; color: #9af3ff; margin-bottom: 4px; }',
+      '.lo-history__report-value { font-size: 12px; color: #fefefe; }',
+      '.lo-history__report-sub { font-size: 9px; color: #f6ff8f; margin-top: 4px; }',
+      '.lo-history__report-table { width: 100%; border-collapse: collapse; font-size: 9px; }',
+      '.lo-history__report-table th, .lo-history__report-table td { padding: 6px 8px; border: 1px solid rgba(42, 255, 213, 0.4); text-align: left; }',
+      '.lo-history__view-toggle { display: flex; gap: 8px; flex-wrap: wrap; margin: 6px 0 10px; }',
+      '.lo-history__view-button { border: 1px solid #1bf0ff; background: rgba(11, 11, 30, 0.75); color: #9af3ff; padding: 6px 10px; font-size: 9px; text-transform: uppercase; letter-spacing: 1px; }',
+      '.lo-history__view-button.is-active { background: #9af3ff; color: #050510; }',
+      '.lo-heatmap__cell--level-0 { fill: rgba(255, 255, 255, 0.08); }',
+      '.lo-heatmap__cell--level-1 { fill: rgba(42, 255, 213, 0.35); }',
+      '.lo-heatmap__cell--level-2 { fill: rgba(42, 255, 213, 0.55); }',
+      '.lo-heatmap__cell--level-3 { fill: rgba(255, 47, 179, 0.55); }',
+      '.lo-heatmap__cell--level-4 { fill: rgba(255, 47, 179, 0.85); }',
+      '.lo-heatmap__legend { display: flex; align-items: center; gap: 6px; margin-top: 8px; font-size: 9px; color: #9af3ff; }',
+      '.lo-heatmap__swatch { width: 12px; height: 12px; border: 1px solid #0b0b1e; display: inline-block; }',
+      '.lo-trend__line { fill: none; stroke: #ff2fb3; stroke-width: 2; }',
+      '.lo-trend__point { fill: #26ffd6; }',
+      '.lo-trend__point--active { fill: #f6ff8f; }',
+      '.lo-history__chart, .lo-history__report { page-break-inside: avoid; break-inside: avoid; }'
+    ].join('\n');
+
+    var title = 'Lousy Outages – Incident charts';
+    var html = [
+      '<!doctype html>',
+      '<html>',
+      '<head>',
+      '<meta charset="utf-8">',
+      '<title>' + title + '</title>',
+      '<style>' + styles + '</style>',
+      '</head>',
+      '<body>',
+      '<h1 style="font-size:18px; margin:0 0 16px;">' + title + '</h1>',
+      clone.innerHTML,
+      '</body>',
+      '</html>'
+    ].join('');
+
+    printWindow.document.open();
+    printWindow.document.write(html);
+    printWindow.document.close();
+
+    var triggerPrint = function () {
+      if (printWindow.focus) {
+        printWindow.focus();
+      }
+      if (typeof printWindow.print === 'function') {
+        printWindow.print();
+      }
+    };
+
+    if (printWindow.document.readyState === 'complete') {
+      triggerPrint();
+    } else {
+      printWindow.addEventListener('load', triggerPrint);
+    }
+  }
+
+  function clearChildren(el) {
+    if (!el) {
+      return;
+    }
+    if (typeof el.innerHTML === 'string') {
+      el.innerHTML = '';
+    }
+    if (Array.isArray(el.children)) {
+      el.children.length = 0;
+    }
+  }
+
+  function scheduleNext(delay) {
+    if (state.timer && state.root) {
+      state.root.clearTimeout(state.timer);
+      state.timer = null;
+    }
+    if (!isDocumentVisible()) {
+      state.visibilityPaused = true;
+      state.nextRefreshAt = null;
+      stopCountdown();
+      if (state.countdownEl) {
+        state.countdownEl.textContent = 'Auto-refresh paused';
+      }
+      return;
+    }
+    var base = state.baseDelay || POLL_MS;
+    var hasExplicitDelay = typeof delay === 'number' && !Number.isNaN(delay);
+    var desired = hasExplicitDelay ? delay : (state.delay || base);
+    if (desired < 0) {
+      desired = 0;
+    }
+    var minimum = hasExplicitDelay ? 0 : (base < POLL_MS ? Math.max(100, base) : 1000);
+    var nextDelay = desired;
+    if (!hasExplicitDelay && nextDelay < minimum) {
+      nextDelay = minimum;
+    }
+    state.delay = nextDelay;
+    state.visibilityPaused = false;
+    state.nextRefreshAt = Date.now() + nextDelay;
+    startCountdown();
+    if (state.root) {
+      state.timer = state.root.setTimeout(function () {
+        state.timer = null;
+        refreshSummary(false, false);
+      }, nextDelay);
+    }
+  }
+
+  function startCountdown() {
+    if (!state.root || !state.countdownEl) {
+      return;
+    }
+    if (state.countdownTimer) {
+      state.root.clearInterval(state.countdownTimer);
+    }
+    updateCountdown();
+    state.countdownTimer = state.root.setInterval(updateCountdown, 1000);
+  }
+
+  function stopCountdown() {
+    if (state.countdownTimer && state.root) {
+      state.root.clearInterval(state.countdownTimer);
+      state.countdownTimer = null;
+    }
+  }
+
+  function updateCountdown() {
+    if (!state.countdownEl) {
+      return;
+    }
+    if (!state.nextRefreshAt) {
+      state.countdownEl.textContent = 'Auto-refresh paused';
+      return;
+    }
+    var diff = state.nextRefreshAt - Date.now();
+    if (diff <= 0) {
+      state.countdownEl.textContent = 'Refreshing…';
+      return;
+    }
+    state.countdownEl.textContent = '';
+  }
+
+  function updateFetched() {
+    if (!state.fetchedEl || !state.fetchedAt) {
+      return;
+    }
+    if (state.fetchedLabelEl) {
+      state.fetchedLabelEl.textContent = state.fetchedLabel || 'Fetched';
+    }
+    var date = new Date(state.fetchedAt);
+    if (Number.isNaN(date.getTime())) {
+      state.fetchedEl.textContent = state.fetchedAt;
+      return;
+    }
+    try {
+      var formatted = new Intl.DateTimeFormat(undefined, {
+        weekday: 'short',
+        year: 'numeric',
+        month: 'short',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit'
+      }).format(date);
+      state.fetchedEl.textContent = formatted;
+    } catch (err) {
+      state.fetchedEl.textContent = date.toISOString();
+    }
+  }
+
+  function setLoading(isLoading) {
+    if (!state.refreshButton) {
+      return;
+    }
+    state.refreshButton.disabled = !!isLoading;
+    state.refreshButton.setAttribute('aria-busy', isLoading ? 'true' : 'false');
+    state.refreshButton.textContent = isLoading ? 'Refreshing…' : 'Refresh now';
+  }
+
+  function toggleSpinner(visible) {
+    if (!state.loadingEl) {
+      return;
+    }
+    if (visible) {
+      state.loadingEl.removeAttribute('hidden');
+    } else {
+      state.loadingEl.setAttribute('hidden', 'hidden');
+    }
+  }
+
+  function showDegraded(active, message) {
+    if (!state.degradedBadge) {
+      return;
+    }
+    if (active) {
+      state.degradedBadge.textContent = message || 'AUTO-REFRESH DEGRADED';
+      state.degradedBadge.removeAttribute('hidden');
+    } else {
+      state.degradedBadge.textContent = '';
+      state.degradedBadge.setAttribute('hidden', 'hidden');
+    }
+  }
+
+  function triggerStaleRefresh() {
+    if (!state.refreshEndpoint || !state.fetchImpl) {
+      return Promise.resolve();
+    }
+    if (state.staleRefreshInFlight) {
+      return Promise.resolve();
+    }
+
+    state.staleRefreshQueued = false;
+    state.staleRefreshInFlight = true;
+
+    return callRefreshEndpoint()
+      .catch(function () {
+        return null;
+      })
+      .then(function () {
+        return refreshSummary(false, true);
+      })
+      .finally(function () {
+        state.staleRefreshInFlight = false;
+      });
+  }
+
+  function maybeQueueStaleRefresh(fetchedIso) {
+    if (!state.refreshEndpoint || !state.fetchImpl) {
+      return;
+    }
+
+    var iso = typeof fetchedIso === 'string' ? fetchedIso : '';
+    if (!iso) {
+      if (state.degradedDueToStale) {
+        state.degradedDueToStale = false;
+        showDegraded(false);
+      }
+      return;
+    }
+
+    var parsed = Date.parse(iso);
+    if (!Number.isFinite(parsed)) {
+      return;
+    }
+
+    var age = Date.now() - parsed;
+    if (age < STALE_REFRESH_THRESHOLD_MS) {
+      if (state.degradedDueToStale) {
+        state.degradedDueToStale = false;
+        showDegraded(false);
+      }
+      return;
+    }
+
+    if (state.staleRefreshInFlight) {
+      return;
+    }
+
+    var now = Date.now();
+    if (state.lastStaleRefreshAttempt && (now - state.lastStaleRefreshAttempt) < STALE_REFRESH_COOLDOWN_MS) {
+      return;
+    }
+
+    state.lastStaleRefreshAttempt = now;
+    state.degradedDueToStale = true;
+    showDegraded(true, 'AUTO-REFRESH STALE — refreshing feed');
+
+    if (state.isRefreshing) {
+      state.staleRefreshQueued = true;
+      return;
+    }
+
+    triggerStaleRefresh();
+  }
+
+  function renderProviders(list) {
+    if (!Array.isArray(list)) {
+      return;
+    }
+    state.latestProviders = list.slice();
+    var orderedList = sortProviders(list);
+    var orderedCards = [];
+    var incidentsCards = [];
+    var signalCards = [];
+    var unverifiedCards = [];
+    orderedList.forEach(function (provider) {
+      if (!provider) {
+        return;
+      }
+      var id = provider.id || provider.provider;
+      if (!id) {
+        return;
+      }
+      var card = null;
+      if (state.container) {
+        card = state.container.querySelector('[data-provider-id="' + escapeSelector(String(id)) + '"]');
+      }
+      if (!card && state.doc) {
+        card = state.doc.querySelector('[data-provider-id="' + escapeSelector(String(id)) + '"]') || state.doc.querySelector('.provider-card[data-id="' + String(id) + '"]');
+      }
+      if (!card) {
+        return;
+      }
+      orderedCards.push(card);
+      var normalized = normalizeStatus(provider.status || provider.overall || provider.overall_status || provider.stateCode);
+      if (card.classList && card.classList.contains('provider-card')) {
+        updateLegacyCard(card, provider, normalized);
+      } else {
+        updateModernCard(card, provider, normalized);
+      }
+      if (state.viewMode === 'incidents') {
+        var kind = resolveTileKind(provider, normalized);
+        if (kind === 'outage') {
+          incidentsCards.push(card);
+        } else if (kind === 'signal') {
+          signalCards.push(card);
+        } else if (kind === 'unknown' || kind === 'manual') {
+          unverifiedCards.push(card);
+        } else if (state.grid) {
+          state.grid.appendChild(card);
+        }
+      } else if (state.grid) {
+        state.grid.appendChild(card);
+      }
+    });
+    if (state.loadingEl) {
+      if (Array.isArray(list) && list.length) {
+        toggleSpinner(false);
+      } else {
+        var hasAnyCard = false;
+        if (state.container) {
+          hasAnyCard = !!state.container.querySelector('[data-provider-id]');
+        }
+        toggleSpinner(!hasAnyCard);
+      }
+    }
+    if (state.viewMode === 'incidents') {
+      appendCardsToSection(state.sectionGrids.incidents, incidentsCards);
+      appendCardsToSection(state.sectionGrids.signals, signalCards);
+      appendCardsToSection(state.sectionGrids.unverified, unverifiedCards);
+    } else if (state.grid && orderedCards.length) {
+      orderedCards.forEach(function (card) {
+        if (card.parentNode === state.grid) {
+          state.grid.appendChild(card);
+        }
+      });
+    }
+    applyProviderVisibility();
+  }
+
+  function appendCardsToSection(section, cards) {
+    if (!section || !cards || !cards.length) {
+      return;
+    }
+    cards.forEach(function (card) {
+      section.appendChild(card);
+    });
+  }
+
+  function resolveTileKind(provider, normalizedStatus) {
+    var tileKind = String((provider && (provider.tile_kind || provider.tileKind)) || '').toLowerCase();
+    if (tileKind) {
+      return tileKind;
+    }
+    var statusInfo = normalizedStatus || normalizeStatus(provider && (provider.status || provider.overall || provider.overall_status || provider.stateCode));
+    if (statusInfo.code === 'operational') {
+      return 'operational';
+    }
+    if (statusInfo.code === 'unknown') {
+      return 'unknown';
+    }
+    var incidents = Array.isArray(provider && provider.incidents) ? provider.incidents : [];
+    if (incidents.length) {
+      return 'outage';
+    }
+    return 'signal';
+  }
+
+  function sortProviders(list) {
+    if (!Array.isArray(list)) {
+      return [];
+    }
+    var hasSortKey = list.some(function (provider) {
+      if (!provider) {
+        return false;
+      }
+      var value = provider.sort_key;
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        return true;
+      }
+      if (typeof value === 'string' && value.trim() !== '' && !Number.isNaN(Number(value))) {
+        return true;
+      }
+      return false;
+    });
+
+    if (!hasSortKey) {
+      return list.slice().sort(compareProvidersLegacy);
+    }
+
+    return list.slice().sort(compareProvidersBySortKey);
+  }
+
+  function compareProvidersBySortKey(a, b) {
+    var keyA = resolveSortKey(a);
+    var keyB = resolveSortKey(b);
+    if (keyA.sortKey !== keyB.sortKey) {
+      return keyA.sortKey - keyB.sortKey;
+    }
+    if (keyA.tileRank !== keyB.tileRank) {
+      return keyA.tileRank - keyB.tileRank;
+    }
+    if (keyA.name !== keyB.name) {
+      return keyA.name < keyB.name ? -1 : 1;
+    }
+    return 0;
+  }
+
+  function resolveSortKey(provider) {
+    var tilePriority = {
+      outage: 0,
+      signal: 1,
+      unknown: 2,
+      manual: 3,
+      operational: 4
+    };
+    var name = provider && (provider.name || provider.id || provider.provider || '');
+    var tileKind = String((provider && (provider.tile_kind || provider.tileKind)) || '').toLowerCase();
+    var sortKey = null;
+    if (provider && typeof provider.sort_key === 'number' && Number.isFinite(provider.sort_key)) {
+      sortKey = provider.sort_key;
+    } else if (provider && typeof provider.sort_key === 'string' && provider.sort_key.trim() !== '' && !Number.isNaN(Number(provider.sort_key))) {
+      sortKey = Number(provider.sort_key);
+    }
+    if (sortKey === null) {
+      sortKey = resolveLegacySortKey(provider);
+    }
+    return {
+      sortKey: sortKey,
+      tileRank: tilePriority[tileKind] !== undefined ? tilePriority[tileKind] : tilePriority.unknown,
+      name: String(name || '').toLowerCase()
+    };
+  }
+
+  function compareProvidersLegacy(a, b) {
+    var keyA = resolveLegacySortTuple(a);
+    var keyB = resolveLegacySortTuple(b);
+    for (var i = 0; i < keyA.length; i += 1) {
+      if (keyA[i] === keyB[i]) {
+        continue;
+      }
+      return keyA[i] < keyB[i] ? -1 : 1;
+    }
+    return 0;
+  }
+
+  function buildIncidentsMeta(providers, meta) {
+    var counts = {
+      active_outage_count: 0,
+      signal_count: 0,
+      unverified_count: 0,
+      generated_at: ''
+    };
+    if (meta && typeof meta === 'object') {
+      if (typeof meta.active_outage_count === 'number' && Number.isFinite(meta.active_outage_count)) {
+        counts.active_outage_count = meta.active_outage_count;
+      }
+      if (typeof meta.signal_count === 'number' && Number.isFinite(meta.signal_count)) {
+        counts.signal_count = meta.signal_count;
+      }
+      if (typeof meta.unverified_count === 'number' && Number.isFinite(meta.unverified_count)) {
+        counts.unverified_count = meta.unverified_count;
+      }
+      if (meta.generated_at) {
+        counts.generated_at = String(meta.generated_at);
+      }
+    }
+
+    var needsFallback = counts.active_outage_count === 0 && counts.signal_count === 0 && counts.unverified_count === 0;
+    if (needsFallback && Array.isArray(providers)) {
+      providers.forEach(function (provider) {
+        if (!provider) {
+          return;
+        }
+        var kind = resolveTileKind(provider);
+        if (kind === 'outage') {
+          counts.active_outage_count += 1;
+        } else if (kind === 'signal') {
+          counts.signal_count += 1;
+        } else if (kind === 'unknown' || kind === 'manual') {
+          counts.unverified_count += 1;
+        }
+      });
+    }
+
+    if (!counts.generated_at && state.fetchedAt) {
+      counts.generated_at = String(state.fetchedAt);
+    }
+
+    return counts;
+  }
+
+  function updateHero(metaCounts) {
+    if (!state.heroWrap) {
+      return;
+    }
+    var showHero = state.viewMode === 'incidents' && metaCounts && metaCounts.active_outage_count === 0;
+    if (showHero) {
+      state.heroWrap.removeAttribute('hidden');
+      if (state.heroTime) {
+        var time = metaCounts.generated_at || state.fetchedAt || '';
+        state.heroTime.textContent = formatTimestamp(time) || '—';
+      }
+    } else {
+      state.heroWrap.setAttribute('hidden', 'hidden');
+    }
+  }
+
+  function updateSectionLabels(metaCounts) {
+    if (state.sectionToggles.signals) {
+      state.sectionToggles.signals.textContent = 'Signals (' + (metaCounts.signal_count || 0) + ')';
+    }
+    if (state.sectionToggles.unverified) {
+      state.sectionToggles.unverified.textContent = 'Can\u2019t verify (' + (metaCounts.unverified_count || 0) + ')';
+    }
+    if (state.modeButtons.incidents) {
+      state.modeButtons.incidents.textContent = 'Incidents (' + (metaCounts.active_outage_count || 0) + ')';
+    }
+  }
+
+  function updateIncidentsUI(providers, meta) {
+    var metaCounts = buildIncidentsMeta(providers, meta);
+    state.incidentsMeta = metaCounts;
+    updateSectionLabels(metaCounts);
+    updateHero(metaCounts);
+  }
+
+  function setViewMode(mode) {
+    var nextMode = mode === 'all' ? 'all' : 'incidents';
+    state.viewMode = nextMode;
+    if (state.modeButtons.incidents) {
+      state.modeButtons.incidents.classList.toggle('is-active', nextMode === 'incidents');
+      state.modeButtons.incidents.setAttribute('aria-pressed', nextMode === 'incidents' ? 'true' : 'false');
+    }
+    if (state.modeButtons.all) {
+      state.modeButtons.all.classList.toggle('is-active', nextMode === 'all');
+      state.modeButtons.all.setAttribute('aria-pressed', nextMode === 'all' ? 'true' : 'false');
+    }
+    if (state.incidentsWrap) {
+      if (nextMode === 'incidents') {
+        state.incidentsWrap.removeAttribute('hidden');
+      } else {
+        state.incidentsWrap.setAttribute('hidden', 'hidden');
+      }
+    }
+    if (state.allProvidersWrap) {
+      if (nextMode === 'all') {
+        state.allProvidersWrap.removeAttribute('hidden');
+      } else {
+        state.allProvidersWrap.setAttribute('hidden', 'hidden');
+      }
+    }
+    updateHero(state.incidentsMeta || {});
+    if (state.latestProviders && state.latestProviders.length) {
+      renderProviders(state.latestProviders);
+    }
+  }
+
+  function toggleSection(key) {
+    var body = state.sectionBodies[key];
+    var toggle = state.sectionToggles[key];
+    if (!body || !toggle) {
+      return;
+    }
+    var isOpen = !body.hasAttribute('hidden');
+    if (isOpen) {
+      body.setAttribute('hidden', 'hidden');
+      toggle.setAttribute('aria-expanded', 'false');
+    } else {
+      body.removeAttribute('hidden');
+      toggle.setAttribute('aria-expanded', 'true');
+    }
+  }
+
+  function resolveLegacySortKey(provider) {
+    return resolveLegacySortTuple(provider)[0];
+  }
+
+  function resolveLegacySortTuple(provider) {
+    var statePriority = {
+      outage: 0,
+      degraded: 1,
+      maintenance: 2,
+      unknown: 3,
+      operational: 4
+    };
+    var normalized = normalizeStatus(provider && (provider.status || provider.overall || provider.overall_status || provider.stateCode));
+    var stateRank = statePriority[normalized.code] !== undefined ? statePriority[normalized.code] : statePriority.unknown;
+    var incidents = Array.isArray(provider && provider.incidents) ? provider.incidents : [];
+    var hasIncidents = incidents.length ? 0 : 1;
+    var hasError = provider && provider.error ? 0 : 1;
+    var risk = provider && typeof provider.risk === 'number' ? provider.risk : 0;
+    var name = String((provider && (provider.name || provider.id || provider.provider || '')) || '').toLowerCase();
+    return [
+      hasIncidents,
+      stateRank,
+      hasError,
+      -1 * risk,
+      name
+    ];
+  }
+
+
+  function getSummaryText(provider) {
+    if (!provider) {
+      return '';
+    }
+    return provider.summary || provider.message || '';
+  }
+
+  function isGenericDegradedCopy(text) {
+    var needle = String(text || '').trim().toLowerCase();
+    if (!needle) {
+      return true;
+    }
+    var phrases = [
+      'service degradation reported.',
+      'major outage reported.',
+      'maintenance in progress.',
+      'status temporarily unavailable.',
+      'can\u2019t verify status right now.'
+    ];
+    return phrases.indexOf(needle) !== -1;
+  }
+
+  function getSignalOnlyCopy(provider, normalized, providerSlug) {
+    if (!provider) {
+      return null;
+    }
+    if (String(providerSlug || '').toLowerCase() !== 'cloudflare') {
+      return null;
+    }
+    var incidents = Array.isArray(provider.incidents) ? provider.incidents : [];
+    if (incidents.length) {
+      return null;
+    }
+    var statusInfo = normalizeStatus(provider.status || provider.stateCode || provider.overall || provider.overall_status || normalized.code);
+    if (statusInfo.code === 'operational' || statusInfo.code === 'unknown') {
+      return null;
+    }
+    var message = String(provider.message || '').trim();
+    var summaryText = String(provider.summary || '').trim();
+    if (!isGenericDegradedCopy(summaryText) || !isGenericDegradedCopy(message)) {
+      return null;
+    }
+    return {
+      message: 'Degraded signal detected',
+      summary: 'No active incident listed yet — may be transient. Click \'View status\' or hit Refresh.'
+    };
+  }
+
+  function getMessageText(provider, normalized, providerSlug) {
+    if (!provider) {
+      return '';
+    }
+    var message = String(provider.message || '').trim();
+    var summaryText = String(provider.summary || '').trim();
+    var incidents = Array.isArray(provider.incidents) ? provider.incidents : [];
+    var statusInfo = normalizeStatus(provider.status || provider.stateCode || provider.overall || provider.overall_status || normalized.code);
+    var hasUnavailableSummary = summaryText && hasUnavailableCopy(summaryText);
+    var hasError = !!provider.error || hasUnavailableSummary;
+    var signalOnlyCopy = getSignalOnlyCopy(provider, normalized, providerSlug);
+
+    if (hasError) {
+      return hasUnavailableSummary ? summaryText : UNKNOWN_MESSAGE;
+    }
+    if (signalOnlyCopy) {
+      return signalOnlyCopy.message;
+    }
+
+    if (!message) {
+      if (incidents.length) {
+        var lead = incidents[0];
+        var incidentTitle = lead && (lead.name || lead.title || lead.summary) ? (lead.name || lead.title || lead.summary) : 'Incident';
+        var condensed = condenseIncidentTitle(providerSlug, incidentTitle);
+        return condensed.text || incidentTitle;
+      }
+      if (statusInfo.code === 'operational') {
+        return 'All systems operational.';
+      }
+      if (statusInfo.code === 'unknown') {
+        return UNKNOWN_MESSAGE;
+      }
+      return summaryText || statusInfo.label || UNKNOWN_MESSAGE;
+    }
+
+    return message;
+  }
+
+  function getStatusLine(provider, normalized, providerSlug) {
+    var summaryText = getSummaryText(provider);
+    var incidents = Array.isArray(provider.incidents) ? provider.incidents : [];
+    var hasIncidents = incidents.length > 0;
+    var statusInfo = normalizeStatus(provider.status || provider.stateCode || provider.overall || provider.overall_status || normalized.code);
+    var hasUnavailableSummary = summaryText && hasUnavailableCopy(summaryText);
+    var hasError = !!provider.error || hasUnavailableSummary;
+    var signalOnlyCopy = getSignalOnlyCopy(provider, normalized, providerSlug);
+
+    if (hasError) {
+      return hasUnavailableSummary ? summaryText : UNKNOWN_MESSAGE;
+    }
+    if (signalOnlyCopy) {
+      return signalOnlyCopy.summary;
+    }
+    if (hasIncidents) {
+      var lead = incidents[0];
+      var incidentTitle = lead && (lead.name || lead.title || lead.summary) ? (lead.name || lead.title || lead.summary) : 'Incident';
+      var condensed = condenseIncidentTitle(providerSlug, incidentTitle);
+      return 'Incident: ' + (condensed.text || 'Incident');
+    }
+    if (statusInfo.code === 'operational') {
+      return 'All systems operational.';
+    }
+    if (statusInfo.code === 'unknown') {
+      return UNKNOWN_MESSAGE;
+    }
+    return summaryText || statusInfo.label || UNKNOWN_MESSAGE;
+  }
+
+  function condenseIncidentTitle(providerSlug, text) {
+    var raw = String(text || '').replace(/\s+/g, ' ').trim();
+    if (!raw) {
+      return { text: '', title: '' };
+    }
+
+    var display = raw;
+    var slug = String(providerSlug || '').toLowerCase();
+    if (slug === 'zscaler') {
+      var parts = display.split(' - ');
+      if (parts.length > 1) {
+        var rightSide = parts.slice(1).join(' - ').trim();
+        if (rightSide && /(\.com|\.net)/i.test(rightSide) && /,/.test(rightSide)) {
+          display = parts[0].trim();
+        }
+      }
+    }
+
+    if (display.length > 140) {
+      display = display.slice(0, 137).replace(/\s+$/, '') + '…';
+    }
+
+    return { text: display, title: raw };
+  }
+
+  function getProviderSlug(provider) {
+    if (!provider) {
+      return '';
+    }
+    return String(provider.id || provider.slug || provider.provider || provider.name || '').toLowerCase();
+  }
+
+  function updateLegacyCard(card, provider, normalized) {
+    var providerSlug = getProviderSlug(provider);
+    var badge = card.querySelector('.status-badge');
+    if (badge) {
+      badge.textContent = provider.status_label || normalized.label;
+      badge.className = 'status-badge ' + (provider.status_class || normalized.className);
+      if (badge.dataset) {
+        badge.dataset.status = provider.status || provider.overall || provider.overall_status || normalized.code;
+      }
+    }
+    var summary = card.querySelector('.provider-card__summary');
+    if (summary) {
+      summary.textContent = getStatusLine(provider, normalized, providerSlug);
+    }
+    var snark = card.querySelector('.provider-card__snark');
+    if (snark) {
+      snark.textContent = snarkOutage(provider.name || provider.provider || provider.id, normalized.label, getSummaryText(provider));
+    }
+    var incidentsWrap = card.querySelector('.incidents');
+    if (incidentsWrap) {
+      clearChildren(incidentsWrap);
+      incidentsWrap.textContent = '';
+      var incidents = Array.isArray(provider.incidents) ? provider.incidents : [];
+      var hasError = !!provider.error || (hasUnavailableCopy(getSummaryText(provider)) && !(provider.incidents || []).length);
+      if (!incidents.length || hasError) {
+        incidentsWrap.setAttribute('hidden', 'hidden');
+      } else if (state.doc && typeof state.doc.createElement === 'function') {
+        incidentsWrap.removeAttribute('hidden');
+        incidents.forEach(function (incident) {
+          var item = state.doc.createElement('p');
+          var impact = incident.impact ? String(incident.impact).replace(/^[a-z]/, function (c) { return c.toUpperCase(); }) : 'Unknown';
+          var updated = formatTimestamp(incident.updated_at || incident.updatedAt);
+          var summaryText = '';
+          if (incident.summary) {
+            var condensedSummary = condenseIncidentTitle(providerSlug, incident.summary);
+            summaryText = ' — ' + condensedSummary.text;
+            if (condensedSummary.title && condensedSummary.title !== condensedSummary.text) {
+              item.setAttribute('title', condensedSummary.title);
+            }
+          }
+          item.textContent = impact + (updated ? ' • ' + updated : '') + summaryText;
+          incidentsWrap.appendChild(item);
+        });
+      }
+    }
+    var link = card.querySelector('.provider-link');
+    if (link && provider.url) {
+      link.setAttribute('href', provider.url);
+    }
+    updateCardMeta(card, provider, normalized);
+  }
+
+  function updateModernCard(card, provider, normalized) {
+    var providerSlug = getProviderSlug(provider);
+    var badge = card.querySelector('[data-lo-badge]');
+    if (badge) {
+      badge.textContent = provider.status_label || normalized.label;
+      badge.className = 'lo-pill ' + (provider.status_class || normalized.className);
+    }
+    var messageText = getMessageText(provider, normalized, providerSlug);
+    var messageEl = card.querySelector('[data-lo-message]');
+    if (messageEl) {
+      messageEl.textContent = messageText;
+    }
+    var signalOnlyCopy = getSignalOnlyCopy(provider, normalized, providerSlug);
+    var summaryText = signalOnlyCopy ? signalOnlyCopy.summary : String(provider.summary || '').trim();
+    if (summaryText && messageText && summaryText.toLowerCase() === messageText.toLowerCase()) {
+      summaryText = '';
+    }
+    var summary = card.querySelector('[data-lo-summary]');
+    if (summaryText) {
+      if (!summary && state.doc) {
+        summary = state.doc.createElement('p');
+        summary.className = 'lo-summary';
+        summary.setAttribute('data-lo-summary', '');
+        if (messageEl && messageEl.parentNode) {
+          messageEl.parentNode.insertBefore(summary, messageEl.nextSibling);
+        } else {
+          card.appendChild(summary);
+        }
+      }
+      if (summary) {
+        summary.textContent = summaryText;
+        summary.removeAttribute('hidden');
+      }
+    } else if (summary) {
+      summary.textContent = '';
+      summary.setAttribute('hidden', 'hidden');
+    }
+    var componentsWrap = card.querySelector('[data-lo-components]');
+    if (componentsWrap) {
+      componentsWrap.innerHTML = '';
+      var components = Array.isArray(provider.components) ? provider.components.filter(function (component) {
+        if (!component) {
+          return false;
+        }
+        var status = String(component.status || '').toLowerCase();
+        return status && status !== 'operational';
+      }) : [];
+      if (components.length) {
+        var title = state.doc.createElement('h4');
+        title.className = 'lo-components__title';
+        title.textContent = 'Impacted components';
+        componentsWrap.appendChild(title);
+        var listEl = state.doc.createElement('ul');
+        listEl.className = 'lo-components__list';
+        components.forEach(function (component) {
+          var item = state.doc.createElement('li');
+          var name = state.doc.createElement('span');
+          name.className = 'lo-component-name';
+          name.textContent = component.name || 'Component';
+          item.appendChild(name);
+          var statusEl = state.doc.createElement('span');
+          statusEl.className = 'lo-component-status';
+          statusEl.textContent = component.status_label || normalizeStatus(component.status).label;
+          item.appendChild(statusEl);
+          listEl.appendChild(item);
+        });
+        componentsWrap.appendChild(listEl);
+      }
+    }
+    var incidentsWrap = card.querySelector('[data-lo-incidents]');
+    if (incidentsWrap) {
+      incidentsWrap.innerHTML = '';
+      var incidents = Array.isArray(provider.incidents) ? provider.incidents : [];
+      var hasError = !!provider.error || hasUnavailableCopy(getSummaryText(provider));
+      if (!incidents.length || hasError) {
+        incidentsWrap.setAttribute('hidden', 'hidden');
+      } else {
+        incidentsWrap.removeAttribute('hidden');
+        var ul = state.doc.createElement('ul');
+        ul.className = 'lo-inc-list';
+        incidents.forEach(function (incident) {
+          var li = state.doc.createElement('li');
+          li.className = 'lo-inc-item';
+          var title = state.doc.createElement('p');
+          title.className = 'lo-inc-title';
+          var condensedName = condenseIncidentTitle(providerSlug, incident.name || 'Incident');
+          title.textContent = condensedName.text || 'Incident';
+          if (condensedName.title && condensedName.title !== condensedName.text) {
+            title.setAttribute('title', condensedName.title);
+          }
+          li.appendChild(title);
+          var meta = state.doc.createElement('p');
+          meta.className = 'lo-inc-meta';
+          var impact = incident.impact ? String(incident.impact).replace(/^[a-z]/, function (c) { return c.toUpperCase(); }) : 'Unknown';
+          var updated = formatTimestamp(incident.updated_at || incident.updatedAt || incident.started_at || incident.startedAt);
+          meta.textContent = impact + (updated ? ' • ' + updated : '');
+          li.appendChild(meta);
+          if (incident.summary) {
+            var details = state.doc.createElement('p');
+            details.className = 'lo-inc-summary';
+            var condensedSummary = condenseIncidentTitle(providerSlug, incident.summary);
+            details.textContent = condensedSummary.text;
+            if (condensedSummary.title && condensedSummary.title !== condensedSummary.text) {
+              details.setAttribute('title', condensedSummary.title);
+            }
+            li.appendChild(details);
+          }
+          if (incident.url) {
+            var link = state.doc.createElement('a');
+            link.className = 'lo-status-link';
+            link.href = incident.url;
+            link.target = '_blank';
+            link.rel = 'noopener noreferrer';
+            link.textContent = 'View incident';
+            li.appendChild(link);
+          }
+          ul.appendChild(li);
+        });
+        incidentsWrap.appendChild(ul);
+      }
+    }
+    var statusLink = card.querySelector('[data-lo-status-url]');
+    if (statusLink) {
+      var destination = provider.url || provider.link;
+      if (destination) {
+        statusLink.href = destination;
+        statusLink.removeAttribute('hidden');
+      } else {
+        statusLink.setAttribute('hidden', 'hidden');
+      }
+    }
+    updateCardMeta(card, provider, normalized);
+  }
+
+  function ensureMetaWrap(card) {
+    if (!card || !state.doc) {
+      return null;
+    }
+    var wrap = card.querySelector('[data-lo-meta]');
+    if (wrap) {
+      return wrap;
+    }
+    wrap = state.doc.createElement('div');
+    wrap.className = 'lo-card-meta-wrap';
+    wrap.setAttribute('data-lo-meta', '');
+    var anchor = card.querySelector('[data-lo-summary]')
+      || card.querySelector('.provider-card__summary')
+      || card.querySelector('[data-lo-message]')
+      || card.querySelector('.provider-card__snark');
+    if (anchor && anchor.parentNode) {
+      anchor.parentNode.insertBefore(wrap, anchor.nextSibling);
+    } else {
+      card.appendChild(wrap);
+    }
+    return wrap;
+  }
+
+  function ensureMetaLine(wrap, attr, className) {
+    if (!wrap || !state.doc) {
+      return null;
+    }
+    var selector = '[' + attr + ']';
+    var line = wrap.querySelector(selector);
+    if (!line) {
+      line = state.doc.createElement('p');
+      line.className = className;
+      line.setAttribute(attr, '');
+      wrap.appendChild(line);
+    }
+    return line;
+  }
+
+  function buildDebugLine(provider) {
+    var httpCode = typeof provider.http_code === 'number' ? provider.http_code : null;
+    var errorText = provider && provider.error ? String(provider.error) : '';
+    if (httpCode !== null && httpCode !== 0) {
+      return 'debug: HTTP ' + httpCode + (errorText ? ' (' + errorText + ')' : '');
+    }
+    if (errorText) {
+      return 'debug: ' + errorText;
+    }
+    return '';
+  }
+
+  function updateCardMeta(card, provider, normalized) {
+    if (!card || !provider) {
+      return;
+    }
+    var statusInfo = normalizeStatus(provider.status || provider.stateCode || provider.overall || provider.overall_status || normalized.code);
+    writeLastKnown(provider, statusInfo);
+    var wrap = ensureMetaWrap(card);
+    if (!wrap) {
+      return;
+    }
+    var fetchedAt = provider.fetched_at || provider.fetchedAt || provider.updated_at || provider.updatedAt || '';
+    var lastChecked = formatTimestamp(fetchedAt) || '—';
+    var lastCheckedEl = ensureMetaLine(wrap, 'data-lo-last-checked', 'lo-card-meta');
+    if (lastCheckedEl) {
+      lastCheckedEl.textContent = 'Last checked: ' + lastChecked;
+    }
+    var lastKnownEl = ensureMetaLine(wrap, 'data-lo-last-known', 'lo-card-meta lo-card-meta--hint');
+    var hintEl = ensureMetaLine(wrap, 'data-lo-unknown-hint', 'lo-card-meta lo-card-meta--hint');
+    var lastKnown = statusInfo.code === 'unknown' ? readLastKnown(getProviderId(provider)) : null;
+    if (statusInfo.code === 'unknown') {
+      if (lastKnown && lastKnown.status) {
+        var lastKnownLabel = lastKnown.status_label || normalizeStatus(lastKnown.status).label;
+        var lastKnownTime = formatTimestamp(lastKnown.fetched_at) || '—';
+        if (lastKnownEl) {
+          lastKnownEl.textContent = 'Last known: ' + lastKnownLabel + (lastKnownTime ? ' (' + lastKnownTime + ')' : '');
+          lastKnownEl.removeAttribute('hidden');
+        }
+        if (hintEl) {
+          hintEl.textContent = UNKNOWN_HINT;
+          hintEl.setAttribute('hidden', 'hidden');
+        }
+      } else {
+        if (lastKnownEl) {
+          lastKnownEl.textContent = '';
+          lastKnownEl.setAttribute('hidden', 'hidden');
+        }
+        if (hintEl) {
+          hintEl.textContent = UNKNOWN_HINT;
+          hintEl.removeAttribute('hidden');
+        }
+      }
+    } else {
+      if (lastKnownEl) {
+        lastKnownEl.textContent = '';
+        lastKnownEl.setAttribute('hidden', 'hidden');
+      }
+      if (hintEl) {
+        hintEl.textContent = '';
+        hintEl.setAttribute('hidden', 'hidden');
+      }
+    }
+    var debugEl = ensureMetaLine(wrap, 'data-lo-debug', 'lo-card-debug');
+    if (debugEl) {
+      var debugLine = state.debug ? buildDebugLine(provider) : '';
+      if (debugLine) {
+        debugEl.textContent = debugLine;
+        debugEl.removeAttribute('hidden');
+      } else {
+        debugEl.textContent = '';
+        debugEl.setAttribute('hidden', 'hidden');
+      }
+    }
+  }
+  function formatTimestamp(iso) {
+    if (!iso) {
+      return '';
+    }
+    var date = new Date(iso);
+    if (Number.isNaN(date.getTime())) {
+      return '';
+    }
+    try {
+      return new Intl.DateTimeFormat(undefined, {
+        month: 'short',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit'
+      }).format(date);
+    } catch (err) {
+      return date.toISOString();
+    }
+  }
+
+  function mapHistoryStatus(code) {
+    var key = String(code || '').toLowerCase();
+    if (
+      key === 'major_outage' ||
+      key === 'critical' ||
+      key === 'outage' ||
+      key === 'major'
+    ) {
+      return { label: 'Outage', className: 'outage' };
+    }
+    if (
+      key === 'minor_outage' ||
+      key === 'partial_outage' ||
+      key === 'degraded_performance' ||
+      key === 'partial' ||
+      key === 'degraded' ||
+      key === 'incident'
+    ) {
+      return { label: 'Degraded', className: 'degraded' };
+    }
+    if (key === 'maintenance' || key === 'maintenance_window') {
+      return { label: 'Maintenance', className: 'maintenance' };
+    }
+    if (key === 'operational' || key === 'none' || key === 'ok') {
+      return { label: 'Operational', className: 'operational' };
+    }
+    return { label: 'Unknown', className: 'unknown' };
+  }
+
+  function parseIncidentTimestamp(value) {
+    if (typeof value === 'number') {
+      return value;
+    }
+    if (value instanceof Date) {
+      return value.getTime();
+    }
+    var parsed = Date.parse(String(value || ''));
+    if (Number.isNaN(parsed)) {
+      return 0;
+    }
+    return parsed;
+  }
+
+  function getIncidentStartTs(incident) {
+    if (!incident || typeof incident !== 'object') {
+      return 0;
+    }
+    return parseIncidentTimestamp(
+      incident.started_at ||
+      incident.first_seen ||
+      incident.detected_at ||
+      incident.updated_at ||
+      incident.last_seen
+    );
+  }
+
+  function getIncidentUpdatedTs(incident) {
+    if (!incident || typeof incident !== 'object') {
+      return 0;
+    }
+    return parseIncidentTimestamp(incident.updated_at || incident.last_seen);
+  }
+
+  function severityRank(sev) {
+    var code = String(sev || '').toLowerCase();
+    if (code === 'outage' || code === 'major_outage' || code === 'major' || code === 'critical') {
+      return 4;
+    }
+    if (
+      code === 'degraded' ||
+      code === 'partial' ||
+      code === 'partial_outage' ||
+      code === 'degraded_performance' ||
+      code === 'incident'
+    ) {
+      return 3;
+    }
+    if (code === 'maintenance') {
+      return 2;
+    }
+    if (code === 'info') {
+      return 1;
+    }
+    return 0;
+  }
+
+  function normalizeIncidentTitle(value) {
+    var text = String(value || '').toLowerCase();
+    text = text.replace(/\bdetails\b/g, '');
+    text = text.replace(/([!?.:,;])\1+/g, '$1');
+    text = text.replace(/\s+/g, ' ').trim();
+    return text;
+  }
+
+  function dedupeIncidents(list) {
+    if (!Array.isArray(list)) {
+      return [];
+    }
+    var seen = {};
+    list.forEach(function (entry) {
+      if (!entry || typeof entry !== 'object') {
+        return;
+      }
+      var providerSlug = String(entry.provider_id || entry.provider || '').toLowerCase();
+      var titleKey = normalizeIncidentTitle(entry.summary || entry.title || '');
+      var startTs = getIncidentStartTs(entry);
+      var key = providerSlug + '|' + titleKey + '|' + Math.floor(startTs / 60000);
+      var updatedTs = getIncidentUpdatedTs(entry);
+      if (!seen[key] || getIncidentUpdatedTs(seen[key]) < updatedTs) {
+        seen[key] = entry;
+      }
+    });
+    return Object.keys(seen).map(function (key) {
+      return seen[key];
+    });
+  }
+
+  function formatHistoryDate(value) {
+    if (!value) {
+      return '';
+    }
+    var parsed = Date.parse(value + 'T00:00:00Z');
+    if (Number.isNaN(parsed)) {
+      return value;
+    }
+    try {
+      return new Intl.DateTimeFormat(undefined, {
+        month: 'short',
+        day: '2-digit',
+        year: 'numeric'
+      }).format(new Date(parsed));
+    } catch (err) {
+      return new Date(parsed).toISOString().slice(0, 10);
+    }
+  }
+
+  function formatIncidentCount(count) {
+    var safe = Number.isFinite(count) ? count : 0;
+    if (safe === 1) {
+      return '1 incident';
+    }
+    return safe + ' incidents';
+  }
+
+  function formatDateRange(meta) {
+    if (!meta) {
+      return '';
+    }
+    var startRaw = meta.window_start || meta.windowStart;
+    var endRaw = meta.window_end || meta.windowEnd;
+    if (!startRaw || !endRaw) {
+      return '';
+    }
+
+    var startDate = Date.parse(startRaw + 'T00:00:00Z');
+    var endDate = Date.parse(endRaw + 'T00:00:00Z');
+    if (Number.isNaN(startDate) || Number.isNaN(endDate)) {
+      return '';
+    }
+
+    var startObj = new Date(startDate);
+    var endObj = new Date(endDate);
+    var startYear = startObj.getUTCFullYear();
+    var endYear = endObj.getUTCFullYear();
+
+    var formatter = function (date, includeYear) {
+      try {
+        return new Intl.DateTimeFormat(undefined, {
+          month: 'short',
+          day: 'numeric',
+          year: includeYear ? 'numeric' : undefined
+        }).format(date);
+      } catch (err) {
+        var iso = date.toISOString().slice(0, 10);
+        return includeYear ? iso : iso.slice(5);
+      }
+    };
+
+    var startLabel = formatter(startObj, startYear !== endYear);
+    var endLabel = formatter(endObj, true);
+
+    return startLabel + ' – ' + endLabel;
+  }
+
+  function formatShortDate(dateStr, includeYear) {
+    if (!dateStr) {
+      return '';
+    }
+    var parsed = Date.parse(dateStr + 'T00:00:00Z');
+    if (Number.isNaN(parsed)) {
+      return dateStr;
+    }
+    try {
+      return new Intl.DateTimeFormat(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: includeYear ? 'numeric' : undefined
+      }).format(new Date(parsed));
+    } catch (err) {
+      var iso = new Date(parsed).toISOString().slice(0, 10);
+      return includeYear ? iso : iso.slice(5);
+    }
+  }
+
+  function buildDailySeries(counts, days) {
+    var today = new Date();
+    today.setUTCHours(0, 0, 0, 0);
+    var labels = [];
+    for (var i = days - 1; i >= 0; i -= 1) {
+      var dt = new Date(today.getTime() - i * 24 * 60 * 60 * 1000);
+      labels.push(dt.toISOString().slice(0, 10));
+    }
+
+    var values = labels.map(function (label) { return counts[label] || 0; });
+    var totalIncidents = 0;
+    var activeDays = 0;
+    var maxCount = 0;
+    var peakDate = '';
+
+    values.forEach(function (value, idx) {
+      totalIncidents += value;
+      if (value > 0) {
+        activeDays += 1;
+      }
+      if (value > maxCount) {
+        maxCount = value;
+        peakDate = labels[idx];
+      }
+    });
+
+    return {
+      labels: labels,
+      values: values,
+      totalIncidents: totalIncidents,
+      activeDays: activeDays,
+      maxCount: maxCount,
+      peakDate: peakDate
+    };
+  }
+
+  function buildTimelineMeta(series) {
+    var meta = state.doc.createElement('div');
+    meta.className = 'lo-history__meta';
+    if (!series || series.totalIncidents <= 0) {
+      meta.textContent = 'No incidents recorded during this window.';
+      return meta;
+    }
+    var dayLabel = series.labels.length === 1 ? 'day' : 'days';
+    var summary = formatIncidentCount(series.totalIncidents) + ' across ' + series.activeDays + ' of ' + series.labels.length + ' ' + dayLabel;
+    if (series.maxCount > 0 && series.peakDate) {
+      summary += ' (busiest: ' + formatShortDate(series.peakDate) + ' with ' + formatIncidentCount(series.maxCount) + ').';
+    } else {
+      summary += '.';
+    }
+    meta.textContent = summary;
+    return meta;
+  }
+
+  function resolveHistoryChartMode(windowDays) {
+    var stored = '';
+    if (state.root && state.root.localStorage) {
+      try {
+        stored = state.root.localStorage.getItem(HISTORY_CHART_MODE_KEY) || '';
+      } catch (err) {
+        stored = '';
+      }
+    }
+    if (stored === 'heatmap' || stored === 'bars' || stored === 'trend') {
+      return stored;
+    }
+    if (windowDays > 45) {
+      return 'heatmap';
+    }
+    if (windowDays <= 30) {
+      return 'bars';
+    }
+    return 'trend';
+  }
+
+  function persistHistoryChartMode(mode) {
+    if (!state.root || !state.root.localStorage) {
+      return;
+    }
+    try {
+      state.root.localStorage.setItem(HISTORY_CHART_MODE_KEY, mode);
+    } catch (err) {
+      // Ignore storage errors.
+    }
+  }
+
+  function renderHistoryCharts(providers, meta) {
+    if (!state.historyCharts || !state.doc) {
+      return;
+    }
+
+    state.historyCharts.innerHTML = '';
+    var chartData = getHistoryChartData();
+    var providerCounts = chartData ? chartData.providerCounts : null;
+    var dailyCounts = chartData ? chartData.dailyCounts : null;
+    var yoy = chartData ? chartData.yearOverYear : null;
+    var hasProviders = providerCounts && Object.keys(providerCounts).length > 0;
+    var hasDaily = dailyCounts && Object.keys(dailyCounts).length > 0;
+
+    if (!hasProviders && !hasDaily) {
+      state.historyCharts.setAttribute('hidden', 'hidden');
+      return;
+    }
+
+    state.historyCharts.removeAttribute('hidden');
+    var frag = state.doc.createDocumentFragment();
+
+    var subtitle = formatDateRange(meta || {});
+
+    if (hasDaily) {
+      var reportCard = buildHistoryReportCard(chartData, subtitle);
+      if (reportCard) {
+        frag.appendChild(reportCard);
+      }
+    }
+
+    if (hasProviders) {
+      var providerChart = buildBarChart(providerCounts, 'Incidents by provider', subtitle);
+      frag.appendChild(providerChart);
+    }
+
+    if (hasDaily) {
+      var timelineChart = buildTimelineSection(
+        dailyCounts,
+        (chartData && chartData.windowDays) || HISTORY_DEFAULT_DAYS,
+        subtitle
+      );
+      frag.appendChild(timelineChart);
+    }
+
+    if (yoy && yoy.current && yoy.previous) {
+      var yoyChart = buildYearOverYearChart(
+        yoy,
+        subtitle,
+        (chartData && chartData.windowDays) || HISTORY_DEFAULT_DAYS
+      );
+      if (yoyChart) {
+        frag.appendChild(yoyChart);
+      }
+    }
+
+    state.historyCharts.appendChild(frag);
+  }
+
+  function buildHistoryReportCard(chartData, subtitle) {
+    if (!chartData || !state.doc) {
+      return null;
+    }
+    var counts = chartData.dailyCounts || {};
+    var series = buildDailySeries(counts, chartData.windowDays || HISTORY_DEFAULT_DAYS);
+    var providerCounts = chartData.providerCounts || {};
+    var providers = Object.keys(providerCounts).map(function (key) {
+      return { label: key, value: providerCounts[key] || 0 };
+    }).sort(function (a, b) { return b.value - a.value; }).slice(0, 5);
+
+    var wrap = state.doc.createElement('div');
+    wrap.className = 'lo-history__report';
+
+    var heading = state.doc.createElement('div');
+    heading.className = 'lo-history__chart-title';
+    heading.textContent = 'Report Card';
+    wrap.appendChild(heading);
+
+    if (subtitle) {
+      var sub = state.doc.createElement('div');
+      sub.className = 'lo-history__subtitle';
+      sub.textContent = subtitle;
+      wrap.appendChild(sub);
+    }
+
+    var grid = state.doc.createElement('div');
+    grid.className = 'lo-history__report-grid';
+
+    var makeStat = function (label, value, subtext) {
+      var stat = state.doc.createElement('div');
+      stat.className = 'lo-history__report-stat';
+      var statLabel = state.doc.createElement('div');
+      statLabel.className = 'lo-history__report-label';
+      statLabel.textContent = label;
+      var statValue = state.doc.createElement('div');
+      statValue.className = 'lo-history__report-value';
+      statValue.textContent = value;
+      stat.appendChild(statLabel);
+      stat.appendChild(statValue);
+      if (subtext) {
+        var statSub = state.doc.createElement('div');
+        statSub.className = 'lo-history__report-sub';
+        statSub.textContent = subtext;
+        stat.appendChild(statSub);
+      }
+      return stat;
+    };
+
+    grid.appendChild(makeStat('Total incidents', formatIncidentCount(series.totalIncidents)));
+    grid.appendChild(makeStat('Active days', series.activeDays + ' / ' + series.labels.length));
+    if (series.maxCount > 0 && series.peakDate) {
+      grid.appendChild(makeStat('Peak day', formatShortDate(series.peakDate, true), formatIncidentCount(series.maxCount) + ' incidents'));
+    } else {
+      grid.appendChild(makeStat('Peak day', '—', 'No incidents yet'));
+    }
+
+    wrap.appendChild(grid);
+
+    var tableWrap = state.doc.createElement('div');
+    tableWrap.className = 'lo-history__report-table-wrap';
+    var tableTitle = state.doc.createElement('div');
+    tableTitle.className = 'lo-history__report-label';
+    tableTitle.textContent = 'Top 5 providers';
+    tableWrap.appendChild(tableTitle);
+
+    var table = state.doc.createElement('table');
+    table.className = 'lo-history__report-table';
+    var thead = state.doc.createElement('thead');
+    thead.innerHTML = '<tr><th scope="col">Provider</th><th scope="col">Incidents</th></tr>';
+    table.appendChild(thead);
+    var tbody = state.doc.createElement('tbody');
+
+    if (providers.length) {
+      providers.forEach(function (entry) {
+        var row = state.doc.createElement('tr');
+        var labelCell = state.doc.createElement('td');
+        labelCell.textContent = entry.label;
+        var valueCell = state.doc.createElement('td');
+        valueCell.textContent = String(entry.value);
+        row.appendChild(labelCell);
+        row.appendChild(valueCell);
+        tbody.appendChild(row);
+      });
+    } else {
+      var emptyRow = state.doc.createElement('tr');
+      var emptyCell = state.doc.createElement('td');
+      emptyCell.setAttribute('colspan', '2');
+      emptyCell.textContent = 'No incidents logged.';
+      emptyRow.appendChild(emptyCell);
+      tbody.appendChild(emptyRow);
+    }
+
+    table.appendChild(tbody);
+    tableWrap.appendChild(table);
+    wrap.appendChild(tableWrap);
+
+    return wrap;
+  }
+
+  function buildTimelineSection(counts, days, subtitle) {
+    var chartWrap = state.doc.createElement('div');
+    chartWrap.className = 'lo-history__chart lo-history__chart--timeline';
+    var heading = state.doc.createElement('div');
+    heading.className = 'lo-history__chart-title';
+    heading.textContent = 'Incidents over time';
+    chartWrap.appendChild(heading);
+    if (subtitle) {
+      var sub = state.doc.createElement('div');
+      sub.className = 'lo-history__subtitle';
+      sub.textContent = subtitle;
+      chartWrap.appendChild(sub);
+    }
+
+    var toggle = state.doc.createElement('div');
+    toggle.className = 'lo-history__view-toggle';
+
+    var buttons = {};
+    var modes = [
+      { mode: 'heatmap', label: 'Heatmap' },
+      { mode: 'bars', label: 'Bars' },
+      { mode: 'trend', label: 'Trend' }
+    ];
+
+    modes.forEach(function (entry) {
+      var button = state.doc.createElement('button');
+      button.type = 'button';
+      button.className = 'lo-history__view-button';
+      button.textContent = entry.label;
+      button.setAttribute('data-history-view', entry.mode);
+      button.setAttribute('aria-pressed', 'false');
+      toggle.appendChild(button);
+      buttons[entry.mode] = button;
+    });
+
+    chartWrap.appendChild(toggle);
+
+    var content = state.doc.createElement('div');
+    content.className = 'lo-history__chart-content';
+    chartWrap.appendChild(content);
+
+    var setActiveMode = function (mode) {
+      if (mode !== 'heatmap' && mode !== 'bars' && mode !== 'trend') {
+        mode = 'bars';
+      }
+      persistHistoryChartMode(mode);
+      Object.keys(buttons).forEach(function (key) {
+        var isActive = key === mode;
+        buttons[key].classList.toggle('is-active', isActive);
+        buttons[key].setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      });
+      clearChildren(content);
+      var chartBody = null;
+      if (mode === 'heatmap') {
+        chartBody = buildCalendarHeatmap(counts, days);
+      } else if (mode === 'trend') {
+        chartBody = buildTrendChart(counts, days);
+      } else {
+        chartBody = buildTimelineChart(counts, days);
+      }
+      if (chartBody) {
+        content.appendChild(chartBody);
+      }
+    };
+
+    var initialMode = resolveHistoryChartMode(days);
+    setActiveMode(initialMode);
+
+    Object.keys(buttons).forEach(function (mode) {
+      buttons[mode].addEventListener('click', function () {
+        setActiveMode(mode);
+      });
+    });
+
+    return chartWrap;
+  }
+
+  function buildBarChart(counts, title, subtitle) {
+    var chartWrap = state.doc.createElement('div');
+    chartWrap.className = 'lo-history__chart';
+    if (title) {
+      var heading = state.doc.createElement('div');
+      heading.className = 'lo-history__chart-title';
+      heading.textContent = title;
+      chartWrap.appendChild(heading);
+      if (subtitle) {
+        var sub = state.doc.createElement('div');
+        sub.className = 'lo-history__subtitle';
+        sub.textContent = subtitle;
+        chartWrap.appendChild(sub);
+      }
+    }
+
+    var entries = Object.keys(counts).map(function (key) {
+      return { label: key, value: counts[key] };
+    }).sort(function (a, b) { return b.value - a.value; }).slice(0, 8);
+    var max = entries.reduce(function (acc, item) { return Math.max(acc, item.value || 0); }, 0) || 1;
+    var width = Math.max(220, entries.length * 70);
+    var height = 160;
+    var topPadding = 30;
+    var bottomPadding = 30;
+    var barWidth = Math.floor((width - 20) / Math.max(entries.length, 1)) - 10;
+    var svg = state.doc.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 ' + width + ' ' + height);
+    svg.setAttribute('role', 'img');
+    svg.setAttribute('aria-label', 'Incidents by provider');
+
+    var yLabel = state.doc.createElementNS('http://www.w3.org/2000/svg', 'text');
+    yLabel.setAttribute('x', '6');
+    yLabel.setAttribute('y', '18');
+    yLabel.setAttribute('class', 'lo-history__chart-text');
+    yLabel.textContent = 'Incidents';
+    svg.appendChild(yLabel);
+
+    entries.forEach(function (entry, index) {
+      var x = 10 + index * (barWidth + 10);
+      var scaled = Math.max(4, Math.round(((entry.value || 0) / max) * (height - topPadding - bottomPadding)));
+      var y = height - bottomPadding - scaled;
+
+      var rect = state.doc.createElementNS('http://www.w3.org/2000/svg', 'rect');
+      rect.setAttribute('x', String(x));
+      rect.setAttribute('y', String(y));
+      rect.setAttribute('width', String(barWidth));
+      rect.setAttribute('height', String(scaled));
+      rect.setAttribute('class', 'lo-history__chart-bar');
+      rect.setAttribute('data-count', String(entry.value));
+      rect.setAttribute('data-label', entry.label);
+      var rectTitle = state.doc.createElementNS('http://www.w3.org/2000/svg', 'title');
+      rectTitle.textContent = entry.label + ' – ' + entry.value + ' incidents';
+      rect.appendChild(rectTitle);
+      svg.appendChild(rect);
+
+      if (scaled >= 20) {
+        var valueLabel = state.doc.createElementNS('http://www.w3.org/2000/svg', 'text');
+        valueLabel.setAttribute('x', String(x + (barWidth / 2)));
+        valueLabel.setAttribute('y', String(Math.max(topPadding, y - 6)));
+        valueLabel.setAttribute('text-anchor', 'middle');
+        valueLabel.setAttribute('class', 'lo-history__chart-text');
+        valueLabel.textContent = String(entry.value);
+        svg.appendChild(valueLabel);
+      }
+
+      var label = state.doc.createElementNS('http://www.w3.org/2000/svg', 'text');
+      label.setAttribute('x', String(x + (barWidth / 2)));
+      label.setAttribute('y', String(height - 12));
+      label.setAttribute('text-anchor', 'middle');
+      label.setAttribute('class', 'lo-history__chart-text');
+      label.textContent = entry.label.length > 8 ? entry.label.slice(0, 8) + '…' : entry.label;
+      svg.appendChild(label);
+    });
+
+    chartWrap.appendChild(svg);
+    return chartWrap;
+  }
+
+  function buildTimelineChart(counts, days) {
+    var chartBody = state.doc.createElement('div');
+    chartBody.className = 'lo-history__chart-body';
+
+    var series = buildDailySeries(counts, days);
+    var labels = series.labels;
+    var values = series.values;
+
+    chartBody.appendChild(buildTimelineMeta(series));
+
+    var tooltip = null;
+    try {
+      tooltip = state.doc.createElement('div');
+      tooltip.className = 'lo-history__chart-tooltip';
+      tooltip.setAttribute('role', 'status');
+      tooltip.setAttribute('aria-live', 'polite');
+      tooltip.textContent = 'Hover or focus a bar to see details.';
+      chartBody.appendChild(tooltip);
+    } catch (err) {
+      tooltip = null;
+    }
+
+    var max = values.reduce(function (acc, val) { return Math.max(acc, val); }, 0) || 1;
+    var width = Math.max(240, labels.length * 10);
+    var height = 170;
+    var topPadding = 28;
+    var bottomPadding = 36;
+    var gap = 2;
+    var barWidth = Math.max(2, Math.floor((width - 16 - ((labels.length - 1) * gap)) / Math.max(labels.length, 1)));
+    var stepX = barWidth + gap;
+
+    var svg = state.doc.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 ' + width + ' ' + height);
+    svg.setAttribute('role', 'img');
+    svg.setAttribute('aria-label', 'Incidents over time');
+
+    var yAxisLabel = state.doc.createElementNS('http://www.w3.org/2000/svg', 'text');
+    yAxisLabel.setAttribute('x', '6');
+    yAxisLabel.setAttribute('y', '18');
+    yAxisLabel.setAttribute('class', 'lo-history__chart-text');
+    yAxisLabel.textContent = 'Incidents per day';
+    svg.appendChild(yAxisLabel);
+
+    var tickIndices = [];
+    labels.forEach(function (label, idx) {
+      if (idx === 0 || idx === labels.length - 1) {
+        tickIndices.push(idx);
+        return;
+      }
+      var parsed = Date.parse(label + 'T00:00:00Z');
+      if (Number.isNaN(parsed)) {
+        return;
+      }
+      var date = new Date(parsed);
+      if (days > 45) {
+        if (date.getUTCDate() === 1) {
+          tickIndices.push(idx);
+        }
+      } else if (date.getUTCDay() === 0) {
+        tickIndices.push(idx);
+      }
+    });
+
+    if (tickIndices.length < 4) {
+      var fallbackStep = Math.max(1, Math.ceil(labels.length / 6));
+      for (var i = 0; i < labels.length; i += fallbackStep) {
+        tickIndices.push(i);
+      }
+    }
+
+    tickIndices = tickIndices.filter(function (value, idx, arr) {
+      return arr.indexOf(value) === idx;
+    }).sort(function (a, b) { return a - b; });
+
+    if (tickIndices.length > 8) {
+      var dropStep = Math.ceil(tickIndices.length / 8);
+      tickIndices = tickIndices.filter(function (_, idx) { return idx % dropStep === 0; });
+      if (tickIndices[tickIndices.length - 1] !== labels.length - 1) {
+        tickIndices.push(labels.length - 1);
+      }
+    }
+
+    labels.forEach(function (label, idx) {
+      var x = 8 + idx * stepX;
+      var scaled = Math.max(2, Math.round((values[idx] / max) * (height - topPadding - bottomPadding)));
+      var y = height - bottomPadding - scaled;
+      var rect = state.doc.createElementNS('http://www.w3.org/2000/svg', 'rect');
+      rect.setAttribute('x', String(x));
+      rect.setAttribute('y', String(y));
+      rect.setAttribute('width', String(barWidth));
+      rect.setAttribute('height', String(scaled));
+      rect.setAttribute('class', 'lo-history__chart-bar lo-history__chart-bar--thin');
+      rect.setAttribute('tabindex', '0');
+      var friendlyLabel = formatShortDate(label);
+      rect.setAttribute('aria-label', friendlyLabel + ': ' + formatIncidentCount(values[idx]));
+      var barTitle = state.doc.createElementNS('http://www.w3.org/2000/svg', 'title');
+      barTitle.textContent = label + ' – ' + values[idx] + ' incidents';
+      rect.appendChild(barTitle);
+
+      var activateBar = function () {
+        if (tooltip) {
+          tooltip.textContent = friendlyLabel + ': ' + formatIncidentCount(values[idx]);
+        }
+        rect.classList.add('lo-history__chart-bar--active');
+      };
+
+      var deactivateBar = function () {
+        if (tooltip) {
+          tooltip.textContent = 'Hover or focus a bar to see details.';
+        }
+        rect.classList.remove('lo-history__chart-bar--active');
+      };
+
+      rect.addEventListener('mouseenter', activateBar);
+      rect.addEventListener('focus', activateBar);
+      rect.addEventListener('mouseleave', deactivateBar);
+      rect.addEventListener('blur', deactivateBar);
+
+      svg.appendChild(rect);
+
+      if (days <= 21 && scaled > 12 && values[idx] > 0) {
+        var countLabel = state.doc.createElementNS('http://www.w3.org/2000/svg', 'text');
+        countLabel.setAttribute('x', String(x + (barWidth / 2)));
+        countLabel.setAttribute('y', String(Math.max(topPadding, y - 3)));
+        countLabel.setAttribute('text-anchor', 'middle');
+        countLabel.setAttribute('class', 'lo-history__chart-text');
+        countLabel.textContent = String(values[idx]);
+        svg.appendChild(countLabel);
+      }
+
+      if (tickIndices.indexOf(idx) !== -1) {
+        var tick = state.doc.createElementNS('http://www.w3.org/2000/svg', 'text');
+        tick.setAttribute('x', String(x + (barWidth / 2)));
+        tick.setAttribute('y', String(height - 12));
+        tick.setAttribute('text-anchor', 'middle');
+        tick.setAttribute('class', 'lo-history__chart-text');
+        tick.textContent = formatShortDate(label);
+        svg.appendChild(tick);
+      }
+    });
+
+    chartBody.appendChild(svg);
+    return chartBody;
+  }
+
+  function buildCalendarHeatmap(counts, days) {
+    var chartBody = state.doc.createElement('div');
+    chartBody.className = 'lo-history__chart-body';
+
+    var series = buildDailySeries(counts, days);
+    chartBody.appendChild(buildTimelineMeta(series));
+
+    var tooltip = null;
+    try {
+      tooltip = state.doc.createElement('div');
+      tooltip.className = 'lo-history__chart-tooltip';
+      tooltip.setAttribute('role', 'status');
+      tooltip.setAttribute('aria-live', 'polite');
+      tooltip.textContent = 'Hover or focus a day to see details.';
+      chartBody.appendChild(tooltip);
+    } catch (err) {
+      tooltip = null;
+    }
+
+    var cellSize = 12;
+    var gap = 3;
+    var padding = 12;
+    var startDate = new Date();
+    startDate.setUTCHours(0, 0, 0, 0);
+    startDate = new Date(startDate.getTime() - (days - 1) * 24 * 60 * 60 * 1000);
+    var leading = startDate.getUTCDay();
+    var totalCells = leading + series.labels.length;
+    var weeks = Math.ceil(totalCells / 7);
+    var width = padding * 2 + weeks * (cellSize + gap) - gap;
+    var height = padding * 2 + 7 * (cellSize + gap) - gap;
+
+    var svg = state.doc.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 ' + width + ' ' + height);
+    svg.setAttribute('role', 'img');
+    svg.setAttribute('aria-label', 'Incident heatmap');
+
+    series.labels.forEach(function (label, idx) {
+      var cellIndex = leading + idx;
+      var col = Math.floor(cellIndex / 7);
+      var row = cellIndex % 7;
+      var x = padding + col * (cellSize + gap);
+      var y = padding + row * (cellSize + gap);
+      var value = series.values[idx] || 0;
+      var intensity = 0;
+      if (series.maxCount > 0 && value > 0) {
+        var ratio = value / series.maxCount;
+        if (ratio <= 0.25) {
+          intensity = 1;
+        } else if (ratio <= 0.5) {
+          intensity = 2;
+        } else if (ratio <= 0.75) {
+          intensity = 3;
+        } else {
+          intensity = 4;
+        }
+      }
+
+      var rect = state.doc.createElementNS('http://www.w3.org/2000/svg', 'rect');
+      rect.setAttribute('x', String(x));
+      rect.setAttribute('y', String(y));
+      rect.setAttribute('width', String(cellSize));
+      rect.setAttribute('height', String(cellSize));
+      rect.setAttribute('rx', '2');
+      rect.setAttribute('class', 'lo-heatmap__cell lo-heatmap__cell--level-' + intensity);
+      rect.setAttribute('tabindex', '0');
+      rect.setAttribute('aria-label', formatShortDate(label) + ': ' + formatIncidentCount(value));
+      var cellTitle = state.doc.createElementNS('http://www.w3.org/2000/svg', 'title');
+      cellTitle.textContent = label + ' – ' + value + ' incidents';
+      rect.appendChild(cellTitle);
+
+      var activateCell = function () {
+        if (tooltip) {
+          tooltip.textContent = formatShortDate(label) + ': ' + formatIncidentCount(value);
+        }
+        rect.classList.add('lo-heatmap__cell--active');
+      };
+
+      var deactivateCell = function () {
+        if (tooltip) {
+          tooltip.textContent = 'Hover or focus a day to see details.';
+        }
+        rect.classList.remove('lo-heatmap__cell--active');
+      };
+
+      rect.addEventListener('mouseenter', activateCell);
+      rect.addEventListener('focus', activateCell);
+      rect.addEventListener('mouseleave', deactivateCell);
+      rect.addEventListener('blur', deactivateCell);
+
+      svg.appendChild(rect);
+    });
+
+    chartBody.appendChild(svg);
+
+    var legend = state.doc.createElement('div');
+    legend.className = 'lo-heatmap__legend';
+    legend.innerHTML = [
+      '<span class="lo-heatmap__legend-label">0</span>',
+      '<span class="lo-heatmap__swatch lo-heatmap__cell--level-0" aria-hidden="true"></span>',
+      '<span class="lo-heatmap__swatch lo-heatmap__cell--level-1" aria-hidden="true"></span>',
+      '<span class="lo-heatmap__swatch lo-heatmap__cell--level-2" aria-hidden="true"></span>',
+      '<span class="lo-heatmap__swatch lo-heatmap__cell--level-3" aria-hidden="true"></span>',
+      '<span class="lo-heatmap__swatch lo-heatmap__cell--level-4" aria-hidden="true"></span>',
+      '<span class="lo-heatmap__legend-label">Peak</span>'
+    ].join('');
+    chartBody.appendChild(legend);
+
+    var peak = state.doc.createElement('div');
+    peak.className = 'lo-history__meta lo-heatmap__peak';
+    if (series.maxCount > 0 && series.peakDate) {
+      peak.textContent = 'Peak day: ' + formatShortDate(series.peakDate, true) + ' (' + formatIncidentCount(series.maxCount) + ').';
+    } else {
+      peak.textContent = 'Peak day: none yet.';
+    }
+    chartBody.appendChild(peak);
+
+    return chartBody;
+  }
+
+  function buildTrendChart(counts, days) {
+    var chartBody = state.doc.createElement('div');
+    chartBody.className = 'lo-history__chart-body';
+
+    var series = buildDailySeries(counts, days);
+    chartBody.appendChild(buildTimelineMeta(series));
+
+    var tooltip = null;
+    try {
+      tooltip = state.doc.createElement('div');
+      tooltip.className = 'lo-history__chart-tooltip';
+      tooltip.setAttribute('role', 'status');
+      tooltip.setAttribute('aria-live', 'polite');
+      tooltip.textContent = 'Hover or focus a point to see details.';
+      chartBody.appendChild(tooltip);
+    } catch (err) {
+      tooltip = null;
+    }
+
+    var rolling = series.values.map(function (_, idx) {
+      var start = Math.max(0, idx - 6);
+      var sum = 0;
+      for (var i = start; i <= idx; i++) {
+        sum += series.values[i] || 0;
+      }
+      var count = idx - start + 1;
+      return sum / count;
+    });
+
+    var max = rolling.reduce(function (acc, val) { return Math.max(acc, val); }, 0) || 1;
+    var width = Math.max(240, series.labels.length * 10);
+    var height = 170;
+    var topPadding = 28;
+    var bottomPadding = 30;
+    var plotHeight = height - topPadding - bottomPadding;
+    var plotWidth = width - 16;
+    var stepX = plotWidth / Math.max(series.labels.length - 1, 1);
+
+    var svg = state.doc.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 ' + width + ' ' + height);
+    svg.setAttribute('role', 'img');
+    svg.setAttribute('aria-label', '7-day rolling average trend');
+
+    var axisLabel = state.doc.createElementNS('http://www.w3.org/2000/svg', 'text');
+    axisLabel.setAttribute('x', '6');
+    axisLabel.setAttribute('y', '18');
+    axisLabel.setAttribute('class', 'lo-history__chart-text');
+    axisLabel.textContent = '7-day rolling avg';
+    svg.appendChild(axisLabel);
+
+    var line = state.doc.createElementNS('http://www.w3.org/2000/svg', 'polyline');
+    var points = rolling.map(function (value, idx) {
+      var x = 8 + idx * stepX;
+      var y = height - bottomPadding - ((value / max) * plotHeight);
+      return x + ',' + y;
+    }).join(' ');
+    line.setAttribute('points', points);
+    line.setAttribute('class', 'lo-trend__line');
+    svg.appendChild(line);
+
+    var tickIndices = [0, series.labels.length - 1];
+    series.labels.forEach(function (label, idx) {
+      if (idx === 0 || idx === series.labels.length - 1) {
+        return;
+      }
+      var parsed = Date.parse(label + 'T00:00:00Z');
+      if (Number.isNaN(parsed)) {
+        return;
+      }
+      var date = new Date(parsed);
+      if (date.getUTCDate() === 1) {
+        tickIndices.push(idx);
+      }
+    });
+
+    tickIndices = tickIndices.filter(function (value, idx, arr) {
+      return arr.indexOf(value) === idx;
+    }).sort(function (a, b) { return a - b; });
+
+    if (tickIndices.length > 6) {
+      var reduceStep = Math.ceil(tickIndices.length / 6);
+      tickIndices = tickIndices.filter(function (_, idx) { return idx % reduceStep === 0; });
+    }
+
+    tickIndices.forEach(function (idx) {
+      var tickLabel = state.doc.createElementNS('http://www.w3.org/2000/svg', 'text');
+      tickLabel.setAttribute('x', String(8 + idx * stepX));
+      tickLabel.setAttribute('y', String(height - 10));
+      tickLabel.setAttribute('text-anchor', idx === 0 ? 'start' : (idx === series.labels.length - 1 ? 'end' : 'middle'));
+      tickLabel.setAttribute('class', 'lo-history__chart-text');
+      tickLabel.textContent = formatShortDate(series.labels[idx]);
+      svg.appendChild(tickLabel);
+    });
+
+    rolling.forEach(function (value, idx) {
+      var x = 8 + idx * stepX;
+      var y = height - bottomPadding - ((value / max) * plotHeight);
+      var point = state.doc.createElementNS('http://www.w3.org/2000/svg', 'circle');
+      point.setAttribute('cx', String(x));
+      point.setAttribute('cy', String(y));
+      point.setAttribute('r', '3');
+      point.setAttribute('class', 'lo-trend__point');
+      point.setAttribute('tabindex', '0');
+      var avgText = value ? value.toFixed(1) : '0.0';
+      point.setAttribute('aria-label', formatShortDate(series.labels[idx]) + ': ' + formatIncidentCount(series.values[idx]) + ' (avg ' + avgText + ')');
+      var pointTitle = state.doc.createElementNS('http://www.w3.org/2000/svg', 'title');
+      pointTitle.textContent = series.labels[idx] + ' – ' + series.values[idx] + ' incidents (avg ' + avgText + ')';
+      point.appendChild(pointTitle);
+
+      var activatePoint = function () {
+        if (tooltip) {
+          tooltip.textContent = formatShortDate(series.labels[idx]) + ': ' + formatIncidentCount(series.values[idx]) + ' (avg ' + avgText + ')';
+        }
+        point.classList.add('lo-trend__point--active');
+      };
+
+      var deactivatePoint = function () {
+        if (tooltip) {
+          tooltip.textContent = 'Hover or focus a point to see details.';
+        }
+        point.classList.remove('lo-trend__point--active');
+      };
+
+      point.addEventListener('mouseenter', activatePoint);
+      point.addEventListener('focus', activatePoint);
+      point.addEventListener('mouseleave', deactivatePoint);
+      point.addEventListener('blur', deactivatePoint);
+
+      svg.appendChild(point);
+    });
+
+    chartBody.appendChild(svg);
+    return chartBody;
+  }
+
+  function buildYearOverYearChart(comparison, subtitle, days) {
+    if (!comparison || !comparison.current || !comparison.previous || !state.doc) {
+      return null;
+    }
+
+    var windowDays = Number.isFinite(days) && days > 0 ? days : HISTORY_DEFAULT_DAYS;
+    var chartWrap = state.doc.createElement('div');
+    chartWrap.className = 'lo-history__chart';
+
+    var heading = state.doc.createElement('div');
+    heading.className = 'lo-history__chart-title';
+    heading.textContent = 'Year-over-year incident pulse';
+    chartWrap.appendChild(heading);
+
+    if (subtitle) {
+      var sub = state.doc.createElement('div');
+      sub.className = 'lo-history__subtitle';
+      sub.textContent = subtitle;
+      chartWrap.appendChild(sub);
+    }
+
+    var canvas = state.doc.createElement('canvas');
+    var width = 560;
+    var height = 240;
+    canvas.width = width;
+    canvas.height = height;
+    canvas.setAttribute('role', 'img');
+    canvas.setAttribute('aria-label', 'Year-over-year incident comparison');
+
+    var ctx = canvas.getContext && canvas.getContext('2d');
+    if (!ctx) {
+      chartWrap.appendChild(canvas);
+      return chartWrap;
+    }
+
+    ctx.imageSmoothingEnabled = false;
+    ctx.fillStyle = '#050510';
+    ctx.fillRect(0, 0, width, height);
+
+    var plotPadding = 36;
+    var plotWidth = width - (plotPadding * 2);
+    var plotHeight = height - (plotPadding * 2);
+    var baseX = plotPadding;
+    var baseY = height - plotPadding;
+
+    ctx.strokeStyle = 'rgba(42, 255, 213, 0.15)';
+    for (var gx = 0; gx <= plotWidth; gx += 20) {
+      ctx.beginPath();
+      ctx.moveTo(baseX + gx, baseY - plotHeight);
+      ctx.lineTo(baseX + gx, baseY);
+      ctx.stroke();
+    }
+    for (var gy = 0; gy <= plotHeight; gy += 20) {
+      ctx.beginPath();
+      ctx.moveTo(baseX, baseY - gy);
+      ctx.lineTo(baseX + plotWidth, baseY - gy);
+      ctx.stroke();
+    }
+
+    var seriesCurrent = buildSeries(windowDays, comparison.current);
+    var seriesPrevious = buildSeries(windowDays, comparison.previous);
+    var maxCurrent = seriesCurrent.reduce(function (acc, val) { return Math.max(acc, val); }, 0);
+    var maxPrevious = seriesPrevious.reduce(function (acc, val) { return Math.max(acc, val); }, 0);
+    var maxValue = Math.max(1, maxCurrent, maxPrevious);
+    var stepX = plotWidth / Math.max(windowDays - 1, 1);
+
+    var drawSeries = function (series, color, glowColor) {
+      ctx.strokeStyle = glowColor;
+      ctx.lineWidth = 4;
+      ctx.beginPath();
+      series.forEach(function (value, idx) {
+        var x = baseX + (idx * stepX);
+        var y = baseY - ((value / maxValue) * plotHeight);
+        if (idx === 0) {
+          ctx.moveTo(x, y);
+        } else {
+          ctx.lineTo(x, y);
+        }
+      });
+      ctx.stroke();
+
+      ctx.strokeStyle = color;
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      series.forEach(function (value, idx) {
+        var x = baseX + (idx * stepX);
+        var y = baseY - ((value / maxValue) * plotHeight);
+        if (idx === 0) {
+          ctx.moveTo(x, y);
+        } else {
+          ctx.lineTo(x, y);
+        }
+        ctx.fillStyle = color;
+        ctx.fillRect(x - 3, y - 3, 6, 6);
+      });
+      ctx.stroke();
+    };
+
+    drawSeries(seriesPrevious, '#00c2ff', 'rgba(0, 194, 255, 0.35)');
+    drawSeries(seriesCurrent, '#ff2fb3', 'rgba(255, 47, 179, 0.35)');
+
+    var legend = state.doc.createElement('div');
+    legend.className = 'lo-retro-legend';
+    legend.innerHTML = [
+      '<span class="lo-retro-legend__swatch" style="background:#ff2fb3;"></span>Current window',
+      '<span class="lo-retro-legend__swatch" style="background:#00c2ff;"></span>Previous year'
+    ].join(' ');
+
+    var delta = (comparison.current.total || 0) - (comparison.previous.total || 0);
+    var deltaText = state.doc.createElement('div');
+    deltaText.className = 'lo-history__subtitle';
+    var deltaLabel = delta === 0 ? 'matches last year' : (delta > 0 ? '+' + delta + ' vs last year' : delta + ' vs last year');
+    deltaText.textContent = 'Total incidents: ' + (comparison.current.total || 0) + ' (' + deltaLabel + ').';
+
+    chartWrap.appendChild(canvas);
+    chartWrap.appendChild(legend);
+    chartWrap.appendChild(deltaText);
+
+    return chartWrap;
+  }
+
+  function buildSeries(days, windowData) {
+    var series = [];
+    var counts = windowData && windowData.daily_counts && typeof windowData.daily_counts === 'object'
+      ? windowData.daily_counts
+      : {};
+    var start = windowData && windowData.start ? Date.parse(windowData.start + 'T00:00:00Z') : NaN;
+
+    for (var i = 0; i < days; i++) {
+      var dateKey;
+      if (!Number.isNaN(start)) {
+        var dateObj = new Date(start + (i * 24 * 60 * 60 * 1000));
+        dateKey = dateObj.toISOString().slice(0, 10);
+      }
+      series.push(counts[dateKey] || 0);
+    }
+
+    return series;
+  }
+
+  function setHistoryLoading() {
+    if (!state.historyList || !state.doc) {
+      return;
+    }
+    state.historyList.innerHTML = '';
+    var placeholder = state.doc.createElement('li');
+    placeholder.className = 'lo-history__item lo-history__item--placeholder';
+    placeholder.textContent = 'Loading incidents…';
+    state.historyList.appendChild(placeholder);
+    if (state.historyEmpty) {
+      state.historyEmpty.setAttribute('hidden', 'hidden');
+    }
+    if (state.historyError) {
+      state.historyError.setAttribute('hidden', 'hidden');
+    }
+    if (state.historyCharts) {
+      state.historyCharts.innerHTML = '';
+      state.historyCharts.setAttribute('hidden', 'hidden');
+    }
+  }
+
+  function renderHistoryList(providers, meta) {
+    if (!state.historyList || !state.doc) {
+      return;
+    }
+    state.historyList.innerHTML = '';
+    state.historyIncidents = [];
+    if (state.historyToggleButton && state.historyToggleButton.parentNode) {
+      state.historyToggleButton.parentNode.removeChild(state.historyToggleButton);
+    }
+    state.historyToggleButton = null;
+    if (state.historyError) {
+      state.historyError.setAttribute('hidden', 'hidden');
+    }
+
+    renderHistoryCharts(providers, meta || {});
+
+    var providerList = Array.isArray(providers) ? providers : [];
+    var prefs = state.visibleProviders || {};
+    var hasPrefs = Object.keys(prefs).length > 0;
+
+    var incidentEntries = [];
+
+    providerList.forEach(function (provider) {
+      if (!provider || typeof provider !== 'object') {
+        return;
+      }
+      var slug = String(provider.id || '').toLowerCase();
+      if (slug && hasPrefs && prefs[slug] === false) {
+        return;
+      }
+      var label = provider.label || provider.name || provider.provider || 'Provider';
+      if (Array.isArray(provider.incidents)) {
+        provider.incidents.forEach(function (entry) {
+          if (!entry || typeof entry !== 'object') {
+            return;
+          }
+          var status = entry && entry.status ? String(entry.status).toLowerCase() : '';
+          if (status === 'operational' || status === 'ok' || status === 'none') {
+            return;
+          }
+          incidentEntries.push({
+            provider: entry.provider || label,
+            provider_id: slug,
+            summary: entry.summary || entry.title || '',
+            status: status || 'unknown',
+            severity: (entry.severity || '').toString(),
+            started_at: entry.started_at || entry.startedAt || null,
+            first_seen: entry.first_seen || entry.firstSeen || null,
+            detected_at: entry.detected_at || entry.detectedAt || null,
+            last_seen: entry.last_seen || entry.lastSeen || null,
+            updated_at: entry.updated_at || entry.updatedAt || null,
+            url: entry.url || ''
+          });
+        });
+      }
+    });
+
+    incidentEntries = dedupeIncidents(incidentEntries);
+
+    incidentEntries.sort(function (a, b) {
+      var aStart = getIncidentStartTs(a);
+      var bStart = getIncidentStartTs(b);
+      if (aStart !== bStart) {
+        return bStart - aStart;
+      }
+      var aUpdated = getIncidentUpdatedTs(a);
+      var bUpdated = getIncidentUpdatedTs(b);
+      if (aUpdated !== bUpdated) {
+        return bUpdated - aUpdated;
+      }
+      return severityRank(b.severity || b.status) - severityRank(a.severity || a.status);
+    });
+
+    state.historyIncidents = incidentEntries.slice();
+
+    if (incidentEntries.length) {
+      if (state.historyEmpty) {
+        state.historyEmpty.setAttribute('hidden', 'hidden');
+      }
+
+      var displayLimit = state.historyExpanded ? HISTORY_LIMIT : HISTORY_RENDER_LIMIT;
+      var displayEntries = incidentEntries.slice(0, displayLimit);
+
+      displayEntries.forEach(function (entry) {
+        var li = state.doc.createElement('li');
+        li.className = 'lo-history__item';
+
+        var timeWrap = state.doc.createElement('div');
+        timeWrap.className = 'lo-history__time';
+        var started = entry.started_at || entry.first_seen || entry.detected_at || entry.updated_at || entry.last_seen;
+        var timeEl = state.doc.createElement('time');
+        timeEl.setAttribute('datetime', started || '');
+        timeEl.textContent = formatTimestamp(started) || formatHistoryDate(started);
+        timeWrap.appendChild(timeEl);
+
+        if (entry.last_seen && entry.last_seen !== entry.first_seen) {
+          var range = state.doc.createElement('span');
+          range.className = 'lo-history__time-range';
+          range.textContent = 'Updated ' + formatTimestamp(entry.last_seen);
+          timeWrap.appendChild(range);
+        }
+
+        var details = state.doc.createElement('div');
+        details.className = 'lo-history__details';
+        var providerName = entry.provider || 'Provider';
+        var providerLabelEl = state.doc.createElement('strong');
+        providerLabelEl.textContent = providerName;
+        details.appendChild(providerLabelEl);
+        var summaryText = entry.summary || 'Incident reported';
+        var condensedSummary = condenseIncidentTitle(entry.provider_id, summaryText);
+        details.appendChild(state.doc.createTextNode(' — '));
+        var summaryEl = state.doc.createElement('span');
+        summaryEl.className = 'lo-history__summary';
+        summaryEl.textContent = condensedSummary.text || summaryText;
+        if (condensedSummary.title && condensedSummary.title !== condensedSummary.text) {
+          summaryEl.setAttribute('title', condensedSummary.title);
+        }
+        details.appendChild(summaryEl);
+        if (entry.url) {
+          var link = state.doc.createElement('a');
+          link.href = entry.url;
+          link.target = '_blank';
+          link.rel = 'noopener';
+          link.className = 'lo-link';
+          link.textContent = 'Details';
+          details.appendChild(state.doc.createTextNode(' '));
+          details.appendChild(link);
+        }
+
+        var badge = state.doc.createElement('span');
+        var mapped = mapHistoryStatus(entry.status);
+        badge.className = 'lo-pill ' + mapped.className + ' lo-history__badge';
+        badge.textContent = mapped.label;
+
+        li.appendChild(timeWrap);
+        li.appendChild(details);
+        li.appendChild(badge);
+
+        state.historyList.appendChild(li);
+      });
+
+      if (incidentEntries.length > HISTORY_RENDER_LIMIT && state.historyList.parentNode) {
+        var toggle = state.doc.createElement('button');
+        toggle.type = 'button';
+        toggle.className = 'lo-button lo-history__toggle';
+        toggle.textContent = state.historyExpanded ? 'Show fewer' : 'Show more';
+        toggle.addEventListener('click', function () {
+          state.historyExpanded = !state.historyExpanded;
+          renderHistoryList(state.historyProviders, state.historyMeta);
+        });
+        state.historyToggleButton = toggle;
+        state.historyList.parentNode.appendChild(toggle);
+      }
+
+      return;
+    }
+
+    if (state.historyEmpty) {
+      state.historyEmpty.textContent = state.historyImportantOnly
+        ? 'No significant incidents in the selected window.'
+        : 'No incidents in the selected window.';
+      state.historyEmpty.removeAttribute('hidden');
+    }
+  }
+
+  function renderHistoryError(message) {
+    if (state.historyList) {
+      state.historyList.innerHTML = '';
+    }
+    if (state.historyEmpty) {
+      state.historyEmpty.setAttribute('hidden', 'hidden');
+    }
+    if (state.historyError) {
+      state.historyError.textContent = message || 'Unable to load incidents right now.';
+      state.historyError.removeAttribute('hidden');
+    }
+  }
+
+  function fetchHistoryData() {
+    if (!state.historyEndpoint || !state.fetchImpl) {
+      return Promise.resolve();
+    }
+    setHistoryLoading();
+
+    var providerIds = [];
+    var cards = state.container ? state.container.querySelectorAll('[data-provider-id], .provider-card') : [];
+    if (cards && cards.length) {
+      cards.forEach(function (card) {
+        var slug = card.getAttribute ? card.getAttribute('data-provider-id') || card.getAttribute('data-id') : null;
+        if (slug) {
+          providerIds.push(String(slug));
+        }
+      });
+    }
+    var prefs = state.visibleProviders || {};
+    var hasPrefs = Object.keys(prefs).length > 0;
+    if (hasPrefs && providerIds.length) {
+      providerIds = providerIds.filter(function (id) {
+        return prefs[String(id).toLowerCase()] !== false;
+      });
+    }
+    if (hasPrefs) {
+      var hasOther = providerIds.some(function (id) {
+        return String(id).toLowerCase() === 'other';
+      });
+      if (!hasOther) {
+        providerIds.push('other');
+      }
+    }
+
+    var windowDays = Number.isFinite(state.historyWindowDays) && state.historyWindowDays > 0
+      ? state.historyWindowDays
+      : HISTORY_DEFAULT_DAYS;
+    var url = appendQuery(state.historyEndpoint, 'days', String(windowDays));
+    url = appendQuery(url, 'limit', String(HISTORY_LIMIT));
+    url = appendQuery(url, 'severity', state.historyImportantOnly ? 'important' : 'all');
+    if (hasPrefs && providerIds.length) {
+      url = appendQuery(url, 'provider', providerIds.join(','));
+    }
+
+    return state.fetchImpl(url, { headers: { Accept: 'application/json' } })
+      .then(function (res) {
+        if (!res || !res.ok) {
+          throw new Error('history unavailable');
+        }
+        return res.json();
+      })
+      .then(function (body) {
+        if (!body || !Array.isArray(body.providers)) {
+          throw new Error('invalid history response');
+        }
+
+        state.historyProviders = body.providers;
+        state.historyMeta = body.meta || {};
+        state.historyExpanded = false;
+        renderHistoryList(body.providers, body.meta || {});
+      })
+      .catch(function (err) {
+        if (state.debug && state.root && state.root.console && typeof state.root.console.error === 'function') {
+          state.root.console.error(err);
+        }
+        state.historyIncidents = [];
+        renderHistoryError('Unable to load incident history right now.');
+      });
+  }
+
+  function handleSubscribeSubmit(event) {
+    event.preventDefault();
+    var form = event.currentTarget;
+    if (!form) {
+      return;
+    }
+    var statusEl = form.querySelector('[data-lo-subscribe-status]');
+    var emailInput = form.querySelector('input[name="email"]');
+    var honeypot = form.querySelector('input[name="website"]');
+    var nonceInput = form.querySelector('input[name="_wpnonce"]');
+    var challengeInput = form.querySelector('input[name="challenge_response"]');
+    var providerInputs = form.querySelectorAll('input[name="providers[]"]:checked');
+    var realtimeInput = form.querySelector('input[name="realtime_alerts"]');
+    var digestInput = form.querySelector('input[name="daily_digest"]');
+    var newsletterInput = form.querySelector('input[name="newsletter"]');
+    var endpoint = form.getAttribute('action') || state.subscribeEndpoint;
+    if (!endpoint || !state.fetchImpl) {
+      return;
+    }
+    var email = emailInput ? emailInput.value.trim() : '';
+    if (!email) {
+      setSubscribeStatus(statusEl, 'Please enter your email.', true);
+      return;
+    }
+    if (honeypot && honeypot.value) {
+      setSubscribeStatus(statusEl, 'Submission blocked.', true);
+      return;
+    }
+    if (!challengeInput || !challengeInput.value.trim()) {
+      setSubscribeStatus(statusEl, 'Please answer the human check.', true);
+      return;
+    }
+    setSubscribeStatus(statusEl, 'Sending…');
+    form.querySelectorAll('button, input[type="submit"]').forEach(function (btn) {
+      btn.disabled = true;
+    });
+    var payload = {
+      email: email,
+      website: honeypot ? honeypot.value : '',
+      _wpnonce: nonceInput ? nonceInput.value : '',
+      challenge_response: challengeInput ? challengeInput.value.trim() : '',
+      providers: Array.prototype.map.call(providerInputs || [], function (input) { return input.value; }),
+      realtime_alerts: !!(realtimeInput && realtimeInput.checked),
+      daily_digest: !!(digestInput && digestInput.checked),
+      newsletter: !!(newsletterInput && newsletterInput.checked)
+    };
+
+    state.fetchImpl(endpoint, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      },
+      body: JSON.stringify(payload)
+    })
+      .then(function (res) {
+        if (!res) {
+          throw new Error('No response');
+        }
+        return res.json().catch(function () { return {}; }).then(function (body) {
+          var payload = body;
+          if (body && typeof body === 'object' && body.data) {
+            payload = body.data;
+          }
+          var message = payload && payload.message ? String(payload.message) : null;
+          var success = res.ok && (!body || body.success !== false);
+          if (!success) {
+            throw new Error(message || 'Subscription failed.');
+          }
+          return { message: message || 'Check your email to confirm your subscription (peek at spam if it’s missing).' };
+        });
+      })
+      .then(function (result) {
+        setSubscribeStatus(statusEl, result && result.message ? result.message : 'Check your email to confirm your subscription (peek at spam if it’s missing).');
+        form.reset();
+      })
+      .catch(function (error) {
+        setSubscribeStatus(statusEl, error && error.message ? error.message : 'Subscription failed.', true);
+      })
+      .finally(function () {
+        form.querySelectorAll('button, input[type="submit"]').forEach(function (btn) {
+          btn.disabled = false;
+        });
+      });
+  }
+
+  function setSubscribeStatus(el, message, isError) {
+    if (!el) {
+      return;
+    }
+    el.textContent = message || '';
+    if (isError) {
+      el.classList.add('lo-subscribe__status--error');
+    } else {
+      el.classList.remove('lo-subscribe__status--error');
+    }
+  }
+
+  function enhanceSubscribeForms() {
+    if (!state.doc) {
+      return;
+    }
+    var forms = state.doc.querySelectorAll('[data-lo-subscribe-form]');
+    forms.forEach(function (form) {
+      if (!form || form.dataset.loEnhanced) {
+        return;
+      }
+      form.dataset.loEnhanced = '1';
+      form.addEventListener('submit', handleSubscribeSubmit);
+    });
+  }
+
+  function setReportStatus(reportState, message, tone) {
+    if (!reportState || !reportState.status) {
+      return;
+    }
+    reportState.status.textContent = message || '';
+    reportState.status.classList.remove('lo-report__status--success', 'lo-report__status--error');
+    if ('success' === tone) {
+      reportState.status.classList.add('lo-report__status--success');
+    } else if ('error' === tone) {
+      reportState.status.classList.add('lo-report__status--error');
+    }
+  }
+
+  function handleReportSubmit(event) {
+    if (event && typeof event.preventDefault === 'function') event.preventDefault();
+    var form = event && event.currentTarget ? event.currentTarget : null;
+    if (!form || !state.fetchImpl) return;
+    var provider = form.querySelector('[data-lo-report-provider]');
+    var symptom = form.querySelector('[data-lo-report-summary]');
+    var severity = form.querySelector('select[name="severity"]');
+    var region = form.querySelector('input[name="region"]');
+    var details = form.querySelector('textarea[name="details"]');
+    var email = form.querySelector('[data-lo-report-contact]');
+    var status = form.querySelector('[data-lo-report-status]');
+    var submit = form.querySelector('[data-lo-report-submit]');
+    if (!provider || !symptom || !submit) return;
+    var reportState = { status: status, submit: submit };
+    var providerId = String(provider.value || '').trim();
+    if (!providerId) {
+      setReportStatus(reportState, 'Select a provider to report.', 'error');
+      return;
+    }
+    var payload = {
+      provider_id: providerId,
+      symptom: String(symptom.value || 'other').trim() || 'other',
+      severity: severity ? String(severity.value || 'unknown') : 'unknown',
+      region: region ? String(region.value || '') : '',
+      details: details ? String(details.value || '') : '',
+      email: email ? String(email.value || '').trim() : ''
+    };
+    var originalLabel = submit.textContent;
+    submit.disabled = true;
+    submit.textContent = 'Sending…';
+    setReportStatus(reportState, 'Sending report…');
+    state.fetchImpl(form.getAttribute('action') || '/wp-json/lousy-outages/v1/report', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload)
+    }).then(function(res){
+      var ok = !!(res && res.ok);
+      return (res ? res.json().catch(function(){ return {}; }) : Promise.resolve({})).then(function(data){ return {ok: ok, data: data}; });
+    }).then(function(result){
+      var ok = result && result.ok && result.data && result.data.success !== false;
+      var message = result && result.data ? (result.data.message || result.data.error || '') : '';
+      if (ok) {
+        form.reset();
+        setReportStatus(reportState, message || 'Thanks — we logged your unconfirmed community report and we’re watching this.', 'success');
+        fetchCommunitySignals();
+        fetchHistoryData().catch(function () {});
+      } else {
+        setReportStatus(reportState, message || 'Could not submit report right now, please try again later.', 'error');
+      }
+    }).catch(function(){
+      setReportStatus(reportState, 'Could not submit report right now, please try again later.', 'error');
+    }).finally(function(){ submit.disabled = false; submit.textContent = originalLabel; });
+  }
+
+  function initReportForm() {
+    if (!state.doc) return;
+    var forms = state.doc.querySelectorAll('[data-lo-report-form]');
+    state.signalsContainer = state.doc.querySelector('[data-lo-signals]');
+    state.signalsEndpoint = state.signalsContainer ? String(state.signalsContainer.getAttribute('data-lo-signals-endpoint') || '') : '';
+    forms.forEach(function(form){
+      if (!form || form.dataset.loReportEnhanced) return;
+      form.dataset.loReportEnhanced = '1';
+      form.addEventListener('submit', handleReportSubmit);
+    });
+    fetchCommunitySignals();
+  }
+
+  function renderCommunitySignals(signals) {
+    if (!state.signalsContainer || !state.doc) return;
+    var list = state.signalsContainer.querySelector('[data-lo-signals-list]');
+    var empty = state.signalsContainer.querySelector('[data-lo-signals-empty]');
+    if (!list || !empty) return;
+    var allowed = { watch: true, trending: true, hot: true };
+    var rows = Array.isArray(signals) ? signals.filter(function (s) {
+      var c = String((s && s.classification) || '').toLowerCase();
+      return !!allowed[c];
+    }) : [];
+    while (list.firstChild) list.removeChild(list.firstChild);
+    if (!rows.length) { empty.hidden = false; return; }
+    empty.hidden = true;
+    rows.slice(0,5).forEach(function (signal) {
+      var cls = String(signal.classification || '').toLowerCase();
+      cls = allowed[cls] ? cls : 'watch';
+      var row = state.doc.createElement('div');
+      row.className = 'lo-signal lo-signal--' + cls;
+      var badge = state.doc.createElement('span');
+      badge.className = 'lo-signal__badge';
+      badge.textContent = cls.charAt(0).toUpperCase() + cls.slice(1);
+      var provider = state.doc.createElement('strong');
+      provider.textContent = String(signal.provider_name || signal.provider_id || 'Provider');
+      var message = state.doc.createElement('span');
+      message.textContent = String(signal.message || 'Unconfirmed community signal. We are watching this.');
+      row.appendChild(badge); row.appendChild(provider); row.appendChild(message);
+      list.appendChild(row);
+    });
+  }
+
+  function fetchCommunitySignals() {
+    if (!state.fetchImpl || !state.signalsEndpoint) return Promise.resolve();
+    return state.fetchImpl(state.signalsEndpoint, { method: 'GET' }).then(function (res) { return res.json(); }).then(function (data) {
+      if (data && data.success && Array.isArray(data.signals)) renderCommunitySignals(data.signals);
+    }).catch(function () {});
+  }
+  function isDocumentVisible() {
+    if (!state.doc || typeof state.doc.visibilityState !== 'string') {
+      return true;
+    }
+    return state.doc.visibilityState === 'visible';
+  }
+
+  function updateTrendingBanner(data) {
+    if (!state.trendingBanner) {
+      return;
+    }
+
+    var info = data || {};
+    var active = !!info.trending;
+    var signals = Array.isArray(info.signals) ? info.signals.filter(Boolean) : [];
+
+    if (active) {
+      state.trendingBanner.removeAttribute('hidden');
+    } else {
+      state.trendingBanner.setAttribute('hidden', 'hidden');
+    }
+
+    if (state.trendingText) {
+      state.trendingText.textContent = 'Potential widespread issues detected — check affected providers';
+    }
+
+    if (state.trendingReasons) {
+      if (signals.length) {
+        state.trendingReasons.textContent = 'Signals: ' + signals.slice(0, 6).join(', ');
+        state.trendingReasons.removeAttribute('hidden');
+      } else {
+        state.trendingReasons.textContent = '';
+        state.trendingReasons.setAttribute('hidden', 'hidden');
+      }
+    }
+
+    if (info.generated_at && state.trendingBanner) {
+      state.trendingBanner.setAttribute('data-lo-trending-generated', info.generated_at);
+    }
+  }
+
+  function handleVisibilityChange() {
+    if (isDocumentVisible()) {
+      state.visibilityPaused = false;
+      if (!state.isRefreshing) {
+        refreshSummary(false, true);
+      }
+    } else {
+      state.visibilityPaused = true;
+      if (state.timer && state.root) {
+        state.root.clearTimeout(state.timer);
+        state.timer = null;
+      }
+      state.nextRefreshAt = null;
+      stopCountdown();
+      if (state.countdownEl) {
+        state.countdownEl.textContent = 'Auto-refresh paused';
+      }
+    }
+  }
+
+  function resetAutoRefresh() {
+    if (!state.baseDelay || state.baseDelay <= 0) {
+      state.baseDelay = POLL_MS;
+    }
+    state.delay = state.baseDelay;
+    state.degradedDueToStale = false;
+    showDegraded(false);
+  }
+
+  function degradeAutoRefresh() {
+    if (!state.baseDelay || state.baseDelay <= 0) {
+      state.baseDelay = POLL_MS;
+    }
+    state.delay = state.baseDelay;
+    state.degradedDueToStale = false;
+    showDegraded(true);
+  }
+
+  function evaluateProviderHealth(list) {
+    if (!Array.isArray(list) || !list.length) {
+      degradeAutoRefresh();
+      return;
+    }
+
+    var total = 0;
+    var okCount = 0;
+    list.forEach(function (provider) {
+      if (!provider) {
+        return;
+      }
+      total += 1;
+      if (!provider.error) {
+        okCount += 1;
+      }
+    });
+
+    if (!total) {
+      degradeAutoRefresh();
+      return;
+    }
+
+    var ratio = okCount / total;
+    if (ratio >= RECOVER_THRESHOLD) {
+      resetAutoRefresh();
+    } else if (ratio < DEGRADE_THRESHOLD) {
+      degradeAutoRefresh();
+    }
+  }
+
+  function refreshSummary(manual, force) {
+    if (!state.fetchImpl || !state.endpoint) {
+      return Promise.resolve();
+    }
+    if (state.isRefreshing) {
+      if (manual) {
+        state.pendingManual = true;
+      }
+      return Promise.resolve();
+    }
+    if (!manual && !force && !isDocumentVisible()) {
+      scheduleNext(state.delay);
+      return Promise.resolve();
+    }
+
+    state.isRefreshing = true;
+
+    if (state.loadingEl && state.container) {
+      var hasCards = !!state.container.querySelector('[data-provider-id]');
+      if (!hasCards) {
+        toggleSpinner(true);
+      }
+    }
+
+    state.lastFetchStartedAt = Date.now();
+
+    var headers = { Accept: 'application/json' };
+    if (state.etag) {
+      headers['If-None-Match'] = state.etag;
+    }
+
+    var requestUrl = state.endpoint;
+    if (manual && requestUrl) {
+      requestUrl = appendQuery(requestUrl, 'refresh', '1');
+    }
+
+    return state.fetchImpl(requestUrl, {
+      credentials: 'same-origin',
+      headers: headers
+    })
+      .then(function (res) {
+        if (!res) {
+          throw new Error('No response');
+        }
+        var etag = res.headers ? res.headers.get('ETag') : null;
+        if (etag) {
+          state.etag = etag;
+        }
+        if (res.status === 304) {
+          resetAutoRefresh();
+          scheduleNext(state.baseDelay);
+          if (state.fetchedAt) {
+            maybeQueueStaleRefresh(state.fetchedAt);
+          }
+          return null;
+        }
+        if (!res.ok) {
+          throw new Error('HTTP ' + res.status);
+        }
+        return res.json();
+      })
+      .then(function (body) {
+        if (!body) {
+          return;
+        }
+        if (Array.isArray(body.providers)) {
+          evaluateProviderHealth(body.providers);
+          renderProviders(body.providers);
+          updateIncidentsUI(body.providers, body.meta || null);
+        } else {
+          resetAutoRefresh();
+        }
+        var fetched = body.fetched_at || (body.meta && (body.meta.fetched_at || body.meta.fetchedAt));
+        if (fetched) {
+          state.fetchedAt = fetched;
+          updateFetched();
+        }
+        var responseSource = body.source || (body.meta && body.meta.source) || state.container && state.container.getAttribute && state.container.getAttribute('data-lo-source');
+        if (responseSource) {
+          var normalizedSource = String(responseSource).toLowerCase();
+          state.fetchedLabel = normalizedSource === 'snapshot' ? 'Last fetched' : 'Fetched';
+          if (state.container && state.container.setAttribute) {
+            state.container.setAttribute('data-lo-source', String(responseSource));
+          }
+        } else {
+          state.fetchedLabel = 'Fetched';
+        }
+        if (state.fetchedLabelEl) {
+          state.fetchedLabelEl.textContent = state.fetchedLabel;
+        }
+        if (state.fetchedAt) {
+          maybeQueueStaleRefresh(state.fetchedAt);
+        }
+        if (body.trending) {
+          updateTrendingBanner(body.trending);
+        } else {
+          updateTrendingBanner({ trending: false, signals: [] });
+        }
+        var elapsed = 0;
+        if (typeof state.lastFetchStartedAt === 'number' && state.lastFetchStartedAt > 0) {
+          elapsed = Date.now() - state.lastFetchStartedAt;
+        }
+        var targetDelay = state.delay || state.baseDelay || POLL_MS;
+        var remainder = targetDelay - elapsed;
+        if (remainder < 0) {
+          remainder = 0;
+        }
+        scheduleNext(remainder);
+      })
+      .catch(function () {
+        degradeAutoRefresh();
+        var retryDelay = state.delay || state.baseDelay || POLL_MS;
+        if (typeof state.lastFetchStartedAt === 'number' && state.lastFetchStartedAt > 0) {
+          var elapsedSinceStart = Date.now() - state.lastFetchStartedAt;
+          if (elapsedSinceStart > 0 && elapsedSinceStart < retryDelay) {
+            retryDelay = retryDelay - elapsedSinceStart;
+          }
+        }
+        scheduleNext(Math.max(0, retryDelay));
+      })
+      .finally(function () {
+        state.isRefreshing = false;
+        var shouldTriggerStale = state.staleRefreshQueued && !state.staleRefreshInFlight;
+        if (shouldTriggerStale) {
+          state.staleRefreshQueued = false;
+        }
+        var replayManual = state.manualQueued;
+        state.manualQueued = false;
+        if (replayManual) {
+          manualRefresh();
+          return;
+        }
+        if (state.pendingManual) {
+          state.pendingManual = false;
+          refreshSummary(true, true);
+          return;
+        }
+        if (shouldTriggerStale) {
+          triggerStaleRefresh();
+        }
+      });
+  }
+
+
+  function callRefreshEndpoint() {
+    if (!state.refreshEndpoint || !state.fetchImpl) {
+      return Promise.resolve();
+    }
+    var headers = {};
+    if (state.refreshNonce) {
+      headers['X-WP-Nonce'] = state.refreshNonce;
+    }
+    return state.fetchImpl(state.refreshEndpoint, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: headers
+    }).then(function (res) {
+      if (!res) {
+        throw new Error('No response');
+      }
+      var statusOk = !!res.ok;
+      return res.json().catch(function () { return null; }).then(function (data) {
+        if (!statusOk && !(data && data.skipped)) {
+          throw new Error('HTTP ' + res.status);
+        }
+        return data;
+      });
+    });
+  }
+
+  function manualRefresh() {
+    if (state.isRefreshing) {
+      state.manualQueued = true;
+      return;
+    }
+    state.manualQueued = false;
+    state.pendingManual = false;
+    var previousFetched = state.fetchedAt;
+    setLoading(true);
+    var refreshFailed = false;
+    callRefreshEndpoint()
+      .catch(function () {
+        refreshFailed = true;
+        return null;
+      })
+      .then(function () {
+        if (refreshFailed) {
+          return refreshSummary(true, true);
+        }
+        function ensureUpdated(attempt) {
+          return refreshSummary(true, true).then(function () {
+            if (!previousFetched || !state.fetchedAt || state.fetchedAt !== previousFetched) {
+              return null;
+            }
+            if (attempt >= MANUAL_REFRESH_MAX_ATTEMPTS) {
+              return null;
+            }
+            return delay(MANUAL_REFRESH_RETRY_DELAY).then(function () {
+              return ensureUpdated(attempt + 1);
+            });
+          });
+        }
+        return ensureUpdated(0);
+      })
+      .finally(function () {
+        setLoading(false);
+      });
+  }
+
+  function init(config) {
+    config = config || {};
+    state.doc = config.document || (state.root ? state.root.document : null);
+    if (!state.doc) {
+      return;
+    }
+    if (typeof config.window === 'object' && config.window) {
+      state.root = config.window;
+    }
+    var debugQuery = false;
+    if (state.root && state.root.location && typeof state.root.location.search === 'string') {
+      try {
+        var params = new URLSearchParams(state.root.location.search);
+        debugQuery = params.get('lo_debug') === '1';
+      } catch (err) {
+        debugQuery = /(?:\?|&)lo_debug=1(?:&|$)/.test(state.root.location.search);
+      }
+    }
+    state.debug = !!config.debug || debugQuery;
+    var fetchImpl = null;
+    if (typeof config.fetch === 'function') {
+      fetchImpl = config.fetch;
+    } else if (state.root && typeof state.root.fetch === 'function') {
+      fetchImpl = state.root.fetch.bind(state.root);
+    } else if (typeof fetch === 'function') {
+      fetchImpl = fetch.bind(globalRoot || null);
+    }
+    state.fetchImpl = fetchImpl;
+    if (!state.fetchImpl) {
+      return;
+    }
+    state.container = config.container
+      || state.doc.querySelector('.lousy-outages-root')
+      || state.doc.querySelector('.lousy-outages')
+      || state.doc.getElementById('lousy-outages')
+      || state.doc.querySelector('.lousy-outages-board');
+    if (!state.container) {
+      return;
+    }
+    state.grid = state.container.querySelector('[data-lo-grid]') || state.container.querySelector('.providers-grid') || state.container;
+    state.allProvidersWrap = state.container.querySelector('[data-lo-all]');
+    state.incidentsWrap = state.container.querySelector('[data-lo-incidents]');
+    state.heroWrap = state.container.querySelector('[data-lo-hero]');
+    state.heroTime = state.container.querySelector('[data-lo-hero-time]');
+    state.modeToggle = state.container.querySelector('[data-lo-mode-toggle]');
+    state.modeButtons = {
+      incidents: state.container.querySelector('[data-lo-mode="incidents"]'),
+      all: state.container.querySelector('[data-lo-mode="all"]')
+    };
+    state.sectionGrids = {
+      incidents: state.container.querySelector('[data-lo-section-grid="incidents"]'),
+      signals: state.container.querySelector('[data-lo-section-grid="signals"]'),
+      unverified: state.container.querySelector('[data-lo-section-grid="unverified"]')
+    };
+    state.sectionBodies = {
+      signals: state.sectionGrids.signals,
+      unverified: state.sectionGrids.unverified
+    };
+    state.sectionToggles = {
+      signals: state.container.querySelector('[data-lo-section-toggle="signals"]'),
+      unverified: state.container.querySelector('[data-lo-section-toggle="unverified"]')
+    };
+    state.fetchedEl = state.container.querySelector('[data-lo-fetched]') || state.container.querySelector('.last-updated span');
+    state.fetchedLabelEl = state.container.querySelector('[data-lo-fetched-label]');
+    state.countdownEl = state.container.querySelector('[data-lo-countdown]') || state.container.querySelector('.board-subtitle');
+    state.refreshButton = state.container.querySelector('[data-lo-refresh]') || state.container.querySelector('.coin-btn');
+    state.degradedBadge = state.container.querySelector('[data-lo-degraded]');
+    state.trendingBanner = state.container.querySelector('[data-lo-trending]');
+    state.trendingText = state.container.querySelector('[data-lo-trending-text]');
+    state.trendingReasons = state.container.querySelector('[data-lo-trending-reasons]');
+    state.exportCSVButton = state.container.querySelector('[data-lo-export-csv]');
+    state.exportPDFButton = state.container.querySelector('[data-lo-export-pdf]');
+    state.loadingEl = state.container.querySelector('[data-lo-loading]');
+    state.historyList = state.container.querySelector('[data-lo-history-list]');
+    state.historyEmpty = state.container.querySelector('[data-lo-history-empty]');
+    state.historyError = state.container.querySelector('[data-lo-history-error]');
+    state.historyCharts = state.container.querySelector('[data-lo-history-charts]');
+    initReportForm();
+    var historyToggle = state.container.querySelector('[data-lo-history-important]');
+    if (historyToggle) {
+      state.historyImportantOnly = historyToggle.checked !== false;
+      historyToggle.addEventListener('change', function (event) {
+        state.historyImportantOnly = event.currentTarget.checked !== false;
+        fetchHistoryData();
+      });
+    }
+    var historyWindow = state.container.querySelector('[data-lo-history-window]');
+    if (historyWindow) {
+      state.historyWindowDays = parseInt(historyWindow.value, 10) || HISTORY_DEFAULT_DAYS;
+      historyWindow.addEventListener('change', function (event) {
+        var next = parseInt(event.currentTarget.value, 10);
+        state.historyWindowDays = Number.isFinite(next) && next > 0 ? next : HISTORY_DEFAULT_DAYS;
+        fetchHistoryData();
+      });
+    }
+    state.historyEndpoint = config.historyEndpoint || '';
+    state.endpoint = config.endpoint || '';
+    state.refreshEndpoint = config.refreshEndpoint || '';
+    state.refreshNonce = config.refreshNonce || '';
+    state.subscribeEndpoint = config.subscribeEndpoint || '';
+    var configuredDelay = parseInt(config.pollInterval || config.refreshInterval || config.pollMs || config.poll_delay, 10);
+    if (!Number.isFinite(configuredDelay) || configuredDelay <= 0) {
+      configuredDelay = POLL_MS;
+    }
+    state.baseDelay = configuredDelay;
+    state.delay = state.baseDelay;
+    state.maxDelay = Math.max(state.maxDelay || 0, MAX_DELAY);
+    state.visibilityPaused = !isDocumentVisible();
+
+    var initial = config.initial || {};
+    var initialProviders = [];
+    if (Array.isArray(initial.providers)) {
+      initialProviders = initial.providers;
+    } else if (Array.isArray(config.providers)) {
+      initialProviders = config.providers;
+    }
+    var containerSource = state.container.getAttribute ? state.container.getAttribute('data-lo-source') : '';
+    var initialSource = initial.source || (config.meta && config.meta.source) || containerSource || '';
+    if (initialSource) {
+      state.fetchedLabel = String(initialSource).toLowerCase() === 'snapshot' ? 'Last fetched' : 'Fetched';
+    }
+    if (state.fetchedLabelEl) {
+      state.fetchedLabelEl.textContent = state.fetchedLabel;
+    }
+    if (initialProviders.length) {
+      renderProviders(initialProviders);
+    }
+    if (initialProviders.length) {
+    }
+    if (state.loadingEl) {
+      toggleSpinner(!initialProviders.length);
+    }
+    var initialFetched = initial.fetched_at || initial.fetchedAt;
+    if (!initialFetched && config.meta && (config.meta.fetched_at || config.meta.fetchedAt)) {
+      initialFetched = config.meta.fetched_at || config.meta.fetchedAt;
+    }
+    state.fetchedAt = initialFetched || null;
+    updateFetched();
+
+    var initialMeta = null;
+    if (initial && typeof initial.meta === 'object') {
+      initialMeta = initial.meta;
+    } else if (config.meta && typeof config.meta === 'object') {
+      initialMeta = config.meta;
+    }
+    updateIncidentsUI(initialProviders, initialMeta);
+    setViewMode('incidents');
+
+    var initialTrending = null;
+    if (initial && typeof initial.trending === 'object') {
+      initialTrending = initial.trending;
+    } else if (config.meta && typeof config.meta.trending === 'object') {
+      initialTrending = config.meta.trending;
+    }
+    updateTrendingBanner(initialTrending || { trending: false, signals: [] });
+
+    initProviderVisibility();
+
+    if (state.refreshButton) {
+      state.refreshButton.addEventListener('click', manualRefresh);
+    }
+
+
+    if (state.exportCSVButton) {
+      state.exportCSVButton.addEventListener('click', downloadCSV);
+    }
+
+    if (state.exportPDFButton) {
+      state.exportPDFButton.addEventListener('click', exportPDF);
+    }
+
+    if (state.modeButtons.incidents) {
+      state.modeButtons.incidents.addEventListener('click', function () {
+        setViewMode('incidents');
+      });
+    }
+
+    if (state.modeButtons.all) {
+      state.modeButtons.all.addEventListener('click', function () {
+        setViewMode('all');
+      });
+    }
+
+    if (state.sectionToggles.signals) {
+      state.sectionToggles.signals.addEventListener('click', function () {
+        toggleSection('signals');
+      });
+    }
+
+    if (state.sectionToggles.unverified) {
+      state.sectionToggles.unverified.addEventListener('click', function () {
+        toggleSection('unverified');
+      });
+    }
+
+    enhanceSubscribeForms();
+
+    if (state.doc && typeof state.doc.addEventListener === 'function') {
+      state.doc.addEventListener('visibilitychange', handleVisibilityChange);
+    }
+
+    queuePostPaintWork();
+  }
+
+  function queuePostPaintWork() {
+    if (state.postPaintStarted) {
+      return;
+    }
+    state.postPaintStarted = true;
+    var kickOff = function () {
+      scheduleNext(state.baseDelay);
+
+      if (state.root && typeof state.root.setTimeout === 'function') {
+        state.root.setTimeout(fetchHistoryData, 350);
+        state.root.setTimeout(function () {
+          refreshSummary(false, true).catch(function () {
+            // Ignore initial failure; countdown/backoff already handled inside refreshSummary.
+          });
+        }, 0);
+      } else {
+        fetchHistoryData().catch(function () {
+          // Chart is optional; ignore failures.
+        });
+        refreshSummary(false, true).catch(function () {
+          // Ignore initial failure; countdown/backoff already handled inside refreshSummary.
+        });
+      }
+    };
+
+    if (state.root && typeof state.root.requestAnimationFrame === 'function') {
+      state.root.requestAnimationFrame(function () {
+        // Wait a tick to let the initial HTML paint before network calls kick in (helps LCP).
+        if (state.root && typeof state.root.setTimeout === 'function') {
+          state.root.setTimeout(kickOff, 0);
+        } else {
+          kickOff();
+        }
+      });
+    } else {
+      kickOff();
+    }
+  }
+
+  function stopAutoRefresh() {
+    if (state.timer && state.root) {
+      state.root.clearTimeout(state.timer);
+      state.timer = null;
+    }
+    stopCountdown();
+    state.nextRefreshAt = null;
+    updateCountdown();
+    showDegraded(false);
+    state.visibilityPaused = true;
+    state.delay = state.baseDelay;
+  }
+
+  return {
+    init: init,
+    stopAutoRefresh: stopAutoRefresh,
+    normalizeStatus: normalizeStatus,
+    snarkOutage: snarkOutage
+  };
+});

--- a/plugins/lousy-outages/includes/Adapters.php
+++ b/plugins/lousy-outages/includes/Adapters.php
@@ -1,0 +1,309 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages\Adapters;
+
+function from_statuspage_summary(string $json): array {
+    $data = json_decode($json, true);
+    if (!is_array($data)) {
+        return ['state' => 'unknown', 'incidents' => [], 'raw' => null];
+    }
+
+    $indicator = strtolower((string) ($data['status']['indicator'] ?? 'none'));
+    $map       = [
+        'none'        => 'operational',
+        'minor'       => 'degraded',
+        'major'       => 'major',
+        'critical'    => 'major',
+        'maintenance' => 'maintenance',
+    ];
+    $state = $map[$indicator] ?? 'unknown';
+
+    $incidents = [];
+    foreach ($data['incidents'] ?? [] as $incident) {
+        if (!is_array($incident)) {
+            continue;
+        }
+        $status = strtolower((string) ($incident['status'] ?? ''));
+
+        $incidents[] = [
+            'id'         => (string) ($incident['id'] ?? ''),
+            'name'       => (string) ($incident['name'] ?? 'Incident'),
+            'status'     => $status ?: 'investigating',
+            'started_at' => $incident['started_at'] ?? ($incident['created_at'] ?? null),
+            'updated_at' => $incident['updated_at'] ?? null,
+            'shortlink'  => $incident['shortlink'] ?? null,
+        ];
+    }
+
+    return [
+        'state'      => $state,
+        'incidents'  => $incidents,
+        'updated_at' => $data['page']['updated_at'] ?? null,
+        'raw'        => $data,
+    ];
+}
+
+function from_statuspage_status(string $json): array {
+    $data = json_decode($json, true);
+    if (! is_array($data)) {
+        return ['state' => 'unknown', 'incidents' => [], 'raw' => null];
+    }
+
+    $indicator = strtolower((string) ($data['status']['indicator'] ?? 'unknown'));
+    $map       = [
+        'none'        => 'operational',
+        'minor'       => 'degraded',
+        'minor_outage'=> 'degraded',
+        'partial'     => 'degraded',
+        'degraded'    => 'degraded',
+        'major'       => 'major',
+        'critical'    => 'major',
+        'maintenance' => 'maintenance',
+    ];
+
+    $state = $map[$indicator] ?? 'unknown';
+
+    return [
+        'state'      => $state,
+        'incidents'  => [],
+        'updated_at' => $data['page']['updated_at'] ?? null,
+        'summary'    => $data['status']['description'] ?? '',
+        'raw'        => $data,
+    ];
+}
+
+function from_slack_current(string $json): array {
+    $data = json_decode($json, true);
+    if (!is_array($data)) {
+        return ['state' => 'unknown', 'incidents' => [], 'raw' => null];
+    }
+
+    $overall = strtolower((string) ($data['status'] ?? 'unknown'));
+
+    $incidents = [];
+    foreach ($data['active_incidents'] ?? [] as $incident) {
+        if (!is_array($incident)) {
+            continue;
+        }
+        $status = strtolower((string) ($incident['status'] ?? 'active'));
+        if (in_array($status, ['resolved', 'completed'], true)) {
+            continue;
+        }
+
+        $incidents[] = [
+            'id'         => (string) ($incident['id'] ?? ''),
+            'name'       => (string) ($incident['title'] ?? 'Incident'),
+            'status'     => $status ?: 'active',
+            'started_at' => $incident['created'] ?? null,
+            'updated_at' => $incident['updated'] ?? null,
+            'shortlink'  => $incident['url'] ?? null,
+        ];
+    }
+
+    $state = ('ok' === $overall && empty($incidents)) ? 'operational' : 'degraded';
+
+    return [
+        'state'      => $state,
+        'incidents'  => $incidents,
+        'updated_at' => $data['last_updated'] ?? ($data['date'] ?? null),
+        'raw'        => $data,
+    ];
+}
+
+function from_rss_atom(string $xml): array {
+    $previous = libxml_use_internal_errors(true);
+    $feed     = simplexml_load_string($xml);
+    if (! $feed) {
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+        return ['state' => 'operational', 'incidents' => [], 'raw' => null];
+    }
+
+    $items = [];
+    $resolve_status = static function (string $title, string $summary): string {
+        $text = strtolower($title . ' ' . $summary);
+        if (preg_match('/\bresolved\b|this issue is now resolved|issue is now resolved|issue has been resolved|ended at/i', $text)) {
+            return 'resolved';
+        }
+        if (preg_match('/\b(scheduled|planned).{0,40}maintenance\b/i', $text)) {
+            return 'maintenance';
+        }
+        if (preg_match('/\b(outage|major|critical)\b/i', $text)) {
+            return 'major';
+        }
+        if (preg_match('/\b(degraded|partial|service disruption)\b/i', $text)) {
+            return 'degraded';
+        }
+        if (preg_match('/\b(investigating|identified|monitoring)\b/i', $text)) {
+            return 'investigating';
+        }
+        return 'unknown';
+    };
+    if (isset($feed->channel)) {
+        foreach ($feed->channel->item as $item) {
+            $title = (string) ($item->title ?? 'Incident');
+            $summary = (string) ($item->description ?? '');
+            $items[] = [
+                'name'       => $title ?: 'Incident',
+                'status'     => $resolve_status($title, $summary),
+                'started_at' => (string) ($item->pubDate ?? ''),
+                'updated_at' => (string) ($item->pubDate ?? ''),
+                'shortlink'  => (string) ($item->link ?? ''),
+            ];
+        }
+    } else {
+        foreach ($feed->entry as $item) {
+            $title = (string) ($item->title ?? 'Incident');
+            $summary = (string) ($item->summary ?? $item->content ?? '');
+            $items[] = [
+                'name'       => $title ?: 'Incident',
+                'status'     => $resolve_status($title, $summary),
+                'started_at' => (string) ($item->updated ?? ($item->published ?? '')),
+                'updated_at' => (string) ($item->updated ?? ($item->published ?? '')),
+                'shortlink'  => (string) ($item->link['href'] ?? ($item->link ?? '')),
+            ];
+        }
+    }
+    libxml_clear_errors();
+    libxml_use_internal_errors($previous);
+
+    $items = array_map(
+        static function (array $item): array {
+            $timestamp = 0;
+            if (! empty($item['updated_at'])) {
+                $timestamp = strtotime((string) $item['updated_at']) ?: 0;
+            }
+            if (! $timestamp && ! empty($item['started_at'])) {
+                $timestamp = strtotime((string) $item['started_at']) ?: 0;
+            }
+            $item['timestamp'] = $timestamp;
+            return $item;
+        },
+        $items
+    );
+
+    usort(
+        $items,
+        static function (array $a, array $b): int {
+            return (int) ($b['timestamp'] ?? 0) <=> (int) ($a['timestamp'] ?? 0);
+        }
+    );
+
+    $items = array_slice($items, 0, 10);
+
+    $resolved_states = ['resolved', 'completed', 'postmortem', 'operational', 'ok'];
+    $hasMajor = false;
+    $hasDegraded = false;
+    $hasMaintenance = false;
+
+    foreach ($items as $item) {
+        $status = strtolower((string) ($item['status'] ?? ''));
+        if (in_array($status, $resolved_states, true)) {
+            continue;
+        }
+        if (in_array($status, ['major', 'outage', 'critical'], true)) {
+            $hasMajor = true;
+            continue;
+        }
+        if (in_array($status, ['degraded', 'partial', 'investigating', 'identified', 'monitoring'], true)) {
+            $hasDegraded = true;
+            continue;
+        }
+        if (in_array($status, ['maintenance', 'scheduled'], true)) {
+            $hasMaintenance = true;
+        }
+    }
+
+    $state = 'operational';
+    if ($hasMajor) {
+        $state = 'major';
+    } elseif ($hasDegraded) {
+        $state = 'degraded';
+    } elseif ($hasMaintenance) {
+        $state = 'maintenance';
+    }
+
+    return [
+        'state'      => $state,
+        'incidents'  => $items,
+        'updated_at' => $items[0]['updated_at'] ?? null,
+        'raw'        => $xml,
+    ];
+}
+
+function from_gcp_incidents_json(string $json): array {
+    $data = json_decode($json, true);
+    if (!is_array($data)) {
+        return ['state' => 'unknown', 'incidents' => [], 'raw' => null];
+    }
+
+    $incidentsRaw = $data['incidents'] ?? null;
+    if (!is_array($incidentsRaw)) {
+        return ['state' => 'unknown', 'incidents' => [], 'raw' => $data];
+    }
+
+    $activeIncidents = [];
+    $hasDisruption = false;
+    foreach ($incidentsRaw as $incident) {
+        if (!is_array($incident)) {
+            continue;
+        }
+        $end = $incident['end'] ?? null;
+        if (!empty($end)) {
+            continue;
+        }
+
+        $updates = isset($incident['updates']) && is_array($incident['updates']) ? $incident['updates'] : [];
+        $mostRecent = isset($incident['most_recent_update']) && is_array($incident['most_recent_update'])
+            ? $incident['most_recent_update']
+            : null;
+        if (!$mostRecent && !empty($updates)) {
+            $mostRecent = end($updates);
+            if (!is_array($mostRecent)) {
+                $mostRecent = null;
+            }
+        }
+
+        $updateStatus = strtoupper((string) ($mostRecent['status'] ?? ''));
+        if ('SERVICE_DISRUPTION' === $updateStatus) {
+            $hasDisruption = true;
+        }
+
+        $incidentStatus = 'investigating';
+        if ('SERVICE_DISRUPTION' === $updateStatus) {
+            $incidentStatus = 'identified';
+        } elseif ('SERVICE_INFORMATION' === $updateStatus) {
+            $incidentStatus = 'monitoring';
+        } elseif ('AVAILABLE' === $updateStatus) {
+            $incidentStatus = 'monitoring';
+        }
+
+        $name = (string) ($incident['external_desc'] ?? $incident['service_name'] ?? 'Google Cloud incident');
+        $activeIncidents[] = [
+            'id'         => (string) ($incident['id'] ?? ''),
+            'name'       => $name ?: 'Google Cloud incident',
+            'status'     => $incidentStatus,
+            'started_at' => $incident['begin'] ?? null,
+            'updated_at' => $mostRecent['when'] ?? ($incident['modified'] ?? null),
+            'shortlink'  => $incident['status_url'] ?? null,
+        ];
+    }
+
+    $state = 'operational';
+    if (!empty($activeIncidents)) {
+        $state = $hasDisruption ? 'major' : 'degraded';
+    }
+
+    $updatedAt = null;
+    if (!empty($activeIncidents)) {
+        $updatedAt = $activeIncidents[0]['updated_at'] ?? null;
+    }
+
+    return [
+        'state'      => $state,
+        'incidents'  => $activeIncidents,
+        'updated_at' => $updatedAt,
+        'raw'        => $data,
+    ];
+}

--- a/plugins/lousy-outages/includes/Adapters/Statuspage.php
+++ b/plugins/lousy-outages/includes/Adapters/Statuspage.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages\Adapters\Statuspage;
+
+/**
+ * Attempt to infer a service state from a Statuspage error payload or body.
+ */
+function detect_state_from_error(string $body): ?string {
+    $body = trim($body);
+    if ('' === $body) {
+        return null;
+    }
+
+    $mapping = [
+        'none'                => 'operational',
+        'minor'               => 'degraded',
+        'minor_outage'        => 'degraded',
+        'degraded_performance'=> 'degraded',
+        'partial'             => 'degraded',
+        'partial_outage'      => 'degraded',
+        'investigating'       => 'degraded',
+        'identified'          => 'degraded',
+        'monitoring'          => 'degraded',
+        'major'               => 'outage',
+        'major_outage'        => 'outage',
+        'critical'            => 'outage',
+        'maintenance'         => 'maintenance',
+    ];
+
+    $state = null;
+    $decoded = json_decode($body, true);
+    if (is_array($decoded)) {
+        $indicator = strtolower((string) ($decoded['status']['indicator'] ?? $decoded['status'] ?? ''));
+        if ($indicator && isset($mapping[$indicator])) {
+            $state = $mapping[$indicator];
+        }
+
+        if (! $state && isset($decoded['page']['status_indicator'])) {
+            $hint = strtolower((string) $decoded['page']['status_indicator']);
+            if (isset($mapping[$hint])) {
+                $state = $mapping[$hint];
+            }
+        }
+    }
+
+    if (! $state) {
+        $haystack = strtolower($body);
+        foreach (['major_outage', 'partial_outage', 'investigating', 'identified', 'monitoring'] as $needle) {
+            if (false !== strpos($haystack, $needle)) {
+                $state = $mapping[$needle] ?? 'degraded';
+                break;
+            }
+        }
+        if (! $state && false !== strpos($haystack, 'critical')) {
+            $state = 'outage';
+        }
+    }
+
+    if (! $state || 'operational' === $state) {
+        return null;
+    }
+
+    return $state;
+}

--- a/plugins/lousy-outages/includes/Api.php
+++ b/plugins/lousy-outages/includes/Api.php
@@ -1,0 +1,950 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+use SuzyEaston\LousyOutages\Storage\IncidentStore;
+use WP_REST_Request;
+use WP_REST_Response;
+
+class Api {
+    private const REPORT_RATE_LIMIT = 3;
+    private const REPORT_RATE_WINDOW = HOUR_IN_SECONDS;
+    private const REPORT_CAPTCHA_TTL = 600;
+
+    private static function build_summary_meta(array $providers): array {
+        $counts = [
+            'active_outage_count' => 0,
+            'signal_count'        => 0,
+            'unverified_count'    => 0,
+            'generated_at'        => gmdate('c'),
+        ];
+
+        foreach ($providers as $provider) {
+            if (!is_array($provider)) {
+                continue;
+            }
+            $tileKind = strtolower((string) ($provider['tile_kind'] ?? $provider['tileKind'] ?? ''));
+            if ('' === $tileKind) {
+                $status = strtolower((string) ($provider['status'] ?? $provider['stateCode'] ?? 'unknown'));
+                if ('operational' === $status) {
+                    $tileKind = 'operational';
+                } elseif ('unknown' === $status) {
+                    $tileKind = 'unknown';
+                } elseif (!empty($provider['incidents'])) {
+                    $tileKind = 'outage';
+                } else {
+                    $tileKind = 'signal';
+                }
+            }
+
+            if ('outage' === $tileKind) {
+                $counts['active_outage_count'] += 1;
+            } elseif ('signal' === $tileKind) {
+                $counts['signal_count'] += 1;
+            } elseif ('unknown' === $tileKind || 'manual' === $tileKind) {
+                $counts['unverified_count'] += 1;
+            }
+        }
+
+        return $counts;
+    }
+
+    public static function bootstrap(): void {
+        add_action('rest_api_init', [self::class, 'register_routes']);
+        add_action('wp_ajax_lo_get_report_phrase', [self::class, 'handle_report_phrase']);
+        add_action('wp_ajax_nopriv_lo_get_report_phrase', [self::class, 'handle_report_phrase']);
+    }
+
+    public static function register_routes(): void {
+        register_rest_route(
+            'lousy/v1',
+            '/refresh',
+            [
+                'methods'             => 'POST',
+                'permission_callback' => [self::class, 'verify_nonce'],
+                'callback'            => [self::class, 'handle_refresh'],
+            ]
+        );
+
+        register_rest_route(
+            'lousy-outages/v1',
+            '/refresh',
+            [
+                'methods'             => ['POST', 'GET'],
+                'permission_callback' => '__return_true',
+                'callback'            => [self::class, 'handle_refresh'],
+            ]
+        );
+
+        register_rest_route(
+            'lousy-outages/v1',
+            '/summary',
+            [
+                'methods'             => 'GET',
+                'permission_callback' => '__return_true',
+                'callback'            => [self::class, 'handle_summary'],
+                'args'                => [
+                    'provider' => [
+                        'description'       => 'Optional provider filter (comma-separated)',
+                        'type'              => 'string',
+                        'sanitize_callback' => 'sanitize_text_field',
+                    ],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            'lousy-outages/v1',
+            '/history',
+            [
+                'methods'             => 'GET',
+                'permission_callback' => '__return_true',
+                'callback'            => [self::class, 'handle_history'],
+                'args'                => [
+                    'provider' => [
+                        'description'       => 'Optional provider filter (comma-separated)',
+                        'type'              => 'string',
+                        'sanitize_callback' => 'sanitize_text_field',
+                    ],
+                    'days' => [
+                        'description'       => 'How many days of history to return (default 30)',
+                        'type'              => 'integer',
+                        'sanitize_callback' => 'absint',
+                    ],
+                    'severity' => [
+                        'description'       => 'Severity filter (e.g., important)',
+                        'type'              => 'string',
+                        'sanitize_callback' => 'sanitize_text_field',
+                    ],
+                    'min_severity' => [
+                        'description'       => 'Minimum severity to include (outage|degraded|maintenance|info)',
+                        'type'              => 'string',
+                        'sanitize_callback' => 'sanitize_text_field',
+                    ],
+                    'limit' => [
+                        'description'       => 'Maximum number of incidents to return (after dedupe)',
+                        'type'              => 'integer',
+                        'sanitize_callback' => 'absint',
+                    ],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            'lousy-outages/v1',
+            '/cron-status',
+            [
+                'methods'             => 'GET',
+                'permission_callback' => '__return_true',
+                'callback'            => [self::class, 'handle_cron_status'],
+            ]
+        );
+
+        register_rest_route(
+            'lousy/v1',
+            '/report',
+            [
+                'methods'             => 'POST',
+                'permission_callback' => '__return_true',
+                'callback'            => [self::class, 'handle_report'],
+                'args'                => [
+                    'provider_id' => [
+                        'description'       => 'Provider identifier',
+                        'type'              => 'string',
+                        'sanitize_callback' => 'sanitize_text_field',
+                        'required'          => true,
+                    ],
+                    'provider_name' => [
+                        'description'       => 'Provider name when reporting other providers',
+                        'type'              => 'string',
+                        'sanitize_callback' => 'sanitize_text_field',
+                        'required'          => false,
+                    ],
+                    'summary' => [
+                        'description'       => 'Summary of the reported issue',
+                        'type'              => 'string',
+                        'sanitize_callback' => 'sanitize_textarea_field',
+                        'required'          => true,
+                    ],
+                    'contact' => [
+                        'description'       => 'Optional contact information for follow-up',
+                        'type'              => 'string',
+                        'sanitize_callback' => 'sanitize_text_field',
+                        'required'          => false,
+                    ],
+                    'captcha_answer' => [
+                        'description'       => 'Captcha phrase response',
+                        'type'              => 'string',
+                        'sanitize_callback' => 'sanitize_text_field',
+                        'required'          => true,
+                    ],
+                    'captcha_token' => [
+                        'description'       => 'Captcha token',
+                        'type'              => 'string',
+                        'sanitize_callback' => 'sanitize_text_field',
+                        'required'          => true,
+                    ],
+                ],
+            ]
+        );
+
+    }
+
+    public static function verify_nonce(): bool {
+        $nonce = $_SERVER['HTTP_X_WP_NONCE'] ?? '';
+        return is_string($nonce) && wp_verify_nonce($nonce, 'wp_rest');
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function report_captcha_phrases(): array {
+        return [
+            'stay noisy vancouver',
+            'keep shipping fixes',
+            'retro radar online',
+            'packets in motion',
+            'less lousy outages',
+        ];
+    }
+
+    private static function normalize_report_captcha(string $value): string {
+        $text = strtolower($value);
+        $text = preg_replace('/[^a-z0-9\\s]+/i', '', $text);
+        if (null === $text) {
+            $text = '';
+        }
+        $text = trim(preg_replace('/\\s+/', ' ', $text) ?? '');
+        return $text;
+    }
+
+    private static function report_captcha_transient_key(string $token): string {
+        return 'lo_report_phrase_' . $token;
+    }
+
+    private static function generate_report_token(): string {
+        if (function_exists('wp_generate_password')) {
+            return wp_generate_password(20, false, false);
+        }
+
+        return bin2hex(random_bytes(16));
+    }
+
+    private static function get_report_ip_hash(WP_REST_Request $request): string {
+        if (function_exists('lo_detect_subscribe_ip') && function_exists('lo_hash_subscriber_ip')) {
+            $ip = lo_detect_subscribe_ip($request);
+            return lo_hash_subscriber_ip($ip);
+        }
+
+        $ip = '';
+        if (!empty($_SERVER['REMOTE_ADDR'])) {
+            $ip = (string) $_SERVER['REMOTE_ADDR'];
+        }
+        $payload = '' !== $ip ? $ip : 'unknown';
+
+        if (function_exists('wp_salt')) {
+            return hash_hmac('sha256', $payload, wp_salt('nonce'));
+        }
+
+        return hash('sha256', $payload);
+    }
+
+    private static function is_report_spam(string $summary): bool {
+        $urlMatches = [];
+        preg_match_all('/https?:\\/\\/|www\\./i', $summary, $urlMatches);
+        if (!empty($urlMatches[0]) && count($urlMatches[0]) > 2) {
+            return true;
+        }
+
+        $tokens = [
+            'viagra',
+            'casino',
+            'bitcoin',
+            'loan',
+            'work from home',
+            'free money',
+            'earn $',
+            'weight loss',
+        ];
+
+        $haystack = strtolower($summary);
+        foreach ($tokens as $token) {
+            if (false !== strpos($haystack, $token)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static function handle_report_phrase(): void {
+        $phrases = self::report_captcha_phrases();
+        if (!$phrases) {
+            wp_send_json([
+                'ok'      => false,
+                'message' => 'No phrases available.',
+            ], 500);
+        }
+
+        $token  = self::generate_report_token();
+        $phrase = $phrases[array_rand($phrases)];
+        $normalized = self::normalize_report_captcha($phrase);
+
+        set_transient(self::report_captcha_transient_key($token), $normalized, self::REPORT_CAPTCHA_TTL);
+
+        wp_send_json([
+            'ok'     => true,
+            'token'  => $token,
+            'phrase' => $phrase,
+        ]);
+    }
+
+    /**
+     * Trigger a manual refresh of provider statuses.
+     */
+    public static function handle_refresh(WP_REST_Request $request): WP_REST_Response {
+        $result = \lousy_outages_refresh_data(true);
+        $skipped = !empty($result['skipped']);
+        $ok      = !empty($result['ok']);
+
+        if ($skipped && ! $ok) {
+            $status = 200;
+        } else {
+            $status = $ok ? 200 : 503;
+        }
+
+        $providers = isset($result['providers']) && is_array($result['providers']) ? $result['providers'] : [];
+        $errors    = isset($result['errors']) && is_array($result['errors']) ? $result['errors'] : [];
+        $trending  = isset($result['trending']) && is_array($result['trending']) ? $result['trending'] : ['trending' => false, 'signals' => []];
+        $refreshed_at = isset($result['refreshedAt']) ? (string) $result['refreshedAt'] : gmdate('c');
+
+        $response = [
+            'ok'            => $ok,
+            'skipped'       => $skipped,
+            'refreshed_at'  => isset($result['refreshed_at']) ? (int) $result['refreshed_at'] : time(),
+            'refreshedAt'   => $refreshed_at,
+            'providerCount' => count($providers),
+            'errors'        => $errors,
+            'providers'     => $providers,
+            'trending'      => $trending,
+            'source'        => 'live',
+        ];
+
+        if (!empty($result['message']) && is_string($result['message'])) {
+            $response['message'] = $result['message'];
+        }
+
+        return new WP_REST_Response($response, $status);
+    }
+
+    public static function handle_summary(WP_REST_Request $request) {
+        $providerParam = $request->get_param('provider');
+        $filters       = self::sanitize_provider_list(is_string($providerParam) ? $providerParam : null);
+
+        $snapshot = \lousy_outages_get_snapshot(false);
+        if (empty($snapshot['providers'])) {
+            $snapshot = \lousy_outages_get_snapshot(true);
+        }
+
+        $providers = isset($snapshot['providers']) && is_array($snapshot['providers']) ? array_values($snapshot['providers']) : [];
+        if (!empty($filters)) {
+            $providers = array_values(array_filter($providers, static function ($provider) use ($filters) {
+                if (!is_array($provider)) {
+                    return false;
+                }
+                $slug = strtolower((string) ($provider['provider'] ?? $provider['id'] ?? ''));
+                return $slug && in_array($slug, $filters, true);
+            }));
+        }
+
+        $trending = isset($snapshot['trending']) && is_array($snapshot['trending'])
+            ? $snapshot['trending']
+            : ['trending' => false, 'signals' => [], 'generated_at' => gmdate('c')];
+        $source = isset($snapshot['source']) ? (string) $snapshot['source'] : 'snapshot';
+        $fetched_at = isset($snapshot['fetched_at']) ? (string) $snapshot['fetched_at'] : gmdate('c');
+        $errors = isset($snapshot['errors']) && is_array($snapshot['errors']) ? $snapshot['errors'] : [];
+
+        $isLite = false;
+        $liteParam = $request->get_param('lite');
+        if (null !== $liteParam) {
+            $value = strtolower((string) $liteParam);
+            $isLite = in_array($value, ['1', 'true', 'yes', 'on'], true);
+        }
+
+        if ($isLite) {
+            $payload = [
+                'trending' => !empty($trending['trending']),
+            ];
+        } else {
+            $meta = self::build_summary_meta($providers);
+            $payload = [
+                'providers'  => $providers,
+                'fetched_at' => $fetched_at,
+                'trending'   => $trending,
+                'source'     => $source,
+                'meta'       => $meta,
+            ];
+            if (!empty($errors)) {
+                $payload['errors'] = $errors;
+            }
+        }
+
+        $json = wp_json_encode($payload);
+        if (!is_string($json)) {
+            $json = '{}';
+        }
+        $etag = '"' . sha1($json) . '"';
+        $incoming = isset($_SERVER['HTTP_IF_NONE_MATCH']) ? trim((string) $_SERVER['HTTP_IF_NONE_MATCH']) : '';
+        $matched = false;
+        if ('' !== $incoming) {
+            $candidates = array_map('trim', explode(',', $incoming));
+            foreach ($candidates as $candidate) {
+                if ($candidate === $etag || $candidate === 'W/' . $etag) {
+                    $matched = true;
+                    break;
+                }
+            }
+        }
+
+        if ($matched) {
+            status_header(304);
+            header('ETag: ' . $etag);
+            header('Cache-Control: no-cache, must-revalidate');
+            exit;
+        }
+
+        status_header(200);
+        header('ETag: ' . $etag);
+        header('Cache-Control: no-cache, must-revalidate');
+        header('Content-Type: application/json; charset=utf-8');
+        echo $json;
+        exit;
+    }
+
+    public static function handle_cron_status(WP_REST_Request $request): WP_REST_Response {
+        $last_refresh_raw   = get_option('lousy_outages_last_fetched', 0);
+        $last_refresh_epoch = is_numeric($last_refresh_raw) ? (int) $last_refresh_raw : 0;
+
+        $last_refresh_iso_option = get_option('lousy_outages_last_fetched_iso');
+        $last_refresh_gmt        = is_string($last_refresh_iso_option) && '' !== trim($last_refresh_iso_option)
+            ? (string) $last_refresh_iso_option
+            : ($last_refresh_epoch > 0 ? gmdate('c', $last_refresh_epoch) : null);
+
+        $last_refresh_local = $last_refresh_epoch > 0 ? wp_date('c', $last_refresh_epoch) : null;
+
+        $next_refresh      = wp_next_scheduled('lousy_outages_cron_refresh');
+        $next_alert_run    = wp_next_scheduled('lousy_outages_refresh');
+        $next_daily_digest = wp_next_scheduled('lo_send_daily_digest');
+
+        $payload = [
+            'ok'                              => true,
+            'last_refresh_epoch'              => $last_refresh_epoch,
+            'last_refresh_gmt'                => $last_refresh_gmt,
+            'last_refresh_local'              => $last_refresh_local,
+            'next_scheduled_refresh'          => $next_refresh ?: null,
+            'next_scheduled_refresh_gmt'      => $next_refresh ? gmdate('c', (int) $next_refresh) : null,
+            'next_scheduled_alert_run'        => $next_alert_run ?: null,
+            'next_scheduled_alert_run_gmt'    => $next_alert_run ? gmdate('c', (int) $next_alert_run) : null,
+            'next_scheduled_daily_digest'     => $next_daily_digest ?: null,
+            'next_scheduled_daily_digest_gmt' => $next_daily_digest ? gmdate('c', (int) $next_daily_digest) : null,
+            'wp_cron_disabled'                => defined('DISABLE_WP_CRON') && DISABLE_WP_CRON,
+            'alternate_wp_cron'               => defined('ALTERNATE_WP_CRON') && ALTERNATE_WP_CRON,
+        ];
+
+        return new WP_REST_Response($payload, 200);
+    }
+
+    /**
+     * Return a compact history document for each provider.
+     *
+     * Schema (per provider):
+     * {
+     *   id: "github",
+     *   history: [ { date: "2024-06-01", incidents: 2, last_status: "degraded" }, ... ]
+     * }
+     */
+    public static function handle_history(WP_REST_Request $request): WP_REST_Response {
+        $providerParam = $request->get_param('provider');
+        $filters       = self::sanitize_provider_list(is_string($providerParam) ? $providerParam : null);
+
+        $daysParam = $request->get_param('days');
+        $days = (int) (is_numeric($daysParam) ? $daysParam : 30);
+        if ($days <= 0) {
+            $days = 30;
+        }
+        if ($days > 365) {
+            $days = 365;
+        }
+
+        $cutoff        = time() - ($days * DAY_IN_SECONDS);
+        $store         = new Store();
+        $incidentStore = new IncidentStore();
+        $log           = $store->get_history_log();
+        $events        = $incidentStore->getStoredIncidents();
+
+        $normalizeStatus = static function (string $status): string {
+            $status = strtolower(trim($status));
+            switch ($status) {
+                case 'ok':
+                case 'none':
+                case 'operational':
+                case 'resolved':
+                    return 'operational';
+                case 'maintenance':
+                case 'maintenance_window':
+                    return 'maintenance';
+                case 'minor':
+                case 'minor_outage':
+                case 'degraded':
+                case 'degraded_performance':
+                case 'partial':
+                case 'partial_outage':
+                case 'incident':
+                case 'investigating':
+                case 'identified':
+                case 'monitoring':
+                    return 'degraded';
+                case 'major_outage':
+                case 'outage':
+                case 'major':
+                case 'critical':
+                    return 'major';
+            }
+
+            return $status ?: 'incident';
+        };
+
+        $severityParam = $request->get_param('severity');
+        $importantOnly = true;
+        if (null !== $severityParam) {
+            $value         = strtolower((string) $severityParam);
+            $importantOnly = ! in_array($value, ['all', 'any', 'everything'], true);
+        }
+
+        $minSeverityParam = $request->get_param('min_severity');
+        $minSeverity      = in_array(strtolower((string) $minSeverityParam), ['outage', 'degraded', 'maintenance', 'info'], true)
+            ? strtolower((string) $minSeverityParam)
+            : '';
+
+        $limitParam = $request->get_param('limit');
+        $limit      = (int) (is_numeric($limitParam) ? $limitParam : 80);
+        if ($limit <= 0) {
+            $limit = 80;
+        }
+        if ($limit > 150) {
+            $limit = 150;
+        }
+
+        $providers      = [];
+        $providerLabels = [];
+        foreach (Providers::enabled() as $id => $provider) {
+            $providerLabels[$id] = isset($provider['name']) ? (string) $provider['name'] : ucfirst((string) $id);
+        }
+        $allowedProviders = array_fill_keys(array_keys($providerLabels), true);
+
+        $ensureProvider = static function (string $slug, string $label) use (&$providers): void {
+            if (!isset($providers[$slug])) {
+                $providers[$slug] = [
+                    'id'        => $slug,
+                    'label'     => $label,
+                    'history'   => [],
+                    'incidents' => [],
+                ];
+            }
+        };
+
+        $severityOrder = [
+            'info'        => 0,
+            'maintenance' => 1,
+            'degraded'    => 2,
+            'outage'      => 3,
+        ];
+
+        $prepared = [];
+
+        foreach ($events as $event) {
+            if (!is_array($event)) {
+                continue;
+            }
+            $event = $incidentStore->normalizeEvent($event);
+
+            $slug = sanitize_key((string) ($event['provider'] ?? ''));
+            $source = strtolower((string) ($event['source'] ?? ''));
+            $severityValue = strtolower((string) ($event['severity'] ?? ''));
+            $isUserReport = ('user_report' === $source || 'user_report' === $severityValue);
+            $allowOther = ('other' === $slug && $isUserReport);
+
+            if ('' === $slug || (!isset($allowedProviders[$slug]) && !$allowOther)) {
+                continue;
+            }
+            if ($allowOther && !isset($providerLabels[$slug])) {
+                $providerLabels[$slug] = (string) ($event['provider_label'] ?? 'Other');
+            }
+            if (!empty($filters) && !in_array($slug, $filters, true)) {
+                continue;
+            }
+
+            $firstSeen     = isset($event['first_seen']) ? (int) $event['first_seen'] : 0;
+            $lastSeen      = isset($event['last_seen']) ? (int) $event['last_seen'] : $firstSeen;
+            // Use incident start time to gate the history window (ignore refreshed old posts).
+            $incidentStart = $firstSeen ?: $lastSeen;
+
+            if ($incidentStart && $incidentStart < $cutoff) {
+                continue;
+            }
+
+            $status    = $normalizeStatus((string) ($event['status'] ?? 'unknown'));
+            $label     = $providerLabels[$slug] ?? ($event['provider_label'] ?? ucfirst($slug));
+            $severity  = isset($event['severity']) ? strtolower((string) $event['severity']) : 'degraded';
+            $important = isset($event['important']) ? (bool) $event['important'] : true;
+
+            if (in_array($status, ['operational', 'ok', 'none'], true)) {
+                continue;
+            }
+
+            if ($importantOnly) {
+                if (! $important) {
+                    continue;
+                }
+                if (in_array($severity, ['maintenance', 'info'], true)) {
+                    continue;
+                }
+            }
+
+            if ($minSeverity && isset($severityOrder[$severity]) && isset($severityOrder[$minSeverity])) {
+                if ($severityOrder[$severity] < $severityOrder[$minSeverity]) {
+                    continue;
+                }
+            }
+
+            $prepared[] = [
+                'id'         => (string) ($event['guid'] ?? sha1($slug . '|' . ($event['title'] ?? '') . '|' . ($firstSeen ?: $lastSeen))),
+                'provider'   => $slug,
+                'provider_label' => (string) $label,
+                'status'     => $status,
+                'severity'   => $severity,
+                'important'  => (bool) $important,
+                'summary'    => (string) ($event['title'] ?? $event['description'] ?? ''),
+                'first_seen' => $firstSeen,
+                'last_seen'  => $lastSeen,
+                'url'        => isset($event['url']) ? (string) $event['url'] : '',
+            ];
+        }
+
+        usort($prepared, static function ($left, $right): int {
+            $leftTs  = isset($left['last_seen']) ? (int) $left['last_seen'] : (int) ($left['first_seen'] ?? 0);
+            $rightTs = isset($right['last_seen']) ? (int) $right['last_seen'] : (int) ($right['first_seen'] ?? 0);
+            return $rightTs <=> $leftTs;
+        });
+
+        $deduped         = [];
+        $latestPerSource = [];
+        $dedupeWindow    = 30 * MINUTE_IN_SECONDS;
+
+        foreach ($prepared as $entry) {
+            $slug      = $entry['provider'];
+            $reference = $entry['last_seen'] ?: $entry['first_seen'];
+
+            if (isset($latestPerSource[$slug])) {
+                $lastIndex = $latestPerSource[$slug];
+                $recent    = $deduped[$lastIndex];
+                $sameTitle = isset($recent['summary'], $entry['summary']) && $recent['summary'] === $entry['summary'];
+                $sameSeverity = isset($recent['severity']) && $recent['severity'] === ($entry['severity'] ?? '');
+                $recentTs     = $recent['last_seen'] ?: $recent['first_seen'];
+
+                if ($sameTitle && $sameSeverity && abs($recentTs - $reference) < $dedupeWindow) {
+                    $deduped[$lastIndex]['first_seen'] = min(
+                        (int) ($deduped[$lastIndex]['first_seen'] ?? $reference),
+                        (int) ($entry['first_seen'] ?? $reference)
+                    );
+                    $deduped[$lastIndex]['last_seen'] = max(
+                        (int) ($deduped[$lastIndex]['last_seen'] ?? $reference),
+                        (int) ($entry['last_seen'] ?? $reference)
+                    );
+                    continue;
+                }
+            }
+
+            $deduped[]              = $entry;
+            $latestPerSource[$slug] = count($deduped) - 1;
+        }
+
+        $chartEvents = $deduped;
+        if (count($deduped) > $limit) {
+            $deduped = array_slice($deduped, 0, $limit);
+        }
+
+        $windowStart = $cutoff;
+        $windowEnd   = time();
+
+        foreach ($chartEvents as $event) {
+            $firstSeen = isset($event['first_seen']) ? (int) $event['first_seen'] : 0;
+            $lastSeen  = isset($event['last_seen']) ? (int) $event['last_seen'] : $firstSeen;
+            $startTs   = $firstSeen ?: $lastSeen;
+            $endTs     = $lastSeen ?: $firstSeen;
+
+            if ($startTs && $startTs < $windowStart) {
+                $windowStart = $startTs;
+            }
+            if ($endTs && $endTs > $windowEnd) {
+                $windowEnd = $endTs;
+            }
+        }
+
+        if ($windowStart <= 0) {
+            $windowStart = $cutoff;
+        }
+        if ($windowEnd <= 0) {
+            $windowEnd = time();
+        }
+
+        foreach ($deduped as $event) {
+            $slug  = $event['provider'];
+            $label = $event['provider_label'] ?? ucfirst($slug);
+            $date  = gmdate('Y-m-d', $event['first_seen'] ?: ($event['last_seen'] ?: time()));
+
+            $ensureProvider($slug, (string) $label);
+
+            if (!isset($providers[$slug]['history'][$date])) {
+                $providers[$slug]['history'][$date] = [
+                    'date'        => $date,
+                    'incidents'   => 0,
+                    'last_status' => $event['status'],
+                ];
+            }
+
+            $providers[$slug]['history'][$date]['incidents'] += 1;
+            $providers[$slug]['history'][$date]['last_status'] = $event['status'];
+
+            $providers[$slug]['incidents'][] = [
+                'id'         => $event['id'],
+                'provider'   => $event['provider_label'],
+                'status'     => $event['status'],
+                'severity'   => $event['severity'],
+                'important'  => $event['important'],
+                'summary'    => $event['summary'],
+                'first_seen' => $event['first_seen'] ? gmdate('c', (int) $event['first_seen']) : null,
+                'last_seen'  => $event['last_seen'] ? gmdate('c', (int) $event['last_seen']) : null,
+                'url'        => $event['url'],
+            ];
+        }
+
+        // Fallback for environments without persisted incidents yet: use legacy status log.
+        if (empty($providers)) {
+            foreach ($log as $entry) {
+                if (!is_array($entry) || empty($entry['id']) || !isset($entry['time'])) {
+                    continue;
+                }
+                $timestamp = (int) $entry['time'];
+                if ($timestamp < $cutoff) {
+                    continue;
+                }
+                $slug = sanitize_key((string) $entry['id']);
+                if ('' === $slug || !isset($allowedProviders[$slug])) {
+                    continue;
+                }
+                if (!empty($filters) && !in_array($slug, $filters, true)) {
+                    continue;
+                }
+                $date   = gmdate('Y-m-d', $timestamp);
+                $status = $normalizeStatus((string) ($entry['status'] ?? 'unknown'));
+                $isIncident = !in_array($status, ['operational', 'none', 'ok'], true);
+
+                if (!$isIncident) {
+                    continue;
+                }
+
+                $ensureProvider($slug, ucfirst($slug));
+
+                if (!isset($providers[$slug]['history'][$date])) {
+                    $providers[$slug]['history'][$date] = [
+                        'date'        => $date,
+                        'incidents'   => 0,
+                        'last_status' => $status,
+                    ];
+                }
+
+                if ($isIncident) {
+                    $providers[$slug]['history'][$date]['incidents'] += 1;
+                }
+                $providers[$slug]['history'][$date]['last_status'] = $status;
+
+                $providers[$slug]['incidents'][] = [
+                    'id'         => sha1($slug . '|' . $timestamp . '|' . $status),
+                    'provider'   => ucfirst($slug),
+                    'status'     => $status,
+                    'severity'   => 'degraded',
+                    'important'  => true,
+                    'summary'    => sprintf('Status reported: %s', ucfirst($status)),
+                    'first_seen' => gmdate('c', $timestamp),
+                    'last_seen'  => null,
+                    'url'        => '',
+                ];
+            }
+        }
+
+        $providerCounts = [];
+        $dailyCounts    = [];
+        foreach ($chartEvents as $event) {
+            $label = $event['provider_label'] ?? ($providerLabels[$event['provider']] ?? $event['provider']);
+            $date  = gmdate('Y-m-d', $event['first_seen'] ?: ($event['last_seen'] ?: time()));
+            $providerCounts[$label] = ($providerCounts[$label] ?? 0) + 1;
+            $dailyCounts[$date]     = ($dailyCounts[$date] ?? 0) + 1;
+        }
+
+        $response = [
+            'generated_at' => gmdate('c'),
+            'meta'         => [
+                'fetchedAt'        => gmdate('c'),
+                'provider_counts'  => $providerCounts,
+                'daily_counts'     => $dailyCounts,
+                'important_only'   => $importantOnly,
+                'window_days'      => $days,
+                'window_start'     => gmdate('Y-m-d', $windowStart),
+                'window_end'       => gmdate('Y-m-d', $windowEnd),
+                'deduped_incidents' => count($deduped),
+            ],
+            'providers'    => [],
+        ];
+
+        $yearOverYear = $incidentStore->getYearOverYearWindow($days, $importantOnly);
+        $response['meta']['year_over_year'] = [
+            'current'  => [
+                'start'        => gmdate('Y-m-d', $yearOverYear['current']['start'] ?? $windowStart),
+                'end'          => gmdate('Y-m-d', $yearOverYear['current']['end'] ?? $windowEnd),
+                'total'        => $yearOverYear['current']['total'] ?? 0,
+                'daily_counts' => $yearOverYear['current']['daily_counts'] ?? [],
+            ],
+            'previous' => [
+                'start'        => gmdate('Y-m-d', $yearOverYear['previous']['start'] ?? ($windowStart - YEAR_IN_SECONDS)),
+                'end'          => gmdate('Y-m-d', $yearOverYear['previous']['end'] ?? ($windowEnd - YEAR_IN_SECONDS)),
+                'total'        => $yearOverYear['previous']['total'] ?? 0,
+                'daily_counts' => $yearOverYear['previous']['daily_counts'] ?? [],
+            ],
+            'delta'    => ($yearOverYear['current']['total'] ?? 0) - ($yearOverYear['previous']['total'] ?? 0),
+        ];
+
+        foreach ($providers as $provider) {
+            $history = $provider['history'];
+            ksort($history);
+            $incidents = $provider['incidents'];
+            usort($incidents, static function ($left, $right): int {
+                $leftTs  = isset($left['last_seen']) ? strtotime((string) $left['last_seen']) : 0;
+                $rightTs = isset($right['last_seen']) ? strtotime((string) $right['last_seen']) : 0;
+                if (!$leftTs) {
+                    $leftTs = isset($left['first_seen']) ? strtotime((string) $left['first_seen']) : 0;
+                }
+                if (!$rightTs) {
+                    $rightTs = isset($right['first_seen']) ? strtotime((string) $right['first_seen']) : 0;
+                }
+
+                return $rightTs <=> $leftTs;
+            });
+
+            $response['providers'][] = [
+                'id'        => $provider['id'],
+                'label'     => $provider['label'],
+                'history'   => array_values($history),
+                'incidents' => array_values($incidents),
+            ];
+        }
+
+        return rest_ensure_response($response);
+    }
+
+    public static function handle_report(WP_REST_Request $request): WP_REST_Response {
+        $providerId = sanitize_text_field((string) $request->get_param('provider_id'));
+        $providerName = sanitize_text_field((string) $request->get_param('provider_name'));
+        $summary    = sanitize_textarea_field((string) $request->get_param('summary'));
+        $contact    = sanitize_text_field((string) $request->get_param('contact'));
+        $captchaAnswer = sanitize_text_field((string) $request->get_param('captcha_answer'));
+        $captchaToken  = sanitize_text_field((string) $request->get_param('captcha_token'));
+
+        if ('' === trim($providerId) || '' === trim($summary)) {
+            return new WP_REST_Response([
+                'ok'      => false,
+                'message' => 'provider_id and summary are required.',
+            ], 400);
+        }
+
+        if (self::is_report_spam($summary)) {
+            return new WP_REST_Response([
+                'ok'      => false,
+                'message' => 'Report blocked due to suspected spam.',
+            ], 400);
+        }
+
+        if ('' === trim($captchaAnswer) || '' === trim($captchaToken)) {
+            return new WP_REST_Response([
+                'ok'      => false,
+                'message' => 'Captcha didn’t match. Try again.',
+            ], 400);
+        }
+
+        $expected = get_transient(self::report_captcha_transient_key($captchaToken));
+        $normalizedAnswer = self::normalize_report_captcha($captchaAnswer);
+        if (!$expected || '' === $normalizedAnswer || !hash_equals((string) $expected, $normalizedAnswer)) {
+            return new WP_REST_Response([
+                'ok'      => false,
+                'message' => 'Captcha didn’t match. Try again.',
+            ], 400);
+        }
+        delete_transient(self::report_captcha_transient_key($captchaToken));
+
+        $rateKey = 'lo_report_rate_' . self::get_report_ip_hash($request);
+        $rateCount = (int) get_transient($rateKey);
+        if ($rateCount >= self::REPORT_RATE_LIMIT) {
+            return new WP_REST_Response([
+                'ok'      => false,
+                'message' => 'Too many reports from this network. Please try again later.',
+            ], 429);
+        }
+        set_transient($rateKey, $rateCount + 1, self::REPORT_RATE_WINDOW);
+
+        $providerName = trim($providerName);
+        if ('other' === $providerId) {
+            if (strlen($providerName) < 2 || strlen($providerName) > 80) {
+                return new WP_REST_Response([
+                    'ok'      => false,
+                    'message' => 'Provider name must be 2-80 characters when reporting Other.',
+                ], 400);
+            }
+        } else {
+            $providerName = '';
+        }
+
+        $providers     = Providers::list();
+        if ('other' === $providerId) {
+            $providerLabel = sprintf('Other — %s', $providerName);
+        } else {
+            $providerLabel = $providers[$providerId]['name'] ?? ($providerId ? ucfirst($providerId) : 'provider');
+        }
+
+        $store = new IncidentStore();
+        $store->addUserReport($providerId, $summary, $contact, $providerLabel);
+
+        return new WP_REST_Response([
+            'ok'       => true,
+            'provider' => $providerId,
+            'message'  => sprintf(
+                'Thanks – we have logged your report for %s. It will appear in the status history as a community report.',
+                $providerLabel
+            ),
+        ], 200);
+    }
+
+
+    private static function sanitize_provider_list(?string $raw): array {
+        if (!$raw) {
+            return [];
+        }
+        $parts = array_filter(array_map('trim', explode(',', $raw)));
+        $parts = array_map(static function ($part) {
+            return strtolower((string) $part);
+        }, $parts);
+
+        return array_values(array_unique($parts));
+    }
+
+}

--- a/plugins/lousy-outages/includes/Cron.php
+++ b/plugins/lousy-outages/includes/Cron.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Cron helpers for refreshing the cached snapshot.
+ */
+
+declare(strict_types=1);
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+if (! function_exists('lo_cron_bootstrap')) {
+    function lo_cron_bootstrap(): void
+    {
+        add_filter('cron_schedules', 'lo_register_snapshot_schedule');
+        add_action('init', 'lo_ensure_snapshot_schedule');
+        add_action('lo_refresh_snapshot', 'lo_run_snapshot_refresh');
+    }
+}
+
+if (! function_exists('lo_cron_activate')) {
+    function lo_cron_activate(): void
+    {
+        lo_ensure_snapshot_schedule();
+    }
+}
+
+if (! function_exists('lo_cron_deactivate')) {
+    function lo_cron_deactivate(): void
+    {
+        wp_clear_scheduled_hook('lo_refresh_snapshot');
+    }
+}
+
+if (! function_exists('lo_register_snapshot_schedule')) {
+    function lo_register_snapshot_schedule(array $schedules): array
+    {
+        $interval = lo_snapshot_interval_seconds();
+        $schedules['lo_snapshot_interval'] = [
+            'interval' => $interval,
+            'display'  => __('Lousy Outages Snapshot Interval', 'lousy-outages'),
+        ];
+
+        return $schedules;
+    }
+}
+
+if (! function_exists('lo_snapshot_interval_seconds')) {
+    function lo_snapshot_interval_seconds(): int
+    {
+        $minutes = (int) get_option('lo_snapshot_interval_minutes', 3);
+        $minutes = (int) apply_filters('lo_snapshot_interval_minutes', $minutes);
+        if ($minutes < 2) {
+            $minutes = 2;
+        }
+        if ($minutes > 5) {
+            $minutes = 5;
+        }
+
+        return max(120, $minutes * MINUTE_IN_SECONDS);
+    }
+}
+
+if (! function_exists('lo_ensure_snapshot_schedule')) {
+    function lo_ensure_snapshot_schedule(): void
+    {
+        if (! wp_next_scheduled('lo_refresh_snapshot')) {
+            wp_schedule_event(time() + 30, 'lo_snapshot_interval', 'lo_refresh_snapshot');
+        }
+    }
+}
+
+if (! function_exists('lo_run_snapshot_refresh')) {
+    function lo_run_snapshot_refresh(): void
+    {
+        if (! function_exists('lo_snapshot_refresh')) {
+            return;
+        }
+
+        $snapshot = lo_snapshot_refresh(true);
+        do_action('lousy_outages_log', 'snapshot_refresh', [
+            'services' => is_array($snapshot['services'] ?? null) ? count($snapshot['services']) : 0,
+            'stale'    => ! empty($snapshot['stale']),
+            'updated'  => $snapshot['updated_at'] ?? gmdate('c'),
+        ]);
+    }
+}

--- a/plugins/lousy-outages/includes/Cron/Refresh.php
+++ b/plugins/lousy-outages/includes/Cron/Refresh.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages\Cron;
+
+use SuzyEaston\LousyOutages\IncidentAlerts;
+
+class Refresh
+{
+    public static function bootstrap(): void
+    {
+        add_filter('cron_schedules', [self::class, 'registerSchedule']);
+        add_action('init', [self::class, 'ensureScheduled']);
+        add_action('lousy_outages_cron_refresh', '\\lousy_outages_refresh_data');
+        add_action('lousy_outages_refresh', [IncidentAlerts::class, 'run']);
+        add_action('lo_send_daily_digest', [IncidentAlerts::class, 'send_daily_digest']);
+    }
+
+    public static function registerSchedule(array $schedules): array
+    {
+        if (! isset($schedules['five_minutes'])) {
+            $schedules['five_minutes'] = [
+                'interval' => 5 * MINUTE_IN_SECONDS,
+                'display'  => __('Every 5 Minutes', 'lousy-outages'),
+            ];
+        }
+
+        if (! isset($schedules['lousy_outages_15min'])) {
+            $schedules['lousy_outages_15min'] = [
+                // Snapshot refresh cadence for HUD data (~30 minutes).
+                'interval' => 30 * MINUTE_IN_SECONDS,
+                'display'  => __('Every 30 Minutes', 'lousy-outages'),
+            ];
+        }
+
+        if (! isset($schedules['lo_daily'])) {
+            $schedules['lo_daily'] = [
+                'interval' => DAY_IN_SECONDS,
+                'display'  => __('Every 24 Hours', 'lousy-outages'),
+            ];
+        }
+
+        return $schedules;
+    }
+
+    public static function ensureScheduled(): void
+    {
+        if (! wp_next_scheduled('lousy_outages_cron_refresh')) {
+            wp_schedule_event(time() + MINUTE_IN_SECONDS, 'lousy_outages_15min', 'lousy_outages_cron_refresh');
+        }
+
+        if (! wp_next_scheduled('lousy_outages_refresh')) {
+            wp_schedule_event(time() + MINUTE_IN_SECONDS, 'five_minutes', 'lousy_outages_refresh');
+        }
+
+        $target = self::nextDigestTimestamp();
+        $scheduled = wp_next_scheduled('lo_send_daily_digest');
+
+        if (! $scheduled || abs($scheduled - $target) > MINUTE_IN_SECONDS) {
+            if ($scheduled) {
+                wp_unschedule_event($scheduled, 'lo_send_daily_digest');
+            }
+            wp_schedule_event($target, 'lo_daily', 'lo_send_daily_digest');
+        }
+    }
+
+    /**
+     * Calculate the UTC timestamp for the next nightly digest run.
+     */
+    private static function nextDigestTimestamp(): int
+    {
+        $tz     = new \DateTimeZone('America/Vancouver');
+        $now    = new \DateTimeImmutable('now', $tz);
+        $target = $now->setTime(23, 59, 30);
+
+        if ($target <= $now) {
+            $target = $target->modify('+1 day');
+        }
+
+        return $target->setTimezone(new \DateTimeZone('UTC'))->getTimestamp();
+    }
+}

--- a/plugins/lousy-outages/includes/Detector.php
+++ b/plugins/lousy-outages/includes/Detector.php
@@ -1,0 +1,23 @@
+<?php
+namespace SuzyEaston\LousyOutages;
+
+class Detector {
+    private Store $store;
+
+    public function __construct( Store $store ) {
+        $this->store = $store;
+    }
+
+    /**
+     * Compare new data with stored to find transitions.
+     */
+    public function detect( string $id, array $data ): ?array {
+        $existing = $this->store->get( $id );
+        $old      = $existing['status'] ?? 'unknown';
+        $new      = $data['status'];
+        if ( $old === $new ) {
+            return null;
+        }
+        return [ 'old' => $old, 'new' => $new ];
+    }
+}

--- a/plugins/lousy-outages/includes/Downdetector.php
+++ b/plugins/lousy-outages/includes/Downdetector.php
@@ -1,0 +1,183 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+class Downdetector {
+    private const CACHE_KEY = 'lousy_outages_downdetector_trends';
+    private const CACHE_TTL = 300;
+
+    /** @var int */
+    private $timeout;
+
+    /** @var string */
+    private $feedUrl;
+
+    public function __construct(int $timeout = 6, ?string $feedUrl = null) {
+        $this->timeout = max(2, $timeout);
+        $defaultUrl    = 'https://downdetector.ca/archive/?format=rss';
+        $this->feedUrl = $feedUrl ?: (string) apply_filters('lousy_outages_downdetector_feed', $defaultUrl);
+    }
+
+    public function matches(array $provider): array {
+        $entries  = $this->getTrends();
+        if (empty($entries)) {
+            return [];
+        }
+
+        $keywords = $this->keywordsFor($provider);
+        if (empty($keywords)) {
+            return [];
+        }
+
+        $matches  = [];
+        $now      = time();
+        $maxAge   = (int) apply_filters('lousy_outages_downdetector_max_age', 120); // minutes
+        $cutoff   = $now - max(10, $maxAge) * 60;
+
+        foreach ($entries as $entry) {
+            $title = isset($entry['title']) ? (string) $entry['title'] : '';
+            if ('' === $title) {
+                continue;
+            }
+
+            $ts = isset($entry['timestamp']) ? (int) $entry['timestamp'] : 0;
+            if ($ts && $ts < $cutoff) {
+                continue;
+            }
+
+            $haystack = strtolower($title);
+            foreach ($keywords as $keyword) {
+                if (false !== strpos($haystack, $keyword)) {
+                    $match = $entry;
+                    if ($ts > 0) {
+                        $match['age_minutes'] = max(0, (int) round(($now - $ts) / 60));
+                    }
+                    $matches[] = $match;
+                    break;
+                }
+            }
+        }
+
+        return $matches;
+    }
+
+    private function getTrends(): array {
+        $cached = get_transient(self::CACHE_KEY);
+        if (is_array($cached)) {
+            return $cached;
+        }
+
+        $response = wp_remote_get($this->feedUrl, [
+            'timeout' => $this->timeout,
+            'headers' => [
+                'Accept'     => 'application/rss+xml, application/xml;q=0.9,*/*;q=0.8',
+                'User-Agent' => $this->userAgent(),
+            ],
+        ]);
+
+        if (is_wp_error($response)) {
+            set_transient(self::CACHE_KEY, [], self::CACHE_TTL);
+            return [];
+        }
+
+        $code = (int) wp_remote_retrieve_response_code($response);
+        if ($code >= 400) {
+            set_transient(self::CACHE_KEY, [], self::CACHE_TTL);
+            return [];
+        }
+
+        $body = (string) wp_remote_retrieve_body($response);
+        if ('' === trim($body)) {
+            set_transient(self::CACHE_KEY, [], self::CACHE_TTL);
+            return [];
+        }
+
+        $entries = $this->parseFeed($body);
+        set_transient(self::CACHE_KEY, $entries, self::CACHE_TTL);
+
+        return $entries;
+    }
+
+    private function parseFeed(string $body): array {
+        $prev = libxml_use_internal_errors(true);
+        $xml  = simplexml_load_string($body);
+        libxml_clear_errors();
+        libxml_use_internal_errors($prev);
+        if (!$xml || !isset($xml->channel->item)) {
+            return [];
+        }
+
+        $entries = [];
+        foreach ($xml->channel->item as $item) {
+            $title = sanitize_text_field((string) ($item->title ?? ''));
+            if ('' === $title) {
+                continue;
+            }
+            $published = (string) ($item->pubDate ?? ($item->published ?? ''));
+            $timestamp = $published ? strtotime($published) : 0;
+            $entries[] = [
+                'title'       => $title,
+                'timestamp'   => $timestamp ?: time(),
+                'publishedAt' => $timestamp ? gmdate('c', $timestamp) : gmdate('c'),
+                'link'        => isset($item->link) ? sanitize_text_field((string) $item->link) : '',
+            ];
+        }
+
+        usort(
+            $entries,
+            static function (array $a, array $b): int {
+                return (int) ($b['timestamp'] ?? 0) <=> (int) ($a['timestamp'] ?? 0);
+            }
+        );
+
+        return $entries;
+    }
+
+    private function keywordsFor(array $provider): array {
+        $id   = strtolower((string) ($provider['id'] ?? ''));
+        $name = strtolower((string) ($provider['name'] ?? ''));
+
+        $map = [
+            'aws'         => ['amazon web services', 'amazon'],
+            'azure'       => ['microsoft', 'microsoft azure'],
+            'google_cloud' => ['google cloud', 'google'],
+            'google_workspace' => ['google workspace', 'google apps', 'gmail', 'google meet', 'google calendar'],
+            'github'      => ['github'],
+            'zscaler'     => ['zscaler'],
+            'cloudflare'  => ['cloudflare'],
+            'openai'      => ['openai'],
+            'digitalocean'=> ['digitalocean', 'digital ocean'],
+            'netlify'     => ['netlify'],
+            'vercel'      => ['vercel'],
+            'atlassian'   => ['atlassian', 'jira', 'confluence', 'bitbucket'],
+            'zoom'        => ['zoom'],
+            'qubeyond'    => ['qubeyond'],
+        ];
+
+        $keywords = [];
+        if ('' !== $name) {
+            $keywords[] = $name;
+        }
+        if ('' !== $id) {
+            $keywords[] = $id;
+        }
+        if (isset($map[$id])) {
+            $keywords = array_merge($keywords, $map[$id]);
+        }
+
+        $keywords = array_map(
+            static function ($keyword): string {
+                return strtolower(trim((string) $keyword));
+            },
+            array_filter($keywords)
+        );
+
+        return array_values(array_unique(array_filter($keywords)));
+    }
+
+    private function userAgent(): string {
+        $site = home_url();
+        return 'Mozilla/5.0 (compatible; LousyOutagesBot/3.1; +' . $site . ')';
+    }
+}

--- a/plugins/lousy-outages/includes/Email.php
+++ b/plugins/lousy-outages/includes/Email.php
@@ -1,0 +1,185 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+use SuzyEaston\LousyOutages\Email\Composer;
+
+class Email {
+    private const STATUS_LABELS = [
+        'degraded'       => 'degraded performance',
+        'partial_outage' => 'partial outage',
+        'major_outage'   => 'major outage',
+        'maintenance'    => 'maintenance window',
+        'operational'    => 'operational',
+        'resolved'       => 'resolved',
+        'recovered'      => 'recovered',
+        'partial'        => 'partial outage',
+        'major'          => 'major outage',
+        'critical'       => 'critical incident',
+        'incident'       => 'incident',
+    ];
+
+    public function send_alert(string $provider, string $status, string $message, string $link): void {
+        $status_slug  = strtolower(trim($status)) ?: 'degraded';
+        $status_label = $this->describe_status($status_slug);
+        $subject      = Composer::subjectForProvider($provider, $status_slug, $message);
+
+        [$text_body, $html_body] = $this->build_bodies($provider, $status_label, $message, $link, false);
+        $this->dispatch($subject, $text_body, $html_body);
+    }
+
+    public function send_recovery(string $provider, string $link): void {
+        $status_label = $this->describe_status('recovered');
+        $subject      = Composer::subjectForProvider($provider, 'resolved', '');
+
+        [$text_body, $html_body] = $this->build_bodies($provider, $status_label, 'Systems stabilized — back to nominal performance.', $link, true);
+        $this->dispatch($subject, $text_body, $html_body);
+    }
+
+    private function dispatch(string $subject, string $text_body, string $html_body): void {
+        $to = get_option('lousy_outages_email', get_option('admin_email'));
+        if (!$to || !is_email($to)) {
+            do_action('lousy_outages_log', 'email_skip', ['reason' => 'invalid_to']);
+            return;
+        }
+
+        $ok = Mailer::send($to, $subject, $text_body, $html_body);
+
+        update_option(
+            'lousy_outages_last_email',
+            [
+                'to'      => $to,
+                'subject' => $subject,
+                'ok'      => $ok,
+                'ts'      => gmdate('c'),
+            ],
+            false
+        );
+
+        do_action('lousy_outages_log', 'email_send', ['ok' => $ok, 'to' => $to, 'subject' => $subject]);
+    }
+
+    /**
+     * @return array{0: string, 1: string}
+     */
+    private function build_bodies(string $provider, string $status_label, string $message, string $link, bool $recovery): array {
+        $provider_label = trim($provider) ?: 'Provider';
+        $message_clean  = $this->clean_message($message);
+        if ('' === $message_clean) {
+            $message_clean = $recovery ? 'Everything is reading green on the console again.' : 'Details incoming — watch the console feed for live notes.';
+        }
+
+        $link = $this->ensure_link($link);
+
+        $status_text = strtoupper($status_label);
+        $cta_text    = $recovery ? 'Review status timeline' : 'Track live status';
+        $summary     = $recovery
+            ? sprintf('%s is back in a healthy state. Systems report nominal values.', $provider_label)
+            : sprintf('%s just flipped to %s. Heads-up below.', $provider_label, $status_label);
+
+        $text_lines = [
+            sprintf('%s — %s', $provider_label, $status_text),
+            $summary,
+            '',
+            $message_clean,
+            '',
+            $cta_text . ': ' . $link,
+            '',
+            'You will only get this one heads-up for the incident. Follow the provider status console for play-by-play updates.',
+            '',
+            'Stay laser-focused,',
+            'Lousy Outages ops console',
+        ];
+
+        $text_body = implode("\n", $text_lines);
+
+        $accent       = $recovery ? '#3be88f' : '#ffb81c';
+        $accent_soft  = $recovery ? 'rgba(59,232,143,0.35)' : 'rgba(255,184,28,0.35)';
+        $badge_bg     = $recovery ? 'rgba(59,232,143,0.18)' : 'rgba(255,184,28,0.18)';
+        $panel_start  = $recovery ? '#021b11' : '#150022';
+        $panel_end    = $recovery ? '#04331c' : '#23093b';
+        $cta_bg       = $recovery ? '#3be88f' : '#ff6f61';
+        $cta_color    = $recovery ? '#032015' : '#050211';
+        $badge_label  = $recovery ? 'RESTORED' : 'ALERT';
+        $meta_caption = $recovery ? 'restoration signal locked' : 'defense grid warning';
+
+        $provider_html = esc_html($provider_label);
+        $status_html   = esc_html($status_text);
+        $summary_html  = nl2br(esc_html($summary));
+        $message_html  = nl2br(esc_html($message_clean));
+        $link_html     = esc_url($link);
+        $cta_html      = sprintf(
+            '<a href="%s" style="display:inline-block;padding:14px 22px;border-radius:999px;border:2px solid %s;background:%s;color:%s;font-weight:700;text-decoration:none;text-transform:uppercase;letter-spacing:0.08em;">%s</a>',
+            $link_html,
+            $accent,
+            $cta_bg,
+            $cta_color,
+            esc_html($cta_text)
+        );
+
+        $html_body = <<<HTML
+<!doctype html>
+<meta charset="utf-8">
+<body style="margin:0;background:#040211;color:#f7f8ff;font-family:'Share Tech Mono','Lucida Console','Courier New',monospace;">
+  <div style="max-width:640px;margin:0 auto;padding:32px 18px;">
+    <div style="background:linear-gradient(135deg,{$panel_start},{$panel_end});border:3px solid {$accent};box-shadow:0 0 36px {$accent_soft};border-radius:22px;padding:30px 28px;">
+      <header style="display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:20px;text-transform:uppercase;">
+        <span style="font-size:14px;letter-spacing:0.14em;color:{$accent};">lousy outages ops</span>
+        <span style="font-size:12px;color:rgba(247,248,255,0.75);">{$meta_caption}</span>
+      </header>
+      <div style="display:inline-flex;align-items:center;gap:10px;background:{$badge_bg};padding:10px 16px;border-radius:999px;margin-bottom:18px;">
+        <span style="font-size:11px;letter-spacing:0.22em;color:{$accent};">{$badge_label}</span>
+        <span style="font-size:12px;letter-spacing:0.16em;color:rgba(247,248,255,0.8);">{$status_html}</span>
+      </div>
+      <h1 style="margin:0 0 12px;font-size:26px;color:#fefefe;letter-spacing:0.08em;text-transform:uppercase;">{$provider_html}</h1>
+      <p style="margin:0 0 14px;font-size:14px;line-height:1.7;color:rgba(247,248,255,0.88);">{$summary_html}</p>
+      <div style="margin:0 0 20px;padding:16px 18px;border:1px dashed rgba({$this->rgbaFromHex($accent)},0.55);border-radius:16px;background:rgba(5,5,25,0.55);">
+        <p style="margin:0;font-size:13px;line-height:1.7;color:#f7f8ff;">{$message_html}</p>
+      </div>
+      <p style="margin:0 0 18px;font-size:12px;color:rgba(247,248,255,0.75);">One alert per incident. For live play-by-play, keep the provider status console open.</p>
+      <p style="margin:0 0 22px;">{$cta_html}</p>
+      <p style="margin:0;font-size:11px;color:rgba(247,248,255,0.6);">If the button stalls, open this link: <a href="{$link_html}" style="color:{$accent};">{$link_html}</a></p>
+    </div>
+  </div>
+</body>
+HTML;
+
+        return [$text_body, $html_body];
+    }
+
+    private function describe_status(string $status): string {
+        $status = strtolower(trim($status));
+        if (isset(self::STATUS_LABELS[$status])) {
+            return self::STATUS_LABELS[$status];
+        }
+
+        return $status ? $status : 'status update';
+    }
+
+    private function ensure_link(string $link): string {
+        $link = trim($link);
+        if ('' !== $link) {
+            return $link;
+        }
+
+        return home_url('/lousy-outages/');
+    }
+
+    private function clean_message(string $message): string {
+        return trim(wp_strip_all_tags($message));
+    }
+
+    private function rgbaFromHex(string $hex): string {
+        $hex = ltrim($hex, '#');
+        if (6 !== strlen($hex)) {
+            return '255,255,255';
+        }
+
+        $r = hexdec(substr($hex, 0, 2));
+        $g = hexdec(substr($hex, 2, 2));
+        $b = hexdec(substr($hex, 4, 2));
+
+        return sprintf('%d,%d,%d', $r, $g, $b);
+    }
+}

--- a/plugins/lousy-outages/includes/Email/Composer.php
+++ b/plugins/lousy-outages/includes/Email/Composer.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages\Email;
+
+use SuzyEaston\LousyOutages\Model\Incident;
+
+class Composer
+{
+    public static function subjectForIncident(Incident $incident, ?string $fallbackStatus = null): string
+    {
+        $shortTitle = self::shortTitle($incident->title);
+        $provider   = trim($incident->provider) ?: 'Provider';
+
+        if ($incident->isResolved()) {
+            return sprintf('[Resolved] %s: %s', $provider, $shortTitle);
+        }
+
+        $statusSlug = strtolower($incident->status ?: 'incident');
+        if (! $statusSlug && $fallbackStatus) {
+            $statusSlug = strtolower($fallbackStatus);
+        }
+
+        $headline = self::statusHeadline($statusSlug);
+        $short    = self::shortTitle($incident->title ?: $headline);
+
+        return sprintf('[Outage Alert] %s: %s', $provider, $short ?: $headline);
+    }
+
+    public static function subjectForProvider(string $provider, string $status, string $title = ''): string
+    {
+        $provider = trim($provider) ?: 'Provider';
+        $status   = strtolower(trim($status));
+        if ('resolved' === $status) {
+            $short = self::shortTitle($title ?: 'Status Restored');
+            return sprintf('[Resolved] %s: %s', $provider, $short);
+        }
+
+        $headline = self::statusHeadline($status);
+        $short    = self::shortTitle($title ?: $headline);
+
+        return sprintf('[Outage Alert] %s: %s', $provider, $short ?: $headline);
+    }
+
+    public static function shortTitle(string $title): string
+    {
+        $stripped = preg_replace('/^(Update:|Identified:|Monitoring:|Resolved:|Investigating:)\s*/i', '', $title);
+        if (null === $stripped) {
+            $stripped = $title;
+        }
+        $clean = trim($stripped);
+        $clean = rtrim($clean);
+        $clean = preg_replace('/[\-–—:]+$/u', '', $clean ?? '');
+        if (null === $clean) {
+            $clean = '';
+        }
+        $clean = rtrim($clean);
+        return $clean ?: 'Incident';
+    }
+
+    private static function statusHeadline(string $status): string
+    {
+        $status = strtolower(trim($status));
+        $map = [
+            'degraded'       => 'Degraded service',
+            'partial_outage' => 'Partial outage',
+            'partial'        => 'Partial outage',
+            'major_outage'   => 'Major outage',
+            'major'          => 'Major outage',
+            'critical'       => 'Critical incident',
+            'maintenance'    => 'Maintenance window',
+            'incident'       => 'Connectivity incident',
+        ];
+
+        if (isset($map[$status])) {
+            return $map[$status];
+        }
+
+        if ('' === $status) {
+            return 'Incident';
+        }
+
+        return ucfirst(str_replace('_', ' ', $status));
+    }
+}

--- a/plugins/lousy-outages/includes/ExternalSignals.php
+++ b/plugins/lousy-outages/includes/ExternalSignals.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+class ExternalSignals {
+    public static function table_name(): string { global $wpdb; return $wpdb->prefix . 'lo_external_signals'; }
+
+    public static function install(): void {
+        global $wpdb;
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        $table = self::table_name();
+        $charset = $wpdb->get_charset_collate();
+        $sql = "CREATE TABLE {$table} (
+            id BIGINT unsigned NOT NULL AUTO_INCREMENT,
+            source VARCHAR(80) NOT NULL,
+            provider_id VARCHAR(80) NOT NULL DEFAULT '',
+            provider_name VARCHAR(160) NOT NULL DEFAULT '',
+            category VARCHAR(80) NOT NULL DEFAULT '',
+            region VARCHAR(80) NOT NULL DEFAULT '',
+            signal_type VARCHAR(80) NOT NULL DEFAULT '',
+            severity VARCHAR(40) NOT NULL DEFAULT 'unknown',
+            confidence TINYINT unsigned NOT NULL DEFAULT 0,
+            title VARCHAR(255) NOT NULL DEFAULT '',
+            message TEXT NULL,
+            url TEXT NULL,
+            observed_at DATETIME NOT NULL,
+            expires_at DATETIME NULL,
+            raw_hash VARCHAR(128) NULL,
+            created_at DATETIME NOT NULL,
+            PRIMARY KEY (id),
+            KEY source (source), KEY provider_id (provider_id), KEY category (category), KEY region (region), KEY observed_at (observed_at), KEY expires_at (expires_at)
+        ) {$charset};";
+        dbDelta($sql);
+    }
+
+    public static function normalize_signal(array $signal): array {
+        $observed = sanitize_text_field((string)($signal['observed_at'] ?? gmdate('Y-m-d H:i:s')));
+        $expires = isset($signal['expires_at']) ? sanitize_text_field((string)$signal['expires_at']) : null;
+        return [
+            'source' => substr(sanitize_key((string)($signal['source'] ?? 'unknown_external')), 0, 80),
+            'provider_id' => substr(sanitize_key((string)($signal['provider_id'] ?? '')), 0, 80),
+            'provider_name' => substr(sanitize_text_field((string)($signal['provider_name'] ?? '')), 0, 160),
+            'category' => substr(sanitize_key((string)($signal['category'] ?? 'general')), 0, 80),
+            'region' => substr(sanitize_text_field((string)($signal['region'] ?? 'global')), 0, 80),
+            'signal_type' => substr(sanitize_key((string)($signal['signal_type'] ?? 'unknown')), 0, 80),
+            'severity' => substr(sanitize_key((string)($signal['severity'] ?? 'unknown')), 0, 40),
+            'confidence' => max(0, min(100, (int)($signal['confidence'] ?? 0))),
+            'title' => substr(sanitize_text_field((string)($signal['title'] ?? 'External signal observed')), 0, 255),
+            'message' => substr(sanitize_textarea_field((string)($signal['message'] ?? '')), 0, 1000),
+            'url' => substr(esc_url_raw((string)($signal['url'] ?? '')), 0, 1000),
+            'observed_at' => $observed,
+            'expires_at' => $expires ?: null,
+            'raw_hash' => isset($signal['raw_hash']) ? substr(sanitize_text_field((string)$signal['raw_hash']),0,128) : hash('sha256', wp_json_encode($signal)),
+        ];
+    }
+
+    public static function record_signal(array $signal): array {
+        global $wpdb; $s=self::normalize_signal($signal);
+        if (!empty($s['raw_hash'])) {
+            $exists = $wpdb->get_var($wpdb->prepare('SELECT id FROM '.self::table_name().' WHERE raw_hash=%s LIMIT 1', $s['raw_hash']));
+            if ($exists) return ['inserted'=>false,'id'=>(int)$exists,'signal'=>$s];
+        }
+        $wpdb->insert(self::table_name(), array_merge($s,['created_at'=>gmdate('Y-m-d H:i:s')]));
+        return ['inserted'=>true,'id'=>(int)$wpdb->insert_id,'signal'=>$s];
+    }
+    public static function record_many(array $signals): array { $out=['inserted'=>0,'skipped'=>0,'rows'=>[]]; foreach($signals as $sig){$r=self::record_signal((array)$sig);$out['rows'][]=$r; $out[$r['inserted']?'inserted':'skipped']++;} return $out; }
+    public static function get_recent_signals(array $args=[]): array { global $wpdb; $limit=max(1,min(200,(int)($args['limit']??50))); return $wpdb->get_results($wpdb->prepare('SELECT * FROM '.self::table_name().' WHERE observed_at >= %s ORDER BY observed_at DESC LIMIT %d', gmdate('Y-m-d H:i:s', time()-((int)($args['windowMinutes']??60))*60), $limit), ARRAY_A) ?: []; }
+    public static function get_recent_counts(int $windowMinutes=60): array { global $wpdb; $rows=$wpdb->get_results($wpdb->prepare('SELECT source, COUNT(*) as signal_count FROM '.self::table_name().' WHERE observed_at >= %s GROUP BY source', gmdate('Y-m-d H:i:s', time()-$windowMinutes*60)), ARRAY_A) ?: []; return $rows; }
+    public static function clear_expired(): int { global $wpdb; $wpdb->query($wpdb->prepare('DELETE FROM '.self::table_name().' WHERE expires_at IS NOT NULL AND expires_at < %s', gmdate('Y-m-d H:i:s'))); return (int)$wpdb->rows_affected; }
+    public static function clear_demo_signals(): int { global $wpdb; $wpdb->query($wpdb->prepare('DELETE FROM '.self::table_name().' WHERE source = %s', 'demo_external')); return (int)$wpdb->rows_affected; }
+    public static function seed_demo_signals(array $options=[]): array {
+        $now=gmdate('Y-m-d H:i:s');
+        $demo=[[ 'source'=>'demo_external','provider_id'=>'cloudflare','provider_name'=>'Cloudflare','category'=>'internet_health','region'=>'us','signal_type'=>'traffic_anomaly','severity'=>'degraded','confidence'=>68,'title'=>'Internet-health anomaly detected','message'=>'Possible emerging issue from demo telemetry. Official incident not yet confirmed.','observed_at'=>$now ],[ 'source'=>'demo_external','provider_id'=>'local_isp','provider_name'=>'Local ISP','category'=>'isp','region'=>'vancouver','signal_type'=>'internet_outage','severity'=>'major','confidence'=>74,'title'=>'Unconfirmed external signal','message'=>'We are watching this provider due to demo external signal.','observed_at'=>$now ]];
+        return self::record_many($demo);
+    }
+}

--- a/plugins/lousy-outages/includes/Feed.php
+++ b/plugins/lousy-outages/includes/Feed.php
@@ -1,0 +1,415 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+use SuzyEaston\LousyOutages\Providers;
+use SuzyEaston\LousyOutages\Storage\IncidentStore;
+
+class Feed {
+    public static function bootstrap(): void {
+        add_action('init', [self::class, 'register']);
+    }
+
+    public static function register(): void {
+        add_feed('lousy-outages', [self::class, 'render']);
+        add_feed('lousy-outages-incidents', [self::class, 'render']);
+
+        add_rewrite_rule('^lousy-outages/feed/?$', 'index.php?feed=lousy-outages', 'top');
+        add_rewrite_rule('^feed/lousy-outages/?$', 'index.php?feed=lousy-outages', 'top');
+        add_rewrite_rule('^feed/lousy-outages-incidents/?$', 'index.php?feed=lousy-outages-incidents', 'top');
+    }
+
+    public static function render(): void {
+        if (function_exists('nocache_headers')) {
+            nocache_headers();
+        }
+
+        $charset = (string) get_option('blog_charset', 'UTF-8');
+        header('Content-Type: application/rss+xml; charset=' . $charset, true);
+
+        $feedName = get_query_var('feed');
+        if ('lousy-outages-incidents' === $feedName) {
+            self::render_incidents_feed($charset);
+            return;
+        }
+        // Use the current request URL to avoid mismatch between query-string and pretty permalinks.
+        $self = esc_url(function_exists('get_self_link') ? get_self_link() : home_url(add_query_arg(null, null)));
+
+        $store  = new Store();
+        $states = $store->get_all();
+        if (empty($states)) {
+            $states = lousy_outages_collect_statuses(false);
+        }
+
+        $fetched_at = get_option('lousy_outages_last_poll');
+        if (!$fetched_at) {
+            $fetched_at = gmdate('c');
+        }
+
+        $providers = [];
+        foreach ($states as $id => $state) {
+            $providers[] = lousy_outages_build_provider_payload($id, $state, $fetched_at);
+        }
+
+        $providers = \lousy_outages_sort_providers($providers);
+
+        $items = self::build_items($providers, $fetched_at);
+        if (empty($items)) {
+            $items = self::collect_recent_incident_items(7, 25);
+        }
+
+        $lastUpdated = !empty($items[0]['pubDate']) ? $items[0]['pubDate'] : self::format_rss_date(gmdate('c'));
+
+        echo '<?xml version="1.0" encoding="' . esc_attr($charset ?: 'UTF-8') . '"?>';
+        ?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title><?php echo esc_html(get_bloginfo('name') . ' – Lousy Outages Alerts'); ?></title>
+    <atom:link href="<?php echo $self; ?>" rel="self" type="application/rss+xml" />
+    <link><?php echo esc_url(home_url('/lousy-outages/')); ?></link>
+    <description><?php echo esc_html('Live incident alerts from the Lousy Outages dashboard.'); ?></description>
+    <language>en-US</language>
+    <lastBuildDate><?php echo esc_html($lastUpdated); ?></lastBuildDate>
+    <?php foreach ($items as $item) : ?>
+      <item>
+        <title><?php echo esc_html($item['title']); ?></title>
+        <link><?php echo esc_url($item['link']); ?></link>
+        <guid isPermaLink="false"><?php echo esc_html($item['guid']); ?></guid>
+        <pubDate><?php echo esc_html($item['pubDate']); ?></pubDate>
+        <description><?php echo esc_html($item['description']); ?></description>
+      </item>
+    <?php endforeach; ?>
+  </channel>
+</rss>
+        <?php
+        exit;
+    }
+
+    // LO: custom incidents RSS with Suzy-voice descriptions.
+    private static function render_incidents_feed(string $charset = 'UTF-8'): void {
+        $items       = self::collect_recent_incident_items(2, 30, true);
+        $lastUpdated = !empty($items[0]['pubDate']) ? $items[0]['pubDate'] : self::format_rss_date(gmdate('c'));
+        // Use the current request URL to avoid mismatch between query-string and pretty permalinks.
+        $self        = esc_url(function_exists('get_self_link') ? get_self_link() : home_url(add_query_arg(null, null)));
+
+        echo '<?xml version="1.0" encoding="' . esc_attr($charset ?: 'UTF-8') . '"?>';
+        ?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title><?php echo esc_html('Lousy Outages — Arcade Ops Feed'); ?></title>
+    <atom:link href="<?php echo $self; ?>" rel="self" type="application/rss+xml" />
+    <link><?php echo esc_url(home_url('/lousy-outages/')); ?></link>
+    <description><?php echo esc_html('Fast, loud, and slightly neon. Outage pings from Suzy Easton’s console.'); ?></description>
+    <language>en-US</language>
+    <lastBuildDate><?php echo esc_html($lastUpdated); ?></lastBuildDate>
+    <?php foreach ($items as $item) : ?>
+      <item>
+        <title><?php echo esc_html($item['title']); ?></title>
+        <link><?php echo esc_url($item['link']); ?></link>
+        <guid isPermaLink="false"><?php echo esc_html($item['guid']); ?></guid>
+        <pubDate><?php echo esc_html($item['pubDate']); ?></pubDate>
+        <description><?php echo esc_html($item['description']); ?></description>
+      </item>
+    <?php endforeach; ?>
+  </channel>
+</rss>
+        <?php
+        exit;
+    }
+
+    private static function build_incident_items(array $providers): array {
+        $cutoff = time() - (2 * DAY_IN_SECONDS);
+        $items  = [];
+
+        foreach ($providers as $provider) {
+            if (!is_array($provider)) {
+                continue;
+            }
+
+            $providerId   = (string) ($provider['id'] ?? '');
+            $providerName = (string) ($provider['name'] ?? $providerId ?: 'Provider');
+            $providerLink = (string) ($provider['url'] ?? self::provider_link($providerId));
+            $incidents    = isset($provider['incidents']) && is_array($provider['incidents']) ? $provider['incidents'] : [];
+
+            foreach ($incidents as $incident) {
+                if (!is_array($incident)) {
+                    continue;
+                }
+
+                $updatedIso = (string) ($incident['updatedAt'] ?? $incident['updated_at'] ?? '');
+                $startedIso = (string) ($incident['startedAt'] ?? $incident['started_at'] ?? '');
+                $updatedTs  = $updatedIso ? strtotime($updatedIso) : 0;
+                $startedTs  = $startedIso ? strtotime($startedIso) : 0;
+                $timestamp  = $updatedTs ?: $startedTs;
+                if ($timestamp && $timestamp < $cutoff) {
+                    continue;
+                }
+
+                $impactCode = strtolower((string) ($incident['impact'] ?? $incident['status'] ?? 'unknown'));
+                $summary    = trim((string) ($incident['summary'] ?? 'Details unavailable'));
+
+                $items[] = self::format_incident_item(
+                    $providerId,
+                    $providerName,
+                    $providerLink,
+                    $impactCode,
+                    $summary,
+                    $timestamp,
+                    (string) ($incident['url'] ?? ''),
+                    isset($incident['id']) ? (string) $incident['id'] : '',
+                    $updatedIso ?: $startedIso
+                );
+            }
+        }
+
+        return self::finalize_incident_items($items, 25, 48);
+    }
+
+    /**
+     * Collect recent incidents directly from the persistent incident store.
+     */
+    private static function collect_recent_incident_items(int $windowDays, int $limit = 25, bool $includeMaintenance = false): array {
+        $store          = new IncidentStore();
+        $events         = $store->getStoredIncidents();
+        $cutoff         = time() - ($windowDays * DAY_IN_SECONDS);
+        $providers      = Providers::list();
+        $providerLabels = [];
+
+        foreach ($providers as $id => $provider) {
+            $providerLabels[$id] = isset($provider['name']) ? (string) $provider['name'] : ucfirst((string) $id);
+        }
+
+        $items = [];
+        foreach ($events as $event) {
+            if (!is_array($event)) {
+                continue;
+            }
+            $event     = $store->normalizeEvent($event);
+            $provider  = sanitize_key((string) ($event['provider'] ?? ''));
+            $startTs   = isset($event['first_seen']) ? (int) $event['first_seen'] : 0;
+            $lastTs    = isset($event['last_seen']) ? (int) $event['last_seen'] : $startTs;
+            $timestamp = $lastTs ?: $startTs;
+            if ($timestamp && $timestamp < $cutoff) {
+                continue;
+            }
+
+            $severity = strtolower((string) ($event['severity'] ?? ''));
+            if (!$includeMaintenance && in_array($severity, ['maintenance', 'info'], true)) {
+                continue;
+            }
+
+            $status       = strtolower((string) ($event['status'] ?? $severity ?: 'incident'));
+            $providerName = $providerLabels[$provider] ?? ($event['provider_label'] ?? ucfirst($provider));
+            $link         = (string) ($event['url'] ?? '');
+            $guid         = isset($event['guid']) ? (string) $event['guid'] : '';
+            $summary      = (string) ($event['title'] ?? $event['description'] ?? 'Incident');
+            $updatedIso   = $timestamp ? gmdate('c', $timestamp) : gmdate('c');
+
+            $items[] = self::format_incident_item(
+                $provider,
+                $providerName,
+                self::provider_link($provider),
+                $status,
+                $summary,
+                $timestamp,
+                $link,
+                $guid,
+                $updatedIso
+            );
+        }
+
+        return self::finalize_incident_items($items, $limit, $windowDays * 24);
+    }
+
+    private static function format_incident_item(
+        string $providerId,
+        string $providerName,
+        string $providerLink,
+        string $impactCode,
+        string $summary,
+        int $timestamp,
+        string $link,
+        string $guid,
+        string $isoTime
+    ): array {
+        $impactCode  = $impactCode ?: 'incident';
+        $statusLabel = Fetcher::status_label($impactCode ?: 'unknown');
+        $emoji       = '⚠️';
+        if ('maintenance' === $impactCode) {
+            $emoji = '🛠️';
+        } elseif ('operational' === $impactCode) {
+            $emoji = 'ℹ️';
+        } elseif ('outage' === $impactCode || 'major' === $impactCode) {
+            $emoji = '🚨';
+        }
+
+        $timeText    = $timestamp ? gmdate('M d, h:i A', $timestamp) : gmdate('M d, h:i A');
+        $detailsLine = ('maintenance' === $impactCode)
+            ? sprintf('%s scheduled maintenance: "%s"', $providerName, $summary)
+            : sprintf('%s looks cranky: "%s"', $providerName, $summary);
+        $description = $emoji . ' ' . $statusLabel . ' • ' . $timeText . "\n"
+            . $detailsLine . "\n"
+            . 'Tap for details. We’ll stash the gritty bits in tonight’s digest.';
+
+        $link = '' !== $link ? $link : $providerLink;
+        if ('' === $guid) {
+            $guid = sha1($providerId . '|' . $summary . '|' . ($isoTime ?: ''));
+        } elseif (false === strpos($guid, ':')) {
+            $guid = $providerId . ':' . $guid;
+        }
+
+        return [
+            'title'       => sprintf('%s: %s', $providerName, $statusLabel),
+            'link'        => $link,
+            'guid'        => $guid,
+            'pubDate'     => self::format_rss_date($isoTime ?: gmdate('c')),
+            'description' => $description,
+            'timestamp'   => $timestamp ?: time(),
+        ];
+    }
+
+    private static function finalize_incident_items(array $items, int $limit, int $emptyWindowHours): array {
+        usort($items, static function ($a, $b) {
+            return ($b['timestamp'] ?? 0) <=> ($a['timestamp'] ?? 0);
+        });
+
+        if (empty($items)) {
+            $items[] = [
+                'title'       => sprintf('All clear: no incidents in the last %d hours', $emptyWindowHours),
+                'link'        => home_url('/lousy-outages/'),
+                'guid'        => 'lousy-outages-incidents-empty-' . gmdate('YmdHis'),
+                'pubDate'     => self::format_rss_date(gmdate('c')),
+                'description' => 'Enjoy the silence. Suzy will holler if something breaks.',
+                'timestamp'   => time(),
+            ];
+        }
+
+        return array_map(static function ($item) {
+            unset($item['timestamp']);
+            return $item;
+        }, array_slice($items, 0, $limit));
+    }
+
+    private static function build_items(array $providers, string $fallback_time): array {
+        $items      = [];
+        $threshold  = (int) get_option('lousy_outages_prealert_threshold', 60);
+        $threshold  = max(0, min(100, $threshold));
+
+        foreach ($providers as $provider) {
+            $incidents = isset($provider['incidents']) && is_array($provider['incidents']) ? $provider['incidents'] : [];
+            if (!empty($incidents)) {
+                $incident  = $incidents[0];
+                $updated   = $incident['updatedAt'] ?? $incident['startedAt'] ?? $fallback_time;
+                $impact    = $incident['impact'] ?? 'incident';
+                $items[]   = self::make_item(
+                    sprintf('%s: %s (%s)', $provider['name'], $incident['title'], ucfirst((string) $impact)),
+                    $provider['id'],
+                    $updated,
+                    $incident['summary'] ?: $provider['summary'],
+                    $provider['id'] . '-' . $incident['id']
+                );
+                continue;
+            }
+
+            $state = strtolower((string) ($provider['stateCode'] ?? 'unknown'));
+            if ('operational' !== $state) {
+                $items[] = self::make_item(
+                    sprintf('%s: %s', $provider['name'], $provider['state']),
+                    $provider['id'],
+                    $provider['updatedAt'] ?? $fallback_time,
+                    $provider['summary'],
+                    $provider['id'] . '-' . md5($provider['stateCode'] . $provider['summary'])
+                );
+                continue;
+            }
+
+            $prealert = isset($provider['prealert']) && is_array($provider['prealert']) ? $provider['prealert'] : [];
+            $risk     = isset($prealert['risk']) ? (int) $prealert['risk'] : 0;
+            if ($risk >= $threshold && $risk > 0) {
+                $signals     = isset($prealert['signals']) && is_array($prealert['signals']) ? implode(', ', $prealert['signals']) : 'Early warning';
+                $summaryBits = [];
+                if (!empty($prealert['summary'])) {
+                    $summaryBits[] = (string) $prealert['summary'];
+                }
+                if (isset($prealert['measures']) && is_array($prealert['measures'])) {
+                    $measures = [];
+                    if (!empty($prealert['measures']['latency_ms'])) {
+                        $measures[] = 'Latency ' . (int) $prealert['measures']['latency_ms'] . ' ms';
+                    }
+                    if (!empty($prealert['measures']['baseline_ms'])) {
+                        $measures[] = 'Baseline ' . (int) $prealert['measures']['baseline_ms'] . ' ms';
+                    }
+                    if ($measures) {
+                        $summaryBits[] = implode(' • ', $measures);
+                    }
+                }
+                $description = $summaryBits ? implode(' — ', $summaryBits) : $provider['summary'];
+                $items[]     = self::make_item(
+                    sprintf('[EARLY WARNING] %s: %s (Risk %d)', $provider['name'], $signals, $risk),
+                    $provider['id'],
+                    $prealert['updated_at'] ?? $provider['updatedAt'] ?? $fallback_time,
+                    $description,
+                    $provider['id'] . '-early-' . md5($signals . $risk . ($prealert['updated_at'] ?? ''))
+                );
+            }
+        }
+
+        usort($items, static function ($a, $b) {
+            return ($b['timestamp'] ?? 0) <=> ($a['timestamp'] ?? 0);
+        });
+
+        $items = array_slice($items, 0, 25);
+
+        if (empty($items)) {
+            $items[] = self::make_item(
+                'All systems operational.',
+                'lousy-outages',
+                $fallback_time,
+                'No active incidents detected across monitored providers.',
+                'lousy-outages-' . gmdate('Ymd')
+            );
+        }
+
+        return array_map(static function ($item) {
+            unset($item['timestamp']);
+            return $item;
+        }, $items);
+    }
+
+    private static function make_item(string $title, string $provider_id, string $time, string $description, string $guid): array {
+        $timestamp = self::parse_time($time);
+        return [
+            'title'     => $title,
+            'link'      => self::provider_link($provider_id),
+            'guid'      => $guid,
+            'pubDate'   => self::format_rss_date($time),
+            'description' => $description,
+            'timestamp' => $timestamp,
+        ];
+    }
+
+    private static function provider_link(string $provider_id): string {
+        $anchor = sanitize_title($provider_id);
+        return home_url('/lousy-outages/#provider-' . $anchor);
+    }
+
+    private static function parse_time(?string $time): int {
+        if (!$time) {
+            return time();
+        }
+        $timestamp = strtotime($time);
+        if (!$timestamp) {
+            return time();
+        }
+        return $timestamp;
+    }
+
+    private static function format_rss_date(string $time): string {
+        $timestamp = strtotime($time);
+        if (!$timestamp) {
+            $timestamp = time();
+        }
+        return gmdate('D, d M Y H:i:s +0000', $timestamp);
+    }
+}

--- a/plugins/lousy-outages/includes/Feeds.php
+++ b/plugins/lousy-outages/includes/Feeds.php
@@ -1,0 +1,393 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+use SuzyEaston\LousyOutages\Storage\IncidentStore;
+
+class Feeds {
+    private const FEED_NAME = 'lousy_outages_status';
+    private const INCIDENT_WINDOW_DAYS = 30;
+    private const INCIDENT_LIMIT = 25;
+    private const OPTION_STATUS_FEED_LAST_BUILD = 'lousy_outages_status_feed_last_build';
+
+    public static function bootstrap(): void {
+        add_action('init', [self::class, 'register']);
+    }
+
+    public static function register(): void {
+        add_feed(self::FEED_NAME, [self::class, 'render_status_feed']);
+        add_feed('lousy-outages-status', [self::class, 'render_status_feed']);
+
+        add_rewrite_rule(
+            '^feed/lousy-outages-status/?$',
+            'index.php?feed=' . self::FEED_NAME,
+            'top'
+        );
+
+        add_rewrite_rule(
+            '^feed/' . self::FEED_NAME . '/?$',
+            'index.php?feed=' . self::FEED_NAME,
+            'top'
+        );
+
+        add_rewrite_rule(
+            '^lousy-outages/feed/status/?$',
+            'index.php?feed=' . self::FEED_NAME,
+            'top'
+        );
+
+        add_rewrite_rule(
+            '^' . self::FEED_NAME . '/feed/?$',
+            'index.php?feed=' . self::FEED_NAME,
+            'top'
+        );
+    }
+
+    public static function render_status_feed(): void {
+        if (function_exists('nocache_headers')) {
+            nocache_headers();
+        }
+
+        $charset = (string) get_option('blog_charset', 'UTF-8');
+        header('Content-Type: application/rss+xml; charset=' . $charset, true);
+
+        [$items, $last_updated] = self::collect_incident_items();
+
+        // Use the current request URL so query-string vs pretty permalink access matches validator expectations.
+        $feed_link = function_exists('get_self_link')
+            ? get_self_link()
+            : home_url(add_query_arg(null, null));
+        if (! $feed_link) {
+            $feed_link = home_url(add_query_arg(null, null));
+        }
+
+        echo '<?xml version="1.0" encoding="' . esc_attr($charset ?: 'UTF-8') . '"?>' . "\n";
+        ?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title><?php echo esc_html('Suzy Easton – Lousy Outages Status Feed'); ?></title>
+    <link><?php echo esc_url(home_url('/lousy-outages/')); ?></link>
+    <description><?php echo esc_html('Aggregated incident and performance updates for third-party providers monitored by the Lousy Outages dashboard.'); ?></description>
+    <atom:link href="<?php echo esc_url($feed_link); ?>" rel="self" type="application/rss+xml" />
+    <language><?php echo esc_html('en-CA'); ?></language>
+    <generator><?php echo esc_html('Lousy Outages'); ?></generator>
+    <ttl><?php echo esc_html('10'); ?></ttl>
+    <lastBuildDate><?php echo esc_html(self::format_rss_date($last_updated)); ?></lastBuildDate>
+<?php foreach ($items as $item) : ?>
+    <item>
+      <title><?php echo esc_html($item['title']); ?></title>
+      <link><?php echo esc_url($item['link']); ?></link>
+      <guid isPermaLink="false"><?php echo esc_html($item['guid']); ?></guid>
+      <pubDate><?php echo esc_html($item['pubDate']); ?></pubDate>
+      <description><?php echo esc_html($item['description']); ?></description>
+<?php if (!empty($item['categories'])) : ?>
+<?php foreach ($item['categories'] as $category) : ?>
+      <category><?php echo esc_html($category); ?></category>
+<?php endforeach; ?>
+<?php endif; ?>
+    </item>
+<?php endforeach; ?>
+  </channel>
+</rss>
+        <?php
+        exit;
+    }
+
+    private static function collect_incident_items(): array {
+        $itemsByKey     = [];
+        $timestamps     = [];
+        $fallback_time  = gmdate('c');
+        $cutoff         = time() - (self::INCIDENT_WINDOW_DAYS * DAY_IN_SECONDS);
+        $store          = new IncidentStore();
+        $providers      = Providers::list();
+        $events         = $store->getStoredIncidents();
+        $default_last_build = '2000-01-01T00:00:00Z';
+
+        if (is_array($events)) {
+            foreach ($events as $event) {
+                if (!is_array($event)) {
+                    continue;
+                }
+
+                $event = $store->normalizeEvent($event);
+
+                $severity       = strtolower((string) ($event['severity'] ?? ''));
+                $isUserReport   = 'user_report' === $severity || 'user_report' === strtolower((string) ($event['source'] ?? ''));
+                $severityKnown  = $isUserReport || in_array($severity, ['outage', 'degraded', 'maintenance', 'info'], true);
+                $importantField = $event['important'] ?? null;
+                $important      = null === $importantField ? null : (bool) $importantField;
+
+                if (false === $important) {
+                    continue;
+                }
+
+                if (!$severityKnown) {
+                    continue;
+                }
+
+                $firstSeen     = isset($event['first_seen']) ? (int) $event['first_seen'] : 0;
+                $lastSeen      = isset($event['last_seen']) ? (int) $event['last_seen'] : $firstSeen;
+                $publishedTime = isset($event['published']) && !is_numeric($event['published'])
+                    ? self::parse_time((string) $event['published'])
+                    : (int) ($event['published'] ?? 0);
+                $timestamp     = $firstSeen ?: ($lastSeen ?: $publishedTime);
+
+                if ($timestamp && $timestamp < $cutoff) {
+                    continue;
+                }
+
+                $provider_id   = sanitize_key((string) ($event['provider'] ?? ''));
+                $provider_data = $providers[$provider_id] ?? [];
+                $provider_name = (string) ($event['provider_label'] ?? ($provider_data['name'] ?? ($provider_id ? ucfirst($provider_id) : 'Provider')));
+                $status_url    = isset($provider_data['status_url']) ? (string) $provider_data['status_url'] : (string) ($provider_data['url'] ?? '');
+
+                $title_text = trim((string) ($event['title'] ?? $event['description'] ?? 'Incident'));
+                $status     = (string) ($event['status'] ?? $event['status_normal'] ?? '');
+                $eventTime  = $timestamp ? gmdate('c', (int) $timestamp) : $fallback_time;
+                $incidentId = sanitize_key((string) ($event['incident_id'] ?? ($event['id'] ?? '')));
+
+                $incidentKey = self::build_incident_key($provider_id, $incidentId, $title_text, $eventTime);
+                $guid        = self::build_guid($provider_id, $incidentId, $title_text, $eventTime);
+
+                $incidentLink = (string) ($event['incident_url'] ?? ($event['url'] ?? ''));
+                if ('' === $incidentLink) {
+                    $incidentLink = self::provider_link($provider_id, $status_url);
+                }
+
+                $itemTimestamp = $timestamp ?: self::parse_time($fallback_time);
+
+                $itemTitle      = sprintf('[%s] %s – %s', strtoupper($severity ?: 'incident'), $provider_name, $title_text ?: 'Incident');
+                $descriptionArgs = [
+                    'provider_label' => $provider_name,
+                    'severity'       => $severity,
+                    'status'         => $status,
+                    'title'          => $title_text,
+                    'impact_summary' => (string) ($event['impact_summary'] ?? ''),
+                    'summary'        => (string) ($event['description'] ?? ''),
+                ];
+
+                if ($isUserReport) {
+                    $title_text                 = $title_text ?: 'Possible issue reported by a user';
+                    $descriptionArgs['severity'] = 'user_report';
+                    $itemTitle                  = sprintf('[COMMUNITY REPORT] %s – %s', $provider_name, $title_text);
+                }
+
+                $categories = array_values(
+                    array_filter(
+                        array_unique(
+                            array_map(
+                                'trim',
+                                [
+                                    $provider_name,
+                                    $severity,
+                                    $status,
+                                    (string) ($event['kind'] ?? ''),
+                                ]
+                            )
+                        )
+                    )
+                );
+
+                $item = [
+                    'title'       => $itemTitle,
+                    'link'        => $incidentLink,
+                    'guid'        => $guid,
+                    'pubDate'     => self::format_rss_date($eventTime),
+                    'description' => self::build_funny_summary($descriptionArgs),
+                    'timestamp'   => $itemTimestamp,
+                    'categories'  => $categories,
+                ];
+
+                if ('' !== $incidentKey) {
+                    $existing = $itemsByKey[$incidentKey] ?? null;
+                    if (! $existing || ($existing['timestamp'] ?? 0) < $itemTimestamp) {
+                        $itemsByKey[$incidentKey] = $item;
+                    }
+                } else {
+                    $itemsByKey[] = $item;
+                }
+            }
+        }
+
+        $items = array_values($itemsByKey);
+        $timestamps = array_values(
+            array_filter(
+                array_map(
+                    static function (array $item): int {
+                        return (int) ($item['timestamp'] ?? 0);
+                    },
+                    $items
+                )
+            )
+        );
+
+        usort(
+            $items,
+            static function (array $a, array $b): int {
+                return ($b['timestamp'] ?? 0) <=> ($a['timestamp'] ?? 0);
+            }
+        );
+
+        if (count($items) > self::INCIDENT_LIMIT) {
+            $items = array_slice($items, 0, self::INCIDENT_LIMIT);
+        }
+
+        if ($timestamps) {
+            $last_updated = gmdate('c', max($timestamps));
+            update_option(self::OPTION_STATUS_FEED_LAST_BUILD, $last_updated, false);
+        } else {
+            $stored_last_build = get_option(self::OPTION_STATUS_FEED_LAST_BUILD);
+            $last_updated = is_string($stored_last_build) && '' !== trim($stored_last_build)
+                ? $stored_last_build
+                : $default_last_build;
+            update_option(self::OPTION_STATUS_FEED_LAST_BUILD, $last_updated, false);
+        }
+
+        return [
+            array_map(
+                static function (array $item): array {
+                    unset($item['timestamp']);
+                    return $item;
+                },
+                $items
+            ),
+            $last_updated,
+        ];
+    }
+
+    private static function build_guid(string $provider_id, string $incident_id, string $summary, string $time): string {
+        return self::build_incident_key($provider_id, $incident_id, $summary, $time);
+    }
+
+    private static function build_incident_key(string $provider_id, string $incident_id, string $summary, string $time): string {
+        $provider  = sanitize_key($provider_id);
+        $incident  = sanitize_key($incident_id);
+        $normalizedSummary = '';
+
+        if ('' !== $incident) {
+            return $provider . ':' . $incident;
+        }
+
+        if (function_exists('mb_strtolower')) {
+            $normalizedSummary = mb_strtolower(trim((string) $summary), 'UTF-8');
+        } else {
+            $normalizedSummary = strtolower(trim((string) $summary));
+        }
+
+        $timestamp = self::parse_time($time);
+        $dateKey   = $timestamp ? gmdate('Y-m-d', $timestamp) : trim((string) $time);
+
+        return sha1($provider . '|' . $normalizedSummary . '|' . $dateKey);
+    }
+
+    private static function provider_link(string $provider_id, string $status_url = ''): string {
+        if ('' !== $status_url) {
+            return $status_url;
+        }
+        $anchor = sanitize_title($provider_id ?: 'provider');
+        return home_url('/lousy-outages/#provider-' . $anchor);
+    }
+
+    /**
+     * Build a concise, professional summary for the feed description.
+     *
+     * @param array<string, mixed> $incident
+     */
+    private static function build_funny_summary(array $incident): string {
+        $provider      = trim((string) ($incident['provider_label'] ?? 'The provider')) ?: 'The provider';
+        $severity      = strtolower((string) ($incident['severity'] ?? ''));
+        $status        = trim((string) ($incident['status'] ?? ''));
+        $impactSummary = trim((string) ($incident['impact_summary'] ?? ''));
+        $fallback      = trim((string) ($incident['summary'] ?? ''));
+        $details       = '' !== $impactSummary ? $impactSummary : $fallback;
+
+        if ('user_report' === $severity) {
+            $summary = sprintf('Community report for %s.', $provider);
+            if ('' !== $details) {
+                $summary .= ' A user reported a possible issue: ' . self::truncate_text($details, 200) . '.';
+            }
+            $summary .= ' This report has not yet been independently verified.';
+
+            return trim($summary);
+        }
+
+        $statusText = $status ?: '';
+
+        switch ($severity) {
+            case 'outage':
+                $body = sprintf(
+                    'Service outage reported for %s. Status: %s.',
+                    $provider,
+                    $statusText ?: 'see provider status page for details'
+                );
+                break;
+            case 'degraded':
+                $body = sprintf(
+                    'Performance issues detected for %s. Status: %s.',
+                    $provider,
+                    $statusText ?: 'see provider status page for details'
+                );
+                break;
+            case 'maintenance':
+            case 'info':
+                $body = sprintf(
+                    'Scheduled maintenance or informational update for %s. Status: %s.',
+                    $provider,
+                    $statusText ?: 'see provider status page for details'
+                );
+                break;
+            default:
+                $body = sprintf(
+                    'Incident update for %s. Status: %s.',
+                    $provider,
+                    $statusText ?: 'see incident details'
+                );
+        }
+
+        if ('' !== $details) {
+            $body .= ' ' . self::truncate_text($details, 200);
+        }
+
+        return trim($body);
+    }
+
+    private static function truncate_text(string $text, int $limit = 180): string {
+        $text = trim($text);
+        if ('' === $text || $limit <= 0) {
+            return '';
+        }
+
+        if (function_exists('mb_strlen')) {
+            if (mb_strlen($text, 'UTF-8') > $limit) {
+                return rtrim(mb_substr($text, 0, $limit - 1, 'UTF-8')) . '…';
+            }
+
+            return $text;
+        }
+
+        if (strlen($text) > $limit) {
+            return rtrim(substr($text, 0, $limit - 1)) . '…';
+        }
+
+        return $text;
+    }
+
+    private static function parse_time(?string $time): int {
+        if (!$time) {
+            return time();
+        }
+
+        $timestamp = strtotime($time);
+        if (!$timestamp) {
+            return time();
+        }
+
+        return (int) $timestamp;
+    }
+
+    private static function format_rss_date(string $time): string {
+        $timestamp = self::parse_time($time);
+        return gmdate('D, d M Y H:i:s +0000', $timestamp);
+    }
+}

--- a/plugins/lousy-outages/includes/Fetch.php
+++ b/plugins/lousy-outages/includes/Fetch.php
@@ -1,0 +1,181 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+/**
+ * Perform an HTTP GET request with sane defaults and graceful error handling.
+ */
+function http_get(string $url, array $args = []): array {
+    $force_ipv4 = ! empty($args['force_ipv4']);
+    if ($force_ipv4) {
+        unset($args['force_ipv4']);
+    }
+
+    $defaults = [
+        'timeout'     => 12,
+        'redirection' => 3,
+        'httpversion' => '1.1',
+        'headers'     => [
+            'User-Agent'    => 'LousyOutages/1.0 (+https://suzyeaston.ca)',
+            'Accept'        => 'application/json, application/xml, text/xml;q=0.9,*/*;q=0.8',
+            'Cache-Control' => 'no-cache',
+        ],
+        'sslverify'   => true,
+        'decompress'  => true,
+    ];
+
+    $merged         = array_replace($defaults, $args);
+    $merged['timeout']     = isset($merged['timeout']) ? max(1, (int) $merged['timeout']) : $defaults['timeout'];
+    $merged['redirection'] = isset($merged['redirection']) ? max(0, (int) $merged['redirection']) : $defaults['redirection'];
+    $merged['headers']     = isset($merged['headers']) && is_array($merged['headers'])
+        ? array_merge($defaults['headers'], $merged['headers'])
+        : $defaults['headers'];
+
+    if ($force_ipv4) {
+        $merged['force_ipv4'] = true;
+        $curl_response = http_get_via_curl($url, $merged, 'forced_ipv4');
+        if (null !== $curl_response) {
+            return $curl_response;
+        }
+        unset($merged['force_ipv4']);
+    }
+
+    if (! function_exists('wp_remote_get')) {
+        if (function_exists('Lousy\\http_get')) {
+            // LO: test harness stub.
+            return \Lousy\http_get($url, $merged);
+        }
+
+        return [
+            'ok'      => false,
+            'status'  => 0,
+            'error'   => 'request_failed',
+            'message' => 'wp_remote_get unavailable',
+            'body'    => null,
+        ];
+    }
+
+    $response = wp_remote_get($url, $merged);
+    if (is_wp_error($response)) {
+        $fallback = http_get_via_curl($url, $merged, $response->get_error_message());
+        if (null !== $fallback) {
+            return $fallback;
+        }
+
+        return [
+            'ok'      => false,
+            'status'  => 0,
+            'error'   => 'request_failed',
+            'message' => $response->get_error_message(),
+            'body'    => null,
+        ];
+    }
+
+    $code = (int) wp_remote_retrieve_response_code($response);
+    $body = wp_remote_retrieve_body($response);
+    if ($code < 200 || $code >= 400) {
+        return [
+            'ok'      => false,
+            'status'  => $code,
+            'error'   => 'http_error',
+            'message' => sprintf('HTTP %d response', $code),
+            'body'    => $body,
+        ];
+    }
+
+    return [
+        'ok'      => true,
+        'status'  => $code,
+        'error'   => null,
+        'message' => null,
+        'body'    => $body,
+    ];
+}
+
+/**
+ * Attempt a direct cURL request when wp_remote_get() fails.
+ */
+function http_get_via_curl(string $url, array $args, string $reason): ?array {
+    if (!function_exists('curl_init')) {
+        return null;
+    }
+
+    $handle = curl_init($url);
+    if (false === $handle) {
+        return null;
+    }
+
+    $timeout  = isset($args['timeout']) ? max(1, (int) $args['timeout']) : 12;
+    $headers  = [];
+    $ua       = $args['headers']['User-Agent'] ?? 'LousyOutages/1.0 (+https://suzyeaston.ca)';
+    $sslcheck = isset($args['sslverify']) ? (bool) $args['sslverify'] : true;
+
+    foreach (($args['headers'] ?? []) as $key => $value) {
+        $headers[] = $key . ': ' . $value;
+    }
+
+    $options = [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_FOLLOWLOCATION => true,
+        CURLOPT_MAXREDIRS      => isset($args['redirection']) ? max(0, (int) $args['redirection']) : 3,
+        CURLOPT_TIMEOUT        => $timeout,
+        CURLOPT_USERAGENT      => $ua,
+        CURLOPT_ENCODING       => '',
+    ];
+
+    if (!empty($args['force_ipv4']) && defined('CURLOPT_IPRESOLVE') && defined('CURL_IPRESOLVE_V4')) {
+        $options[CURLOPT_IPRESOLVE] = CURL_IPRESOLVE_V4;
+    }
+    if (defined('CURLOPT_HTTP_VERSION_1_1')) {
+        $options[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_1;
+    }
+
+    if (!empty($headers)) {
+        $options[CURLOPT_HTTPHEADER] = $headers;
+    }
+
+    if ($sslcheck) {
+        $options[CURLOPT_SSL_VERIFYPEER] = true;
+        $options[CURLOPT_SSL_VERIFYHOST] = 2;
+    } else {
+        $options[CURLOPT_SSL_VERIFYPEER] = false;
+        $options[CURLOPT_SSL_VERIFYHOST] = 0;
+    }
+
+    curl_setopt_array($handle, $options);
+
+    $body = curl_exec($handle);
+    if (false === $body) {
+        $error = curl_error($handle) ?: $reason;
+        curl_close($handle);
+        return [
+            'ok'      => false,
+            'status'  => 0,
+            'error'   => 'request_failed',
+            'message' => $error,
+            'body'    => null,
+        ];
+    }
+
+    $status = curl_getinfo($handle, defined('CURLINFO_RESPONSE_CODE') ? CURLINFO_RESPONSE_CODE : CURLINFO_HTTP_CODE);
+    curl_close($handle);
+
+    if ($status < 200 || $status >= 400) {
+        return [
+            'ok'      => false,
+            'status'  => (int) $status,
+            'error'   => 'http_error',
+            'message' => sprintf('HTTP %d response', $status),
+            'body'    => $body,
+        ];
+    }
+
+    return [
+        'ok'      => true,
+        'status'  => (int) $status,
+        'error'   => null,
+        'message' => null,
+        'body'    => $body,
+    ];
+}

--- a/plugins/lousy-outages/includes/Fetcher.php
+++ b/plugins/lousy-outages/includes/Fetcher.php
@@ -1,0 +1,1947 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+// Changelog:
+// - 2024-06-05: Improve HTTP resilience, add history fallbacks, enhance error reporting.
+
+require_once __DIR__ . '/Fetch.php';
+
+if (! defined('DAY_IN_SECONDS')) {
+    define('DAY_IN_SECONDS', 24 * 60 * 60);
+}
+
+use function SuzyEaston\LousyOutages\http_get;
+use function SuzyEaston\LousyOutages\Adapters\from_rss_atom;
+use function SuzyEaston\LousyOutages\Adapters\from_slack_current;
+use function SuzyEaston\LousyOutages\Adapters\from_statuspage_status;
+use function SuzyEaston\LousyOutages\Adapters\from_statuspage_summary;
+use function SuzyEaston\LousyOutages\Adapters\from_gcp_incidents_json;
+use function SuzyEaston\LousyOutages\Adapters\Statuspage\detect_state_from_error;
+
+class Fetcher {
+    private const STATUS_LABELS = [
+        'operational' => 'Operational',
+        'degraded'    => 'Degraded',
+        'outage'      => 'Outage',
+        'major'       => 'Major Outage',
+        'maintenance' => 'Maintenance',
+        'unknown'     => 'Unknown',
+    ];
+    private const UNCERTAIN_SUMMARY = 'Can’t verify right now — provider page may still be operational.';
+
+    private $timeout;
+
+    public function __construct(int $timeout = 8) {
+        $this->timeout = max(2, $timeout);
+    }
+
+    public static function status_label(string $code): string {
+        $code = strtolower($code);
+        return self::STATUS_LABELS[$code] ?? self::STATUS_LABELS['unknown'];
+    }
+
+    public function fetch(array $provider): array {
+        $id        = (string) ($provider['id'] ?? '');
+        $providerId = strtolower($id);
+        $name      = (string) ($provider['name'] ?? $id);
+        $type      = strtolower((string) ($provider['type'] ?? 'statuspage'));
+        $endpoint  = $this->resolve_endpoint($provider, $type);
+        $statusUrl = isset($provider['status_url']) ? $provider['status_url'] : ($provider['url'] ?? '');
+
+        $defaults = [
+            'id'           => $id,
+            'name'         => $name,
+            'provider'     => $provider['provider'] ?? $name,
+            'status'       => 'unknown',
+            'status_label' => self::status_label('unknown'),
+            'summary'      => 'Waiting for status…',
+            'message'      => 'Waiting for status…',
+            'updated_at'   => gmdate('c'),
+            'url'          => is_string($statusUrl) ? $statusUrl : '',
+            'incidents'    => [],
+            'error'        => null,
+            'source_type'  => $type,
+        ];
+
+        if (! $endpoint) {
+            if ('manual' === $type) {
+                // LO: manual providers have human-updated messaging only.
+                $defaults['summary'] = 'No public feed available. We’ll update status when the provider posts an advisory.';
+            } else {
+                $defaults['summary'] = 'No public status endpoint available';
+            }
+            $defaults['message'] = $defaults['summary'];
+            return $this->apply_tile_metadata($defaults, $provider, true);
+        }
+
+        $optional = ! empty($provider['optional']) || ('rss-optional' === $type);
+        $headers  = $this->build_headers($type);
+        $response = http_get($endpoint, [
+            'timeout'     => $this->timeout,
+            'headers'     => $headers,
+            'redirection' => 3,
+        ]);
+        $response    = $this->maybe_retry_ipv4($response, $endpoint, $headers);
+        $adapterType = $type;
+
+        $status          = (int) ($response['status'] ?? 0);
+        $fallbackSummary = null;
+        $historyFallback = false;
+
+        if (! $response['ok'] && in_array($status, [401, 403, 404], true)) {
+            $statuspageStatus = $this->attempt_statuspage_status($provider, $endpoint);
+            if ($statuspageStatus) {
+                $response    = $statuspageStatus['response'];
+                $adapterType = $statuspageStatus['adapter'];
+                $status      = (int) ($response['status'] ?? 0);
+            }
+        }
+
+        if (! $response['ok'] && in_array($status, [401, 403, 404], true)) {
+            $fallback = $this->attempt_statuspage_history($provider, $endpoint);
+            if ($fallback) {
+                $response        = $fallback['response'];
+                $adapterType     = $fallback['adapter'];
+                $fallbackSummary = null;
+                $status          = (int) ($response['status'] ?? 0);
+                $historyFallback = true;
+            }
+        }
+
+        if (! $response['ok']) {
+            return $this->handle_failed_response($defaults, $provider, $type, $response, $fallbackSummary, $optional);
+        }
+
+        $body = (string) ($response['body'] ?? '');
+        if ('' === trim($body)) {
+            if ($optional) {
+                return $this->apply_tile_metadata($this->optional_unavailable($defaults, 'Empty body'), $provider, true);
+            }
+            return $this->apply_tile_metadata(
+                $this->failed_defaults($defaults, 'data_error:empty_body', 'Empty response from status endpoint'),
+                $provider,
+                true
+            );
+        }
+
+        if ('zscaler' === $providerId && $this->is_html_response($body)) {
+            $response = [
+                'ok'      => false,
+                'status'  => (int) ($response['status'] ?? 0),
+                'error'   => 'html_response',
+                'message' => 'Unexpected HTML response',
+                'body'    => $body,
+            ];
+            return $this->handle_failed_response($defaults, $provider, $type, $response, $fallbackSummary, $optional);
+        }
+
+        $normalized = $this->adapt_response($adapterType, $body);
+        $result     = $this->assemble_result($defaults, $normalized, $provider);
+
+        if (! $historyFallback && $this->should_verify_cloudflare_status($provider, $type, $result)) {
+            $verification = $this->attempt_statuspage_status($provider, $endpoint);
+            if ($verification && ! empty($verification['response']['body'])) {
+                $verified = $this->adapt_response($verification['adapter'], (string) $verification['response']['body']);
+                $verifiedState = strtolower((string) ($verified['state'] ?? 'unknown'));
+                $verifiedStatus = $this->normalize_status_code($verifiedState);
+                if ('operational' === $verifiedStatus) {
+                    $result['status'] = 'operational';
+                    $result['status_label'] = self::status_label('operational');
+                    $result['summary'] = 'All systems operational.';
+                    $result['message'] = 'All systems operational.';
+                    $result['state'] = 'operational';
+                    $result['status_class'] = 'status--operational';
+                    $result['verified_via'] = 'status.json';
+                    $result['verification_note'] = 'summary.json reported degraded with no incidents; status.json reported operational';
+                    $verifiedUpdated = $this->iso($verified['updated_at'] ?? null);
+                    if ($verifiedUpdated) {
+                        $result['updated_at'] = $verifiedUpdated;
+                    }
+                }
+            }
+        }
+
+        if ($historyFallback) {
+            $result = $this->failed_defaults(
+                $defaults,
+                'status_history_fallback',
+                'Status temporarily unavailable.',
+                'unknown',
+                0,
+                null,
+                'Status history fallback'
+            );
+        }
+
+        return $this->apply_tile_metadata($result, $provider, $historyFallback);
+    }
+
+    private function build_headers(string $type): array {
+        $ua      = 'LousyOutages/1.0 (+https://suzyeaston.ca)';
+        $accept  = 'application/json, application/xml, text/xml;q=0.9,*/*;q=0.8';
+        if (in_array($type, ['rss', 'atom'], true)) {
+            $accept = 'application/rss+xml, application/atom+xml, application/xml;q=0.9,*/*;q=0.8';
+        }
+
+        return [
+            'User-Agent'    => $ua,
+            'Accept'        => $accept,
+            'Accept-Language' => 'en',
+            'Cache-Control' => 'no-cache',
+        ];
+    }
+
+    private function resolve_endpoint(array $provider, string $type): ?string {
+        $keys = ['url', 'summary', 'rss', 'atom', 'current', 'endpoint'];
+
+        foreach ($keys as $key) {
+            if (empty($provider[$key]) || ! is_string($provider[$key])) {
+                continue;
+            }
+            return $provider[$key];
+        }
+
+        return null;
+    }
+
+    private function attempt_statuspage_history(array $provider, ?string $endpoint = null): ?array {
+        $urls = $this->statuspage_history_urls($provider, $endpoint);
+        if (!$urls) {
+            return null;
+        }
+
+        foreach ($urls as $entry) {
+            [$url, $adapter] = $entry;
+            $headers  = $this->build_headers($adapter);
+            $response = http_get($url, [
+                'timeout'     => $this->timeout,
+                'headers'     => $headers,
+                'redirection' => 3,
+            ]);
+            $response = $this->maybe_retry_ipv4($response, $url, $headers);
+
+            if ($response['ok'] && '' !== trim((string) ($response['body'] ?? ''))) {
+                return [
+                    'response' => $response,
+                    'adapter'  => $adapter,
+                ];
+            }
+        }
+
+        return null;
+    }
+
+    private function statuspage_history_urls(array $provider, ?string $endpoint = null): array {
+        $base = $this->derive_statuspage_base($provider, $endpoint);
+        if (! $base) {
+            return [];
+        }
+
+        $base = trailingslashit($base);
+
+        return [
+            [$base . 'history.rss', 'rss'],
+            [$base . 'history.atom', 'atom'],
+        ];
+    }
+
+    private function attempt_statuspage_status(array $provider, ?string $endpoint = null): ?array {
+        $candidates = [];
+
+        if (! empty($provider['status_endpoint']) && is_string($provider['status_endpoint'])) {
+            $candidates[] = $provider['status_endpoint'];
+        }
+
+        $base = $this->derive_statuspage_base($provider, $endpoint);
+        if ($base) {
+            $candidates[] = $base . 'api/v2/status.json';
+            $candidates[] = $base . 'status.json';
+        }
+
+        foreach ($candidates as $candidate) {
+            $headers  = $this->build_headers('status');
+            $response = http_get($candidate, [
+                'timeout'     => $this->timeout,
+                'headers'     => $headers,
+                'redirection' => 3,
+            ]);
+            $response = $this->maybe_retry_ipv4($response, $candidate, $headers);
+
+            if ($response['ok'] && '' !== trim((string) ($response['body'] ?? ''))) {
+                return [
+                    'response' => $response,
+                    'adapter'  => 'status',
+                ];
+            }
+        }
+
+        return null;
+    }
+
+    private function derive_statuspage_base(array $provider, ?string $endpoint = null): string {
+        $candidates = [];
+
+        if (! empty($provider['status_url']) && is_string($provider['status_url'])) {
+            $candidates[] = $provider['status_url'];
+        }
+
+        if ($endpoint) {
+            $candidates[] = $endpoint;
+        }
+
+        $resolved = $this->resolve_endpoint($provider, 'statuspage');
+        if ($resolved) {
+            $candidates[] = $resolved;
+        }
+
+        foreach ($candidates as $candidate) {
+            $normalized = $this->normalize_statuspage_base((string) $candidate);
+            if ($normalized) {
+                return $normalized;
+            }
+        }
+
+        return '';
+    }
+
+    private function normalize_statuspage_base(string $candidate): string {
+        $candidate = trim($candidate);
+        if ('' === $candidate) {
+            return '';
+        }
+
+        $candidate = preg_replace('#/api/v\d+(?:\.\d+)*?/(summary\.json|status\.json|current)$#', '/', $candidate);
+        $candidate = preg_replace('#/api/v\d+(?:\.\d+)*?/history\.(?:rss|atom)$#', '/', $candidate);
+        $candidate = preg_replace('#/history\.(?:rss|atom)$#', '/', $candidate);
+
+        $parts = wp_parse_url($candidate);
+        if (empty($parts['scheme']) || empty($parts['host'])) {
+            return '';
+        }
+
+        $base = $parts['scheme'] . '://' . $parts['host'];
+
+        $path = isset($parts['path']) ? trim((string) $parts['path'], '/') : '';
+        if ('' !== $path) {
+            $segments = array_filter(explode('/', $path), static fn($segment) => '' !== $segment);
+            $cleaned  = [];
+            foreach ($segments as $segment) {
+                $lower = strtolower($segment);
+                if (preg_match('#^(summary\.json|status\.json|current|history\.(?:rss|atom))$#', $lower)) {
+                    continue;
+                }
+                if ('api' === $lower) {
+                    continue;
+                }
+                if (preg_match('#^v\d#', $lower)) {
+                    continue;
+                }
+                $cleaned[] = $segment;
+            }
+            if ($cleaned) {
+                $base .= '/' . implode('/', $cleaned);
+            }
+        }
+
+        return trailingslashit($base);
+    }
+
+    private function adapt_response(string $type, string $body): array {
+        switch ($type) {
+            case 'slack':
+            case 'slack_current':
+                return from_slack_current($body);
+            case 'rss':
+            case 'atom':
+            case 'rss-optional':
+                return from_rss_atom($body);
+            case 'status':
+                return from_statuspage_status($body);
+            case 'gcp_json':
+                return from_gcp_incidents_json($body);
+            default:
+                return from_statuspage_summary($body);
+        }
+    }
+
+    private function handle_failed_response(array $defaults, array $provider, string $type, array $response, ?string $fallbackSummary, bool $optional): array {
+        $status          = (int) ($response['status'] ?? 0);
+        $message         = (string) ($response['message'] ?? '');
+        $networkKind     = $response['retry_kind'] ?? $this->classify_network_error($message);
+        $errorCode       = $status > 0
+            ? 'http_error:' . $status
+            : 'network_error:' . ($networkKind ?: ((string) ($response['error'] ?? 'request_failed')));
+        $summaryText     = $fallbackSummary ?: $this->failure_summary($status, $networkKind);
+        $statusResult    = 'unknown';
+
+        if ('statuspage' === $type && $status >= 500 && $status < 600) {
+            $detected = detect_state_from_error((string) ($response['body'] ?? ''));
+            if ($detected) {
+                $statusResult = $detected;
+                if (!$fallbackSummary) {
+                    $summaryText = ('outage' === $detected)
+                        ? 'Status API error indicates major outage'
+                        : 'Status API error indicates active incident';
+                }
+            }
+        }
+
+        if ($optional) {
+            return $this->apply_tile_metadata(
+                $this->optional_unavailable($defaults, $message ?: $summaryText),
+                $provider,
+                true
+            );
+        }
+
+        $providerId = strtolower((string) ($provider['id'] ?? $defaults['id'] ?? ''));
+        if ('zscaler' === $providerId) {
+            $cached = $this->get_recent_cached_state($providerId, 6 * HOUR_IN_SECONDS);
+            if ($cached) {
+                return $this->build_cached_unknown_result($defaults, $cached, self::UNCERTAIN_SUMMARY);
+            }
+        }
+
+        $failed = $this->failed_defaults($defaults, $errorCode, $summaryText, $statusResult, $status, $networkKind, $message);
+        return $this->apply_tile_metadata($failed, $provider, true);
+    }
+
+    private function assemble_result(array $defaults, array $normalized, array $provider): array {
+        $state   = strtolower((string) ($normalized['state'] ?? 'unknown'));
+        $status  = $this->normalize_status_code($state);
+        $incidentBuckets = $this->normalize_incident_buckets($normalized['incidents'] ?? [], $provider, $status);
+        $incidents       = $incidentBuckets['active'];
+        $recentIncidents = $incidentBuckets['recent'];
+        $summary         = $this->summarize($normalized, $incidents, $status);
+
+        $result = $defaults;
+        $result['status']       = $status;
+        $result['status_label'] = self::status_label($status);
+        $result['summary']      = $summary;
+        $result['message']      = $summary;
+        $result['incidents']    = $incidents;
+        $result['recent_incidents'] = $recentIncidents;
+        $result['state']        = $state;
+        $result['raw']          = $normalized['raw'] ?? null;
+
+        $updated = $this->iso($normalized['updated_at'] ?? null);
+        if (! $updated && ! empty($incidents)) {
+            $updated = $incidents[0]['updated_at'] ?? ($incidents[0]['started_at'] ?? null);
+        }
+        $result['updated_at'] = $updated ?: $defaults['updated_at'];
+
+        return $result;
+    }
+
+    private function apply_tile_metadata(array $result, array $provider, bool $fetchFailed): array {
+        $status    = strtolower((string) ($result['status'] ?? 'unknown'));
+        $incidents = is_array($result['incidents'] ?? null) ? $result['incidents'] : [];
+        $type      = strtolower((string) ($provider['type'] ?? $result['source_type'] ?? ''));
+
+        $tileKind = $this->determine_tile_kind($status, $incidents, $type, $fetchFailed);
+        $result['tile_kind'] = $tileKind;
+        $result['sort_key']  = $this->sort_key_for_tile($tileKind, $status);
+
+        return $result;
+    }
+
+    private function determine_tile_kind(string $status, array $incidents, string $type, bool $fetchFailed): string {
+        if ('manual' === $type) {
+            return 'manual';
+        }
+        if ($fetchFailed) {
+            return 'unknown';
+        }
+        if ('operational' === $status) {
+            return 'operational';
+        }
+        if ('unknown' === $status) {
+            return 'unknown';
+        }
+        if (!empty($incidents)) {
+            return 'outage';
+        }
+        return 'signal';
+    }
+
+    private function sort_key_for_tile(string $tileKind, string $status): int {
+        $status = strtolower($status);
+        $isMajor = in_array($status, ['outage', 'major', 'critical', 'major_outage'], true);
+        $isDegraded = in_array($status, ['degraded', 'partial', 'minor', 'warning'], true);
+        $isMaintenance = in_array($status, ['maintenance', 'scheduled'], true);
+
+        if ('outage' === $tileKind) {
+            if ($isMajor) {
+                return 10;
+            }
+            if ($isMaintenance) {
+                return 30;
+            }
+            return 20;
+        }
+        if ('signal' === $tileKind) {
+            if ($isMajor) {
+                return 40;
+            }
+            if ($isMaintenance) {
+                return 60;
+            }
+            return 50;
+        }
+        if ('unknown' === $tileKind) {
+            return 90;
+        }
+        if ('manual' === $tileKind) {
+            return 95;
+        }
+        if ('operational' === $tileKind) {
+            return 70;
+        }
+        return 100;
+    }
+
+    private function summarize(array $normalized, array $incidents, string $status): string {
+        $summary = '';
+        if (! $summary && ! empty($incidents)) {
+            $summary = $incidents[0]['title'] ?? ($incidents[0]['summary'] ?? '');
+        }
+        if (! $summary) {
+            if ('operational' === $status) {
+                $summary = 'All systems operational.';
+            } elseif ('unknown' === $status) {
+                $summary = 'Status temporarily unavailable.';
+            } elseif (isset($normalized['summary'])) {
+                $summary = $this->sanitize((string) $normalized['summary']);
+            }
+        }
+        if (! $summary) {
+            switch ($status) {
+                case 'degraded':
+                    $summary = 'Service degradation reported.';
+                    break;
+                case 'outage':
+                    $summary = 'Major outage reported.';
+                    break;
+                case 'maintenance':
+                    $summary = 'Maintenance in progress.';
+                    break;
+                default:
+                    $summary = 'Status temporarily unavailable.';
+                    break;
+            }
+        }
+
+        return $this->sanitize($summary);
+    }
+
+    private function is_html_response(string $body): bool {
+        $trimmed = ltrim($body);
+        if ('' === $trimmed) {
+            return false;
+        }
+        if (0 === strpos($trimmed, '<')) {
+            return true;
+        }
+        return false !== stripos($trimmed, 'enable JavaScript');
+    }
+
+    private function get_recent_cached_state(string $providerId, int $maxAgeSeconds): ?array {
+        if ('' === $providerId) {
+            return null;
+        }
+        if (! class_exists(Store::class)) {
+            return null;
+        }
+
+        $store  = new Store();
+        $cached = $store->get($providerId);
+        if (! is_array($cached)) {
+            return null;
+        }
+
+        $updated = $cached['updated_at'] ?? ($cached['updatedAt'] ?? null);
+        if (! $updated) {
+            return null;
+        }
+        $timestamp = strtotime((string) $updated);
+        if (! $timestamp) {
+            return null;
+        }
+        if ((time() - $timestamp) > $maxAgeSeconds) {
+            return null;
+        }
+
+        $status = $this->normalize_status_code((string) ($cached['status'] ?? 'unknown'));
+        if ('unknown' === $status) {
+            return null;
+        }
+
+        return $cached;
+    }
+
+    private function build_cached_unknown_result(array $defaults, array $cached, string $summary): array {
+        $status = $this->normalize_status_code((string) ($cached['status'] ?? 'unknown'));
+
+        $result = $defaults;
+        $result['status']       = $status;
+        $result['status_label'] = self::status_label($status);
+        $result['summary']      = $summary;
+        $result['message']      = $summary;
+        $result['updated_at']   = $this->iso($cached['updated_at'] ?? ($cached['updatedAt'] ?? null)) ?: $defaults['updated_at'];
+        $result['incidents']    = (isset($cached['incidents']) && is_array($cached['incidents'])) ? $cached['incidents'] : [];
+        $result['recent_incidents'] = (isset($cached['recent_incidents']) && is_array($cached['recent_incidents']))
+            ? $cached['recent_incidents']
+            : [];
+        $result['error']       = 'cached_fallback';
+        $result['confidence']  = 'low';
+        $result['tile_kind']   = 'unknown';
+        $result['sort_key']    = $this->sort_key_for_tile('unknown', $status);
+
+        return $result;
+    }
+
+    private function should_verify_cloudflare_status(array $provider, string $type, array $result): bool {
+        if (strtolower((string) ($provider['id'] ?? '')) !== 'cloudflare') {
+            return false;
+        }
+        if ('statuspage' !== strtolower($type)) {
+            return false;
+        }
+
+        $status = strtolower((string) ($result['status'] ?? 'unknown'));
+        if (in_array($status, ['operational', 'unknown'], true)) {
+            return false;
+        }
+
+        $incidents = is_array($result['incidents'] ?? null) ? $result['incidents'] : [];
+        if (! empty($incidents)) {
+            return false;
+        }
+
+        $summary = (string) ($result['summary'] ?? '');
+        $message = (string) ($result['message'] ?? '');
+        if (! $this->is_generic_summary_message($summary) || ! $this->is_generic_summary_message($message)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function is_generic_summary_message(string $text): bool {
+        $needle = strtolower(trim($text));
+        if ('' === $needle) {
+            return true;
+        }
+
+        $phrases = [
+            'service degradation reported.',
+            'major outage reported.',
+            'maintenance in progress.',
+            'status temporarily unavailable.',
+        ];
+
+        return in_array($needle, $phrases, true);
+    }
+
+    private function normalize_incident_buckets(array $incidents, array $provider, string $status): array {
+        $active         = [];
+        $recent         = [];
+        $historyCutoff  = time() - (35 * DAY_IN_SECONDS);
+        foreach ($incidents as $incident) {
+            if (! is_array($incident)) {
+                continue;
+            }
+
+            $rawStatus = strtolower((string) ($incident['status'] ?? ''));
+            $isResolved = in_array($rawStatus, ['resolved', 'completed', 'postmortem'], true);
+            if (! $isResolved && in_array($rawStatus, ['unknown', ''], true) && empty($incident['impact'])) {
+                continue;
+            }
+
+            $title   = $this->sanitize($incident['title'] ?? ($incident['name'] ?? 'Incident'));
+            $summary = $this->sanitize($incident['summary'] ?? '');
+            if (! $summary && $rawStatus) {
+                $summary = ucfirst(str_replace('_', ' ', $rawStatus));
+            }
+            if (! $summary) {
+                $summary = $title ?: 'Incident';
+            }
+
+            $started = $this->iso($incident['started_at'] ?? ($incident['startedAt'] ?? null));
+            $updated = $this->iso($incident['updated_at'] ?? ($incident['updatedAt'] ?? null)) ?: $started;
+            $updatedTs = $updated ? strtotime($updated) : null;
+            $startedTs = $started ? strtotime($started) : null;
+            $effective = $updatedTs ?? $startedTs ?? 0;
+            if ($effective && $effective < $historyCutoff) {
+                continue;
+            }
+
+            $impactSource = $incident['impact'] ?? $rawStatus ?: $status;
+            $impact       = $this->map_impact($impactSource);
+            $maint = preg_match(
+                '/\b(scheduled|planned).{0,40}maintenance\b/i',
+                ($title . ' ' . $summary)
+            ) === 1;
+            if ($maint) {
+                $impact = 'maintenance';
+            }
+            if ($isResolved) {
+                $impact = 'operational';
+            }
+
+            $url = '';
+            if (! empty($incident['url']) && is_string($incident['url'])) {
+                $url = $incident['url'];
+            } elseif (! empty($incident['shortlink']) && is_string($incident['shortlink'])) {
+                $url = $incident['shortlink'];
+            } elseif (! empty($provider['status_url']) && is_string($provider['status_url'])) {
+                $url = $provider['status_url'];
+            }
+
+            $entry = [
+                'id'         => (string) ($incident['id'] ?? md5(wp_json_encode($incident))),
+                'title'      => $title ?: 'Incident',
+                'summary'    => $summary,
+                'started_at' => $started,
+                'updated_at' => $updated,
+                'status'     => $impact,
+                'impact'     => $impact,
+                'eta'        => $this->sanitize($incident['eta'] ?? ''),
+                'url'        => $url,
+            ];
+
+            if ($isResolved) {
+                $recent[] = $entry;
+                continue;
+            }
+
+            $active[] = $entry;
+        }
+
+        return [
+            'active' => array_slice($active, 0, 10),
+            'recent' => array_slice($recent, 0, 10),
+        ];
+    }
+
+    private function maybe_retry_ipv4(array $response, string $endpoint, array $headers): array {
+        if ($response['ok'] ?? false) {
+            return $response;
+        }
+
+        $status  = (int) ($response['status'] ?? 0);
+        $message = (string) ($response['message'] ?? '');
+
+        if (0 !== $status) {
+            return $response;
+        }
+
+        $kind = $this->classify_network_error($message);
+        if (! $kind) {
+            return $response;
+        }
+
+        $retry = http_get($endpoint, [
+            'timeout'     => $this->timeout,
+            'headers'     => $headers,
+            'redirection' => 3,
+            'force_ipv4'  => true,
+        ]);
+
+        if (! ($retry['ok'] ?? false) && empty($retry['message']) && $message) {
+            $retry['message'] = $message;
+        }
+
+        if (! ($retry['ok'] ?? false) && ! isset($retry['retry_kind'])) {
+            $retry['retry_kind'] = $kind;
+        }
+
+        return $retry;
+    }
+
+    private function classify_network_error(string $message): ?string {
+        $needle = strtolower($message);
+        if ('' === $needle) {
+            return null;
+        }
+
+        $dns_patterns = [
+            'could not resolve host',
+            "couldn't resolve host",
+            'name or service not known',
+            'no address associated',
+        ];
+
+        foreach ($dns_patterns as $pattern) {
+            if (false !== strpos($needle, $pattern)) {
+                return 'dns';
+            }
+        }
+
+        if (preg_match('/\bdns\b/', $needle)) {
+            return 'dns';
+        }
+
+        $tls_patterns = [
+            'ssl',
+            'tls',
+            'certificate',
+            'handshake',
+        ];
+
+        foreach ($tls_patterns as $pattern) {
+            if (false !== strpos($needle, $pattern)) {
+                return 'tls';
+            }
+        }
+
+        return null;
+    }
+
+    private function failure_summary(int $status, ?string $networkKind): string {
+        if (in_array($status, [401, 403], true)) {
+            return 'Unauthorized or forbidden at API; trying history feed…';
+        }
+
+        if (404 === $status) {
+            return 'Summary endpoint missing; trying history feed…';
+        }
+
+        if ('dns' === $networkKind) {
+            return 'Could not resolve host';
+        }
+
+        if ('tls' === $networkKind) {
+            return 'TLS handshake failed';
+        }
+
+        if ($status >= 500 && $status < 600) {
+            return 'Status API error';
+        }
+
+        if (0 === $status) {
+            return 'Network request failed';
+        }
+
+        return 'Status fetch failed';
+    }
+
+    private function optional_unavailable(array $defaults, string $error): array {
+        $defaults['status']  = 'unknown';
+        $defaults['summary'] = 'Optional source unavailable';
+        $defaults['message'] = $defaults['summary'];
+        $defaults['error']   = $error ? 'optional_unavailable: ' . $error : 'optional_unavailable';
+        return $defaults;
+    }
+
+    private function failed_defaults(array $defaults, string $code, string $summary, string $status = 'unknown', int $httpStatus = 0, ?string $networkKind = null, string $rawMessage = ''): array {
+        $defaults['status']       = $status ?: 'unknown';
+        $defaults['status_label'] = self::status_label($defaults['status']);
+
+        $suppress = $this->should_suppress_error($httpStatus, $code, $networkKind, $rawMessage);
+        $displaySummary = $suppress ? 'Status temporarily unavailable.' : ($summary ?: 'Status fetch failed');
+
+        $defaults['summary'] = $displaySummary;
+        $defaults['message'] = $displaySummary;
+        $defaults['error']   = $suppress ? null : $code;
+
+        return $defaults;
+    }
+
+    private function should_suppress_error(int $httpStatus, string $code, ?string $networkKind, string $rawMessage): bool {
+        if (in_array($httpStatus, [401, 403, 404], true)) {
+            return true;
+        }
+
+        if (0 === $httpStatus) {
+            $codeLower = strtolower($code);
+            if (0 === strpos($codeLower, 'network_error:dns')) {
+                return true;
+            }
+            if ('dns' === strtolower((string) $networkKind)) {
+                return true;
+            }
+            if ($rawMessage && $this->is_dns_error($rawMessage)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function is_dns_error(string $message): bool {
+        if ('' === trim($message)) {
+            return false;
+        }
+
+        return 'dns' === $this->classify_network_error($message);
+    }
+
+    private function sanitize(?string $text): string {
+        if (! $text) {
+            return '';
+        }
+        return trim(wp_strip_all_tags($text));
+    }
+
+    private function iso($value): ?string {
+        if (! $value) {
+            return null;
+        }
+        if ($value instanceof \DateTimeInterface) {
+            return gmdate('c', (int) $value->getTimestamp());
+        }
+        $ts = strtotime((string) $value);
+        if (! $ts) {
+            return null;
+        }
+        return gmdate('c', $ts);
+    }
+
+    private function map_impact($impact): string {
+        $impact = strtolower((string) $impact);
+        switch ($impact) {
+            case 'critical':
+            case 'major':
+            case 'major_outage':
+            case 'outage':
+                return 'outage';
+            case 'maintenance':
+            case 'scheduled':
+                return 'maintenance';
+            case 'operational':
+            case 'ok':
+                return 'operational';
+            case 'minor':
+            case 'degraded':
+            case 'partial':
+            case 'partial_outage':
+            case 'investigating':
+            case 'identified':
+            case 'monitoring':
+            case 'in_progress':
+            case 'reported':
+            case 'active':
+            case 'warning':
+                return 'degraded';
+            default:
+                return 'minor';
+        }
+    }
+
+    private function normalize_status_code(string $status): string {
+        $status = strtolower($status);
+        switch ($status) {
+            case 'operational':
+            case 'ok':
+            case 'none':
+                return 'operational';
+            case 'degraded':
+            case 'partial':
+            case 'minor':
+            case 'warning':
+                return 'degraded';
+            case 'outage':
+            case 'major':
+            case 'major_outage':
+            case 'critical':
+            case 'down':
+                return 'outage';
+            case 'maintenance':
+            case 'scheduled':
+                return 'maintenance';
+            default:
+                return 'unknown';
+        }
+    }
+}
+
+class Lousy_Outages_Fetcher {
+    private const TRANSIENT_PREFIX = 'lousy_outages_provider_';
+    private const CACHE_TTL = 90;
+    private const REQUEST_TIMEOUT = 8;
+    private const USER_AGENT = 'LousyOutages/1.2 (+https://suzyeaston.ca)';
+    private const ACCEPT_HEADER = 'application/json, application/rss+xml, application/atom+xml, text/html, */*';
+    // RSS/Atom incident recency windows (filterable).
+    private const FEED_ACTIVE_WINDOW_HOURS = 6;
+    private const FEED_RECENT_INCIDENT_DAYS = 7;
+
+    /**
+     * Manual verification checklist:
+     * - Simulate HTTP 401/403/404/DNS errors to ensure tiles surface UNKNOWN with helpful copy.
+     * - Trigger two sequential fetches to hit the 304 path and confirm the degraded banner clears.
+     * - Confirm severity sorting bubbles major/degraded tiles above operational ones.
+     * - Exercise the subscribe endpoint with valid/invalid emails and non-JS POST fallback.
+     */
+    private static $PROVIDERS = [
+        // Statuspage JSON (keep as JSON)
+        'cloudflare' => ['kind' => 'statuspage', 'base' => 'https://www.cloudflarestatus.com'],
+        'zoom'       => ['kind' => 'statuspage', 'base' => 'https://status.zoom.us'],
+        'teamviewer' => ['kind' => 'statuspage', 'base' => 'https://status.teamviewer.com'],
+
+        // Switch these to RSS/Atom (per Suzy’s feeds)
+        'zscaler'    => ['kind' => 'rss', 'feed' => 'https://trust.zscaler.com/rss-feed', 'link' => 'https://trust.zscaler.com/cloud-status'],
+        'slack'      => ['kind' => 'rss', 'feed' => 'https://slack-status.com/feed/rss', 'link' => 'https://status.slack.com'],
+        'google_workspace' => [
+            'kind' => 'rss',
+            'feed' => 'https://www.google.com/appsstatus/rss/en-CA',
+            'link' => 'https://www.google.com/appsstatus/dashboard/',
+        ],
+        'google_cloud' => [
+            'kind' => 'rss',
+            'feed' => 'https://status.cloud.google.com/rss',
+            'link' => 'https://status.cloud.google.com/',
+        ],
+        'azure'      => [
+            'kind' => 'rss',
+            'feed' => [
+                'https://rssfeed.azure.status.microsoft/en-us/status/feed/',
+                'https://azurestatuscdn.azureedge.net/en-us/status/feed/',
+            ],
+            'link' => 'https://status.azure.com/en-us/status',
+        ],
+        // Clouds
+        'aws' => [
+            'kind'  => 'rss-multi',
+            'feeds' => [
+                'https://status.aws.amazon.com/rss/clouddirectory-us-east-1.rss',
+                'https://status.aws.amazon.com/rss/clouddirectory-ca-central-1.rss',
+                'https://status.aws.amazon.com/rss/apigateway-us-east-2.rss',
+                'https://status.aws.amazon.com/rss/bedrock-us-west-2.rss',
+            ],
+            'link' => 'https://status.aws.amazon.com/',
+        ],
+
+        // CrowdStrike: trust center only
+        'crowdstrike' => ['kind' => 'link-only', 'url' => 'https://trust.crowdstrike.com'],
+    ];
+
+    private static $NAMES = [
+        'cloudflare' => 'Cloudflare',
+        'zoom'       => 'Zoom',
+        'teamviewer' => 'TeamViewer',
+        'zscaler'    => 'Zscaler',
+        'slack'      => 'Slack',
+        'google_workspace' => 'Google Workspace',
+        'google_cloud'     => 'Google Cloud',
+        'azure'      => 'Microsoft Azure',
+        'aws'        => 'Amazon Web Services',
+        'crowdstrike'=> 'CrowdStrike',
+    ];
+
+    private const STATUS_LABELS = [
+        'operational' => 'Operational',
+        'degraded'    => 'Degraded',
+        'major'       => 'Major Outage',
+        'outage'      => 'Outage',
+        'maintenance' => 'Maintenance',
+        'unknown'     => 'Unknown',
+    ];
+
+    private const STATUS_CLASSES = [
+        'operational' => 'status--operational',
+        'degraded'    => 'status--degraded',
+        'major'       => 'status--outage',
+        'outage'      => 'status--outage',
+        'maintenance' => 'status--maintenance',
+        'unknown'     => 'status--unknown',
+    ];
+
+    private const STATUS_PRIORITY = [
+        'major'       => 4,
+        'outage'      => 4,
+        'degraded'    => 3,
+        'maintenance' => 2,
+        'unknown'     => 1,
+        'operational' => 0,
+    ];
+
+    public function get_provider_map(): array {
+        $map = [];
+        foreach (self::$PROVIDERS as $slug => $config) {
+            $slug = (string) $slug;
+            $map[$slug] = [
+                'slug'       => $slug,
+                'name'       => $this->display_name($slug),
+                'kind'       => $config['kind'],
+                'status_url' => $this->provider_link($slug, $config),
+                'link'       => $this->provider_link($slug, $config),
+            ];
+        }
+        return $map;
+    }
+
+    public function get_all(?array $filters = null): array {
+        $slugs = $this->resolve_slugs($filters);
+        $providers = [];
+        $errors = [];
+        $latest = 0;
+
+        foreach ($slugs as $slug) {
+            $config = self::$PROVIDERS[$slug];
+            $cache  = $this->get_cache($slug);
+            $tile   = $this->fetch_provider($slug, $config, $cache);
+            $providers[$slug] = $tile;
+
+            if (!empty($tile['error'])) {
+                $errors[] = [
+                    'id'      => $slug,
+                    'provider'=> $tile['name'],
+                    'message' => (string) $tile['error'],
+                ];
+            }
+
+            $timestamp = strtotime($tile['fetched_at'] ?? '');
+            if ($timestamp) {
+                $latest = max($latest, $timestamp);
+            }
+
+            $this->save_cache($slug, $cache);
+        }
+
+        $sorted = array_values($providers);
+        usort($sorted, [self::class, 'compare_tiles']);
+
+        $fetched_at = $latest ? gmdate('c', $latest) : gmdate('c');
+        $trending   = (new Trending())->evaluate($sorted);
+
+        return [
+            'providers'  => $sorted,
+            'fetched_at' => $fetched_at,
+            'errors'     => $errors,
+            'trending'   => $trending,
+        ];
+    }
+
+    private function resolve_slugs(?array $filters): array {
+        $available = array_keys(self::$PROVIDERS);
+        if (!$filters) {
+            return $available;
+        }
+        $selected = [];
+        foreach ($filters as $slug) {
+            $slug = strtolower(trim((string) $slug));
+            if ($slug && in_array($slug, $available, true)) {
+                $selected[] = $slug;
+            }
+        }
+        return $selected ? array_values(array_unique($selected)) : $available;
+    }
+
+    private static function compare_tiles(array $a, array $b): int {
+        $rank = self::STATUS_PRIORITY;
+        $statusA = strtolower((string) ($a['status'] ?? 'unknown'));
+        $statusB = strtolower((string) ($b['status'] ?? 'unknown'));
+        $ra = $rank[$statusA] ?? $rank['unknown'];
+        $rb = $rank[$statusB] ?? $rank['unknown'];
+        if ($ra !== $rb) {
+            return $rb <=> $ra;
+        }
+
+        $nameA = strtolower((string) ($a['name'] ?? $a['provider'] ?? ''));
+        $nameB = strtolower((string) ($b['name'] ?? $b['provider'] ?? ''));
+        return $nameA <=> $nameB;
+    }
+
+    private function fetch_provider(string $slug, array $config, array &$cache): array {
+        $kind = $config['kind'];
+        switch ($kind) {
+            case 'statuspage':
+                $tile = $this->fetch_statuspage($slug, $config, $cache);
+                break;
+            case 'rss':
+            case 'atom':
+                $feeds = [];
+                if (isset($config['feed'])) {
+                    if (is_array($config['feed'])) {
+                        $feeds = array_values(array_filter(array_map('strval', $config['feed'])));
+                    } elseif (is_string($config['feed']) && '' !== trim($config['feed'])) {
+                        $feeds = [(string) $config['feed']];
+                    }
+                }
+                $tile = $this->fetch_feed($slug, $config, $cache, $feeds, $kind);
+                break;
+            case 'rss-multi':
+                $feeds = isset($config['feeds']) && is_array($config['feeds']) ? array_filter(array_map('strval', $config['feeds'])) : [];
+                $tile  = $this->fetch_feed($slug, $config, $cache, $feeds, 'rss');
+                break;
+            case 'scrape':
+                $tile = $this->fetch_scrape($slug, $config, $cache);
+                break;
+            case 'link-only':
+            default:
+                $tile = $this->build_tile($slug, $config, 'unknown', 'View status →', '', [], 0, []);
+                break;
+        }
+
+        $cache['tile'] = $tile;
+        return $tile;
+    }
+
+    private function fetch_statuspage(string $slug, array $config, array &$cache): array {
+        $base = rtrim((string) ($config['base'] ?? ''), '/');
+        if ('' === $base) {
+            return $this->build_tile($slug, $config, 'unknown', 'Status endpoint unavailable.', '', [], 0, ['error' => 'missing_endpoint']);
+        }
+
+        $summaryUrl  = $base . '/api/v2/summary.json';
+        $fallbackUrl = $base . '/api/v2/incidents/unresolved.json';
+
+        $request = $this->request_with_cache($slug, $cache, 'summary', $summaryUrl);
+        if (!empty($request['error'])) {
+            return $this->error_tile_from_request($slug, $config, $request['error'], 0);
+        }
+
+        $summaryFetchedAt = isset($cache['segments']['summary']['fetched_at']) ? $cache['segments']['summary']['fetched_at'] : gmdate('c');
+        $statusCode = (int) $request['status'];
+        $body       = (string) ($request['body'] ?? '');
+
+        if (($statusCode >= 200 && $statusCode < 300) || 304 === $statusCode) {
+            $parsed = $this->parse_statuspage_summary($body);
+            if ($parsed) {
+                $indicator = strtolower((string) $parsed['indicator']);
+                $status    = $this->map_indicator($indicator);
+                $message   = $parsed['description'] ?: $this->default_message($status);
+                $summary   = '';
+                $incidents = $parsed['incidents'];
+                if ($incidents) {
+                    $status  = $this->severity_from_incidents($incidents);
+                    $lead    = $incidents[0];
+                    $message = $lead['name'] ?? 'Incident';
+                    $summary = $this->format_incident_summary($lead);
+                } else {
+                    if ('operational' === $status || $this->is_no_incidents_message($message)) {
+                        $message = 'All systems operational.';
+                    } elseif ('unknown' === $status) {
+                        $message = 'Status temporarily unavailable.';
+                    }
+                }
+
+                return $this->build_tile($slug, $config, $status, $message, $summary, $incidents, $statusCode, [
+                    'indicator' => $indicator,
+                    'link'      => $this->provider_link($slug, $config),
+                    'fetched_at' => $summaryFetchedAt,
+                ]);
+            }
+        }
+
+        if (in_array($statusCode, [401, 403, 404], true)) {
+            $fallback = $this->request_with_cache($slug, $cache, 'unresolved', $fallbackUrl);
+            if (!empty($fallback['error'])) {
+                return $this->error_tile_from_request($slug, $config, $fallback['error'], $statusCode);
+            }
+            $fallbackFetchedAt = isset($cache['segments']['unresolved']['fetched_at']) ? $cache['segments']['unresolved']['fetched_at'] : $summaryFetchedAt;
+            $fbStatus = (int) $fallback['status'];
+            $fbBody   = (string) ($fallback['body'] ?? '');
+            if (($fbStatus >= 200 && $fbStatus < 300) || 304 === $fbStatus) {
+                $incidents = $this->parse_statuspage_incidents($fbBody);
+                if ($incidents) {
+                    $severity = $this->severity_from_incidents($incidents);
+                    $lead     = $incidents[0];
+                    $message  = $lead['name'] ?? 'Incident';
+                    $summary  = $this->format_incident_summary($lead);
+                    return $this->build_tile($slug, $config, $severity, $message, $summary, $incidents, $fbStatus, [
+                        'indicator' => 'major' === $severity ? 'critical' : 'minor',
+                        'link'      => $this->provider_link($slug, $config),
+                        'fetched_at' => $fallbackFetchedAt,
+                    ]);
+                }
+            }
+        }
+
+        $message = $statusCode ? sprintf('HTTP %d fetching status.', $statusCode) : 'Status temporarily unavailable.';
+        $extra = [
+            'fetched_at' => $summaryFetchedAt,
+        ];
+
+        if ($this->should_suppress_http_error($statusCode ?: 0, $message)) {
+            $message = 'Status temporarily unavailable.';
+        } else {
+            $extra['error'] = $message;
+        }
+
+        return $this->build_tile($slug, $config, 'unknown', $message, '', [], $statusCode ?: 0, $extra);
+    }
+
+    private function fetch_feed(string $slug, array $config, array &$cache, array $feeds, string $kind): array {
+        if (!$feeds) {
+            return $this->build_tile($slug, $config, 'unknown', 'Feed URL unavailable.', '', [], 0, ['error' => 'missing_feed']);
+        }
+
+        $items = [];
+        $httpStatus = 0;
+        $errors = [];
+        $fetchedTimes = [];
+
+        foreach ($feeds as $index => $feedUrl) {
+            $key = 'feed_' . $index;
+            $request = $this->request_with_cache($slug, $cache, $key, $feedUrl);
+            if (!empty($request['error'])) {
+                $errors[] = $request['error'];
+                continue;
+            }
+            $httpStatus = (int) $request['status'];
+            if ($httpStatus >= 400 && $httpStatus < 600) {
+                $errors[] = 'HTTP ' . $httpStatus . ' fetching feed.';
+                continue;
+            }
+            $body = (string) ($request['body'] ?? '');
+            $items = array_merge($items, $this->parse_feed_items($body, $kind));
+            if (isset($cache['segments']['feed_' . $index]['fetched_at'])) {
+                $fetchedTimes[] = $cache['segments']['feed_' . $index]['fetched_at'];
+            }
+        }
+
+        if (!$items && $errors) {
+            return $this->error_tile_from_request($slug, $config, $errors[0], $httpStatus ?: 0);
+        }
+
+        $feedFetchedAt = gmdate('c');
+        if ($fetchedTimes) {
+            $latestTs = 0;
+            foreach ($fetchedTimes as $timeStr) {
+                $timeVal = strtotime((string) $timeStr);
+                if ($timeVal && $timeVal > $latestTs) {
+                    $latestTs = $timeVal;
+                }
+            }
+            if ($latestTs) {
+                $feedFetchedAt = gmdate('c', $latestTs);
+            }
+        }
+
+        if ($items) {
+            usort(
+                $items,
+                static function ($a, $b) {
+                    return ($b['timestamp'] ?? 0) <=> ($a['timestamp'] ?? 0);
+                }
+            );
+
+            // LO: trim feed noise to last 35 days and dedupe noisy providers.
+            $cutoff = time() - (35 * DAY_IN_SECONDS);
+            $items  = array_values(
+                array_filter(
+                    $items,
+                    static function ($item) use ($cutoff) {
+                        return ($item['timestamp'] ?? 0) >= $cutoff;
+                    }
+                )
+            );
+
+            $seen = [];
+            $items = array_values(
+                array_filter(
+                    $items,
+                    static function ($item) use (&$seen) {
+                        $key = sha1(
+                            ($item['title'] ?? '') . '|' . ($item['iso'] ?? '') . '|' . ($item['link'] ?? '')
+                        );
+                        if (isset($seen[$key])) {
+                            return false;
+                        }
+                        $seen[$key] = true;
+                        return true;
+                    }
+                )
+            );
+        }
+
+        if (!$items) {
+            return $this->build_tile($slug, $config, 'operational', 'All systems operational.', '', [], $httpStatus ?: 200, ['fetched_at' => $feedFetchedAt]);
+        }
+
+        $active = [];
+        $incidents = [];
+        $activeWindowHours = apply_filters(
+            'lo_feed_active_window_hours',
+            self::FEED_ACTIVE_WINDOW_HOURS,
+            $slug,
+            $config
+        );
+        $recentIncidentDays = apply_filters(
+            'lo_feed_recent_incident_days',
+            self::FEED_RECENT_INCIDENT_DAYS,
+            $slug,
+            $config
+        );
+        $activeWindowHours = is_numeric($activeWindowHours) ? max(1, (int) $activeWindowHours) : self::FEED_ACTIVE_WINDOW_HOURS;
+        $recentIncidentDays = is_numeric($recentIncidentDays) ? max(1, (int) $recentIncidentDays) : self::FEED_RECENT_INCIDENT_DAYS;
+        $threshold = time() - ($activeWindowHours * HOUR_IN_SECONDS);
+        $recentThreshold = time() - ($recentIncidentDays * DAY_IN_SECONDS);
+        $severityRank = [
+            'outage'      => 0,
+            'degraded'    => 1,
+            'maintenance' => 2,
+            'unknown'     => 3,
+        ];
+        $activeStatus = 'operational';
+
+        foreach ($items as $item) {
+            $timestamp = (int) ($item['timestamp'] ?? 0);
+            $text = strtolower($item['summary'] . ' ' . $item['title']);
+            $statusCode = $this->infer_incident_status($text);
+            $impact     = $this->map_impact($statusCode);
+            $isActive   = in_array($impact, ['outage', 'degraded'], true);
+
+            if (!$isActive || $timestamp < $threshold) {
+                continue;
+            }
+
+            $active[] = $item;
+            $rank     = $severityRank[$impact] ?? $severityRank['unknown'];
+            $current  = $severityRank[$activeStatus] ?? PHP_INT_MAX;
+            if ($rank < $current) {
+                $activeStatus = $impact;
+            }
+
+            $incidents[] = [
+                'name'       => $item['title'],
+                'status'     => $statusCode,
+                'impact'     => $impact,
+                'started_at' => $item['iso'],
+                'updated_at' => $item['iso'],
+                'url'        => $item['link'],
+            ];
+
+            if (count($incidents) >= 10) {
+                break;
+            }
+        }
+
+        if (!$active) {
+            $summary = '';
+            $lastIncident = null;
+            foreach ($items as $item) {
+                $timestamp = (int) ($item['timestamp'] ?? 0);
+                if ($timestamp < $recentThreshold) {
+                    continue;
+                }
+                $text = strtolower($item['summary'] . ' ' . $item['title']);
+                $statusCode = $this->infer_incident_status($text);
+                $impact = $this->map_impact($statusCode);
+                if (!in_array($impact, ['outage', 'degraded'], true)) {
+                    continue;
+                }
+                $lastIncident = $item;
+                break;
+            }
+
+            if ($lastIncident) {
+                $reported = $this->format_local_time((int) ($lastIncident['timestamp'] ?? 0));
+                $reportedText = $reported ? ' (reported ' . $reported . ')' : '';
+                $summary = 'Last incident: ' . $lastIncident['title'] . $reportedText;
+            }
+
+            return $this->build_tile($slug, $config, 'operational', 'All systems operational.', $summary, [], $httpStatus ?: 200, [
+                'fetched_at' => $feedFetchedAt,
+            ]);
+        }
+
+        $lead = $active[0];
+        $summary = '';
+        if (!empty($lead['timestamp'])) {
+            $summaryTime = $this->format_local_time((int) $lead['timestamp']);
+            if ($summaryTime) {
+                $summary = 'Updated ' . $summaryTime;
+            }
+        }
+
+        return $this->build_tile($slug, $config, $activeStatus, $lead['title'], $summary, $incidents, $httpStatus ?: 200, [
+            'fetched_at' => $feedFetchedAt,
+        ]);
+    }
+
+    private function fetch_scrape(string $slug, array $config, array &$cache): array {
+        $url = (string) ($config['url'] ?? '');
+        if ('' === $url) {
+            return $this->build_tile($slug, $config, 'unknown', 'Status page unavailable.', '', [], 0, ['error' => 'missing_url']);
+        }
+        $request = $this->request_with_cache($slug, $cache, 'scrape', $url);
+        if (!empty($request['error'])) {
+            return $this->error_tile_from_request($slug, $config, $request['error'], 0);
+        }
+        $scrapeFetchedAt = isset($cache['segments']['scrape']['fetched_at']) ? $cache['segments']['scrape']['fetched_at'] : gmdate('c');
+        $body = (string) ($request['body'] ?? '');
+        $headline = $this->extract_headline($body);
+        if ('' === $headline) {
+            $headline = 'Unable to read status headline.';
+        }
+        $status = (stripos($headline, 'running smoothly') !== false) ? 'operational' : 'degraded';
+        return $this->build_tile($slug, $config, $status, $headline, '', [], (int) $request['status'], [
+            'fetched_at' => $scrapeFetchedAt,
+        ]);
+    }
+
+    private function build_tile(string $slug, array $config, string $status, string $message, string $summary, array $incidents, int $http_code, array $extra): array {
+        $status = strtolower($status ?: 'unknown');
+        if (!isset(self::STATUS_LABELS[$status])) {
+            $status = 'unknown';
+        }
+
+        $link = $extra['link'] ?? $this->provider_link($slug, $config);
+        $fetchedAt = $extra['fetched_at'] ?? gmdate('c');
+        $indicator = $extra['indicator'] ?? null;
+        $error = $extra['error'] ?? null;
+
+        $normalizedIncidents = [];
+        foreach ($incidents as $incident) {
+            if (!is_array($incident)) {
+                continue;
+            }
+            $normalizedIncidents[] = [
+                'name'       => $this->clean_string($incident['name'] ?? 'Incident'),
+                'status'     => strtolower($incident['status'] ?? 'unknown'),
+                'started_at' => $incident['started_at'] ?? '',
+                'updated_at' => $incident['updated_at'] ?? '',
+                'url'        => $incident['url'] ?? '',
+            ];
+        }
+
+        $summary_text = $summary;
+        if (array_key_exists('summary', $extra)) {
+            $summary_text = (string) $extra['summary'];
+        }
+
+        $tile = [
+            'id'           => $slug,
+            'provider'     => $slug,
+            'name'         => $this->display_name($slug),
+            'kind'         => $config['kind'] ?? 'link-only',
+            'status'       => $status,
+            'status_label' => self::STATUS_LABELS[$status],
+            'status_class' => self::STATUS_CLASSES[$status],
+            'overall'      => $status,
+            'message'      => $this->clean_string($message),
+            'summary'      => $this->clean_string($summary_text),
+            'incidents'    => $normalizedIncidents,
+            'components'   => [],
+            'fetched_at'   => $fetchedAt,
+            'http_code'    => $http_code,
+            'indicator'    => $indicator,
+            'link'         => $link,
+            'url'          => $link,
+            'error'        => $error,
+        ];
+
+        if ('unknown' === $status && !$error && $http_code >= 500) {
+            $tile['error'] = sprintf('HTTP %d response from provider.', $http_code);
+        }
+
+        if (!empty($tile['error'])) {
+            $tile['error'] = $this->clean_string($tile['error']);
+        }
+
+        return $tile;
+    }
+
+    private function error_tile_from_request(string $slug, array $config, string $message, int $http_code): array {
+        $http = $http_code ?: 0;
+        $display = $message ?: 'Status fetch failed.';
+        $suppress = $this->should_suppress_http_error($http, $message);
+
+        $extra = [];
+        if (!$suppress && '' !== $display) {
+            $extra['error'] = $display;
+        }
+
+        if ($suppress) {
+            $display = 'Status temporarily unavailable.';
+        }
+
+        return $this->build_tile($slug, $config, 'unknown', $display, '', [], $http, $extra);
+    }
+
+    private function should_suppress_http_error(int $code, string $message): bool {
+        if (in_array($code, [401, 403, 404], true)) {
+            return true;
+        }
+
+        if (0 === $code && $this->is_dns_error($message)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function parse_statuspage_summary(string $body): ?array {
+        $data = json_decode($body, true);
+        if (!is_array($data)) {
+            return null;
+        }
+        $indicator = $data['status']['indicator'] ?? 'none';
+        $description = isset($data['status']['description']) ? $this->clean_string($data['status']['description']) : '';
+        $incidents = $this->normalize_statuspage_incident_array($data['incidents'] ?? []);
+        return [
+            'indicator'    => $indicator,
+            'description'  => $description,
+            'incidents'    => $incidents,
+        ];
+    }
+
+    private function parse_statuspage_incidents(string $body): array {
+        $data = json_decode($body, true);
+        if (!is_array($data)) {
+            return [];
+        }
+        return $this->normalize_statuspage_incident_array($data);
+    }
+
+    private function normalize_statuspage_incident_array($value): array {
+        if (!is_array($value)) {
+            return [];
+        }
+        $incidents = [];
+        foreach ($value as $incident) {
+            if (!is_array($incident)) {
+                continue;
+            }
+            $status = strtolower((string) ($incident['status'] ?? 'unknown'));
+            if (in_array($status, ['resolved', 'completed', 'postmortem'], true)) {
+                continue;
+            }
+            $name = $this->clean_string($incident['name'] ?? 'Incident');
+            $updates = isset($incident['incident_updates']) && is_array($incident['incident_updates']) ? $incident['incident_updates'] : [];
+            $summary = $this->latest_statuspage_summary($updates);
+            $started = $this->normalize_time($incident['started_at'] ?? $incident['created_at'] ?? '');
+            $updated = $this->normalize_time($incident['updated_at'] ?? $incident['resolved_at'] ?? '');
+            $url = isset($incident['shortlink']) ? (string) $incident['shortlink'] : ((isset($incident['url']) && is_string($incident['url'])) ? $incident['url'] : '');
+            $incidents[] = [
+                'name'       => $name,
+                'status'     => $status ?: 'unknown',
+                'started_at' => $started,
+                'updated_at' => $updated ?: $started,
+                'url'        => $url,
+            ];
+        }
+        return $incidents;
+    }
+
+    private function latest_statuspage_summary(array $updates): string {
+        $latest = '';
+        $latestTs = 0;
+        foreach ($updates as $update) {
+            if (!is_array($update)) {
+                continue;
+            }
+            $ts = strtotime((string) ($update['updated_at'] ?? $update['created_at'] ?? ''));
+            if ($ts && $ts > $latestTs) {
+                $latestTs = $ts;
+                $latest = $this->clean_string($update['body'] ?? '');
+            }
+        }
+        return $latest;
+    }
+
+    private function parse_feed_items(string $body, string $kind): array {
+        if ('' === trim($body)) {
+            return [];
+        }
+        $xml = @simplexml_load_string($body, 'SimpleXMLElement', LIBXML_NOCDATA);
+        if (false === $xml) {
+            return [];
+        }
+        $items = [];
+        if (isset($xml->channel->item)) {
+            foreach ($xml->channel->item as $item) {
+                $title = $this->clean_string((string) ($item->title ?? ''));
+                $link  = (string) ($item->link ?? '');
+                $timestamp = strtotime((string) ($item->pubDate ?? $item->date ?? ''));
+                $iso = $timestamp ? gmdate('c', $timestamp) : '';
+                $summary = $this->clean_string((string) ($item->description ?? ''));
+                $items[] = [
+                    'title'     => $title ?: 'Incident',
+                    'link'      => $link,
+                    'summary'   => $summary,
+                    'timestamp' => $timestamp ?: 0,
+                    'iso'       => $iso,
+                ];
+            }
+        } elseif (isset($xml->entry)) {
+            foreach ($xml->entry as $entry) {
+                $title = $this->clean_string((string) ($entry->title ?? ''));
+                $link  = '';
+                if (isset($entry->link)) {
+                    foreach ($entry->link as $linkNode) {
+                        $rel = (string) ($linkNode['rel'] ?? '');
+                        if ('' === $rel || 'alternate' === $rel) {
+                            $link = (string) ($linkNode['href'] ?? '');
+                            break;
+                        }
+                    }
+                }
+                $timestamp = strtotime((string) ($entry->updated ?? $entry->published ?? ''));
+                $iso = $timestamp ? gmdate('c', $timestamp) : '';
+                $summary = $this->clean_string((string) ($entry->summary ?? $entry->content ?? ''));
+                $items[] = [
+                    'title'     => $title ?: 'Incident',
+                    'link'      => $link,
+                    'summary'   => $summary,
+                    'timestamp' => $timestamp ?: 0,
+                    'iso'       => $iso,
+                ];
+            }
+        }
+        return $items;
+    }
+
+    private function infer_incident_status(string $text): string {
+        if (preg_match('/\bresolved\b|this issue is now resolved|issue is now resolved|issue has been resolved|ended at|postmortem/i', $text)) {
+            return 'operational';
+        }
+        if (preg_match('/\b(scheduled|planned).{0,40}maintenance\b/i', $text)) {
+            return 'maintenance';
+        }
+        if (preg_match('/\b(major|critical|outage)\b/i', $text)) {
+            return 'major_outage';
+        }
+        if (preg_match('/\b(degraded|partial|service disruption|connectivity)\b/i', $text)) {
+            return 'degraded';
+        }
+        if (false !== strpos($text, 'investigat')) {
+            return 'investigating';
+        }
+        if (false !== strpos($text, 'identify')) {
+            return 'identified';
+        }
+        if (false !== strpos($text, 'monitor')) {
+            return 'monitoring';
+        }
+        return 'unknown';
+    }
+
+    private function extract_headline(string $body): string {
+        if (preg_match('/<h1[^>]*>(.*?)<\/h1>/is', $body, $matches)) {
+            return $this->clean_string($matches[1]);
+        }
+        if (preg_match('/aria-label="([^"]*dashboard[^"]*)"/i', $body, $matches)) {
+            return $this->clean_string($matches[1]);
+        }
+        $text = $this->clean_string(wp_strip_all_tags($body));
+        return $text ? mb_substr($text, 0, 140) : '';
+    }
+
+    private function map_indicator(string $indicator): string {
+        $indicator = strtolower($indicator);
+        switch ($indicator) {
+            case 'none':
+            case 'operational':
+                return 'operational';
+            case 'minor':
+            case 'degraded_performance':
+                return 'degraded';
+            case 'major':
+            case 'critical':
+            case 'major_outage':
+                return 'major';
+            default:
+                return 'unknown';
+        }
+    }
+
+    private function severity_from_incidents(array $incidents): string {
+        foreach ($incidents as $incident) {
+            $status = strtolower((string) ($incident['status'] ?? ''));
+            if (in_array($status, ['critical', 'major', 'major_outage'], true)) {
+                return 'major';
+            }
+        }
+        return $incidents ? 'degraded' : 'operational';
+    }
+
+    private function request_with_cache(string $slug, array &$cache, string $key, string $url): array {
+        if ('' === $url) {
+            return ['status' => 0, 'body' => null, 'error' => ''];
+        }
+
+        if (!isset($cache['segments']) || !is_array($cache['segments'])) {
+            $cache['segments'] = [];
+        }
+        $segment = isset($cache['segments'][$key]) && is_array($cache['segments'][$key]) ? $cache['segments'][$key] : null;
+        if ($segment && !empty($segment['url']) && $segment['url'] !== $url) {
+            $segment = null;
+        }
+
+        $headers = [
+            'User-Agent'      => self::USER_AGENT,
+            'Accept'          => self::ACCEPT_HEADER,
+            'Cache-Control'   => 'no-cache',
+        ];
+        if ($segment) {
+            if (!empty($segment['etag'])) {
+                $headers['If-None-Match'] = $segment['etag'];
+            }
+            if (!empty($segment['last_modified'])) {
+                $headers['If-Modified-Since'] = $segment['last_modified'];
+            }
+        }
+
+        $response = wp_remote_get($url, [
+            'timeout'     => self::REQUEST_TIMEOUT,
+            'headers'     => $headers,
+            'redirection' => 3,
+        ]);
+
+        if (is_wp_error($response)) {
+            return [
+                'status' => 0,
+                'body'   => null,
+                'error'  => $response->get_error_message(),
+            ];
+        }
+
+        $status = (int) wp_remote_retrieve_response_code($response);
+        if (304 === $status && $segment && isset($segment['body'])) {
+            return [
+                'status'     => 304,
+                'body'       => $segment['body'],
+                'http_code'  => $segment['http_code'] ?? 304,
+                'etag'       => $segment['etag'] ?? '',
+                'fetched_at' => $segment['fetched_at'] ?? gmdate('c'),
+            ];
+        }
+
+        $body = (string) wp_remote_retrieve_body($response);
+        $etag = wp_remote_retrieve_header($response, 'etag');
+        $last = wp_remote_retrieve_header($response, 'last-modified');
+
+        $cache['segments'][$key] = [
+            'url'           => $url,
+            'body'          => $body,
+            'etag'          => is_string($etag) ? $etag : '',
+            'last_modified' => is_string($last) ? $last : '',
+            'http_code'     => $status,
+            'fetched_at'    => gmdate('c'),
+        ];
+
+        return [
+            'status' => $status,
+            'body'   => $body,
+        ];
+    }
+
+    private function get_cache(string $slug): array {
+        $cached = get_transient(self::TRANSIENT_PREFIX . $slug);
+        if (!is_array($cached)) {
+            return [];
+        }
+        if (!isset($cached['segments']) || !is_array($cached['segments'])) {
+            $cached['segments'] = [];
+        }
+        return $cached;
+    }
+
+    private function save_cache(string $slug, array $cache): void {
+        set_transient(self::TRANSIENT_PREFIX . $slug, $cache, self::CACHE_TTL);
+    }
+
+    private function provider_link(string $slug, array $config): string {
+        if (!empty($config['link'])) {
+            return (string) $config['link'];
+        }
+        if (!empty($config['base'])) {
+            return rtrim((string) $config['base'], '/') . '/';
+        }
+        if (!empty($config['url'])) {
+            return (string) $config['url'];
+        }
+        if (!empty($config['feed'])) {
+            return (string) $config['feed'];
+        }
+        return '';
+    }
+
+    private function display_name(string $slug): string {
+        if (isset(self::$NAMES[$slug])) {
+            return self::$NAMES[$slug];
+        }
+        $slug = str_replace(['-', '_'], ' ', $slug);
+        $slug = ucwords($slug);
+        return $slug ?: 'Provider';
+    }
+
+    private function normalize_time($value): string {
+        if (empty($value)) {
+            return '';
+        }
+        $timestamp = strtotime((string) $value);
+        return $timestamp ? gmdate('c', $timestamp) : '';
+    }
+
+    private function default_message(string $status): string {
+        switch ($status) {
+            case 'operational':
+                return 'All systems operational.';
+            case 'degraded':
+                return 'Service degradation detected';
+            case 'major':
+                return 'Major outage detected';
+            default:
+                return 'Status temporarily unavailable.';
+        }
+    }
+
+    private function format_incident_summary(array $incident): string {
+        $status = isset($incident['status']) ? (string) $incident['status'] : '';
+        $statusLabel = $status ? ucwords(str_replace('_', ' ', $status)) : 'Incident';
+        $updated = $this->format_local_time($incident['updated_at'] ?? ($incident['started_at'] ?? ''));
+        return trim($statusLabel . ($updated ? ' • Updated ' . $updated : ''));
+    }
+
+    private function is_no_incidents_message(string $message): bool {
+        $needle = strtolower(trim($message));
+        if ('' === $needle) {
+            return false;
+        }
+        $phrases = [
+            'no active incidents',
+            'no incidents',
+            'no current incidents',
+            'no known incidents',
+            'no reported incidents',
+            'all systems operational',
+        ];
+        foreach ($phrases as $phrase) {
+            if (false !== strpos($needle, $phrase)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function format_local_time($value): string {
+        if (empty($value)) {
+            return '';
+        }
+        $timestamp = is_numeric($value) ? (int) $value : strtotime((string) $value);
+        if (!$timestamp) {
+            return '';
+        }
+        $format = get_option('date_format') . ' ' . get_option('time_format');
+        return wp_date($format, $timestamp);
+    }
+
+    private function clean_string($value): string {
+        return trim(wp_strip_all_tags((string) $value));
+    }
+
+    private function is_dns_error(string $message): bool {
+        $needle = strtolower($message);
+        foreach (['could not resolve host', "couldn't resolve host", 'name or service not known', 'no address associated', 'cURL error 6'] as $pattern) {
+            if (false !== strpos($needle, strtolower($pattern))) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+if (! class_exists('LousyOutages\\Fetcher')) {
+    class_alias(__NAMESPACE__ . '\\Fetcher', 'LousyOutages\\Fetcher');
+}
+
+if (! class_exists('LousyOutages\\Lousy_Outages_Fetcher')) {
+    class_alias(__NAMESPACE__ . '\\Lousy_Outages_Fetcher', 'LousyOutages\\Lousy_Outages_Fetcher');
+}

--- a/plugins/lousy-outages/includes/I18n.php
+++ b/plugins/lousy-outages/includes/I18n.php
@@ -1,0 +1,79 @@
+<?php
+namespace SuzyEaston\LousyOutages;
+
+class I18n {
+    private const STRINGS = [
+        'en-CA' => [
+            'updatedLabel'      => 'Updated:',
+            'providerHeader'    => 'Provider',
+            'statusHeader'      => 'Status',
+            'messageHeader'     => 'Message',
+            'buttonLabel'       => 'Insert coin to refresh',
+            'buttonShortLabel'  => 'Insert coin',
+            'buttonLoading'     => 'Refreshing…',
+            'teaserCaption'     => 'Check if your favourite services are up. Insert coin to refresh.',
+            'microcopy'         => 'Vancouver weather: cloudy with a chance of outages.',
+            'offlineMessage'    => 'Arcade link is jittery. Data might be stale—try again soon.',
+            'tickerFallback'    => 'All quiet on the outage front.',
+            'unknownStatus'     => 'Unknown',
+            'noPublicStatus'    => 'No public status API',
+            'viewDashboard'     => 'View Full Dashboard →',
+            'detailsLabel'      => 'Details',
+            'detailsHide'       => 'Hide details',
+            'noIncidents'       => 'No active incidents. Go write a chorus.',
+            'degradedNoIncidents' => 'Status page shows degraded performance. Pop over there for the detailed log.',
+            'etaInvestigating'  => 'ETA: investigating — translation: nobody knows yet.',
+            'viewProvider'      => 'View provider status →',
+        ],
+        'en-US' => [
+            'updatedLabel'      => 'Updated:',
+            'providerHeader'    => 'Provider',
+            'statusHeader'      => 'Status',
+            'messageHeader'     => 'Message',
+            'buttonLabel'       => 'Insert coin to refresh',
+            'buttonShortLabel'  => 'Insert coin',
+            'buttonLoading'     => 'Refreshing…',
+            'teaserCaption'     => 'Check if your favourite services are up. Insert coin to refresh.',
+            'microcopy'         => 'Vancouver weather: cloudy with a chance of outages.',
+            'offlineMessage'    => 'Arcade link is jittery. Data might be stale—try again soon.',
+            'tickerFallback'    => 'All quiet on the outage front.',
+            'unknownStatus'     => 'Unknown',
+            'noPublicStatus'    => 'No public status API',
+            'viewDashboard'     => 'View Full Dashboard →',
+            'detailsLabel'      => 'Details',
+            'detailsHide'       => 'Hide details',
+            'noIncidents'       => 'No active incidents. Go write a chorus.',
+            'degradedNoIncidents' => 'Status page shows degraded performance. Pop over there for the detailed log.',
+            'etaInvestigating'  => 'ETA: investigating — translation: nobody knows yet.',
+            'viewProvider'      => 'View provider status →',
+        ],
+    ];
+
+    public static function determine_locale(): string {
+        $default = 'en-CA';
+        $site    = function_exists( '\\get_locale' ) ? (string) get_locale() : $default;
+        $site    = str_replace( '_', '-', $site );
+
+        if ( isset( self::STRINGS[ $site ] ) ) {
+            return $site;
+        }
+
+        if ( 0 === strpos( strtolower( $site ), 'en-us' ) ) {
+            return 'en-US';
+        }
+
+        return $default;
+    }
+
+    public static function strings( ?string $locale = null ): array {
+        $locale   = $locale ? str_replace( '_', '-', $locale ) : self::determine_locale();
+        $fallback = self::STRINGS['en-US'];
+        $primary  = self::STRINGS[ $locale ] ?? [];
+
+        return array_merge( $fallback, $primary );
+    }
+
+    public static function all(): array {
+        return self::STRINGS;
+    }
+}

--- a/plugins/lousy-outages/includes/IncidentAlerts.php
+++ b/plugins/lousy-outages/includes/IncidentAlerts.php
@@ -1,0 +1,1842 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+use SuzyEaston\LousyOutages\Email\Composer;
+use SuzyEaston\LousyOutages\Mailer;
+use SuzyEaston\LousyOutages\Model\Incident;
+use SuzyEaston\LousyOutages\Providers;
+use SuzyEaston\LousyOutages\Sources\Sources;
+use SuzyEaston\LousyOutages\Sources\StatuspageSource;
+use SuzyEaston\LousyOutages\Storage\IncidentStore;
+use WP_REST_Request;
+
+class IncidentAlerts {
+    private const SUMMARY_PROVIDERS = [
+        'github'    => 'https://www.githubstatus.com/api/v2/summary.json',
+        'atlassian' => 'https://status.atlassian.com/api/v2/summary.json',
+        'vercel'    => 'https://www.vercel-status.com/api/v2/summary.json',
+        'digitalocean' => 'https://status.digitalocean.com/api/v2/summary.json',
+    ];
+
+    private const RSS_PROVIDERS = [
+        'cloudflare' => 'https://www.cloudflarestatus.com/history.rss',
+        'aws'        => 'https://status.aws.amazon.com/rss/all.rss',
+        'azure'      => [
+            'https://rssfeed.azure.status.microsoft/en-us/status/feed/',
+            'https://azurestatuscdn.azureedge.net/en-us/status/feed/',
+        ],
+        'slack'      => 'https://slack-status.com/feed/rss',
+        'zscaler'    => 'https://trust.zscaler.com/rss-feed',
+    ];
+
+    private const RSS_HEADERS = [
+        'User-Agent'    => 'LousyOutages/1.2 (+https://suzyeaston.ca)',
+        'Accept'        => 'application/rss+xml, application/atom+xml;q=0.9,*/*;q=0.8',
+        'Cache-Control' => 'no-cache',
+    ];
+
+    private const ALERTABLE_STATES = ['degraded', 'partial_outage', 'major_outage', 'maintenance', 'major', 'outage'];
+
+    private const OPTION_SUBSCRIBERS       = 'lo_subscribers';
+    private const OPTION_UNSUB_TOKENS      = 'lo_unsub_tokens';
+    private const OPTION_SEEN              = 'lo_seen_incidents';
+    private const OPTION_LAST_CHECK        = 'lo_last_status_check';
+    private const OPTION_ALERTED_INCIDENTS = 'lousy_outages_alerted_incidents';
+    private const OPTION_ALERTED_SUBJECTS  = 'lousy_outages_alerted_subjects';
+    private const OPTION_LAST_ALERT_DELIVERY_RESULT = 'lousy_outages_last_alert_delivery_result';
+    private const OPTION_LAST_ALERT_SUCCESS = 'lousy_outages_last_alert_success';
+    private const OPTION_LAST_ALERT_FAILURE = 'lousy_outages_last_alert_failure';
+    private const OPTION_LAST_SYNTHETIC_ALERT = 'lousy_outages_last_synthetic_alert';
+    private const OPTION_ALERT_DELIVERY_FAILURE = 'lousy_outages_alert_delivery_failure';
+
+    private const ALERT_RETENTION_HOURS        = 48;
+    private const SUBJECT_ALERT_WINDOW_HOURS   = 12;
+    private const REALTIME_ALERT_WINDOW_HOURS  = 12;
+
+    public static function bootstrap(): void {
+        add_action('init', [self::class, 'ensure_schedule']);
+        add_action('init', [self::class, 'maybe_trigger_fallback'], 20);
+        add_action('admin_notices', [self::class, 'render_admin_notice']);
+        add_action('rest_api_init', [self::class, 'register_routes']);
+    }
+
+    public static function ensure_schedule(): void {
+        if (!wp_next_scheduled('lo_check_statuses')) {
+            wp_schedule_event(time() + 60, 'lo_five_minutes', 'lo_check_statuses');
+            do_action('lousy_outages_log', 'cron_scheduled', ['hook' => 'lo_check_statuses']);
+        }
+    }
+
+    public static function maybe_trigger_fallback(): void {
+        if (wp_doing_cron()) {
+            return;
+        }
+
+        $next = wp_next_scheduled('lo_check_statuses');
+        if ($next) {
+            return;
+        }
+
+        $last = get_option(self::OPTION_LAST_CHECK);
+        $last_ts = $last ? strtotime((string) $last) : 0;
+        if ($last_ts && (time() - $last_ts) < 15 * MINUTE_IN_SECONDS) {
+            return;
+        }
+
+        if (defined('DISABLE_WP_CRON') && DISABLE_WP_CRON) {
+            do_action('lousy_outages_log', 'cron_disabled', ['hook' => 'lo_check_statuses']);
+            return;
+        }
+
+        wp_schedule_single_event(time() + 60, 'lo_check_statuses');
+        do_action('lousy_outages_log', 'cron_fallback_scheduled', ['hook' => 'lo_check_statuses']);
+    }
+
+    public static function register_routes(): void {
+        register_rest_route(
+            'lousy-outages/v1',
+            '/unsubscribe-email',
+            [
+                'methods'             => 'GET',
+                'permission_callback' => '__return_true',
+                'callback'            => [self::class, 'handle_unsubscribe'],
+                'args'                => [
+                    'email' => [
+                        'required'          => true,
+                        'sanitize_callback' => 'sanitize_email',
+                        'validate_callback' => 'is_email',
+                    ],
+                    'token' => [
+                        'required'          => true,
+                        'sanitize_callback' => 'sanitize_text_field',
+                    ],
+                ],
+            ]
+        );
+    }
+
+    public static function handle_unsubscribe(WP_REST_Request $request) {
+        $rawEmail = $request->get_param('email');
+        $emailRaw = is_string($rawEmail) ? rawurldecode($rawEmail) : '';
+        $email    = is_string($emailRaw) ? sanitize_email($emailRaw) : '';
+        $token    = sanitize_text_field((string) $request->get_param('token'));
+
+        if (!$email || !is_email($email) || '' === $token) {
+            return self::redirect_with_status('invalid');
+        }
+
+        $saved = self::get_saved_unsubscribe_token($email);
+        if ('' === $saved || !hash_equals($saved, $token)) {
+            return self::redirect_with_status('invalid');
+        }
+
+        self::remove_subscriber($email);
+        Subscriptions::mark_unsubscribed_by_email($email);
+
+        return self::redirect_with_status('unsubscribed');
+    }
+
+    private static function redirect_with_status(string $status) {
+        $status = sanitize_key($status);
+        $target = add_query_arg('sub', rawurlencode($status), home_url('/lousy-outages/'));
+        status_header(302);
+        wp_safe_redirect($target);
+        exit;
+    }
+
+    public static function run(): void {
+        do_action('lousy_outages_log', 'lo_check_statuses_run', ['ts' => gmdate('c')]);
+
+        $store     = new IncidentStore();
+        $incidents = self::collect_incidents();
+        $store->persistIncidents($incidents);
+        update_option(self::OPTION_LAST_CHECK, gmdate('c'), false);
+
+        self::process_incidents($incidents, ['mode' => 'real']);
+    }
+
+    public static function process_incidents(array $incidents, array $options = []): array
+    {
+        $store           = $options['store'] ?? new IncidentStore();
+        $dryRun          = !empty($options['dry_run']);
+        $synthetic       = !empty($options['synthetic']);
+        $inboxOnly       = !empty($options['notification_only']);
+        $alertedIncidents = self::get_alerted_incidents();
+        $alertedSubjects  = self::get_alerted_subjects();
+        $activeKeys       = [];
+        $nowUtc           = current_time('timestamp', true);
+        $subjectWindow    = self::SUBJECT_ALERT_WINDOW_HOURS * HOUR_IN_SECONDS;
+        $result = ['total_incidents'=>count($incidents),'considered'=>0,'sent'=>0,'skipped'=>0,'failed'=>0,'recipients'=>[],'failures'=>[],'skipped_reasons'=>[],'synthetic'=>(bool)$synthetic,'dry_run'=>(bool)$dryRun,'mode'=>(string)($options['mode'] ?? 'real')];
+        foreach ($incidents as $incident) {
+            if (! $incident instanceof Incident) {
+                continue;
+            }
+            $result['considered']++;
+
+            $incidentKey      = self::make_incident_key($incident);
+            $subjectKey       = self::make_subject_key($incident);
+            $effectiveTs      = self::incident_effective_timestamp($incident);
+            $isAlertableState = self::is_alertable_incident($incident);
+            if ($isAlertableState && '' !== $incidentKey) {
+                $activeKeys[] = $incidentKey;
+            }
+
+            if ('maintenance' === strtolower((string) $incident->impact)) {
+                // LO: scheduled maintenance is digest-only.
+                continue;
+            }
+
+            if (! $store->canSend($incident)) {
+                $result['skipped']++;
+                $result['skipped_reasons'][] = 'store_can_send_false';
+                continue;
+            }
+
+            if (! $isAlertableState) {
+                $result['skipped']++;
+                $result['skipped_reasons'][] = 'not_alertable';
+                continue;
+            }
+
+            if (null !== $effectiveTs && ($nowUtc - $effectiveTs) > (self::REALTIME_ALERT_WINDOW_HOURS * HOUR_IN_SECONDS)) {
+                do_action('lousy_outages_log', 'alert_skip', [
+                    'provider'      => $incident->provider,
+                    'incident_key'  => $incidentKey,
+                    'subject_key'   => $subjectKey,
+                    'reason'        => 'stale_incident',
+                    'effective_ts'  => $effectiveTs,
+                ]);
+                $result['skipped']++;
+                $result['skipped_reasons'][] = 'stale_incident';
+                continue;
+            }
+
+            if ('' === $incidentKey) {
+                do_action('lousy_outages_log', 'alert_skip', [
+                    'provider'     => $incident->provider,
+                    'reason'       => 'missing_incident_key',
+                    'incident_key' => $incidentKey,
+                    'subject_key'  => $subjectKey,
+                    'status'       => strtolower((string) $incident->status),
+                    'impact'       => strtolower((string) ($incident->impact ?? '')),
+                ]);
+                $result['skipped']++;
+                $result['skipped_reasons'][] = 'missing_incident_key';
+                continue;
+            }
+
+            if (isset($alertedIncidents[$incidentKey])) {
+                do_action('lousy_outages_log', 'alert_skip', [
+                    'provider'      => $incident->provider,
+                    'incident_key'  => $incidentKey,
+                    'subject_key'   => $subjectKey,
+                    'reason'        => 'duplicate',
+                    'effective_ts'  => $effectiveTs,
+                ]);
+                $result['skipped']++;
+                $result['skipped_reasons'][] = 'duplicate';
+                continue;
+            }
+
+            if ('' === $subjectKey) {
+                do_action('lousy_outages_log', 'alert_subject_key_missing', [
+                    'provider'      => $incident->provider,
+                    'incident_key'  => $incidentKey,
+                    'subject_key'   => $subjectKey,
+                    'reason'        => 'missing_subject_key',
+                    'effective_ts'  => $effectiveTs,
+                ]);
+            } elseif (isset($alertedSubjects[$subjectKey])) {
+                $meta = $alertedSubjects[$subjectKey];
+                $last = isset($meta['last_notified_at']) ? (int) $meta['last_notified_at'] : 0;
+
+                if ($last && ($nowUtc - $last) <= $subjectWindow) {
+                    do_action('lousy_outages_log', 'alert_skip_subject', [
+                        'provider'      => $incident->provider,
+                        'incident_key'  => $incidentKey,
+                        'subject_key'   => $subjectKey,
+                        'reason'        => 'subject_throttle',
+                        'last_notified' => $last,
+                        'effective_ts'  => $effectiveTs,
+                    ]);
+                    $result['skipped']++;
+                    $result['skipped_reasons'][] = 'subject_throttle';
+                    continue;
+                }
+            }
+
+            $sendResult = self::send_incident_alert_email($incident, ['dry_run' => $dryRun, 'notification_only' => $inboxOnly]);
+            $result['recipients'] = array_values(array_unique(array_merge($result['recipients'], $sendResult['recipients'])));
+            if (!empty($sendResult['ok'])) {
+                if (!$dryRun) {
+                    $store->markSent($incident);
+                }
+                $markSentCalled = !$dryRun;
+                $alertedIncidents[$incidentKey] = [
+                    'first_notified_at' => $nowUtc,
+                    'status'            => strtolower((string) $incident->status),
+                    'impact'            => strtolower((string) ($incident->impact ?? '')),
+                    'url'               => $incident->url,
+                ];
+
+                if ('' !== $subjectKey) {
+                    $first = isset($alertedSubjects[$subjectKey]['first_notified_at']) ? (int) $alertedSubjects[$subjectKey]['first_notified_at'] : 0;
+                    $alertedSubjects[$subjectKey] = [
+                        'first_notified_at' => $first ?: $nowUtc,
+                        'last_notified_at'  => $nowUtc,
+                    ];
+                }
+
+                do_action('lousy_outages_log', 'alert_send', [
+                    'provider'      => $incident->provider,
+                    'incident_key'  => $incidentKey,
+                    'subject_key'   => $subjectKey,
+                    'impact'        => strtolower((string) ($incident->impact ?? '')),
+                    'status'        => strtolower((string) $incident->status),
+                    'effective_ts'  => $effectiveTs,
+                ]);
+                $result['sent']++;
+                self::record_alert_delivery(true, $incident, $sendResult['recipients'], '', $markSentCalled, $options);
+            } else {
+                $result['failed']++;
+                $failureReason = (string) ($sendResult['error'] ?? 'send_failed');
+                $result['failures'][] = $failureReason;
+                self::record_alert_delivery(false, $incident, $sendResult['recipients'], $failureReason, false, $options);
+            }
+        }
+
+        $alertedIncidents = self::prune_alerted_incidents($alertedIncidents, $activeKeys, $nowUtc);
+        $alertedSubjects  = self::prune_alerted_subjects($alertedSubjects, $nowUtc);
+        self::set_alerted_incidents($alertedIncidents);
+        self::set_alerted_subjects($alertedSubjects);
+        return $result;
+    }
+
+    public static function send_daily_digest(): void {
+        $store  = new IncidentStore();
+        $stored = $store->getStoredIncidents();
+
+        if (empty($stored)) {
+            return;
+        }
+
+        $timezone = new \DateTimeZone('America/Vancouver');
+        $nowLocal = new \DateTimeImmutable('now', $timezone);
+        $today    = $nowLocal->setTime(0, 0, 0);
+        $startTs  = $today->getTimestamp();
+        $endTs    = $startTs + DAY_IN_SECONDS;
+
+        $items = [];
+
+        foreach ($stored as $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+
+            $status = isset($entry['status']) ? (string) $entry['status'] : '';
+            if ('operational' === strtolower($status)) {
+                continue;
+            }
+
+            $firstSeen = isset($entry['first_seen']) ? (int) $entry['first_seen'] : 0;
+            if ($firstSeen <= 0) {
+                continue;
+            }
+
+            $firstLocal = (new \DateTimeImmutable('@' . $firstSeen))->setTimezone($timezone)->getTimestamp();
+            if ($firstLocal < $startTs || $firstLocal >= $endTs) {
+                continue;
+            }
+
+            $providerLabel = trim((string) ($entry['provider_label'] ?? $entry['provider'] ?? ''));
+            if ('' === $providerLabel) {
+                $providerLabel = ucwords(str_replace(['-', '_'], ' ', (string) ($entry['provider'] ?? 'Provider')));
+            }
+
+            $title = isset($entry['title']) ? (string) $entry['title'] : '';
+            if ('' === trim($title)) {
+                continue;
+            }
+
+            $slug = sanitize_key((string) ($entry['provider'] ?? $providerLabel));
+            $url  = isset($entry['url']) ? (string) $entry['url'] : '';
+            if ('' === $url) {
+                $url = self::provider_url($slug);
+            }
+
+            $items[] = [
+                'provider_id'=> $slug,
+                'provider'  => $providerLabel,
+                'title'     => Composer::shortTitle($title),
+                'status'    => self::status_label($status),
+                'statusRaw' => $status,
+                'url'       => $url,
+                'updated'   => $firstSeen,
+            ];
+        }
+
+        if (empty($items)) {
+            return;
+        }
+
+        usort(
+            $items,
+            static function (array $a, array $b): int {
+                $providerCompare = strcmp((string) ($a['provider'] ?? ''), (string) ($b['provider'] ?? ''));
+                if (0 !== $providerCompare) {
+                    return $providerCompare;
+                }
+
+                return (int) (($a['updated'] ?? 0) <=> ($b['updated'] ?? 0));
+            }
+        );
+
+        $items = apply_filters('lo_daily_digest_items', $items);
+        if (! is_array($items) || empty($items)) {
+            return;
+        }
+
+        $lastSentIso = $store->getLastDigestSent();
+        $lastSentTs  = $lastSentIso ? strtotime($lastSentIso) : 0;
+        if ($lastSentTs) {
+            $lastLocal = (new \DateTimeImmutable('@' . $lastSentTs))->setTimezone($timezone);
+            if ($lastLocal->format('Y-m-d') === $nowLocal->format('Y-m-d')) {
+                return;
+            }
+        }
+
+        $subscribers = array_values(array_filter(self::get_subscribers(), static function (string $email): bool {
+            return Subscriptions::subscriber_wants_digest($email);
+        }));
+        if (empty($subscribers)) {
+            return;
+        }
+
+        $footer_text = apply_filters('lo_daily_digest_unsubscribe_text', 'Unsubscribe');
+        $footer_html = apply_filters('lo_daily_digest_unsubscribe_label', 'Unsubscribe');
+        $sentAny = false;
+
+        foreach ($subscribers as $email) {
+            $filtered = self::filter_digest_items_for_subscriber($items, $email);
+            if (empty($filtered)) {
+                continue;
+            }
+            $maxPerProvider = (int) apply_filters('lo_daily_digest_max_items_per_provider', 3, $email, $filtered);
+            $grouped = self::group_digest_items($filtered, $maxPerProvider);
+
+            $composition = function_exists('LO_compose_daily_digest') ? LO_compose_daily_digest($grouped) : null;
+            if (! is_array($composition)) {
+                continue;
+            }
+
+            $subject = isset($composition['subject']) ? (string) $composition['subject'] : '';
+            $html    = isset($composition['html']) ? (string) $composition['html'] : '';
+            $text    = isset($composition['text']) ? (string) $composition['text'] : '';
+
+            if ('' === trim($subject) || '' === trim($html)) {
+                continue;
+            }
+
+            $token = self::build_unsubscribe_token($email);
+            $unsubscribe = add_query_arg(
+                [
+                    'lo_unsub' => 1,
+                    'email'    => rawurlencode($email),
+                    'token'    => $token,
+                ],
+                home_url('/lousy-outages/')
+            );
+
+            $text_body = $text;
+            if ('' !== trim($text_body)) {
+                $text_body .= "
+
+" . $footer_text . ': ' . $unsubscribe;
+            }
+
+            $html_body = $html;
+            $html_body .= sprintf(
+                '<p style="margin:24px 0 0;font-size:13px;line-height:1.6;color:rgba(255,255,255,0.75);">%s: <a href="%s" style="color:#8f80ff;text-decoration:none;">%s</a></p>',
+                esc_html($footer_html),
+                esc_url($unsubscribe),
+                esc_html($unsubscribe)
+            );
+
+            $headers = [
+                'List-Unsubscribe: <' . esc_url_raw($unsubscribe) . '>',
+                'List-Unsubscribe-Post: List-Unsubscribe=One-Click',
+            ];
+
+            if (Mailer::send($email, $subject, $text_body, $html_body, $headers)) {
+                $sentAny = true;
+            }
+        }
+
+        if ($sentAny) {
+            $store->updateLastDigestSent(gmdate('c'));
+            $store->persistIncidents([]); // prune stale records.
+        }
+    }
+
+
+    public static function filter_digest_items_for_subscriber(array $items, string $email): array {
+        $prefs = Subscriptions::get_preferences_for_email($email);
+        $providers = isset($prefs['providers']) && is_array($prefs['providers']) ? $prefs['providers'] : [];
+        if (empty($providers)) {
+            return $items;
+        }
+
+        return array_values(array_filter($items, static function (array $item) use ($providers): bool {
+            $providerId = sanitize_key((string) ($item['provider_id'] ?? ''));
+            return '' !== $providerId && in_array($providerId, $providers, true);
+        }));
+    }
+
+    public static function group_digest_items(array $items, int $maxPerProvider = 3): array {
+        $maxPerProvider = max(1, $maxPerProvider);
+        $grouped = [];
+        foreach ($items as $item) {
+            if (!is_array($item)) { continue; }
+            $providerId = sanitize_key((string) ($item['provider_id'] ?? ''));
+            if ($providerId === '') { $providerId = sanitize_key((string) ($item['provider'] ?? 'unknown')); }
+            $grouped[$providerId][] = $item;
+        }
+
+        $result = [];
+        foreach ($grouped as $providerId => $providerItems) {
+            usort($providerItems, static fn(array $a, array $b): int => (int)(($b['updated'] ?? 0) <=> ($a['updated'] ?? 0)));
+            $kept = array_slice($providerItems, 0, $maxPerProvider);
+            foreach ($kept as $k) { $result[] = $k; }
+            $extra = count($providerItems) - count($kept);
+            if ($extra > 0) {
+                $first = $providerItems[0];
+                $providerLabel = (string) ($first['provider'] ?? ucwords(str_replace(['-','_'],' ', $providerId)));
+                $result[] = [
+                    'provider_id' => $providerId,
+                    'provider' => $providerLabel,
+                    'title' => sprintf('+%d more %s updates grouped to reduce noise', $extra, $providerLabel),
+                    'status' => 'Grouped updates',
+                    'statusRaw' => 'grouped',
+                    'url' => (string) ($first['url'] ?? self::provider_url($providerId)),
+                    'updated' => (int) ($first['updated'] ?? time()),
+                    'grouped' => true,
+                ];
+            }
+        }
+        return $result;
+    }
+    /**
+     * @return Incident[]
+     */
+    public static function collect_incidents(): array {
+        $combined = [];
+
+        foreach (self::collect_from_registered_sources() as $incident) {
+            $normalized = self::normalize_incident($incident);
+            if ($normalized instanceof Incident) {
+                $combined[$normalized->provider . '|' . $normalized->id] = $normalized;
+            }
+        }
+
+        foreach (self::collect_from_snapshot() as $incident) {
+            $normalized = self::normalize_incident($incident);
+            if ($normalized instanceof Incident) {
+                $combined[$normalized->provider . '|' . $normalized->id] = $normalized;
+            }
+        }
+
+        foreach (self::collect_from_legacy_feeds() as $incident) {
+            $normalized = self::normalize_incident($incident);
+            if ($normalized instanceof Incident) {
+                $combined[$normalized->provider . '|' . $normalized->id] = $normalized;
+            }
+        }
+
+        return array_values($combined);
+    }
+
+    /**
+     * @return array<int, Incident>
+     */
+    private static function collect_from_registered_sources(): array {
+        $incidents = [];
+        $allowed   = array_fill_keys(array_keys(Providers::enabled()), true);
+
+        foreach (Sources::all() as $slug => $source) {
+            if (! $source instanceof StatuspageSource) {
+                continue;
+            }
+
+            if (!isset($allowed[$slug])) {
+                continue;
+            }
+
+            $payload = $source->fetch();
+            $status  = isset($payload['status']) ? (string) $payload['status'] : 'operational';
+            $updated = isset($payload['updated']) ? (int) $payload['updated'] : time();
+
+            foreach ($payload['incidents'] as $incident) {
+                if (! $incident instanceof Incident) {
+                    continue;
+                }
+
+                $incidents[] = new Incident(
+                    self::provider_label($slug, $incident->provider),
+                    $slug . ':' . $incident->id,
+                    $incident->title,
+                    $incident->status,
+                    $incident->url ?: self::provider_url($slug),
+                    $incident->component,
+                    $incident->impact,
+                    $incident->detected_at,
+                    $incident->resolved_at
+                );
+            }
+
+            if (empty($payload['incidents']) && in_array($status, ['degraded', 'partial_outage', 'major_outage', 'maintenance'], true)) {
+                $label = self::provider_label($slug, '');
+                $incidents[] = new Incident(
+                    $label,
+                    $slug . ':status:' . md5($status . '|' . $updated),
+                    sprintf('%s status: %s', $label, ucfirst(str_replace('_', ' ', $status))),
+                    $status,
+                    self::provider_url($slug),
+                    null,
+                    self::impact_from_status($status),
+                    $updated,
+                    null
+                );
+            }
+        }
+
+        return $incidents;
+    }
+
+    private static function normalize_incident($incident): ?Incident {
+        if ($incident instanceof Incident) {
+            return $incident;
+        }
+
+        if (! is_array($incident)) {
+            return null;
+        }
+
+        return self::incident_from_array($incident);
+    }
+
+    private static function incident_from_array(array $data): ?Incident {
+        $provider = '';
+        if (isset($data['provider'])) {
+            $provider = (string) $data['provider'];
+        } elseif (isset($data['service'])) {
+            $provider = sanitize_key((string) $data['service']);
+        }
+
+        if ('' === $provider && isset($data['id']) && is_string($data['id'])) {
+            $parts = explode(':', $data['id']);
+            if (count($parts) > 1) {
+                $provider = (string) array_shift($parts);
+            }
+        }
+
+        $provider = sanitize_key($provider);
+        if ('' === $provider) {
+            return null;
+        }
+
+        $id = isset($data['id']) ? (string) $data['id'] : md5($provider . '|' . wp_json_encode($data));
+
+        $title = '';
+        foreach (['title', 'name', 'summary', 'body'] as $field) {
+            if (! empty($data[$field]) && is_string($data[$field])) {
+                $title = trim((string) $data[$field]);
+                if ('' !== $title) {
+                    break;
+                }
+            }
+        }
+        if ('' === $title && isset($data['status']) && is_string($data['status'])) {
+            $title = trim((string) $data['status']);
+        }
+        if ('' === $title) {
+            $title = 'Incident';
+        }
+
+        $statusRaw = '';
+        foreach (['status', 'state', 'status_code'] as $field) {
+            if (! empty($data[$field]) && is_string($data[$field])) {
+                $statusRaw = (string) $data[$field];
+                break;
+            }
+        }
+        $impactRaw = isset($data['impact']) ? (string) $data['impact'] : '';
+        $bodyText  = '';
+        foreach (['body', 'summary', 'description'] as $field) {
+            if (! empty($data[$field]) && is_string($data[$field])) {
+                $bodyText = trim((string) $data[$field]);
+                if ('' !== $bodyText) {
+                    break;
+                }
+            }
+        }
+
+        $status = self::normalize_status_code($statusRaw, $impactRaw);
+        if (self::isScheduledMaintenance($title, $bodyText)) {
+            $status    = 'maintenance';
+            $impactRaw = 'maintenance';
+        }
+
+        if ('zscaler' === $provider && self::isZscalerIpRangeAdvisory($title, $bodyText)) {
+            $status    = 'maintenance';
+            $impactRaw = 'maintenance';
+        }
+
+        $impact = self::normalize_impact($impactRaw ?: self::impact_from_status($status));
+
+        $url = '';
+        foreach (['url', 'shortlink', 'link'] as $field) {
+            if (! empty($data[$field]) && is_string($data[$field])) {
+                $url = (string) $data[$field];
+                break;
+            }
+        }
+        if ('' === $url) {
+            $url = self::provider_url($provider);
+        }
+
+        $components = self::components_to_string($data['components'] ?? null);
+
+        $detected = self::to_epoch($data['detected_at'] ?? $data['started_at'] ?? $data['startedAt'] ?? $data['timestamp'] ?? $data['updated_at'] ?? null) ?? time();
+        $resolved = null;
+        if ('resolved' === $status) {
+            $resolved = self::to_epoch($data['resolved_at'] ?? $data['updated_at'] ?? null) ?? $detected;
+        }
+
+        return new Incident(
+            self::provider_label($provider, isset($data['service']) ? (string) $data['service'] : ''),
+            $id,
+            $title,
+            $status,
+            $url,
+            $components,
+            $impact,
+            $detected,
+            $resolved
+        );
+    }
+
+    private static function normalize_status_code(string $status, string $impact): string {
+        $status = self::slugify_status($status);
+        $impact = self::slugify_status($impact);
+
+        if ('resolved' === $status || 'postmortem' === $status) {
+            return 'resolved';
+        }
+
+        if ('operational' === $status || 'none' === $status) {
+            return 'operational';
+        }
+
+        if ('maintenance' === $status) {
+            return 'maintenance';
+        }
+
+        switch ($status) {
+            case 'minor':
+            case 'degraded':
+            case 'investigating':
+            case 'identified':
+            case 'monitoring':
+            case 'in_progress':
+            case 'warning':
+                return 'degraded';
+            case 'partial':
+            case 'partial_outage':
+            case 'major':
+                return 'partial_outage';
+            case 'major_outage':
+            case 'outage':
+            case 'critical':
+                return 'major_outage';
+        }
+
+        switch ($impact) {
+            case 'critical':
+                return 'major_outage';
+            case 'major':
+                return 'partial_outage';
+            case 'maintenance':
+                return 'maintenance';
+            case 'minor':
+                return 'degraded';
+        }
+
+        return 'degraded';
+    }
+
+    private static function normalize_impact(?string $impact): ?string {
+        $impact = self::slugify_status((string) $impact);
+        if ('' === $impact) {
+            return null;
+        }
+
+        if (in_array($impact, ['minor', 'major', 'critical', 'none', 'maintenance'], true)) {
+            return $impact;
+        }
+
+        switch ($impact) {
+            case 'partial':
+            case 'partial_outage':
+            case 'major_outage':
+            case 'outage':
+                return 'critical';
+            case 'degraded':
+            case 'investigating':
+            case 'identified':
+            case 'monitoring':
+            case 'warning':
+                return 'minor';
+            default:
+                return 'minor';
+        }
+    }
+
+    private static function impact_from_status(string $status): string {
+        switch ($status) {
+            case 'major_outage':
+                return 'critical';
+            case 'partial_outage':
+                return 'major';
+            case 'maintenance':
+                return 'maintenance';
+            case 'resolved':
+            case 'operational':
+                return 'none';
+            default:
+                return 'minor';
+        }
+    }
+
+    private static function to_epoch($value): ?int {
+        if ($value instanceof \DateTimeInterface) {
+            return $value->getTimestamp();
+        }
+
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (is_string($value)) {
+            $trimmed = trim($value);
+            if ('' === $trimmed) {
+                return null;
+            }
+            if (ctype_digit($trimmed)) {
+                return (int) $trimmed;
+            }
+            $time = strtotime($trimmed);
+            if (false !== $time) {
+                return $time;
+            }
+        }
+
+        return null;
+    }
+
+    private static function components_to_string($components): ?string {
+        if (empty($components)) {
+            return null;
+        }
+
+        $names = [];
+        if (is_array($components)) {
+            foreach ($components as $component) {
+                if (is_array($component) && isset($component['name'])) {
+                    $names[] = (string) $component['name'];
+                } elseif (is_string($component)) {
+                    $names[] = $component;
+                }
+            }
+        } elseif (is_string($components)) {
+            $names[] = $components;
+        }
+
+        $names = array_values(array_filter(array_map('trim', $names)));
+        if (empty($names)) {
+            return null;
+        }
+
+        return implode(', ', array_unique($names));
+    }
+
+    private static function provider_label(string $slug, string $fallback = ''): string {
+        static $providers;
+        if (null === $providers) {
+            $providers = Providers::list();
+        }
+
+        if (isset($providers[$slug]['name'])) {
+            return (string) $providers[$slug]['name'];
+        }
+
+        if ('' !== $fallback) {
+            return $fallback;
+        }
+
+        return ucwords(str_replace(['-', '_'], ' ', $slug));
+    }
+
+    private static function provider_url(string $slug): string {
+        static $providers;
+        if (null === $providers) {
+            $providers = Providers::list();
+        }
+
+        if (isset($providers[$slug]['status_url']) && is_string($providers[$slug]['status_url'])) {
+            return (string) $providers[$slug]['status_url'];
+        }
+
+        if (isset($providers[$slug]['url']) && is_string($providers[$slug]['url'])) {
+            return (string) $providers[$slug]['url'];
+        }
+
+        return (string) home_url('/lousy-outages/');
+    }
+
+    private static function slugify_status(string $status): string {
+        $status = strtolower(trim($status));
+        if ('' === $status) {
+            return '';
+        }
+
+        $slug = preg_replace('/[^a-z0-9]+/', '_', $status);
+        if (null === $slug) {
+            return $status;
+        }
+
+        return trim($slug, '_');
+    }
+
+    private static function status_label(string $status): string {
+        $status = self::slugify_status($status);
+        $map = [
+            'degraded'       => 'Degraded',
+            'partial_outage' => 'Partial Outage',
+            'major_outage'   => 'Major Outage',
+            'maintenance'    => 'Maintenance',
+            'resolved'       => 'Resolved',
+            'operational'    => 'Operational',
+            'incident'       => 'Incident',
+            'partial'        => 'Partial Outage',
+            'major'          => 'Major Outage',
+            'critical'       => 'Critical Outage',
+        ];
+
+        if (isset($map[$status])) {
+            return $map[$status];
+        }
+
+        return ucfirst(str_replace('_', ' ', $status ?: 'Status'));
+    }
+
+    private static function collect_from_legacy_feeds(): array {
+        $incidents = [];
+
+        foreach (self::SUMMARY_PROVIDERS as $provider => $url) {
+            $result = self::fetch_statuspage($provider, $url);
+            if (!empty($result)) {
+                $incidents = array_merge($incidents, $result);
+            }
+        }
+
+        foreach (self::RSS_PROVIDERS as $provider => $endpoints) {
+            $urls = is_array($endpoints) ? array_filter(array_map('strval', $endpoints)) : [(string) $endpoints];
+            $result = self::fetch_rss($provider, $urls);
+            if (!empty($result)) {
+                $incidents = array_merge($incidents, $result);
+            }
+        }
+
+        return $incidents;
+    }
+
+    private static function collect_from_snapshot(): array {
+        $snapshot  = \lousy_outages_get_snapshot(true);
+        $providers = [];
+        $fetchedAt = gmdate('c');
+        $providerDirectory = Providers::list();
+
+        if (is_array($snapshot)) {
+            if (!empty($snapshot['providers']) && is_array($snapshot['providers'])) {
+                $providers = $snapshot['providers'];
+            }
+            if (!empty($snapshot['fetched_at']) && is_string($snapshot['fetched_at'])) {
+                $fetchedAt = (string) $snapshot['fetched_at'];
+            }
+        }
+
+        if (empty($providers)) {
+            $states = \lousy_outages_collect_statuses(true);
+            $stored = get_option('lousy_outages_last_poll');
+            if (is_string($stored) && '' !== trim($stored)) {
+                $fetchedAt = $stored;
+            }
+            foreach ($states as $id => $state) {
+                if (!is_array($state)) {
+                    continue;
+                }
+                $providers[] = \lousy_outages_build_provider_payload((string) $id, $state, $fetchedAt);
+            }
+        }
+
+        if (empty($providers)) {
+            return [];
+        }
+
+        $incidents = [];
+
+        foreach ($providers as $provider) {
+            if (!is_array($provider)) {
+                continue;
+            }
+
+            $providerId = isset($provider['id']) ? (string) $provider['id'] : '';
+            if ('' === $providerId) {
+                continue;
+            }
+
+            $providerName = (string) ($provider['name'] ?? $providerId);
+            $statusCode   = strtolower((string) ($provider['stateCode'] ?? 'unknown'));
+            $statusLabel  = (string) ($provider['state'] ?? ($statusCode ? ucfirst($statusCode) : 'Status change'));
+            if ('' === $statusLabel) {
+                $statusLabel = $statusCode ? ucfirst($statusCode) : 'Status change';
+            }
+            $summary    = (string) ($provider['summary'] ?? $statusLabel);
+            $updatedAt  = isset($provider['updatedAt']) ? (string) $provider['updatedAt'] : $fetchedAt;
+            $url        = isset($provider['url']) ? (string) $provider['url'] : '';
+            $components = isset($provider['components']) && is_array($provider['components']) ? $provider['components'] : [];
+            $incidentList = isset($provider['incidents']) && is_array($provider['incidents']) ? $provider['incidents'] : [];
+            $sourceType = strtolower((string) ($provider['sourceType'] ?? ($providerDirectory[$providerId]['type'] ?? '')));
+
+            if (in_array($sourceType, ['manual', 'unknown', ''], true) && empty($incidentList)) {
+                // LO: manual providers (e.g., CrowdStrike) should not trigger fallback alerts.
+                continue;
+            }
+
+            if (!empty($incidentList)) {
+                foreach ($incidentList as $incident) {
+                    if (!is_array($incident)) {
+                        continue;
+                    }
+                    $rawId = isset($incident['id']) ? (string) $incident['id'] : '';
+                    if ('' === $rawId) {
+                        $rawId = md5($providerId . wp_json_encode($incident));
+                    }
+                    $incidentId      = $providerId . ':' . $rawId;
+                    $incidentSummary = (string) ($incident['summary'] ?? $summary);
+                    $impact          = strtolower((string) ($incident['impact'] ?? ($statusCode ?: 'major')));
+
+                    $incidents[$incidentId] = [
+                        'id'         => $incidentId,
+                        'provider'   => $providerId,
+                        'name'       => (string) ($incident['title'] ?? $incidentSummary ?: 'Incident'),
+                        'impact'     => $impact,
+                        'status'     => $statusLabel,
+                        'started_at' => self::normalize_timestamp($incident['startedAt'] ?? $incident['started_at'] ?? $updatedAt, $updatedAt),
+                        'url'        => (string) ($incident['url'] ?? $url),
+                        'components' => $components,
+                        'body'       => $incidentSummary,
+                    ];
+                }
+                continue;
+            }
+
+            if (!in_array($statusCode, self::ALERTABLE_STATES, true)) {
+                continue;
+            }
+
+            // Use a stable hash that ignores timestamp churn so we only alert once per
+            // ongoing status incident. Some providers (notably Zscaler) bump the
+            // `updatedAt` field every few hours while the same maintenance reminder is
+            // active, which used to produce a new GUID each poll and re-trigger emails.
+            // By basing the hash on the status code + summary we preserve uniqueness for
+            // distinct incidents, while IncidentStore::shouldSend() clears the cached
+            // GUID once the provider returns to "operational", allowing future events to
+            // alert correctly.
+            $statusId = $providerId . ':status:' . md5($statusCode . '|' . $summary);
+            $incidents[$statusId] = [
+                'id'         => $statusId,
+                'provider'   => $providerId,
+                'name'       => sprintf('%s status: %s', $providerName, $statusLabel),
+                'impact'     => $statusCode,
+                'status'     => $statusLabel,
+                'started_at' => self::normalize_timestamp($updatedAt, $fetchedAt),
+                'url'        => $url,
+                'components' => $components,
+                'body'       => $summary,
+            ];
+        }
+
+        return array_values($incidents);
+    }
+
+    private static function normalize_timestamp($value, string $fallback): string {
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format(DATE_ATOM);
+        }
+
+        if (is_int($value) || is_float($value)) {
+            $timestamp = (int) round((float) $value);
+            if ($timestamp > 0) {
+                return gmdate('c', $timestamp);
+            }
+        }
+
+        if (is_string($value)) {
+            $trimmed = trim($value);
+            if ('' !== $trimmed) {
+                return $trimmed;
+            }
+        }
+
+        return $fallback;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private static function fetch_statuspage(string $provider, string $url): array {
+        $response = wp_remote_get($url, ['timeout' => 15]);
+        if (is_wp_error($response)) {
+            self::log_error($provider, $response->get_error_message());
+            return [];
+        }
+
+        $code = (int) wp_remote_retrieve_response_code($response);
+        if ($code < 200 || $code >= 300) {
+            self::log_error($provider, 'HTTP ' . $code);
+            return [];
+        }
+
+        $body = wp_remote_retrieve_body($response);
+        $data = json_decode($body, true);
+        if (!is_array($data)) {
+            self::log_error($provider, 'invalid JSON payload');
+            return [];
+        }
+
+        $componentNames = [];
+        if (!empty($data['components']) && is_array($data['components'])) {
+            foreach ($data['components'] as $component) {
+                if (isset($component['id'], $component['name'])) {
+                    $componentNames[(string) $component['id']] = (string) $component['name'];
+                }
+            }
+        }
+
+        $incidents = [];
+        $entries   = isset($data['incidents']) && is_array($data['incidents']) ? $data['incidents'] : [];
+
+        foreach ($entries as $incident) {
+            $impact = strtolower((string) ($incident['impact'] ?? ''));
+            if (!in_array($impact, ['major', 'critical'], true)) {
+                continue;
+            }
+
+            $components = [];
+            if (!empty($incident['components']) && is_array($incident['components'])) {
+                foreach ($incident['components'] as $component) {
+                    if (is_array($component)) {
+                        if (!empty($component['name']) && is_string($component['name'])) {
+                            $components[] = trim($component['name']);
+                        } elseif (!empty($component['id'])) {
+                            $id = (string) $component['id'];
+                            if (isset($componentNames[$id])) {
+                                $components[] = $componentNames[$id];
+                            }
+                        }
+                    } elseif (is_string($component) && isset($componentNames[$component])) {
+                        $components[] = $componentNames[$component];
+                    }
+                }
+            }
+
+            $components = array_values(array_unique(array_filter($components)));
+
+            $incidents[] = [
+                'id'         => $provider . ':' . (string) ($incident['id'] ?? wp_hash(wp_json_encode($incident))),
+                'provider'   => $provider,
+                'name'       => (string) ($incident['name'] ?? 'Unknown incident'),
+                'impact'     => $impact,
+                'components' => $components,
+                'started_at' => (string) ($incident['started_at'] ?? $incident['created_at'] ?? ''),
+                'url'        => (string) ($incident['shortlink'] ?? $incident['url'] ?? ''),
+            ];
+        }
+
+        return $incidents;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private static function fetch_rss(string $provider, array $urls): array {
+        $errors = [];
+
+        foreach ($urls as $url) {
+            $url = trim($url);
+            if ('' === $url) {
+                continue;
+            }
+
+            [$incidents, $error] = self::fetch_rss_from_url($provider, $url);
+
+            if ($incidents) {
+                return $incidents;
+            }
+
+            if ($error) {
+                $errors[] = $error;
+            }
+        }
+
+        if ($errors) {
+            $unique = array_values(array_unique($errors));
+            self::log_error($provider, implode(' | ', $unique));
+        }
+
+        return [];
+    }
+
+    /**
+     * @return array{0: array<int, array<string, mixed>>, 1: string}
+     */
+    private static function fetch_rss_from_url(string $provider, string $url): array {
+        $response = wp_remote_get($url, [
+            'timeout' => 15,
+            'headers' => self::RSS_HEADERS,
+        ]);
+
+        if (is_wp_error($response)) {
+            return [[], $response->get_error_message() . ' (' . $url . ')'];
+        }
+
+        $code = (int) wp_remote_retrieve_response_code($response);
+        if ($code < 200 || $code >= 300) {
+            return [[], 'HTTP ' . $code . ' (' . $url . ')'];
+        }
+
+        $body = wp_remote_retrieve_body($response);
+        if (!is_string($body) || '' === trim($body)) {
+            return [[], 'empty RSS body (' . $url . ')'];
+        }
+
+        $xml = @simplexml_load_string($body);
+        if (false === $xml) {
+            return [[], 'unable to parse RSS (' . $url . ')'];
+        }
+
+        $items = [];
+        if (isset($xml->channel->item)) {
+            $items = $xml->channel->item;
+        } elseif (isset($xml->entry)) {
+            $items = $xml->entry;
+        }
+
+        $incidents = [];
+        $keywords  = ['major outage', 'critical', 'service disruption', 'service issue', 'service interruption'];
+
+        foreach ($items as $item) {
+            $title = isset($item->title) ? strtolower((string) $item->title) : '';
+            $desc  = isset($item->description) ? strtolower((string) $item->description) : '';
+            $match = false;
+            foreach ($keywords as $keyword) {
+                if (false !== strpos($title, $keyword) || false !== strpos($desc, $keyword)) {
+                    $match = true;
+                    break;
+                }
+            }
+
+            if (!$match) {
+                continue;
+            }
+
+            $guid = isset($item->guid) ? (string) $item->guid : '';
+            if (!$guid && isset($item->id)) {
+                $guid = (string) $item->id;
+            }
+
+            $link = '';
+            if (isset($item->link)) {
+                $link = (string) $item->link;
+                if (is_object($item->link) && isset($item->link['href'])) {
+                    $link = (string) $item->link['href'];
+                }
+            }
+
+            $started = '';
+            if (isset($item->pubDate)) {
+                $started = (string) $item->pubDate;
+            } elseif (isset($item->updated)) {
+                $started = (string) $item->updated;
+            }
+
+            $incidents[] = [
+                'id'         => $provider . ':' . hash('sha256', $guid ?: $link ?: (string) ($item->title ?? 'incident')),
+                'provider'   => $provider,
+                'name'       => (string) ($item->title ?? 'Incident'),
+                'impact'     => 'major',
+                'components' => [],
+                'started_at' => $started,
+                'url'        => $link,
+            ];
+        }
+
+        return [$incidents, ''];
+    }
+
+    public static function add_subscriber(string $email): void {
+        $email = strtolower(sanitize_email($email));
+        if (!$email || !is_email($email)) {
+            return;
+        }
+
+        $subscribers = get_option(self::OPTION_SUBSCRIBERS, []);
+        if (!is_array($subscribers)) {
+            $subscribers = [];
+        }
+
+        if (!in_array($email, $subscribers, true)) {
+            $subscribers[] = $email;
+            update_option(self::OPTION_SUBSCRIBERS, array_values($subscribers), false);
+        }
+
+        self::build_unsubscribe_token($email);
+    }
+
+    public static function remove_subscriber(string $email): void {
+        $email = strtolower(sanitize_email($email));
+        if (!$email) {
+            return;
+        }
+
+        $subscribers = get_option(self::OPTION_SUBSCRIBERS, []);
+        if (!is_array($subscribers) || empty($subscribers)) {
+            return;
+        }
+
+        $updated = array_values(array_filter($subscribers, static function ($item) use ($email) {
+            return strtolower((string) $item) !== $email;
+        }));
+
+        if ($updated !== $subscribers) {
+            update_option(self::OPTION_SUBSCRIBERS, $updated, false);
+        }
+
+        self::delete_unsubscribe_token($email);
+    }
+
+    public static function get_subscribers(): array {
+        $subscribers = get_option(self::OPTION_SUBSCRIBERS, []);
+        if (!is_array($subscribers)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map('sanitize_email', $subscribers)));
+    }
+
+    private static function normalize_unsubscribe_email(string $email): string {
+        $normalized = strtolower(trim((string) sanitize_email($email)));
+        return $normalized;
+    }
+
+    private static function get_unsubscribe_tokens(): array {
+        $tokens = get_option(self::OPTION_UNSUB_TOKENS, []);
+        if (!is_array($tokens)) {
+            return [];
+        }
+
+        $sanitized = [];
+        foreach ($tokens as $rawEmail => $rawToken) {
+            if (!is_string($rawToken) || '' === trim($rawToken)) {
+                continue;
+            }
+
+            $normalized = self::normalize_unsubscribe_email((string) $rawEmail);
+            if ('' === $normalized) {
+                continue;
+            }
+
+            $sanitized[$normalized] = (string) $rawToken;
+        }
+
+        if ($sanitized !== $tokens) {
+            self::save_unsubscribe_tokens($sanitized);
+        }
+
+        return $sanitized;
+    }
+
+    private static function save_unsubscribe_tokens(array $tokens): void {
+        $sanitized = [];
+        foreach ($tokens as $email => $token) {
+            if (!is_string($token) || '' === trim($token)) {
+                continue;
+            }
+            $normalized = self::normalize_unsubscribe_email((string) $email);
+            if ('' === $normalized) {
+                continue;
+            }
+            $sanitized[$normalized] = (string) $token;
+        }
+
+        update_option(self::OPTION_UNSUB_TOKENS, $sanitized, false);
+    }
+
+    public static function get_saved_unsubscribe_token(string $email): string {
+        $normalized = self::normalize_unsubscribe_email($email);
+        if ('' === $normalized) {
+            return '';
+        }
+
+        $tokens = self::get_unsubscribe_tokens();
+        $value  = $tokens[$normalized] ?? '';
+
+        return is_string($value) ? (string) $value : '';
+    }
+
+    public static function delete_unsubscribe_token(string $email): void {
+        $normalized = self::normalize_unsubscribe_email($email);
+        if ('' === $normalized) {
+            return;
+        }
+
+        $tokens = self::get_unsubscribe_tokens();
+        if (!isset($tokens[$normalized])) {
+            return;
+        }
+
+        unset($tokens[$normalized]);
+        self::save_unsubscribe_tokens($tokens);
+    }
+
+    public static function build_unsubscribe_token(string $email): string {
+        $normalized = self::normalize_unsubscribe_email($email);
+        if ('' === $normalized) {
+            return '';
+        }
+
+        $tokens = self::get_unsubscribe_tokens();
+        if (!isset($tokens[$normalized]) || '' === trim((string) $tokens[$normalized])) {
+            $tokens[$normalized] = wp_generate_uuid4();
+            self::save_unsubscribe_tokens($tokens);
+        }
+
+        return (string) $tokens[$normalized];
+    }
+
+    public static function make_synthetic_incident(array $overrides = []): Incident
+    {
+        $now = time();
+        $id = isset($overrides['id']) ? (string) $overrides['id'] : ('synthetic-' . wp_generate_uuid4());
+        return new Incident(
+            (string) ($overrides['provider'] ?? 'Lousy Outages QA'),
+            $id,
+            (string) ($overrides['title'] ?? 'Synthetic outage alert test'),
+            (string) ($overrides['status'] ?? 'major_outage'),
+            (string) ($overrides['url'] ?? home_url('/lousy-outages/')),
+            $overrides['component'] ?? null,
+            (string) ($overrides['impact'] ?? 'critical'),
+            (int) ($overrides['detected_at'] ?? $now),
+            $overrides['resolved_at'] ?? null
+        );
+    }
+
+    private static function send_incident_alert_email(Incident $incident, array $options = []): array {
+        $providerId = sanitize_key((string) $incident->provider);
+        $subscribers = array_values(array_filter(self::get_subscribers(), static function (string $email) use ($providerId): bool {
+            return Subscriptions::subscriber_wants_realtime($email)
+                && Subscriptions::subscriber_wants_provider($email, $providerId);
+        }));
+        $notificationEmail = sanitize_email((string) get_option('lousy_outages_email', get_option('admin_email')));
+        $notificationOnly = !empty($options['notification_only']);
+        if ($notificationOnly) {
+            $subscribers = [];
+        }
+        if ($notificationEmail && is_email($notificationEmail)) {
+            $subscribers[] = $notificationEmail;
+        }
+        $subscribers = array_values(array_unique(array_filter(array_map('sanitize_email', $subscribers))));
+        if (empty($subscribers)) {
+            return ['ok'=>false,'recipients'=>[],'error'=>'no_recipients'];
+        }
+        if (!empty($options['dry_run'])) {
+            return ['ok'=>true,'recipients'=>$subscribers,'error'=>''];
+        }
+
+        $provider      = $incident->provider;
+        $statusLabel   = self::status_label($incident->status);
+        $impact        = $incident->impact ?? self::impact_from_status($incident->status);
+        $timestamp     = gmdate('c', $incident->detected_at);
+        $components    = $incident->component ? array_map('trim', explode(',', $incident->component)) : [];
+        $componentLine = $incident->component ?: 'All monitored components';
+        $url           = $incident->url ?: self::provider_url(sanitize_key($provider));
+        $summary       = $incident->title;
+
+        foreach ($subscribers as $email) {
+            $token = self::build_unsubscribe_token($email);
+            $unsubscribe = add_query_arg(
+                [
+                    'lo_unsub' => 1,
+                    'email'    => rawurlencode($email),
+                    'token'    => $token,
+                ],
+                home_url('/lousy-outages/')
+            );
+
+            $incident_payload = [
+                'service'         => $provider,
+                'status'          => $incident->status,
+                'impact'          => $impact,
+                'summary'         => $summary,
+                'notes'           => '',
+                'timestamp'       => $timestamp,
+                'components'      => $componentLine,
+                'components_list' => $components,
+                'url'             => $url,
+                'unsubscribe_url' => $unsubscribe,
+            ];
+
+            $sent = send_lo_outage_alert_email($email, $incident_payload);
+
+            if (! $sent) {
+                self::log_error($provider, 'mail send failed for ' . $email);
+                return ['ok'=>false,'recipients'=>$subscribers,'error'=>'mail send failed for ' . $email];
+            }
+        }
+
+        return ['ok'=>true,'recipients'=>$subscribers,'error'=>''];
+    }
+
+    /**
+     * Backwards compatible alias for sending realtime incident alerts.
+     */
+    private static function email_incident(Incident $incident): bool {
+        $result = self::send_incident_alert_email($incident);
+        return !empty($result['ok']);
+    }
+
+    private static function record_alert_delivery(bool $ok, Incident $incident, array $recipients, string $reason, bool $markSentCalled, array $options = []): void
+    {
+        $payload = ['timestamp'=>gmdate('c'),'recipient_count'=>count($recipients),'recipients'=>$recipients,'provider'=>$incident->provider,'incident_id'=>$incident->id,'title'=>$incident->title,'status'=>$incident->status,'mark_sent_called'=>$markSentCalled,'synthetic'=>!empty($options['synthetic']),'mode'=>(string)($options['mode'] ?? 'real'),'reason'=>$reason];
+        update_option(self::OPTION_LAST_ALERT_DELIVERY_RESULT, $payload, false);
+        if ($ok) {
+            update_option(self::OPTION_LAST_ALERT_SUCCESS, $payload, false);
+            if (!empty($options['synthetic'])) {
+                update_option(self::OPTION_LAST_SYNTHETIC_ALERT, $payload, false);
+            }
+        } else {
+            update_option(self::OPTION_LAST_ALERT_FAILURE, $payload, false);
+            update_option(self::OPTION_ALERT_DELIVERY_FAILURE, $payload, false);
+            if (defined('WP_DEBUG') && WP_DEBUG) {
+                error_log('[lousy_outages] alert_delivery_failure ' . wp_json_encode($payload));
+            }
+        }
+    }
+
+    /**
+     * Determine if the incident is eligible for realtime alerts.
+     */
+    private static function is_alertable_incident(Incident $incident): bool
+    {
+        $status = strtolower((string) $incident->status);
+        $impact = strtolower((string) ($incident->impact ?? ''));
+
+        if (in_array($status, ['operational', 'resolved'], true)) {
+            return false;
+        }
+
+        if (in_array($status, self::ALERTABLE_STATES, true)) {
+            return true;
+        }
+
+        if ('' !== $impact && in_array($impact, self::ALERTABLE_STATES, true)) {
+            return true;
+        }
+
+        return in_array($impact, ['minor', 'critical', 'partial', 'partial_outage', 'major_outage', 'major', 'outage'], true);
+    }
+
+    private static function incident_effective_timestamp(Incident $incident): ?int
+    {
+        $data = (array) $incident;
+
+        $candidates = [
+            $data['detected_at'] ?? null,
+            $data['detectedAt'] ?? null,
+            $data['started_at'] ?? null,
+            $data['startedAt'] ?? null,
+            $data['timestamp'] ?? null,
+            $data['updated_at'] ?? null,
+            $data['updatedAt'] ?? null,
+            $data['resolved_at'] ?? null,
+        ];
+
+        foreach ($candidates as $value) {
+            $parsed = self::parse_time($value);
+            if (null !== $parsed) {
+                return $parsed;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Build a stable key for de-duplicating incident alerts.
+     */
+    private static function make_incident_key(Incident $incident): string
+    {
+        $providerSlug = sanitize_key((string) $incident->provider) ?: 'provider';
+
+        $title = trim((string) ($incident->title ?? ''));
+        if ('' === $title) {
+            $title = trim((string) ($incident->summary ?? ''));
+        }
+        if ('' === $title) {
+            $title = 'incident';
+        }
+
+        $normalizedTitle = sanitize_title_with_dashes($title);
+        if ('' === $normalizedTitle) {
+            $normalizedTitle = md5($title);
+        }
+
+        $idPart = '';
+        $rawId  = trim((string) ($incident->id ?? ''));
+        if ('' !== $rawId) {
+            $idPart = sanitize_title_with_dashes($rawId);
+        } elseif (! empty($incident->url)) {
+            $idPart = sanitize_title_with_dashes((string) $incident->url);
+        }
+
+        $keyParts = [$providerSlug, $normalizedTitle];
+        if ('' !== $idPart) {
+            $keyParts[] = $idPart;
+        }
+
+        return implode(':', $keyParts);
+    }
+
+    private static function make_subject_key(Incident $incident): string
+    {
+        $providerSlug = sanitize_key((string) $incident->provider) ?: '';
+
+        $title = trim((string) ($incident->title ?? ''));
+        if ('' === $title) {
+            $title = trim((string) ($incident->summary ?? ''));
+        }
+        if ('' === $title) {
+            $title = 'incident';
+        }
+
+        $normalizedTitle = sanitize_title_with_dashes($title);
+        if ('' === $normalizedTitle) {
+            $normalizedTitle = md5($title);
+        }
+
+        if ('' === $providerSlug || '' === $normalizedTitle) {
+            return '';
+        }
+
+        return $providerSlug . ':' . $normalizedTitle;
+    }
+
+    /**
+     * Retrieve stored incident keys that have already been alerted.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private static function get_alerted_incidents(): array
+    {
+        $stored = get_option(self::OPTION_ALERTED_INCIDENTS, []);
+
+        return is_array($stored) ? $stored : [];
+    }
+
+    /**
+     * Persist the map of alerted incidents.
+     *
+     * @param array<string, array<string, mixed>> $map
+     */
+    private static function set_alerted_incidents(array $map): void
+    {
+        update_option(self::OPTION_ALERTED_INCIDENTS, $map, false);
+    }
+
+    /**
+     * Retrieve stored subject keys that have already been alerted.
+     *
+     * @return array<string, array<string, int>>
+     */
+    private static function get_alerted_subjects(): array
+    {
+        $stored = get_option(self::OPTION_ALERTED_SUBJECTS, []);
+
+        return is_array($stored) ? $stored : [];
+    }
+
+    /**
+     * Persist the map of alerted subjects.
+     *
+     * @param array<string, array<string, int>> $map
+     */
+    private static function set_alerted_subjects(array $map): void
+    {
+        update_option(self::OPTION_ALERTED_SUBJECTS, $map, false);
+    }
+
+    /**
+     * Remove stale or resolved incident keys to keep the option small.
+     *
+     * @param array<string, array<string, mixed>> $map
+     * @param array<int, string>                  $activeKeys
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private static function prune_alerted_incidents(array $map, array $activeKeys, int $nowUtc): array
+    {
+        $activeLookup = array_fill_keys($activeKeys, true);
+        $retention    = self::ALERT_RETENTION_HOURS * HOUR_IN_SECONDS;
+
+        foreach ($map as $key => $meta) {
+            $firstNotified = isset($meta['first_notified_at']) ? (int) $meta['first_notified_at'] : 0;
+            $isActive      = isset($activeLookup[$key]);
+
+            if (! $isActive) {
+                $map[$key]['resolved_at'] = $nowUtc;
+            }
+
+            if ($firstNotified && ($nowUtc - $firstNotified) > $retention) {
+                unset($map[$key]);
+                continue;
+            }
+
+            if (! $isActive && 0 === $firstNotified) {
+                unset($map[$key]);
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * Remove stale subject keys to keep the option small.
+     *
+     * @param array<string, array<string, int>> $map
+     *
+     * @return array<string, array<string, int>>
+     */
+    private static function prune_alerted_subjects(array $map, int $nowUtc): array
+    {
+        $retention = self::ALERT_RETENTION_HOURS * HOUR_IN_SECONDS;
+
+        foreach ($map as $key => $meta) {
+            $firstNotified = isset($meta['first_notified_at']) ? (int) $meta['first_notified_at'] : 0;
+            $lastNotified  = isset($meta['last_notified_at']) ? (int) $meta['last_notified_at'] : 0;
+
+            if ($lastNotified && ($nowUtc - $lastNotified) > $retention) {
+                unset($map[$key]);
+                continue;
+            }
+
+            if ($firstNotified && ($nowUtc - $firstNotified) > $retention) {
+                unset($map[$key]);
+            }
+        }
+
+        return $map;
+    }
+
+    private static function parse_time($value): ?int
+    {
+        if (is_int($value)) {
+            return $value > 0 ? $value : null;
+        }
+
+        if (is_string($value) && ctype_digit($value)) {
+            $int = (int) $value;
+            return $int > 0 ? $int : null;
+        }
+
+        if (empty($value)) {
+            return null;
+        }
+
+        $timestamp = strtotime((string) $value);
+        if (false === $timestamp) {
+            return null;
+        }
+
+        return $timestamp;
+    }
+
+    private static function isScheduledMaintenance(string $title, string $description): bool
+    {
+        $haystack = $title . ' ' . $description;
+
+        return 1 === preg_match('/\\b(scheduled|planned).{0,40}maintenance\\b/i', $haystack);
+    }
+
+    private static function isZscalerIpRangeAdvisory(string $title, string $description): bool
+    {
+        $haystack = strtolower($title . ' ' . $description);
+
+        if (false === strpos($haystack, 'ip address')) {
+            return false;
+        }
+
+        return 1 === preg_match('/\\b(additions?|updates?|changes?)\\b.{0,80}\\b(ip address ranges?)\\b/i', $haystack);
+    }
+
+    private static function log_error(string $provider, string $message): void {
+        error_log('[lousy_outages] incident_fetch provider=' . $provider . ' ' . $message);
+    }
+
+    public static function render_admin_notice(): void {
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+
+        if (!function_exists('get_current_screen')) {
+            return;
+        }
+
+        $screen = get_current_screen();
+        if (!$screen || ('dashboard' !== $screen->id && 'toplevel_page_lousy-outages' !== $screen->id && 'plugins' !== $screen->id)) {
+            return;
+        }
+
+        $messages = [];
+
+        $last = get_option(self::OPTION_LAST_CHECK);
+        if ($last) {
+            $messages[] = sprintf('Last provider check ran at %s (UTC)', $last);
+        } else {
+            $messages[] = 'Lousy Outages incident checker has not run yet.';
+        }
+
+        if (defined('DISABLE_WP_CRON') && DISABLE_WP_CRON) {
+            $messages[] = 'WordPress cron is disabled. Configure a real server cron to hit wp-cron.php or run "wp cron event run lo_check_statuses" regularly.';
+        } elseif (!wp_next_scheduled('lo_check_statuses')) {
+            $messages[] = 'No upcoming outage scans are scheduled. A fallback run was queued, but setting up a server cron is recommended for reliability.';
+        }
+
+        $safe_messages = array_map('esc_html', $messages);
+        echo '<div class="notice notice-info"><p>' . implode('</p><p>', $safe_messages) . '</p></div>';
+    }
+}
+
+add_action('lo_check_statuses', [IncidentAlerts::class, 'run']);

--- a/plugins/lousy-outages/includes/MailTransport.php
+++ b/plugins/lousy-outages/includes/MailTransport.php
@@ -1,0 +1,207 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+use PHPMailer\PHPMailer\PHPMailer;
+use WP_Error;
+
+class MailTransport
+{
+    private const SENDMAIL_PATH = '/usr/sbin/sendmail';
+
+    private static bool $active = false;
+    /** @var array<string,mixed> */
+    private static array $context = [];
+    private static bool $forceMail = false;
+    private static string $transport = 'mail';
+    private static bool $fallbackAttempted = false;
+
+    public static function bootstrap(): void
+    {
+        add_action('phpmailer_init', [self::class, 'configure']);
+        add_action('wp_mail_failed', [self::class, 'handleFailure']);
+        add_filter('wp_mail_from', [self::class, 'fromAddress']);
+        add_filter('wp_mail_from_name', [self::class, 'fromName']);
+    }
+
+    /**
+     * @param array<string,mixed> $context
+     */
+    public static function begin(array $context = []): void
+    {
+        self::$active = true;
+        self::$context = $context;
+        self::$fallbackAttempted = false;
+    }
+
+    public static function end(): void
+    {
+        self::$active = false;
+        self::$context = [];
+        self::$forceMail = false;
+        self::$fallbackAttempted = false;
+        self::$transport = 'mail';
+    }
+
+    public static function isActive(): bool
+    {
+        return self::$active;
+    }
+
+    public static function configure($phpmailer): void
+    {
+        if (! self::isActive() || ! $phpmailer instanceof PHPMailer) {
+            return;
+        }
+
+        $fromAddress = self::resolveFromAddress();
+        $envelopeSender = (string) apply_filters('lousy_outages_envelope_from', $fromAddress);
+        $envelopeSender = self::cleanAddress($envelopeSender);
+        if (! is_email($envelopeSender)) {
+            $envelopeSender = $fromAddress;
+        }
+
+        $phpmailer->Sender = $envelopeSender;
+
+        if (self::$forceMail) {
+            $phpmailer->isMail();
+            $phpmailer->Mailer = 'mail';
+            self::$transport = 'mail';
+            self::$forceMail = false;
+            self::addDebugHeaders($phpmailer, $envelopeSender, $fromAddress);
+            return;
+        }
+
+        $sendmailPath = self::SENDMAIL_PATH;
+        if (is_string($sendmailPath) && is_executable($sendmailPath)) {
+            $phpmailer->isSendmail();
+            $phpmailer->Sendmail = $sendmailPath . ' -t -i -f ' . escapeshellarg($envelopeSender);
+            self::$transport = 'sendmail';
+            self::addDebugHeaders($phpmailer, $envelopeSender, $fromAddress);
+            return;
+        }
+
+        $phpmailer->isSMTP();
+        $phpmailer->Host = '127.0.0.1';
+        $phpmailer->Port = 25;
+        $phpmailer->SMTPAuth = false;
+        $phpmailer->SMTPAutoTLS = false;
+        $phpmailer->SMTPKeepAlive = false;
+        self::$transport = 'smtp';
+        self::addDebugHeaders($phpmailer, $envelopeSender, $fromAddress);
+    }
+
+    public static function fromAddress(string $address = ''): string
+    {
+        if (! self::isActive()) {
+            return $address;
+        }
+
+        $desired = sanitize_email('noreply@suzyeaston.ca');
+        if (isset(self::$context['from_address'])) {
+            $contextAddress = self::cleanAddress((string) self::$context['from_address']);
+            if (is_email($contextAddress)) {
+                $desired = $contextAddress;
+            }
+        }
+
+        return $desired ?: $address;
+    }
+
+    public static function fromName(string $name = ''): string
+    {
+        if (! self::isActive()) {
+            return $name;
+        }
+
+        $desired = sanitize_text_field('Lousy Outages');
+        if (isset(self::$context['from_name'])) {
+            $contextName = trim(preg_replace('/[\r\n]+/', ' ', (string) self::$context['from_name']));
+            if ('' !== $contextName) {
+                $desired = sanitize_text_field($contextName);
+            }
+        }
+
+        return $desired ?: $name;
+    }
+
+    public static function handleFailure(WP_Error $error): void
+    {
+        if (! self::isActive()) {
+            return;
+        }
+
+        self::logFailure($error);
+
+        if ('smtp' !== self::$transport || self::$fallbackAttempted) {
+            return;
+        }
+
+        $message = strtolower($error->get_error_message());
+        if (false === strpos($message, 'smtp connect() failed') && false === strpos($message, 'could not connect to smtp')) {
+            return;
+        }
+
+        $data = $error->get_error_data();
+        if (! is_array($data)) {
+            return;
+        }
+
+        $to          = $data['to'] ?? '';
+        $subject     = $data['subject'] ?? '';
+        $body        = $data['message'] ?? '';
+        $headers     = $data['headers'] ?? [];
+        $attachments = $data['attachments'] ?? [];
+
+        if (empty($to)) {
+            return;
+        }
+
+        self::$fallbackAttempted = true;
+        self::$forceMail = true;
+
+        wp_mail($to, (string) $subject, (string) $body, $headers, $attachments);
+
+        self::$forceMail = false;
+    }
+
+    private static function logFailure(WP_Error $error): void
+    {
+        $logMessage = '[' . gmdate('c') . '] ' . $error->get_error_message() . "\n";
+        $data = $error->get_error_data();
+        if ($data) {
+            $logMessage .= print_r($data, true) . "\n";
+        }
+
+        $target = trailingslashit(WP_CONTENT_DIR) . 'uploads/lo-mail.log';
+        error_log($logMessage, 3, $target);
+    }
+
+    private static function resolveFromAddress(): string
+    {
+        $fromAddress = 'noreply@suzyeaston.ca';
+        if (isset(self::$context['from_address'])) {
+            $fromAddress = (string) self::$context['from_address'];
+        }
+
+        $fromAddress = self::cleanAddress((string) sanitize_email($fromAddress));
+        if (! is_email($fromAddress)) {
+            $fromAddress = 'noreply@suzyeaston.ca';
+        }
+
+        return $fromAddress;
+    }
+
+    private static function cleanAddress(string $value): string
+    {
+        return trim(str_replace(["\r", "\n"], '', $value));
+    }
+
+    private static function addDebugHeaders(PHPMailer $phpmailer, string $envelopeSender, string $fromAddress): void
+    {
+        $phpmailer->addCustomHeader('X-Lousy-Outages-Transport', self::$transport);
+        $phpmailer->addCustomHeader('X-Lousy-Outages-Envelope-From', $envelopeSender);
+        $phpmailer->addCustomHeader('X-Lousy-Outages-From', $fromAddress);
+    }
+}

--- a/plugins/lousy-outages/includes/Mailer.php
+++ b/plugins/lousy-outages/includes/Mailer.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+class Mailer {
+    /**
+     * Send an HTML email via WordPress with optional extra headers and plain-text fallback.
+     *
+     * @param array<int,string> $extra_headers
+     */
+    public static function send(string $email, string $subject, string $text_body, string $html_body, array $extra_headers = []): bool {
+        $email = sanitize_email($email);
+        if (!$email || !is_email($email)) {
+            do_action('lousy_outages_log', 'email_skip', ['reason' => 'invalid_recipient']);
+            return false;
+        }
+
+        $from_email = 'noreply@suzyeaston.ca';
+        $from_email = (string) apply_filters('lousy_outages_mail_from_email', $from_email, $email);
+        if (!is_email($from_email)) {
+            $from_email = 'noreply@suzyeaston.ca';
+        }
+
+        $from_name = wp_specialchars_decode(get_bloginfo('name', 'display'), ENT_QUOTES);
+        if ('' === trim((string) $from_name)) {
+            $from_name = 'Lousy Outages';
+        }
+        $from_name = (string) apply_filters('lousy_outages_mail_from_name', $from_name, $email);
+        $from_name = trim(preg_replace('/[\r\n]+/', ' ', $from_name));
+
+        $reply_to = apply_filters('lousy_outages_mail_reply_to', $from_email, $email);
+
+        $headers  = [
+            'MIME-Version: 1.0',
+            'Content-Type: text/html; charset=UTF-8',
+        ];
+
+        if (!empty($extra_headers)) {
+            foreach ($extra_headers as $header) {
+                if (!is_string($header)) {
+                    continue;
+                }
+                $header = trim($header);
+                if ('' === $header) {
+                    continue;
+                }
+                $headers[] = $header;
+            }
+        }
+
+        if (is_email($from_email)) {
+            $headers[] = 'From: ' . trim($from_name ? sprintf('%s <%s>', $from_name, $from_email) : $from_email);
+        }
+
+        if (is_string($reply_to) && is_email($reply_to)) {
+            $headers[] = 'Reply-To: ' . $reply_to;
+        }
+
+        $alt_body_callback = static function ($phpmailer) use ($text_body): void {
+            if (!is_string($text_body) || '' === $text_body) {
+                return;
+            }
+            if (is_object($phpmailer) && property_exists($phpmailer, 'AltBody')) {
+                $phpmailer->AltBody = $text_body;
+            }
+        };
+
+        add_action('phpmailer_init', $alt_body_callback);
+        MailTransport::begin([
+            'from_address' => $from_email,
+            'from_name' => $from_name,
+        ]);
+
+        try {
+            $sent = wp_mail($email, $subject, $html_body, $headers);
+        } finally {
+            MailTransport::end();
+            remove_action('phpmailer_init', $alt_body_callback);
+        }
+
+        if (! $sent && defined('WP_DEBUG') && WP_DEBUG) {
+            error_log(sprintf('[lousy_outages] mail_send_failed recipient=%s subject=%s', $email, $subject));
+        }
+
+        return (bool) $sent;
+    }
+}

--- a/plugins/lousy-outages/includes/Model/Incident.php
+++ b/plugins/lousy-outages/includes/Model/Incident.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages\Model;
+
+class Incident
+{
+    public string $provider;
+    public string $id;
+    public string $title;
+    public string $status;
+    public string $url;
+    public ?string $component;
+    public ?string $impact;
+    public int $detected_at;
+    public ?int $resolved_at;
+
+    public function __construct(
+        string $provider,
+        string $id,
+        string $title,
+        string $status,
+        string $url,
+        ?string $component,
+        ?string $impact,
+        int $detected_at,
+        ?int $resolved_at
+    ) {
+        $this->provider   = $provider;
+        $this->id         = $id;
+        $this->title      = $title;
+        $this->status     = $status;
+        $this->url        = $url;
+        $this->component  = $component;
+        $this->impact     = $impact;
+        $this->detected_at = $detected_at;
+        $this->resolved_at = $resolved_at;
+    }
+
+    public function isResolved(): bool
+    {
+        return 'resolved' === $this->status;
+    }
+}

--- a/plugins/lousy-outages/includes/Precursor.php
+++ b/plugins/lousy-outages/includes/Precursor.php
@@ -1,0 +1,170 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+class Precursor {
+    private $timeout;
+
+    public function __construct($timeout = 5) {
+        $this->timeout      = max(2, (int) $timeout);
+    }
+
+    public function evaluate(array $provider, array $current_state): array {
+        $risk     = 0;
+        $signals  = array();
+        $measures = array('latency_ms' => null, 'baseline_ms' => null, 'http_ok' => null);
+        $summary  = 'No early signals';
+        $details  = array();
+        $probes   = $this->probe_urls_for($provider);
+
+        $lat_ms  = null;
+        $http_ok = true;
+
+        if (!empty($probes)) {
+            $probe_url = $probes[0];
+            $t0        = microtime(true);
+            $resp      = wp_remote_request($probe_url, array(
+                'method'  => 'HEAD',
+                'timeout' => $this->timeout,
+                'headers' => array('User-Agent' => $this->user_agent()),
+            ));
+            $lat_ms = (int) round((microtime(true) - $t0) * 1000);
+            $measures['latency_ms'] = $lat_ms;
+
+            if (is_wp_error($resp)) {
+                $http_ok = false;
+            } else {
+                $code = (int) wp_remote_retrieve_response_code($resp);
+                if (in_array($code, array(401, 403, 405), true)) {
+                    $t0   = microtime(true);
+                    $resp = wp_remote_request($probe_url, array(
+                        'method'  => 'GET',
+                        'timeout' => $this->timeout,
+                        'headers' => array('User-Agent' => $this->user_agent()),
+                    ));
+                    $lat_ms = (int) round((microtime(true) - $t0) * 1000);
+                    $measures['latency_ms'] = $lat_ms;
+                    if (is_wp_error($resp)) {
+                        $http_ok = false;
+                    } else {
+                        $code = (int) wp_remote_retrieve_response_code($resp);
+                        $http_ok = ($code >= 200 && $code < 400);
+                    }
+                } else {
+                    $http_ok = ($code >= 200 && $code < 400);
+                }
+            }
+
+            $measures['http_ok'] = $http_ok;
+
+            $baseline = $this->update_and_get_baseline(isset($provider['id']) ? $provider['id'] : '', $lat_ms, $http_ok);
+            if (null !== $baseline) {
+                $measures['baseline_ms'] = $baseline;
+            }
+
+            if ($baseline && $lat_ms > (int) round($baseline * 1.8)) {
+                $risk += 40;
+                $signals[] = 'latency_spike';
+            }
+            if (!$http_ok) {
+                $risk += 40;
+                $signals[] = 'http_errors';
+            }
+        }
+
+        $status       = strtolower((string) ($current_state['status'] ?? 'unknown'));
+        $summary_text = (string) ($current_state['summary'] ?? '');
+        $sniff_text   = strtolower($summary_text);
+        if ('operational' === $status && (false !== strpos($sniff_text, 'degrad') || false !== strpos($sniff_text, 'partial'))) {
+            $risk += 20;
+            $signals[] = 'component_degraded';
+        }
+
+        if ($risk > 0) {
+            $summary = 'Early warning: signals detected: ' . implode(', ', $signals);
+        }
+
+        return array(
+            'risk'       => min(100, $risk),
+            'summary'    => $summary,
+            'signals'    => $signals,
+            'measures'   => $measures,
+            'updated_at' => gmdate('c'),
+            'details'    => $details,
+        );
+    }
+
+    private function probe_urls_for(array $provider): array {
+        $settings = get_option('lousy_outages_probes', array());
+        if (!is_array($settings)) {
+            $settings = array();
+        }
+        $id = isset($provider['id']) ? (string) $provider['id'] : '';
+        if ('' !== $id && isset($settings[$id]) && is_array($settings[$id]) && !empty($settings[$id])) {
+            $urls = array();
+            foreach ($settings[$id] as $url) {
+                if (is_string($url) && '' !== trim($url)) {
+                    $urls[] = trim($url);
+                }
+            }
+            if (!empty($urls)) {
+                return $urls;
+            }
+        }
+        if ('zscaler' === $id) {
+            return array('https://trust.zscaler.com/');
+        }
+        return array();
+    }
+
+    private function update_and_get_baseline($provider_id, $latest_ms, $http_ok) {
+        $provider_id = (string) $provider_id;
+        if ('' === $provider_id) {
+            return is_int($latest_ms) ? $latest_ms : null;
+        }
+
+        if (null === $latest_ms) {
+            return null;
+        }
+
+        $latest_ms = (int) $latest_ms;
+        if ($latest_ms <= 0) {
+            $stored = get_option('lousy_outages_precursor_baselines', array());
+            if (!is_array($stored) || !isset($stored[$provider_id]['avg'])) {
+                return null;
+            }
+            return (int) round((float) $stored[$provider_id]['avg']);
+        }
+
+        $key = 'lousy_outages_precursor_baselines';
+        $all = get_option($key, array());
+        if (!is_array($all)) {
+            $all = array();
+        }
+        $entry = isset($all[$provider_id]) && is_array($all[$provider_id]) ? $all[$provider_id] : array('avg' => null, 'n' => 0);
+
+        if (!$http_ok && null !== $entry['avg']) {
+            return (int) round((float) $entry['avg']);
+        }
+
+        if (null === $entry['avg'] || !$entry['n']) {
+            $entry['avg'] = (float) $latest_ms;
+            $entry['n']   = 1;
+        } else {
+            $alpha        = 0.2;
+            $entry['avg'] = (1.0 - $alpha) * (float) $entry['avg'] + $alpha * (float) $latest_ms;
+            $entry['n']   = (int) $entry['n'] + 1;
+        }
+
+        $all[$provider_id] = $entry;
+        update_option($key, $all, false);
+
+        return (int) round((float) $entry['avg']);
+    }
+
+    private function user_agent(): string {
+        $site = home_url();
+        return 'Mozilla/5.0 (compatible; LousyOutagesBot/3.1; +' . $site . ')';
+    }
+}

--- a/plugins/lousy-outages/includes/Providers.php
+++ b/plugins/lousy-outages/includes/Providers.php
@@ -1,0 +1,386 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+class Providers {
+    private const OPTION_DEFAULT_ENABLED = 'lousy_outages_default_enabled_providers';
+    private const BLOCKED_PROVIDER_IDS = ['linear'];
+
+    private static function defaultProviders(): array {
+        return [
+            // Statuspage JSON
+            [
+                'id'         => 'github',
+                'name'       => 'GitHub',
+                'type'       => 'statuspage',
+                'url'        => 'https://www.githubstatus.com/api/v2/summary.json',
+                'status_url' => 'https://www.githubstatus.com/',
+            ],
+            [
+                'id'         => 'cloudflare',
+                'name'       => 'Cloudflare',
+                'type'       => 'statuspage',
+                'url'        => 'https://www.cloudflarestatus.com/api/v2/summary.json',
+                'status_url' => 'https://www.cloudflarestatus.com/',
+            ],
+            [
+                'id'         => 'openai',
+                'name'       => 'OpenAI',
+                'type'       => 'statuspage',
+                'url'        => 'https://status.openai.com/api/v2/summary.json',
+                'status_url' => 'https://status.openai.com/',
+            ],
+            [
+                'id'         => 'atlassian',
+                'name'       => 'Atlassian',
+                'type'       => 'statuspage',
+                'url'        => 'https://status.atlassian.com/api/v2/summary.json',
+                'status_url' => 'https://status.atlassian.com/',
+            ],
+            [
+                'id'         => 'digitalocean',
+                'name'       => 'DigitalOcean',
+                'type'       => 'statuspage',
+                'url'        => 'https://status.digitalocean.com/api/v2/summary.json',
+                'status_url' => 'https://status.digitalocean.com/',
+            ],
+            [
+                'id'         => 'netlify',
+                'name'       => 'Netlify',
+                'type'       => 'statuspage',
+                'url'        => 'https://www.netlifystatus.com/api/v2/summary.json',
+                'status_url' => 'https://www.netlifystatus.com/',
+            ],
+            [
+                'id'         => 'vercel',
+                'name'       => 'Vercel',
+                'type'       => 'statuspage',
+                'url'        => 'https://www.vercel-status.com/api/v2/summary.json',
+                'status_url' => 'https://www.vercel-status.com/',
+            ],
+            [
+                'id'         => 'zoom',
+                'name'       => 'Zoom',
+                'type'       => 'statuspage',
+                'url'        => 'https://status.zoom.us/api/v2/summary.json',
+                'status_url' => 'https://status.zoom.us/',
+            ],
+            [
+                'id'         => 'zscaler',
+                'name'       => 'Zscaler',
+                'type'       => 'statuspage',
+                'url'        => 'https://status.zscaler.com/api/v2/summary.json',
+                'status_url' => 'https://trust.zscaler.com/zscaler.net/',
+            ],
+
+            // High-value adds (Statuspage JSON)
+            [
+                'id'         => 'teamviewer',
+                'name'       => 'TeamViewer',
+                'type'       => 'statuspage',
+                'url'        => 'https://status.teamviewer.com/api/v2/summary.json',
+                'status_url' => 'https://status.teamviewer.com/',
+            ],
+            [
+                'id'         => 'sentry',
+                'name'       => 'Sentry',
+                'type'       => 'statuspage',
+                'url'        => 'https://status.sentry.io/api/v2/summary.json',
+                'status_url' => 'https://status.sentry.io/',
+            ],
+
+            // RSS/Atom feeds
+            ['id' => 'aws', 'name' => 'AWS', 'type' => 'rss', 'url' => 'https://status.aws.amazon.com/rss/all.rss'],
+            [
+                'id'         => 'slack',
+                'name'       => 'Slack',
+                // LO: Use the current-status endpoint for live state; RSS is only for history.
+                'type'       => 'slack_current',
+                'url'        => 'https://status.slack.com/api/v2.0.0/current',
+                'status_url' => 'https://status.slack.com/',
+            ],
+            [
+                'id'         => 'crowdstrike',
+                'name'       => 'CrowdStrike',
+                'type'       => 'manual', // LO: manual provider with no feed.
+                'url'        => '',
+                'status_url' => 'https://trust.crowdstrike.com/',
+            ],
+            ['id' => 'azure', 'name' => 'Azure', 'type' => 'rss', 'url' => 'https://rssfeed.azure.status.microsoft/en-us/status/feed/'],
+            [
+                'id'         => 'google_workspace',
+                'name'       => 'Google Workspace',
+                'type'       => 'rss',
+                'url'        => 'https://www.google.com/appsstatus/rss/en-CA',
+                'status_url' => 'https://www.google.com/appsstatus/dashboard/',
+            ],
+            [
+                'id'         => 'google_cloud',
+                'name'       => 'Google Cloud',
+                'type'       => 'gcp_json',
+                'url'        => 'https://status.cloud.google.com/incidents.json',
+                'status_url' => 'https://status.cloud.google.com/',
+            ],
+        ];
+    }
+
+    /**
+     * Return the provider configuration map.
+     */
+    public static function list(): array {
+        $defaults  = self::defaultProviders();
+        $providers = [];
+
+        $blocked = array_fill_keys( self::BLOCKED_PROVIDER_IDS, true );
+
+        foreach ( $defaults as $provider ) {
+            if ( ! is_array( $provider ) ) {
+                continue;
+            }
+
+            $id = isset( $provider['id'] ) ? (string) $provider['id'] : '';
+            if ( '' === $id ) {
+                continue;
+            }
+
+            if ( isset( $blocked[ $id ] ) ) {
+                continue;
+            }
+
+            $providers[ $id ] = $provider;
+        }
+
+        $providers = apply_filters( 'lousy_outages_providers', $providers );
+        if ( ! is_array( $providers ) ) {
+            $providers = [];
+        }
+
+        foreach ( $providers as $id => &$provider ) {
+            if ( ! is_array( $provider ) ) {
+                unset( $providers[ $id ] );
+                continue;
+            }
+
+            if ( isset( $blocked[ $id ] ) ) {
+                unset( $providers[ $id ] );
+                continue;
+            }
+
+            $provider = self::prepare_provider( (string) $id, $provider );
+        }
+        unset( $provider );
+
+        return $providers;
+    }
+
+    /**
+     * Return enabled providers from options or defaults.
+     */
+    public static function enabled(): array {
+        $blocked         = array_fill_keys( self::BLOCKED_PROVIDER_IDS, true );
+        $all             = self::list();
+        $default_enabled = array_keys(
+            array_filter(
+                $all,
+                static fn( array $prov ): bool => ! empty( $prov['enabled'] )
+            )
+        );
+        $saved               = get_option( 'lousy_outages_providers', false );
+        $stored_default_list = get_option( self::OPTION_DEFAULT_ENABLED, null );
+        $previous_defaults   = is_array( $stored_default_list )
+            ? array_values(
+                array_filter(
+                    array_map( 'strval', $stored_default_list ),
+                    static fn( $value ): bool => '' !== (string) $value
+                )
+            )
+            : [];
+
+        if ( is_array( $saved ) ) {
+            $enabled_ids = [];
+            foreach ( $saved as $id ) {
+                if ( ! is_scalar( $id ) ) {
+                    continue;
+                }
+                $id = (string) $id;
+                if ( '' === $id ) {
+                    continue;
+                }
+                if ( isset( $blocked[ $id ] ) ) {
+                    continue;
+                }
+                $enabled_ids[] = $id;
+            }
+
+            $new_defaults = array_diff( $default_enabled, $previous_defaults );
+            $updated      = false;
+
+            if ( ! empty( $new_defaults ) ) {
+                foreach ( $new_defaults as $id ) {
+                    if ( ! in_array( $id, $enabled_ids, true ) ) {
+                        $enabled_ids[] = $id;
+                        $updated       = true;
+                    }
+                }
+            }
+
+            if ( $updated ) {
+                $enabled_ids = array_values( array_unique( $enabled_ids ) );
+                update_option( 'lousy_outages_providers', $enabled_ids, false );
+            }
+
+            if ( $previous_defaults !== $default_enabled ) {
+                update_option( self::OPTION_DEFAULT_ENABLED, $default_enabled, false );
+            }
+        } else {
+            $enabled_ids = $default_enabled;
+
+            if ( $previous_defaults !== $default_enabled ) {
+                update_option( self::OPTION_DEFAULT_ENABLED, $default_enabled, false );
+            }
+        }
+
+        $enabled = [];
+        foreach ( $enabled_ids as $id ) {
+            if ( isset( $blocked[ $id ] ) ) {
+                continue;
+            }
+            if ( isset( $all[ $id ] ) ) {
+                $enabled[ $id ] = $all[ $id ];
+            }
+        }
+
+        return $enabled;
+    }
+
+    private static function prepare_provider( string $id, array $provider ): array {
+        $provider['id']   = $id;
+        $provider['name'] = (string) ( $provider['name'] ?? $id );
+        $provider['type'] = strtolower( (string) ( $provider['type'] ?? 'statuspage' ) );
+
+        if ( ! isset( $provider['url'] ) ) {
+            $endpoint = self::coalesce_endpoint( $provider );
+            if ( null !== $endpoint ) {
+                $provider['url'] = $endpoint;
+            }
+        }
+
+        $provider['enabled'] = array_key_exists( 'enabled', $provider )
+            ? (bool) $provider['enabled']
+            : ! ( isset( $provider['disabled'] ) && $provider['disabled'] );
+        unset( $provider['disabled'] );
+
+        $provider['optional'] = ! empty( $provider['optional'] );
+
+        if ( empty( $provider['status_url'] ) || ! is_string( $provider['status_url'] ) ) {
+            $provider['status_url'] = self::derive_status_url( $provider );
+        }
+
+        // Maintain legacy endpoint keys for backwards compatibility with filters.
+        if ( 'statuspage' === $provider['type'] && empty( $provider['summary'] ) && ! empty( $provider['url'] ) ) {
+            $provider['summary'] = $provider['url'];
+        }
+        if ( 'rss' === $provider['type'] && empty( $provider['rss'] ) && ! empty( $provider['url'] ) ) {
+            $provider['rss'] = $provider['url'];
+        }
+        if ( 'atom' === $provider['type'] && empty( $provider['atom'] ) && ! empty( $provider['url'] ) ) {
+            $provider['atom'] = $provider['url'];
+        }
+        if ( in_array( $provider['type'], [ 'slack', 'slack_current' ], true ) && empty( $provider['current'] ) && ! empty( $provider['url'] ) ) {
+            $provider['current'] = $provider['url'];
+        }
+
+        return $provider;
+    }
+
+    private static function coalesce_endpoint( array $provider ): ?string {
+        foreach ( [ 'summary', 'url', 'rss', 'atom', 'current', 'endpoint' ] as $key ) {
+            if ( empty( $provider[ $key ] ) || ! is_string( $provider[ $key ] ) ) {
+                continue;
+            }
+
+            return $provider[ $key ];
+        }
+
+        return null;
+    }
+
+    private static function derive_status_url( array $provider ): string {
+        $wellKnown = [
+            'zscaler'  => 'https://trust.zscaler.com/',
+            'slack'    => 'https://status.slack.com/',
+            'qubeyond' => 'https://status.qubeyond.com/',
+        ];
+
+        if ( ! empty( $provider['id'] ) && isset( $wellKnown[ $provider['id'] ] ) ) {
+            return trailingslashit( $wellKnown[ $provider['id'] ] );
+        }
+
+        $type           = strtolower( (string) ( $provider['type'] ?? 'statuspage' ) );
+        $candidates     = [];
+        $candidate_keys = [ 'status_url', 'url', 'summary', 'rss', 'atom', 'current', 'endpoint' ];
+
+        foreach ( $candidate_keys as $key ) {
+            if ( empty( $provider[ $key ] ) || ! is_string( $provider[ $key ] ) ) {
+                continue;
+            }
+            $candidates[] = $provider[ $key ];
+        }
+
+        foreach ( $candidates as $candidate ) {
+            $candidate = trim( $candidate );
+            if ( '' === $candidate ) {
+                continue;
+            }
+
+            $adjusted = $candidate;
+            if ( in_array( $type, [ 'statuspage', 'slack', 'slack_current' ], true ) ) {
+                $adjusted = preg_replace( '#/api/v\d+(?:\.\d+)*?/(summary\.json|current|status\.json)$#', '/', $adjusted );
+                $adjusted = preg_replace( '#/api/v\d+(?:\.\d+)*?/history\.(?:rss|atom)$#', '/', (string) $adjusted );
+            }
+
+            if ( in_array( $type, [ 'rss', 'atom', 'rss-optional' ], true ) ) {
+                $adjusted = preg_replace( '#/(?:feed(?:s)?/?)?(?:[^/]*\.(?:rss|atom|xml))/?$#i', '/', (string) $adjusted );
+            }
+
+            $parts = wp_parse_url( $adjusted ?: $candidate );
+            if ( empty( $parts['scheme'] ) || empty( $parts['host'] ) ) {
+                continue;
+            }
+
+            $base = $parts['scheme'] . '://' . $parts['host'];
+            if ( ! empty( $parts['path'] ) ) {
+                $path = trim( (string) $parts['path'], '/' );
+                if ( '' !== $path ) {
+                    if ( in_array( $type, [ 'statuspage', 'slack', 'slack_current' ], true ) ) {
+                        $path = preg_replace( '#^api/.*$#', '', $path );
+                    } elseif ( in_array( $type, [ 'rss', 'atom', 'rss-optional' ], true ) ) {
+                        $segments = array_filter( explode( '/', $path ), static fn( $seg ) => '' !== $seg );
+                        while ( $segments ) {
+                            $last = strtolower( (string) end( $segments ) );
+                            if ( '' === $last ) {
+                                array_pop( $segments );
+                                continue;
+                            }
+                            if ( preg_match( '#\.(?:rss|atom|xml)$#', $last ) || in_array( $last, [ 'feed', 'feeds', 'rss', 'atom' ], true ) ) {
+                                array_pop( $segments );
+                                continue;
+                            }
+                            break;
+                        }
+                        $path = implode( '/', $segments );
+                    }
+                    $path = trim( (string) $path, '/' );
+                    if ( '' !== $path ) {
+                        $base .= '/' . $path;
+                    }
+                }
+            }
+
+            return trailingslashit( $base );
+        }
+
+        return trailingslashit( home_url( '/' ) );
+    }
+}

--- a/plugins/lousy-outages/includes/SMS.php
+++ b/plugins/lousy-outages/includes/SMS.php
@@ -1,0 +1,36 @@
+<?php
+namespace SuzyEaston\LousyOutages;
+
+class SMS {
+    private function send( string $body ): void {
+        $sid   = get_option( 'lousy_outages_twilio_sid' );
+        $token = get_option( 'lousy_outages_twilio_token' );
+        $from  = get_option( 'lousy_outages_twilio_from' );
+        $to    = get_option( 'lousy_outages_phone' );
+        if ( ! $sid || ! $token || ! $from || ! $to ) {
+            return;
+        }
+        $url = sprintf( 'https://api.twilio.com/2010-04-01/Accounts/%s/Messages.json', $sid );
+        wp_remote_post( $url, [
+            'timeout' => 10,
+            'headers' => [
+                'Authorization' => 'Basic ' . base64_encode( $sid . ':' . $token ),
+            ],
+            'body'    => [
+                'From' => $from,
+                'To'   => $to,
+                'Body' => $body,
+            ],
+        ] );
+    }
+
+    public function send_alert( string $provider, string $status, string $message, string $link ): void {
+        $body = sprintf( '🚨 Lousy Outages: %s -> %s. %s (%s)', $provider, $status, $message, $link );
+        $this->send( $body );
+    }
+
+    public function send_recovery( string $provider, string $link ): void {
+        $body = sprintf( '✅ Lousy Outages: %s recovered. (%s)', $provider, $link );
+        $this->send( $body );
+    }
+}

--- a/plugins/lousy-outages/includes/SignalCollector.php
+++ b/plugins/lousy-outages/includes/SignalCollector.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+use SuzyEaston\LousyOutages\Sources\CloudflareRadarSource;
+use SuzyEaston\LousyOutages\Sources\SyntheticCanarySource;
+
+class SignalCollector {
+    public static function sources(): array { return [new CloudflareRadarSource(), new SyntheticCanarySource()]; }
+    public static function collect(array $options=[]): array {
+        $result=['started_at'=>gmdate('c'),'finished_at'=>'','sources'=>[],'total_collected'=>0,'total_stored'=>0];
+        foreach(self::sources() as $source){ $r=self::collect_source($source->id(),$options); $result['sources'][]=$r; $result['total_collected']+=(int)$r['collected_count']; $result['total_stored']+=(int)$r['stored_count']; }
+        $result['finished_at']=gmdate('c'); self::mark_last_collection_result($result); return $result;
+    }
+    public static function collect_source(string $sourceId, array $options=[]): array {
+        foreach(self::sources() as $source){ if($source->id()!==$sourceId) continue; $configured=$source->is_configured(); if(!$configured) return ['source'=>$source->id(),'configured'=>false,'attempted'=>false,'collected_count'=>0,'stored_count'=>0,'errors'=>[]]; $signals=$source->collect($options); $stored=ExternalSignals::record_many($signals); return ['source'=>$source->id(),'configured'=>true,'attempted'=>true,'collected_count'=>count($signals),'stored_count'=>(int)($stored['inserted']??0),'errors'=>[]]; }
+        return ['source'=>$sourceId,'configured'=>false,'attempted'=>false,'collected_count'=>0,'stored_count'=>0,'errors'=>['unknown source']];
+    }
+    public static function get_last_collection_result(): array { $r=get_option('lousy_outages_last_external_collection',[]); return is_array($r)?$r:[]; }
+    public static function mark_last_collection_result(array $result): void { update_option('lousy_outages_last_external_collection',$result,false); }
+}

--- a/plugins/lousy-outages/includes/SignalEngine.php
+++ b/plugins/lousy-outages/includes/SignalEngine.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+class SignalEngine {
+    public static function classify_score(int $count, int $uniqueReporterCount = 0): string {
+        $watch = (int) apply_filters('lo_signal_watch_threshold', 2);
+        $trending = (int) apply_filters('lo_signal_trending_threshold', 3);
+        $hot = (int) apply_filters('lo_signal_hot_threshold', 5);
+        if ($count >= $hot) return 'hot';
+        if ($count >= $trending) return 'trending';
+        if ($count >= $watch) return 'watch';
+        return 'quiet';
+    }
+
+    public static function score_provider(array $reports, array $options = []): array {
+        $count = count($reports);
+        $symptoms = [];
+        $unique = [];
+        $last = '';
+        foreach ($reports as $r) {
+            $sym = (string)($r['symptom'] ?? 'other');
+            $symptoms[$sym] = ($symptoms[$sym] ?? 0) + 1;
+            $ip = (string)($r['ip_hash'] ?? '');
+            if ($ip) $unique[$ip] = true;
+            $created = (string)($r['created_at'] ?? '');
+            if ($created > $last) $last = $created;
+        }
+        arsort($symptoms);
+        $top = (string)array_key_first($symptoms);
+        $class = self::classify_score($count, count($unique));
+        $message = self::message_for_class($class);
+        return ['report_count'=>$count,'unique_reporter_count'=>count($unique),'top_symptom'=>$top ?: 'other','classification'=>$class,'message'=>$message,'last_reported_at'=>$last];
+    }
+
+    public static function message_for_class(string $class): string {
+        if ($class === 'watch') return 'A few community reports are coming in. Possible issue reported by users. Unconfirmed signal — we’re watching this.';
+        if ($class === 'trending') return 'Community reports are trending for this provider. Unconfirmed signal; no official incident yet.';
+        if ($class === 'hot') return 'High volume of community reports. No official confirmation yet unless listed below. Unconfirmed signal.';
+        return 'No unusual community reports.';
+    }
+
+    public static function summarize_recent_signals(int $windowMinutes = 60): array {
+        $windowMinutes = (int) apply_filters('lo_signal_window_minutes', $windowMinutes);
+        $reports = UserReports::get_recent_reports(['windowMinutes'=>$windowMinutes,'limit'=>500]);
+        $providers = Providers::list();
+        $grouped = [];
+        foreach ($reports as $r) { $grouped[(string)$r['provider_id']][] = $r; }
+        $signals = [];
+        foreach ($grouped as $provider_id => $rows) {
+            $score = self::score_provider($rows);
+            $signals[] = array_merge($score, [
+                'provider_id'=>$provider_id,
+                'provider_name'=>(string)($providers[$provider_id]['name'] ?? ucfirst($provider_id)),
+                'severity'=>(string)($rows[0]['severity'] ?? 'unknown'),
+                'region'=>(string)($rows[0]['region'] ?? ''),
+                'official_status_known'=>false,
+            ]);
+        }
+        usort($signals, static fn($a,$b)=>($b['report_count']<=>$a['report_count']));
+        return $signals;
+    }
+
+    public static function summarize_fused_signals(int $windowMinutes = 60): array {
+        $community = self::summarize_recent_signals($windowMinutes);
+        $external = class_exists('\SuzyEaston\LousyOutages\ExternalSignals') ? ExternalSignals::get_recent_signals(['windowMinutes'=>$windowMinutes,'limit'=>200]) : [];
+        $buckets = [];
+        foreach ($community as $row) {
+            $key = ($row['provider_id'] ?? '') . '|' . ($row['category'] ?? '') . '|' . ($row['region'] ?? '');
+            $buckets[$key] = ['provider_id'=>(string)$row['provider_id'],'provider_name'=>(string)$row['provider_name'],'category'=>(string)($row['category']??'community'),'region'=>(string)($row['region']??''),'report_count'=>(int)$row['report_count'],'external_signal_count'=>0,'synthetic_failure_count'=>0,'sources'=>['community_reports'],'official_status_known'=>false,'confirmed'=>false,'last_observed_at'=>(string)($row['last_reported_at']??''),'base_confidence'=> self::class_confidence((string)$row['classification']) ];
+        }
+        foreach ($external as $row) {
+            $key = ($row['provider_id'] ?? '') . '|' . ($row['category'] ?? '') . '|' . ($row['region'] ?? '');
+            if (!isset($buckets[$key])) { $buckets[$key]=['provider_id'=>(string)($row['provider_id']??''),'provider_name'=>(string)($row['provider_name']??'Unknown'),'category'=>(string)($row['category']??''),'region'=>(string)($row['region']??''),'report_count'=>0,'external_signal_count'=>0,'synthetic_failure_count'=>0,'sources'=>[],'official_status_known'=>false,'confirmed'=>false,'last_observed_at'=>(string)($row['observed_at']??''),'base_confidence'=>0]; }
+            $buckets[$key]['external_signal_count']++;
+            $src=(string)($row['source']??'external'); if(!in_array($src,$buckets[$key]['sources'],true)) $buckets[$key]['sources'][]=$src;
+            if (($row['source']??'')==='synthetic_canary') $buckets[$key]['synthetic_failure_count']++;
+            $buckets[$key]['base_confidence'] = max((int)$buckets[$key]['base_confidence'], (int)($row['confidence'] ?? 0));
+            if ((string)($row['observed_at']??'') > (string)$buckets[$key]['last_observed_at']) $buckets[$key]['last_observed_at']=(string)$row['observed_at'];
+        }
+        $signals=[];
+        foreach($buckets as $b){ $conf=(int)$b['base_confidence']; if(count($b['sources'])>=2) $conf += 15; if(!$b['confirmed']) $conf=min($conf,95); $class=$conf>=70?'hot':($conf>=45?'trending':($conf>=25?'watch':'quiet')); $msg='Community reports are trending for this provider. Official incident not confirmed.'; if($b['report_count']>0 && $b['external_signal_count']>0){$msg='External internet-health signals and community reports both suggest a possible issue.';} elseif($b['external_signal_count']>0 && $b['synthetic_failure_count']===0 && $b['report_count']===0){$msg='External internet-health telemetry suggests a possible issue. Official incident not confirmed.';} elseif($b['synthetic_failure_count']>0 && $b['report_count']===0){$msg='A lightweight public canary check failed. This is an unconfirmed signal.';}
+            $signals[]=$b + ['confidence'=>$conf,'classification'=>$class,'message'=>$msg,'id'=>md5($b['provider_id'].'|'.$b['category'].'|'.$b['region'])];
+        }
+        usort($signals, static fn($a,$b)=>($b['confidence']<=>$a['confidence']));
+        return $signals;
+    }
+
+    private static function class_confidence(string $class): int { if($class==='watch') return 20; if($class==='trending') return 45; if($class==='hot') return 65; return 0; }
+
+}

--- a/plugins/lousy-outages/includes/SignalSourceInterface.php
+++ b/plugins/lousy-outages/includes/SignalSourceInterface.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+interface SignalSourceInterface {
+    public function id(): string;
+    public function label(): string;
+    public function is_configured(): bool;
+    /** @return array<int,array<string,mixed>> */
+    public function collect(array $options = []): array;
+}

--- a/plugins/lousy-outages/includes/Snapshot.php
+++ b/plugins/lousy-outages/includes/Snapshot.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Snapshot caching and REST exposure for Lousy Outages.
+ */
+
+declare(strict_types=1);
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+if (! function_exists('lo_snapshot_bootstrap')) {
+    function lo_snapshot_bootstrap(): void
+    {
+        add_action('rest_api_init', 'lo_snapshot_register_route');
+    }
+}
+
+if (! function_exists('lo_snapshot_register_route')) {
+    function lo_snapshot_register_route(): void
+    {
+        register_rest_route(
+            'lousy/v1',
+            '/snapshot',
+            [
+                'methods'             => \WP_REST_Server::READABLE,
+                'permission_callback' => '__return_true',
+                'callback'            => 'lo_snapshot_rest_callback',
+            ]
+        );
+    }
+}
+
+if (! function_exists('lo_snapshot_rest_callback')) {
+    function lo_snapshot_rest_callback(\WP_REST_Request $request)
+    {
+        return rest_ensure_response(lo_snapshot_get_cached());
+    }
+}
+
+if (! function_exists('lo_snapshot_transient_key')) {
+    function lo_snapshot_transient_key(): string
+    {
+        return 'lo_snapshot_payload_v1';
+    }
+}
+
+if (! function_exists('lo_snapshot_last_good_key')) {
+    function lo_snapshot_last_good_key(): string
+    {
+        return 'lo_snapshot_last_good_v1';
+    }
+}
+
+if (! function_exists('lo_snapshot_default_ttl')) {
+    function lo_snapshot_default_ttl(): int
+    {
+        $ttl = (int) apply_filters('lo_snapshot_ttl', 300);
+        if ($ttl < 120) {
+            $ttl = 120;
+        }
+        if ($ttl > 900) {
+            $ttl = 900;
+        }
+
+        return $ttl;
+    }
+}
+
+if (! function_exists('lo_snapshot_refresh')) {
+    function lo_snapshot_refresh(bool $force_refresh = true): array
+    {
+        if (! function_exists('lousy_outages_get_snapshot')) {
+            return lo_snapshot_get_cached();
+        }
+
+        $raw = lousy_outages_get_snapshot($force_refresh);
+        // Keep snapshot updated_at aligned with the canonical last-fetched option
+        // used by the HUD/meta displays.
+        $last_fetched_iso = function_exists('lousy_outages_get_last_fetched_iso')
+            ? lousy_outages_get_last_fetched_iso()
+            : null;
+        $updated_at = $last_fetched_iso
+            ? $last_fetched_iso
+            : (isset($raw['fetched_at']) ? (string) $raw['fetched_at'] : gmdate('c'));
+        $services = [];
+        if (! empty($raw['providers']) && is_array($raw['providers'])) {
+            foreach ($raw['providers'] as $provider) {
+                if (! is_array($provider)) {
+                    continue;
+                }
+                $services[] = lo_snapshot_normalize_service($provider, $updated_at);
+            }
+        }
+
+        $payload = [
+            'updated_at' => $updated_at,
+            'services'   => $services,
+        ];
+
+        return lo_snapshot_store($payload);
+    }
+}
+
+if (! function_exists('lo_snapshot_store')) {
+    function lo_snapshot_store(array $payload): array
+    {
+        $ttl = lo_snapshot_default_ttl();
+        $expires_at = time() + $ttl;
+
+        $stored = [
+            'updated_at' => (string) ($payload['updated_at'] ?? gmdate('c')),
+            'services'   => is_array($payload['services'] ?? null) ? array_values($payload['services']) : [],
+            'expires_at' => $expires_at,
+        ];
+
+        set_transient(lo_snapshot_transient_key(), $stored, $ttl);
+        update_option(lo_snapshot_last_good_key(), $stored, false);
+
+        return lo_snapshot_prepare_response($stored, false);
+    }
+}
+
+if (! function_exists('lo_snapshot_get_cached')) {
+    function lo_snapshot_get_cached(): array
+    {
+        $cached = get_transient(lo_snapshot_transient_key());
+        if (is_array($cached) && ! empty($cached['services'])) {
+            $stale = isset($cached['expires_at']) ? (int) $cached['expires_at'] < time() : false;
+            return lo_snapshot_prepare_response($cached, $stale);
+        }
+
+        $stored = get_option(lo_snapshot_last_good_key(), []);
+        if (is_array($stored) && ! empty($stored['services'])) {
+            return lo_snapshot_prepare_response($stored, true);
+        }
+
+        return [
+            'updated_at'  => gmdate('c'),
+            'ttl_seconds' => lo_snapshot_default_ttl(),
+            'services'    => [],
+            'stale'       => true,
+        ];
+    }
+}
+
+if (! function_exists('lo_snapshot_prepare_response')) {
+    function lo_snapshot_prepare_response(array $stored, bool $stale): array
+    {
+        $ttl = lo_snapshot_default_ttl();
+        $last_fetched_iso = function_exists('lousy_outages_get_last_fetched_iso')
+            ? lousy_outages_get_last_fetched_iso()
+            : null;
+        $response = [
+            'updated_at'  => $last_fetched_iso
+                ? $last_fetched_iso
+                : (isset($stored['updated_at']) ? (string) $stored['updated_at'] : gmdate('c')),
+            'ttl_seconds' => $ttl,
+            'services'    => [],
+            'stale'       => $stale,
+        ];
+
+        if (! empty($stored['services']) && is_array($stored['services'])) {
+            foreach ($stored['services'] as $service) {
+                if (! is_array($service)) {
+                    continue;
+                }
+                $response['services'][] = lo_snapshot_normalize_service($service, $response['updated_at']);
+            }
+        }
+
+        return $response;
+    }
+}
+
+if (! function_exists('lo_snapshot_normalize_service')) {
+    function lo_snapshot_normalize_service(array $service, string $fetched_at): array
+    {
+        $status_code = strtolower((string) ($service['stateCode'] ?? $service['status'] ?? 'unknown'));
+        $status_label = (string) ($service['state'] ?? $service['status_label'] ?? ucfirst($status_code));
+        $updated_at = (string) ($service['updatedAt'] ?? $service['updated_at'] ?? $fetched_at);
+        $risk = 0;
+        if (isset($service['risk'])) {
+            $risk = (int) $service['risk'];
+        } elseif (isset($service['prealert']['risk'])) {
+            $risk = (int) $service['prealert']['risk'];
+        }
+
+        return [
+            'id'          => (string) ($service['id'] ?? $service['provider'] ?? ''),
+            'name'        => (string) ($service['name'] ?? $service['provider'] ?? ''),
+            'status'      => $status_code ?: 'unknown',
+            'status_text' => $status_label ?: 'Unknown',
+            'summary'     => (string) ($service['summary'] ?? $service['message'] ?? ''),
+            'updated_at'  => $updated_at ?: $fetched_at,
+            'url'         => (string) ($service['url'] ?? ''),
+            'risk'        => max(0, $risk),
+        ];
+    }
+}

--- a/plugins/lousy-outages/includes/Sources/CloudflareRadarSource.php
+++ b/plugins/lousy-outages/includes/Sources/CloudflareRadarSource.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages\Sources;
+
+use SuzyEaston\LousyOutages\SignalSourceInterface;
+
+class CloudflareRadarSource implements SignalSourceInterface {
+    private function token(): string { if (defined('LOUSY_OUTAGES_CLOUDFLARE_RADAR_TOKEN')) return (string) LOUSY_OUTAGES_CLOUDFLARE_RADAR_TOKEN; $env=getenv('LOUSY_OUTAGES_CLOUDFLARE_RADAR_TOKEN'); if($env) return (string)$env; return (string)get_option('lousy_outages_cloudflare_radar_token',''); }
+    public function id(): string { return 'cloudflare_radar'; }
+    public function label(): string { return 'Cloudflare Radar'; }
+    public function is_configured(): bool { return '' !== trim($this->token()); }
+    public function collect(array $options = []): array {
+        if (!$this->is_configured()) return [];
+        $endpoints = [
+            'internet_outage' => 'https://api.cloudflare.com/client/v4/radar/outages',
+            'traffic_anomaly' => 'https://api.cloudflare.com/client/v4/radar/anomalies'
+        ];
+        $out=[];
+        foreach($endpoints as $type=>$url){
+            $res = wp_remote_get($url,['timeout'=>8,'headers'=>['Authorization'=>'Bearer '.$this->token(),'User-Agent'=>'LousyOutages/'.(defined('LOUSY_OUTAGES_VERSION')?LOUSY_OUTAGES_VERSION:'0.1.0')]]);
+            if (is_wp_error($res)) continue;
+            if ((int)wp_remote_retrieve_response_code($res)!==200) continue;
+            $body=json_decode((string)wp_remote_retrieve_body($res),true);
+            $items=(array)($body['result'] ?? []);
+            foreach(array_slice($items,0,10) as $item){
+                $out[]=[ 'source'=>'cloudflare_radar','provider_id'=>sanitize_key((string)($item['asn'] ?? '')),'provider_name'=>sanitize_text_field((string)($item['name'] ?? $item['asn_name'] ?? 'Internet Health')),'category'=>'internet_health','region'=>sanitize_text_field((string)($item['location'] ?? $item['country'] ?? 'global')),'signal_type'=>$type,'severity'=>'degraded','confidence'=>70,'title'=>sanitize_text_field((string)($item['title'] ?? 'Internet-health anomaly detected')),'message'=>sanitize_text_field((string)($item['description'] ?? 'Unconfirmed external signal from internet-health telemetry.')),'url'=>esc_url_raw((string)($item['url'] ?? 'https://radar.cloudflare.com')),'observed_at'=>sanitize_text_field((string)($item['time'] ?? gmdate('Y-m-d H:i:s'))) ];
+            }
+        }
+        return $out;
+    }
+}

--- a/plugins/lousy-outages/includes/Sources/Sources.php
+++ b/plugins/lousy-outages/includes/Sources/Sources.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages\Sources;
+
+/**
+ * Registry for incident sources.
+ */
+class Sources
+{
+    /** @var array<string, object> */
+    private static array $sources = [];
+
+    public static function register(string $key, object $source): void
+    {
+        self::$sources[$key] = $source;
+    }
+
+    /**
+     * @return array<string, object>
+     */
+    public static function all(): array
+    {
+        return self::$sources;
+    }
+}

--- a/plugins/lousy-outages/includes/Sources/StatuspageSource.php
+++ b/plugins/lousy-outages/includes/Sources/StatuspageSource.php
@@ -1,0 +1,262 @@
+<?php
+// Compat class (no namespaces, no typed properties).
+if ( ! class_exists('LO_StatuspageSource') ) {
+  class LO_StatuspageSource {
+    /** @var string */ public $name;
+    /** @var string */ public $api;
+    /** @var string */ public $home;
+
+    function __construct($name, $api, $home) {
+      $this->name = (string)$name;
+      $this->api  = (string)$api;
+      $this->home = (string)$home;
+    }
+
+    /** Return shape expected by callers: ['status'=>string,'incidents'=>LO_Incident[],'updated'=>int] */
+    function fetch() {
+      $payload   = $this->fetch_payload();
+      $data      = isset($payload['data']) && is_array($payload['data']) ? $payload['data'] : null;
+      $incidents = is_array($data) ? $this->fetch_incidents($data) : array();
+      $overall   = 'unknown';
+      $updated   = time();
+
+      if (is_array($data)) {
+        $ind = isset($data['status']['indicator']) ? strtolower((string)$data['status']['indicator']) : 'none';
+        // 'none','minor','major','critical','maintenance'
+        $overall = ($ind==='none') ? 'operational'
+          : ($ind==='minor' ? 'degraded'
+          : ($ind==='major' ? 'partial_outage'
+          : ($ind==='critical' ? 'major_outage' : 'maintenance')));
+        if (!empty($data['page']['updated_at'])) {
+          $ts = strtotime((string)$data['page']['updated_at']);
+          if ($ts) $updated = $ts;
+        }
+      }
+
+      $result = array(
+        'status'    => $overall,
+        'incidents' => $incidents,
+        'updated'   => $updated,
+      );
+
+      if (!empty($payload['stale'])) {
+        $result['stale'] = true;
+      }
+
+      if (!empty($payload['message'])) {
+        $result['message'] = $payload['message'];
+      }
+
+      return $result;
+    }
+
+    /** @return array LO_Incident[] */
+    function fetch_incidents($payload = null) {
+      if (!is_array($payload)) {
+        $payload_response = $this->fetch_payload();
+        $payload = isset($payload_response['data']) && is_array($payload_response['data']) ? $payload_response['data'] : null;
+      }
+      if (!is_array($payload)) {
+        return array();
+      }
+
+      $out = array();
+
+      if (isset($payload['incidents']) && is_array($payload['incidents'])) {
+        foreach ($payload['incidents'] as $i) {
+          if (!is_array($i)) continue;
+          $raw   = isset($i['status']) ? strtolower((string)$i['status']) : '';
+          $impact = isset($i['impact']) ? strtolower((string)$i['impact']) : '';
+          $map   = array('investigating'=>'degraded','identified'=>'degraded','monitoring'=>'degraded','postmortem'=>'resolved','resolved'=>'resolved');
+          $state = isset($map[$raw]) ? $map[$raw] : 'degraded';
+          if ($state !== 'resolved' && $impact) {
+            $impact_map = array('minor'=>'degraded','major'=>'partial_outage','critical'=>'major_outage','maintenance'=>'maintenance');
+            if (isset($impact_map[$impact])) {
+              $state = $impact_map[$impact];
+            }
+          }
+
+          $title = isset($i['name']) ? (string)$i['name'] : 'Incident';
+          $url   = !empty($i['shortlink']) ? (string)$i['shortlink'] : $this->home;
+          $det   = !empty($i['started_at']) ? strtotime((string)$i['started_at'])
+                : (!empty($i['created_at']) ? strtotime((string)$i['created_at']) : time());
+          $resd  = ($state==='resolved' && !empty($i['resolved_at'])) ? strtotime((string)$i['resolved_at']) : null;
+
+          $out[] = LO_Incident::create(
+            $this->name,
+            LO_Incident::make_id($this->name, $title, $det ?: time()),
+            $title,
+            $state,
+            $url,
+            null,
+            null,
+            $det ?: time(),
+            $resd
+          );
+        }
+      }
+
+      // If no listed incidents, still show a card (operational/degraded by indicator)
+      if (empty($out) && isset($payload['status']['indicator'])) {
+        $ind = strtolower((string)$payload['status']['indicator']);
+        if ($ind === 'none') {
+          $out[] = LO_Incident::operational($this->name, $this->home);
+        } else {
+          $title = 'Provider reports ' . $ind . ' impact';
+          $state = ($ind==='minor' ? 'degraded' : ($ind==='major' ? 'partial_outage' : ($ind==='critical' ? 'major_outage' : 'maintenance')));
+          $slug = sanitize_key($this->name);
+          $id = $slug . ':indicator:' . $ind;
+          $updated = time();
+          if (!empty($payload['page']['updated_at'])) {
+            $ts = strtotime((string)$payload['page']['updated_at']);
+            if ($ts) $updated = $ts;
+          }
+          $out[] = LO_Incident::create($this->name, $id, $title, $state, $this->home, null, null, $updated, null);
+        }
+      }
+
+      return $out;
+    }
+
+    /** @return array{data:?array,stale?:bool,message?:string} */
+    private function fetch_payload() {
+      $cache_key = $this->cache_key();
+      $response  = $this->request_json($this->api);
+
+      if ($response['ok']) {
+        $data = $response['data'];
+        $this->store_cache($cache_key, $data);
+        return array('data' => $data);
+      }
+
+      $fallback = $this->fetch_fallback_payload();
+      if ($fallback) {
+        $this->store_cache($cache_key, $fallback);
+        return array('data' => $fallback);
+      }
+
+      $cached = get_transient($cache_key);
+      if (is_array($cached) && !empty($cached['data']) && is_array($cached['data'])) {
+        return array(
+          'data'  => $cached['data'],
+          'stale' => true,
+          'message' => 'Status temporarily unavailable (using cached data).',
+        );
+      }
+
+      return array(
+        'data' => null,
+        'message' => 'Status temporarily unavailable.',
+      );
+    }
+
+    private function fetch_fallback_payload() {
+      $base = $this->statuspage_base();
+      if (!$base) {
+        return null;
+      }
+
+      $base = trailingslashit($base);
+      $status_response = $this->request_json($base . 'api/v2/status.json');
+      if (! $status_response['ok']) {
+        return null;
+      }
+
+      $status_data = $status_response['data'];
+      $incidents_response = $this->request_json($base . 'api/v2/incidents/unresolved.json');
+      $incidents_data = $incidents_response['ok'] ? $incidents_response['data'] : null;
+
+      if (!is_array($status_data)) {
+        return null;
+      }
+
+      $payload = $status_data;
+      $payload['incidents'] = is_array($incidents_data) && isset($incidents_data['incidents']) && is_array($incidents_data['incidents'])
+        ? $incidents_data['incidents']
+        : [];
+
+      return $payload;
+    }
+
+    private function request_json($url) {
+      $res = wp_remote_get($url, array(
+        'timeout' => 10,
+        'headers' => $this->request_headers(),
+      ));
+
+      if (is_wp_error($res)) {
+        return array('ok' => false, 'code' => 0, 'data' => null);
+      }
+
+      $code = (int) wp_remote_retrieve_response_code($res);
+      if ($code < 200 || $code >= 300) {
+        return array('ok' => false, 'code' => $code, 'data' => null);
+      }
+
+      $body = (string) wp_remote_retrieve_body($res);
+      if ('' === trim($body)) {
+        return array('ok' => false, 'code' => $code, 'data' => null);
+      }
+
+      $json = json_decode($body, true);
+      if (!is_array($json)) {
+        return array('ok' => false, 'code' => $code, 'data' => null);
+      }
+
+      return array('ok' => true, 'code' => $code, 'data' => $json);
+    }
+
+    private function request_headers() {
+      return array(
+        'Accept'     => 'application/json',
+        'User-Agent' => $this->user_agent(),
+      );
+    }
+
+    private function statuspage_base() {
+      $base = preg_replace('#/api/v\\d+(?:\\.\\d+)?/summary\\.json$#', '/', (string)$this->api);
+      if ($base && $base !== $this->api) {
+        return $base;
+      }
+      if (!empty($this->home)) {
+        return $this->home;
+      }
+      return null;
+    }
+
+    private function cache_key() {
+      $slug = sanitize_key($this->name);
+      return 'lo_statuspage_cache_' . ($slug ?: md5($this->api));
+    }
+
+    private function store_cache($key, $data) {
+      $ttl = defined('HOUR_IN_SECONDS') ? 6 * HOUR_IN_SECONDS : 6 * 3600;
+      set_transient($key, array('data' => $data, 'cached_at' => time()), $ttl);
+    }
+
+    private function user_agent() {
+      $site = home_url();
+      return 'LousyOutagesStatus/1.0 (+'.$site.')';
+    }
+  }
+}
+
+// Bridge the namespaced calls to this compat class.
+if ( ! class_exists('SuzyEaston\\LousyOutages\\Sources\\StatuspageSource') ) {
+  class_alias('LO_StatuspageSource', 'SuzyEaston\\LousyOutages\\Sources\\StatuspageSource');
+}
+
+if ( ! class_exists('LousyOutages\\Sources\\StatuspageSource') ) {
+  class_alias('LO_StatuspageSource', 'LousyOutages\\Sources\\StatuspageSource');
+}
+
+// Incident compat (if not already present)
+if ( ! class_exists('LO_Incident') ) {
+  $compat = __DIR__ . '/../compat.php';
+  if ( file_exists($compat) ) {
+    require_once $compat;
+  }
+}
+if ( ! class_exists('LO_Incident') ) {
+  require_once __DIR__ . '/../Model/Incident.php';
+}

--- a/plugins/lousy-outages/includes/Sources/SyntheticCanarySource.php
+++ b/plugins/lousy-outages/includes/Sources/SyntheticCanarySource.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages\Sources;
+
+use SuzyEaston\LousyOutages\SignalSourceInterface;
+
+class SyntheticCanarySource implements SignalSourceInterface {
+    public function id(): string { return 'synthetic_canary'; }
+    public function label(): string { return 'Synthetic Canary'; }
+    public function is_configured(): bool { return (bool) apply_filters('lo_synthetic_canary_enabled', true); }
+    public function collect(array $options = []): array {
+        if (!$this->is_configured()) return [];
+        $targets = apply_filters('lo_synthetic_canary_targets', [[ 'id'=>'site_home','label'=>'Site Home','url'=>home_url('/'),'provider_id'=>'site','category'=>'site','region'=>'local','method'=>'HEAD','expected_statuses'=>[200,204,301,302],'timeout_seconds'=>5 ]]);
+        $max=max(1,min(10,(int)apply_filters('lo_synthetic_canary_max_targets',5)));
+        $out=[];
+        foreach(array_slice((array)$targets,0,$max) as $t){
+            $method=strtoupper((string)($t['method']??'HEAD')); $timeout=max(1,min(5,(int)($t['timeout_seconds']??5))); $url=esc_url_raw((string)($t['url']??'')); if(!$url) continue;
+            $start=microtime(true);
+            $res = $method==='GET' ? wp_remote_get($url,['timeout'=>$timeout,'redirection'=>2]) : wp_remote_head($url,['timeout'=>$timeout,'redirection'=>2]);
+            $elapsed=(microtime(true)-$start)*1000;
+            $expected=array_map('intval',(array)($t['expected_statuses']??[200,204,301,302]));
+            if (is_wp_error($res)) { $out[]=$this->failure($t,'http_check_failed','major','Synthetic check failed for '.($t['label']??$url),'A lightweight public canary check failed. This is an unconfirmed signal, not proof of a provider outage.'); continue; }
+            $code=(int)wp_remote_retrieve_response_code($res);
+            if (!in_array($code,$expected,true)) { $out[]=$this->failure($t,'http_check_failed','degraded','Synthetic check failed for '.($t['label']??$url),'Synthetic check failures observed. Official incident not yet confirmed.'); continue; }
+            $th=(float)apply_filters('lo_synthetic_canary_latency_ms',2500);
+            if ($elapsed > $th) { $out[]=$this->failure($t,'http_latency_high','degraded','Synthetic latency high for '.($t['label']??$url),'A lightweight public canary check failed. This is an unconfirmed signal.'); }
+        }
+        return $out;
+    }
+    private function failure(array $t,string $type,string $severity,string $title,string $msg): array { return ['source'=>'synthetic_canary','provider_id'=>sanitize_key((string)($t['provider_id']??$t['id']??'')),'provider_name'=>sanitize_text_field((string)($t['label']??'Synthetic Canary')),'category'=>sanitize_key((string)($t['category']??'synthetic')),'region'=>sanitize_text_field((string)($t['region']??'global')),'signal_type'=>$type,'severity'=>$severity,'confidence'=>40,'title'=>$title,'message'=>$msg,'url'=>esc_url_raw((string)($t['url']??'')),'observed_at'=>gmdate('Y-m-d H:i:s')]; }
+}

--- a/plugins/lousy-outages/includes/Sources/index.php
+++ b/plugins/lousy-outages/includes/Sources/index.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages\Sources;
+
+Sources::register('openai', new StatuspageSource('OpenAI', 'https://status.openai.com/api/v2/summary.json', 'https://status.openai.com'));
+Sources::register('teamviewer', new StatuspageSource('TeamViewer', 'https://status.teamviewer.com/api/v2/summary.json', 'https://status.teamviewer.com'));
+Sources::register('zscaler', new StatuspageSource('Zscaler', 'https://status.zscaler.com/api/v2/summary.json', 'https://status.zscaler.com'));
+Sources::register('cloudflare', new StatuspageSource('Cloudflare', 'https://www.cloudflarestatus.com/api/v2/summary.json', 'https://www.cloudflarestatus.com'));
+Sources::register('zoom', new StatuspageSource('Zoom', 'https://status.zoom.us/api/v2/summary.json', 'https://status.zoom.us'));

--- a/plugins/lousy-outages/includes/Storage/IncidentStore.php
+++ b/plugins/lousy-outages/includes/Storage/IncidentStore.php
@@ -1,0 +1,706 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages\Storage;
+
+use SuzyEaston\LousyOutages\Model\Incident;
+
+class IncidentStore
+{
+    private const OPTION_EVENTS = 'lo_event_log';
+    private const OPTION_EVENTS_COMPACTED = 'lo_event_log_compacted_v1';
+    private const OPTION_LAST_DIGEST = 'lousy_outages_daily_digest_last_sent';
+    private const ALERT_COOLDOWN = 90; // Minutes.
+    // Keep events long enough for multi-year comparisons.
+    private const EVENT_RETENTION = 2 * YEAR_IN_SECONDS; // (~24 months)
+    private const IMPORTANT_EVENT_RETENTION = 4 * YEAR_IN_SECONDS;
+    private const IMPORTANT_EVENT_CAP = 1000;
+
+    /**
+     * Determine whether an alert email should fire for the incident.
+     */
+    public function shouldSend(Incident $incident): bool
+    {
+        if (! $this->canSend($incident)) {
+            return false;
+        }
+
+        $this->markSent($incident);
+
+        return true;
+    }
+
+    /**
+     * Determine whether an alert email should fire for the incident without mutating send markers.
+     */
+    public function canSend(Incident $incident): bool
+    {
+        $providerKey = $this->providerKey($incident);
+        $guid        = $this->incidentGuid($incident);
+        $status      = $this->normalizeStatus($incident->status);
+
+        $this->updateLastStatus($providerKey, $status);
+
+        if ('operational' === $status) {
+            update_option($this->lastGuidOption($providerKey), '', false);
+            return false;
+        }
+
+        if ('maintenance' === $status) {
+            return false;
+        }
+
+        if (! in_array($status, ['incident', 'degraded', 'partial', 'major', 'critical'], true)) {
+            return false;
+        }
+
+        $classification = $this->classifyIncident($providerKey, $incident->title, $status);
+        if (! $classification['important']) {
+            return false;
+        }
+
+        $lastGuid = (string) get_option($this->lastGuidOption($providerKey), '');
+        if ('' !== $lastGuid && '' !== $guid && hash_equals($lastGuid, $guid)) {
+            return false;
+        }
+
+        $lastAlertAt = (int) get_option($this->lastAlertOption($providerKey), 0);
+        $now         = time();
+        if ($lastAlertAt && ($now - $lastAlertAt) < (self::ALERT_COOLDOWN * MINUTE_IN_SECONDS)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Persist last-send markers for an incident after successful delivery.
+     */
+    public function markSent(Incident $incident): void
+    {
+        $providerKey = $this->providerKey($incident);
+        $guid        = $this->incidentGuid($incident);
+        $status      = $this->normalizeStatus($incident->status);
+        $now         = time();
+
+        update_option($this->lastGuidOption($providerKey), $guid, false);
+        update_option($this->lastAlertOption($providerKey), $now, false);
+        update_option($this->lastStatusOption($providerKey), $status, false);
+    }
+
+    /**
+     * Persist incident snapshots for digest and history.
+     *
+     * @param Incident[] $incidents
+     */
+    public function persistIncidents(array $incidents): void
+    {
+        $events = $this->loadEvents();
+        $now    = time();
+
+        foreach ($incidents as $incident) {
+            if (! $incident instanceof Incident) {
+                continue;
+            }
+
+            $providerKey = $this->providerKey($incident);
+            $eventKey    = $this->eventKey($providerKey, $incident);
+            $status      = $this->normalizeStatus($incident->status);
+
+            $components = [];
+            if ($incident->component) {
+                $components[] = $incident->component;
+            }
+
+            $publishedTs = $incident->detected_at ?: $now;
+
+            $entry = [
+                'provider'       => $providerKey,
+                'provider_label' => $incident->provider,
+                'guid'           => $this->incidentGuid($incident),
+                'title'          => $incident->title,
+                'description'    => $incident->title,
+                'status'         => $status,
+                'components'     => $components,
+                'published'      => gmdate('Y-m-d H:i:s T', $publishedTs),
+                'first_seen'     => $publishedTs,
+                'last_seen'      => $now,
+                'url'            => $incident->url,
+                'raw'            => null,
+            ];
+
+            $classification          = $this->classifyIncident($providerKey, $incident->title, $status);
+            $entry['severity']       = $classification['severity'];
+            $entry['important']      = $classification['important'];
+            $entry['status_normal']  = $status;
+            $entry['impact_summary'] = $classification['summary'];
+
+            if (isset($events[$eventKey]['first_seen'])) {
+                $entry['first_seen'] = (int) $events[$eventKey]['first_seen'];
+            }
+
+            $events[$eventKey] = $entry;
+        }
+
+        $events = $this->pruneEvents($events, $now);
+        update_option(self::OPTION_EVENTS, $events, false);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function addUserReport(string $providerId, string $summary, string $contact = '', string $providerLabel = ''): array
+    {
+        $events = $this->loadEvents();
+        $now    = time();
+
+        $providerKey   = sanitize_key($providerId) ?: 'provider';
+        $providerLabel = '' !== trim($providerLabel) ? trim($providerLabel) : ucfirst($providerKey);
+        $cleanSummary  = trim($summary);
+        $cleanContact  = trim($contact);
+
+        $eventKey = 'user_report|' . $providerKey . '|' . sha1($cleanSummary . '|' . microtime(true));
+
+        $event = [
+            'provider'       => $providerKey,
+            'provider_label' => $providerLabel,
+            'guid'           => $eventKey,
+            'title'          => 'User report',
+            'description'    => $cleanSummary,
+            'status'         => 'User-reported issue',
+            'status_normal'  => 'User-reported issue',
+            'severity'       => 'user_report',
+            'important'      => true,
+            'impact_summary' => $cleanSummary,
+            'source'         => 'user_report',
+            'published'      => gmdate('Y-m-d H:i:s T', $now),
+            'first_seen'     => $now,
+            'last_seen'      => $now,
+        ];
+
+        if ('' !== $cleanContact) {
+            $event['user_contact'] = $cleanContact;
+        }
+
+        $events[$eventKey] = $event;
+
+        $events = $this->pruneEvents($events, $now);
+        update_option(self::OPTION_EVENTS, $events, false);
+
+        return $event;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getStoredIncidents(): array
+    {
+        $stored = $this->loadEvents();
+        return array_values($stored);
+    }
+
+    /**
+     * Return incidents between two timestamps, filtered to outage-like severities by default.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function getIncidentsInRange(int $start, int $end, bool $importantOnly = true): array
+    {
+        $events   = $this->loadEvents();
+        $filtered = [];
+
+        foreach ($events as $event) {
+            if (!is_array($event)) {
+                continue;
+            }
+
+            $event = $this->normalizeEvent($event);
+
+            $firstSeen = isset($event['first_seen']) ? (int) $event['first_seen'] : 0;
+            $lastSeen  = isset($event['last_seen']) ? (int) $event['last_seen'] : $firstSeen;
+            $timestamp = $lastSeen ?: $firstSeen;
+
+            if ($timestamp <= 0) {
+                continue;
+            }
+
+            if ($timestamp < $start || $timestamp > $end) {
+                continue;
+            }
+
+            $severity  = isset($event['severity']) ? strtolower((string) $event['severity']) : 'incident';
+            $important = isset($event['important']) ? (bool) $event['important'] : true;
+
+            if ($importantOnly && (! $important || in_array($severity, ['maintenance', 'info'], true))) {
+                continue;
+            }
+
+            if (in_array($severity, ['operational', 'ok', 'none'], true)) {
+                continue;
+            }
+
+            $filtered[] = $event;
+        }
+
+        return $filtered;
+    }
+
+    public function getYearOverYearWindow(int $days, bool $importantOnly = true): array
+    {
+        $now          = time();
+        $currentStart = $now - ($days * DAY_IN_SECONDS);
+        $prevStart    = $currentStart - YEAR_IN_SECONDS;
+        $prevEnd      = $now - YEAR_IN_SECONDS;
+
+        return [
+            'current'  => $this->summarizeWindow($currentStart, $now, $importantOnly),
+            'previous' => $this->summarizeWindow($prevStart, $prevEnd, $importantOnly),
+        ];
+    }
+
+    /**
+     * @return array{start: int, end: int, total: int, daily_counts: array<string, int>, events: array<int, array<string, mixed>>}
+     */
+    private function summarizeWindow(int $start, int $end, bool $importantOnly = true): array
+    {
+        $events       = $this->getIncidentsInRange($start, $end, $importantOnly);
+        $dailyCounts  = [];
+
+        foreach ($events as $event) {
+            $firstSeen = isset($event['first_seen']) ? (int) $event['first_seen'] : 0;
+            $lastSeen  = isset($event['last_seen']) ? (int) $event['last_seen'] : $firstSeen;
+            $timestamp = $lastSeen ?: $firstSeen;
+            if (!$timestamp) {
+                continue;
+            }
+
+            $date = gmdate('Y-m-d', $timestamp);
+            $dailyCounts[$date] = ($dailyCounts[$date] ?? 0) + 1;
+        }
+
+        return [
+            'start'        => $start,
+            'end'          => $end,
+            'total'        => count($events),
+            'daily_counts' => $dailyCounts,
+            'events'       => $events,
+        ];
+    }
+
+    /**
+     * Ensure historical events carry the latest classification fields.
+     *
+     * @param array<string, mixed> $event
+     * @return array<string, mixed>
+     */
+    public function normalizeEvent(array $event): array
+    {
+        $status     = $this->normalizeStatus((string) ($event['status'] ?? ''));
+        $title      = isset($event['title']) ? (string) $event['title'] : '';
+        $providerId = isset($event['provider']) ? (string) $event['provider'] : '';
+        $severity   = isset($event['severity']) ? strtolower((string) $event['severity']) : '';
+        $source     = isset($event['source']) ? (string) $event['source'] : '';
+
+        $isUserReport  = ('user_report' === $source || 'user_report' === $severity);
+        $isOperational = in_array($severity, ['operational', 'ok', 'none'], true);
+
+        $classification = $this->classifyIncident($providerId, $title, $status);
+
+        if (! $isUserReport && ! $isOperational) {
+            $event['severity']       = $classification['severity'];
+            $event['important']      = $classification['important'];
+            $event['impact_summary'] = $classification['summary'];
+            $event['status_normal']  = $status;
+
+            if ('maintenance' === $classification['severity'] && 'degraded' === $status) {
+                $event['status_normal'] = 'maintenance';
+            }
+        } else {
+            $event['status_normal'] = $event['status_normal'] ?? $status;
+        }
+
+        return $event;
+    }
+
+    public function getLastDigestSent(): string
+    {
+        $value = get_option(self::OPTION_LAST_DIGEST, '');
+        return is_string($value) ? $value : '';
+    }
+
+    public function updateLastDigestSent(string $iso): void
+    {
+        update_option(self::OPTION_LAST_DIGEST, $iso, false);
+    }
+
+    private function providerKey(Incident $incident): string
+    {
+        $slug = '';
+        if (false !== strpos($incident->id, ':')) {
+            $slug = substr($incident->id, 0, (int) strpos($incident->id, ':')) ?: '';
+        }
+
+        if ('' === $slug) {
+            $slug = $incident->provider;
+        }
+
+        $slug = sanitize_key((string) $slug);
+
+        return $slug ?: 'provider';
+    }
+
+    private function incidentGuid(Incident $incident): string
+    {
+        $guid = trim((string) $incident->id);
+        if ('' !== $guid) {
+            return $guid;
+        }
+
+        return sha1($incident->provider . '|' . $incident->title . '|' . $incident->detected_at);
+    }
+
+    private function normalizeStatus(string $status): string
+    {
+        $status = strtolower(trim($status));
+
+        switch ($status) {
+            case 'resolved':
+            case 'operational':
+            case 'none':
+                return 'operational';
+            case 'maintenance':
+            case 'maintenance_window':
+                return 'maintenance';
+            case 'degraded':
+            case 'minor':
+            case 'investigating':
+            case 'identified':
+            case 'monitoring':
+                return 'degraded';
+            case 'partial':
+            case 'partial_outage':
+                return 'partial';
+            case 'major_outage':
+            case 'major':
+            case 'outage':
+                return 'major';
+            case 'critical':
+                return 'critical';
+        }
+
+        return $status ? 'incident' : 'incident';
+    }
+
+    /**
+     * @return array{severity: string, important: bool, summary: string}
+     */
+    public function classifyIncident(string $providerKey, string $title, string $status): array
+    {
+        $normalizedStatus = $this->normalizeStatus($status);
+        $severity         = $this->mapSeverity($normalizedStatus);
+        $titleLower       = strtolower($title);
+        $providerLower    = strtolower($providerKey);
+        $important        = ! in_array($severity, ['maintenance', 'info'], true);
+        $summary          = '';
+
+        // Zscaler maintenance / expansion advisories are very noisy.
+        if ('zscaler' === $providerLower) {
+            $noisePatterns = [
+                'reminder',
+                'upcoming',
+                'url filtering',
+                'url filtering rules',
+                'pagination',
+                'search functionality',
+                'admin',
+                'administrator',
+                'portal',
+                'dashboard',
+                'analytics',
+                'audit log',
+                'policy',
+                'rules',
+                'allowlist',
+                'allow list',
+                'update to',
+                'scheduled update',
+                'security update',
+                'advisory',
+                'react2shell',
+                'data center expansions',
+                'data centre expansions',
+                'new dcs',
+                'additions to hub ip address ranges',
+                'aggregate & hub ip',
+                'aggregate and hub ip',
+                'hub ip address ranges',
+                'addition to hub services',
+                'additions to hub services',
+                'hub services',
+                'datacenter network maintenance',
+                'datacentre network maintenance',
+                'critical datacenter network maintenance',
+                'critical datacentre network maintenance',
+                'upcoming new dcs and expansions',
+                'upcoming data center expansions',
+                'allowlist',
+                'allow list',
+                'action required',
+                'expansion',
+            ];
+            $impactWords = [
+                'traffic forwarding',
+                'not loading',
+                'issue',
+                'degradation',
+                'customers may experience',
+                'impact',
+                'outage',
+                'disruption',
+                'failure',
+            ];
+
+            $filteredNoise = apply_filters('lo_zscaler_noise_patterns', $noisePatterns);
+            if (! is_array($filteredNoise)) {
+                $filteredNoise = $noisePatterns;
+            }
+            $noisePatterns = $filteredNoise;
+
+            $filteredImpact = apply_filters('lo_zscaler_impact_terms', $impactWords);
+            if (! is_array($filteredImpact)) {
+                $filteredImpact = $impactWords;
+            }
+            $impactWords = $filteredImpact;
+
+            $hasImpact = false;
+            foreach ($impactWords as $signal) {
+                if (false !== strpos($titleLower, (string) $signal)) {
+                    $hasImpact = true;
+                    break;
+                }
+            }
+
+            $hasNoise = false;
+            foreach ($noisePatterns as $pattern) {
+                if (false !== strpos($titleLower, (string) $pattern)) {
+                    $hasNoise = true;
+                    break;
+                }
+            }
+
+            if ($hasNoise && ! $hasImpact) {
+                $severity  = 'maintenance';
+                $important = false;
+                $summary   = 'Filtered Zscaler advisory';
+            }
+        }
+
+        if ('cloudflare' === $providerLower) {
+            if (false !== strpos($titleLower, 'provider reports minor impact')) {
+                $important = false;
+                $severity  = 'info';
+                $summary   = 'Minor Cloudflare signal suppressed';
+            }
+
+            // Suppress status-only Cloudflare indicator events (digest-only).
+            if (preg_match('/^cloudflare status:\s*(degraded|partial(?: outage)?|major(?: outage)?|critical)$/', $titleLower)) {
+                $important = false;
+                $severity  = 'info';
+                $summary   = 'Cloudflare status-only indicator suppressed (digest-only)';
+            }
+        }
+
+        if ('maintenance' === $severity && '' === $summary) {
+            $maintenanceNoise = ['upgrade', 'expansion', 'expanding', 'migration', 'deploy', 'capacity'];
+            foreach ($maintenanceNoise as $word) {
+                if (false !== strpos($titleLower, $word)) {
+                    $important = false;
+                    $summary   = 'Maintenance advisory';
+                    break;
+                }
+            }
+        }
+
+        if (! $summary) {
+            $summary = $important ? 'Significant incident' : 'Informational incident';
+        }
+
+        return [
+            'severity'  => $severity,
+            'important' => $important,
+            'summary'   => $summary,
+        ];
+    }
+
+    private function mapSeverity(string $status): string
+    {
+        switch ($status) {
+            case 'major':
+            case 'critical':
+            case 'major_outage':
+            case 'outage':
+                return 'outage';
+            case 'partial':
+            case 'partial_outage':
+            case 'degraded':
+                return 'degraded';
+            case 'maintenance':
+                return 'maintenance';
+            case 'operational':
+                return 'info';
+        }
+
+        return 'degraded';
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function loadEvents(): array
+    {
+        $stored = get_option(self::OPTION_EVENTS, []);
+        if (! is_array($stored)) {
+            return [];
+        }
+
+        $compacted = get_option(self::OPTION_EVENTS_COMPACTED, false);
+        if (! $compacted && count($stored) > 1000) {
+            $stored = $this->compactNoisyEvents($stored);
+            update_option(self::OPTION_EVENTS, $stored, false);
+            update_option(self::OPTION_EVENTS_COMPACTED, 1, false);
+        }
+
+        return $stored;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $events
+     * @return array<string, array<string, mixed>>
+     */
+    private function pruneEvents(array $events, int $now): array
+    {
+        $standardCutoff  = $now - self::EVENT_RETENTION;
+        $importantCutoff = $now - self::IMPORTANT_EVENT_RETENTION;
+        $importantEvents = [];
+
+        foreach ($events as $key => $event) {
+            $lastSeen = isset($event['last_seen']) ? (int) $event['last_seen'] : 0;
+            $severity = isset($event['severity']) ? strtolower((string) $event['severity']) : '';
+            $important = !empty($event['important']);
+            $isImportantIncident = $important && in_array($severity, ['outage', 'degraded'], true);
+            $cutoff = $isImportantIncident ? $importantCutoff : $standardCutoff;
+
+            if ($cutoff > 0 && $lastSeen && $lastSeen < $cutoff) {
+                unset($events[$key]);
+                continue;
+            }
+
+            if ($isImportantIncident && $lastSeen) {
+                $importantEvents[$key] = $lastSeen;
+            }
+        }
+
+        if (count($importantEvents) > self::IMPORTANT_EVENT_CAP) {
+            asort($importantEvents, SORT_NUMERIC);
+            $excess = count($importantEvents) - self::IMPORTANT_EVENT_CAP;
+            foreach (array_keys($importantEvents) as $key) {
+                if ($excess <= 0) {
+                    break;
+                }
+                unset($events[$key]);
+                $excess--;
+            }
+        }
+
+        return $events;
+    }
+
+    /**
+     * Remove noisy duplicate synthetic indicator events.
+     *
+     * @param array<string, array<string, mixed>> $events
+     * @return array<string, array<string, mixed>>
+     */
+    private function compactNoisyEvents(array $events): array
+    {
+        $keepLatest = [];
+        $now = time();
+        $cloudflareCutoff = $now - (7 * DAY_IN_SECONDS);
+        $allowedIndicators = ['minor', 'major', 'critical', 'maintenance'];
+
+        foreach ($events as $key => $event) {
+            if (! is_array($event)) {
+                continue;
+            }
+
+            $provider = isset($event['provider']) ? sanitize_key((string) $event['provider']) : '';
+            $title    = isset($event['title']) ? strtolower((string) $event['title']) : '';
+            $guid     = isset($event['guid']) ? strtolower((string) $event['guid']) : '';
+
+            $indicator = '';
+
+            if (false !== strpos($guid, ':indicator:')) {
+                $parts = explode(':indicator:', $guid);
+                $indicator = isset($parts[1]) ? strtolower((string) $parts[1]) : '';
+            } elseif (0 === strpos($title, 'provider reports ')) {
+                if (preg_match('/^provider reports\s+([a-z]+)\s+impact/', $title, $matches)) {
+                    $indicator = strtolower($matches[1]);
+                }
+            }
+
+            if (! in_array($indicator, $allowedIndicators, true)) {
+                continue;
+            }
+
+            $lastSeen = isset($event['last_seen']) ? (int) $event['last_seen'] : 0;
+            $firstSeen = isset($event['first_seen']) ? (int) $event['first_seen'] : 0;
+            $timestamp = $lastSeen ?: $firstSeen;
+
+            if ('cloudflare' === $provider && $timestamp && $timestamp < $cloudflareCutoff) {
+                unset($events[$key]);
+                continue;
+            }
+
+            $dedupeKey = $provider . '|' . $indicator;
+            if (! isset($keepLatest[$dedupeKey])) {
+                $keepLatest[$dedupeKey] = ['key' => $key, 'timestamp' => $timestamp];
+                continue;
+            }
+
+            $existing = $keepLatest[$dedupeKey];
+            if ($timestamp >= $existing['timestamp']) {
+                unset($events[$existing['key']]);
+                $keepLatest[$dedupeKey] = ['key' => $key, 'timestamp' => $timestamp];
+            } else {
+                unset($events[$key]);
+            }
+        }
+
+        return $events;
+    }
+
+    private function eventKey(string $providerKey, Incident $incident): string
+    {
+        return $providerKey . '|' . $this->incidentGuid($incident);
+    }
+
+    private function lastGuidOption(string $providerKey): string
+    {
+        return 'lo_last_guid_' . $providerKey;
+    }
+
+    private function lastStatusOption(string $providerKey): string
+    {
+        return 'lo_last_status_' . $providerKey;
+    }
+
+    private function lastAlertOption(string $providerKey): string
+    {
+        return 'lo_last_alert_at_' . $providerKey;
+    }
+
+    private function updateLastStatus(string $providerKey, string $status): void
+    {
+        update_option($this->lastStatusOption($providerKey), $status, false);
+    }
+}

--- a/plugins/lousy-outages/includes/Store.php
+++ b/plugins/lousy-outages/includes/Store.php
@@ -1,0 +1,116 @@
+<?php
+namespace SuzyEaston\LousyOutages;
+
+class Store {
+    private string $option = 'lousy_outages_states';
+    private string $log_option = 'lousy_outages_log';
+    private string $history_option = 'lousy_outages_history';
+    private int $history_retention = 3 * YEAR_IN_SECONDS; // retain 3 years of daily signals.
+
+    public function get_all(): array {
+        $stored = get_option( $this->option, [] );
+
+        if ( ! is_array( $stored ) || empty( $stored ) ) {
+            return [];
+        }
+
+        $enabled = Providers::enabled();
+        if ( ! is_array( $enabled ) || empty( $enabled ) ) {
+            return [];
+        }
+
+        $allowed = array_fill_keys( array_keys( $enabled ), true );
+
+        return array_intersect_key( $stored, $allowed );
+    }
+
+    public function get( string $id ): ?array {
+        $all = $this->get_all();
+        return $all[ $id ] ?? null;
+    }
+
+    public function update( string $id, array $data ): void {
+        $status = $data['status'] ?? 'unknown';
+        if ( empty( $data['status_label'] ) ) {
+            $data['status_label'] = Fetcher::status_label( $status );
+        }
+        $all        = $this->get_all();
+        $all[ $id ] = $data;
+        update_option( $this->option, $all, false );
+        $this->log( $id, $status );
+    }
+
+    private function log( string $id, string $status ): void {
+        $log   = get_option( $this->log_option, [] );
+        $log[] = [ 'id' => $id, 'status' => $status, 'time' => time() ];
+        update_option( $this->log_option, $log, false );
+        $this->append_history( $id, $status, time() );
+    }
+
+    public function get_history_log(): array {
+        $history = get_option( $this->history_option, [] );
+        if ( ! is_array( $history ) ) {
+            return [];
+        }
+
+        return array_values( $history );
+    }
+
+    /**
+     * Return all history entries within a specific window.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function get_history_window( int $start, int $end ): array {
+        $history = $this->get_history_log();
+
+        return array_values( array_filter( $history, static function ( $entry ) use ( $start, $end ) {
+            if ( ! is_array( $entry ) || ! isset( $entry['time'] ) ) {
+                return false;
+            }
+
+            $timestamp = (int) $entry['time'];
+
+            return $timestamp >= $start && $timestamp <= $end;
+        } ) );
+    }
+
+    /**
+     * Provide current and previous-year windows to support year-over-year comparisons.
+     */
+    public function get_year_over_year_history( int $days ): array {
+        $now           = time();
+        $currentStart  = $now - ( $days * DAY_IN_SECONDS );
+        $previousStart = $currentStart - YEAR_IN_SECONDS;
+        $previousEnd   = $now - YEAR_IN_SECONDS;
+
+        return [
+            'current'  => $this->get_history_window( $currentStart, $now ),
+            'previous' => $this->get_history_window( $previousStart, $previousEnd ),
+        ];
+    }
+
+    private function append_history( string $id, string $status, int $timestamp ): void {
+        $history = get_option( $this->history_option, [] );
+        if ( ! is_array( $history ) ) {
+            $history = [];
+        }
+
+        $history[] = [
+            'id'     => $id,
+            'status' => $status,
+            'time'   => $timestamp,
+        ];
+
+        $cutoff = time() - $this->history_retention;
+        $history = array_values( array_filter( $history, static function ( $entry ) use ( $cutoff ) {
+            if ( ! is_array( $entry ) || ! isset( $entry['time'] ) ) {
+                return false;
+            }
+
+            return (int) $entry['time'] >= $cutoff;
+        } ) );
+
+        update_option( $this->history_option, $history, false );
+    }
+}

--- a/plugins/lousy-outages/includes/Subscribe.php
+++ b/plugins/lousy-outages/includes/Subscribe.php
@@ -1,0 +1,698 @@
+<?php
+declare(strict_types=1);
+
+use SuzyEaston\LousyOutages\IncidentAlerts;
+use SuzyEaston\LousyOutages\Mailer;
+use SuzyEaston\LousyOutages\Providers;
+use SuzyEaston\LousyOutages\SignalEngine;
+use SuzyEaston\LousyOutages\Subscriptions;
+use SuzyEaston\LousyOutages\UserReports;
+
+class Lousy_Outages_Subscribe {
+    public static function bootstrap(): void {
+        add_action('rest_api_init', [self::class, 'register_routes']);
+    }
+
+    public static function register_routes(): void {
+        register_rest_route('lousy-outages/v1', '/subscribe', [
+            'methods'             => 'POST',
+            'permission_callback' => '__return_true',
+            'args'                => [
+                'email' => [
+                    'required'          => true,
+                    'sanitize_callback' => 'sanitize_email',
+                    'validate_callback' => 'is_email',
+                ],
+            ],
+            'callback'            => 'lo_handle_subscribe',
+        ]);
+
+        register_rest_route('lousy-outages/v1', '/confirm', [
+            'methods'             => 'GET',
+            'callback'            => [self::class, 'confirm'],
+            'permission_callback' => '__return_true',
+        ]);
+
+        register_rest_route('lousy-outages/v1', '/unsubscribe', [
+            'methods'             => 'GET',
+            'callback'            => [self::class, 'unsubscribe'],
+            'permission_callback' => '__return_true',
+        ]);
+        register_rest_route('lousy-outages/v1', '/report', [
+            'methods' => 'POST',
+            'callback' => [self::class, 'report_issue'],
+            'permission_callback' => '__return_true',
+        ]);
+        register_rest_route('lousy-outages/v1', '/signals', [
+            'methods' => 'GET',
+            'callback' => [self::class, 'get_signals'],
+            'permission_callback' => '__return_true',
+        ]);
+
+    }
+
+    public static function report_issue(\WP_REST_Request $request) {
+        $provider_id = sanitize_key((string) $request->get_param('provider_id'));
+        $providers = Providers::list();
+        if (!isset($providers[$provider_id])) {
+            return new \WP_REST_Response(['success'=>false,'message'=>'Please select a valid provider.'], 400);
+        }
+
+        $result = UserReports::record_report([
+            'provider_id' => $provider_id,
+            'symptom' => (string) $request->get_param('symptom'),
+            'severity' => (string) $request->get_param('severity'),
+            'region' => (string) $request->get_param('region'),
+            'details' => (string) $request->get_param('details'),
+            'email' => (string) $request->get_param('email'),
+        ]);
+        if (!empty($result['rate_limited'])) {
+            return new \WP_REST_Response(['success'=>false,'rate_limited'=>true,'message'=>$result['message']], 429);
+        }
+        if (empty($result['success'])) {
+            return new \WP_REST_Response(['success'=>false,'message'=>'Unable to record that report right now.'], 400);
+        }
+        $count = UserReports::count_recent_reports($provider_id, 60);
+        $classification = SignalEngine::classify_score($count);
+        return new \WP_REST_Response([
+            'success'=>true,
+            'message'=>'Thanks — we logged your unconfirmed community report and we’re watching this.',
+            'provider_name'=>(string)$providers[$provider_id]['name'],
+            'signal_classification'=>$classification,
+            'report_count_window'=>$count,
+            'signals'=>SignalEngine::summarize_recent_signals(60),
+        ], 200);
+    }
+
+
+
+    public static function get_signals(\WP_REST_Request $request) {
+        $window = max(1, (int)$request->get_param('window_minutes'));
+        if ($window <= 1) { $window = 60; }
+        $signals = SignalEngine::summarize_fused_signals($window);
+        $safeSignals = [];
+        foreach ($signals as $signal) {
+            $safeSignals[] = [
+                'provider_id' => (string)($signal['provider_id'] ?? ''),
+                'provider_name' => (string)($signal['provider_name'] ?? ''),
+                'classification' => (string)($signal['classification'] ?? 'quiet'),
+                'report_count' => (int)($signal['report_count'] ?? 0),
+                                'region' => (string)($signal['region'] ?? ''),
+                'message' => (string)($signal['message'] ?? ''),
+                'category' => (string)($signal['category'] ?? ''),
+                'region' => (string)($signal['region'] ?? ''),
+                'confidence' => (int)($signal['confidence'] ?? 0),
+                'external_signal_count' => (int)($signal['external_signal_count'] ?? 0),
+                'synthetic_failure_count' => (int)($signal['synthetic_failure_count'] ?? 0),
+                'sources' => array_values(array_map('strval', (array)($signal['sources'] ?? []))),
+                'confirmed' => !empty($signal['confirmed']),
+                'last_observed_at' => (string)($signal['last_observed_at'] ?? ''),
+                'official_status_known' => !empty($signal['official_status_known']),
+            ];
+        }
+
+        return new \WP_REST_Response([
+            'success' => true,
+            'window_minutes' => $window,
+            'signals' => $safeSignals,
+            'generated_at' => gmdate('c'),
+        ], 200);
+    }
+    public static function confirm(\WP_REST_Request $request) {
+        $token = sanitize_text_field((string) $request->get_param('token'));
+        if ('' === $token) {
+            return self::redirect_with_status('invalid');
+        }
+
+        $record = Subscriptions::find_by_token($token);
+        if (!$record) {
+            return self::redirect_with_status('invalid');
+        }
+
+        $status = strtolower((string) ($record['status'] ?? ''));
+        $email  = isset($record['email']) ? sanitize_email((string) $record['email']) : '';
+
+        if (Subscriptions::STATUS_SUBSCRIBED === $status) {
+            if ($email && is_email($email)) {
+                self::send_already_subscribed_email($email, $token);
+            }
+            return self::redirect_with_status('confirmed');
+        }
+
+        if (!self::mark_confirmed($token)) {
+            return self::redirect_with_status('invalid');
+        }
+
+        if ($email && is_email($email)) {
+            IncidentAlerts::add_subscriber($email);
+            self::send_welcome_email($email, $token);
+        }
+
+        return self::redirect_with_status('confirmed');
+    }
+
+    public static function unsubscribe(\WP_REST_Request $request) {
+        $token = sanitize_text_field((string) $request->get_param('token'));
+        if ('' === $token) {
+            return self::redirect_with_status('invalid');
+        }
+
+        $record = Subscriptions::find_by_token($token);
+        if (!$record) {
+            return self::redirect_with_status('invalid');
+        }
+
+        if (!self::mark_unsubscribed($token)) {
+            return self::redirect_with_status('invalid');
+        }
+
+        $email = isset($record['email']) ? sanitize_email((string) $record['email']) : '';
+        if ($email && is_email($email)) {
+            IncidentAlerts::remove_subscriber($email);
+            self::send_unsubscribed_email($email);
+        }
+
+        return self::redirect_with_status('unsubscribed');
+    }
+
+    public static function send_confirm_email(string $email, string $token): void {
+        $email = sanitize_email($email);
+        if (!$email || !is_email($email)) {
+            return;
+        }
+
+        $confirm_url = add_query_arg('token', rawurlencode($token), rest_url('lousy-outages/v1/confirm'));
+
+        $unsubscribe_url = lo_unsubscribe_url_for($email);
+        $sent            = lo_send_confirmation($email, $confirm_url);
+
+        do_action('lousy_outages_log', 'confirmation_email_dispatched', [
+            'email'           => $email,
+            'sent'            => $sent,
+            'confirm_url'     => $confirm_url,
+            'unsubscribe_url' => $unsubscribe_url,
+        ]);
+    }
+
+    private static function mark_confirmed(string $token): bool {
+        $record = Subscriptions::find_by_token($token);
+        if (!$record) {
+            return false;
+        }
+
+        $status  = strtolower((string) ($record['status'] ?? ''));
+        $created = isset($record['created_at']) ? strtotime((string) $record['created_at']) : false;
+        $cutoff  = time() - 14 * DAY_IN_SECONDS;
+
+        if (Subscriptions::STATUS_PENDING === $status) {
+            if (!$created || $created < $cutoff) {
+                Subscriptions::update_status_by_token($token, Subscriptions::STATUS_UNSUBSCRIBED);
+                return false;
+            }
+
+            return Subscriptions::update_status_by_token($token, Subscriptions::STATUS_SUBSCRIBED);
+        }
+
+        if (Subscriptions::STATUS_SUBSCRIBED === $status) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static function mark_unsubscribed(string $token): bool {
+        $record = Subscriptions::find_by_token($token);
+        if (!$record) {
+            return false;
+        }
+
+        if (Subscriptions::STATUS_UNSUBSCRIBED === strtolower((string) ($record['status'] ?? ''))) {
+            return true;
+        }
+
+        return Subscriptions::update_status_by_token($token, Subscriptions::STATUS_UNSUBSCRIBED);
+    }
+
+    private static function redirect_with_status(string $status) {
+        $status = sanitize_key($status);
+        if ($status) {
+            self::store_flash_cookie($status);
+        }
+        return self::redirect('/lousy-outages/?sub=' . rawurlencode($status ?: '')); 
+    }
+
+    private static function store_flash_cookie(string $status): void {
+        if (headers_sent()) {
+            return;
+        }
+
+        $value = sanitize_key($status);
+        if ('' === $value) {
+            return;
+        }
+
+        $params = [
+            'expires'  => time() + 300,
+            'path'     => '/',
+            'secure'   => is_ssl(),
+            'httponly' => false,
+            'samesite' => 'Lax',
+        ];
+
+        setcookie('lo_sub_msg', $value, $params);
+    }
+
+    private static function redirect(string $path) {
+        status_header(302);
+        header('Location: ' . home_url($path));
+        exit;
+    }
+
+    private static function send_welcome_email(string $email, string $token): void {
+        $unsubscribe_url = lo_unsubscribe_url_for($email);
+        $dashboard_url = home_url('/lousy-outages/');
+
+        $subject = '🔔 Subscribed to Lousy Outages';
+
+        $text_body = <<<TEXT
+confirmed. you're now getting the Lousy Outages briefings. 🛰️
+
+expect:
+- outage and degradation alerts for cloudflare, aws, azure, google cloud, google workspace, slack, zscaler, qubeyond (and their friends)
+- mini postmortems with timelines + impact notes
+- security watch items so you can harden things before the next wobble
+
+open the live dashboard any time:
+{$dashboard_url}
+
+need out? one-click escape hatch:
+<{$unsubscribe_url}>
+
+"Stay hungry. Stay foolish."
+— Steve Jobs
+ 
+ ps: make sure the alerts land — add suzyeaston.ca to your safe senders and peek at spam if nothing shows up.
+TEXT;
+
+        $html_body = <<<HTML
+<!doctype html>
+<meta charset="utf-8">
+<body style="font-family: ui-sans-serif,system-ui,Segoe UI,Roboto,Arial; background:#050505; color:#ffe9c4;">
+  <div style="max-width:560px;margin:24px auto;padding:20px;border:2px solid #ffb81c;border-radius:14px;background:linear-gradient(140deg,#0b0b0b,#1a0b00);box-shadow:0 18px 36px rgba(0,0,0,0.45);">
+    <h2 style="margin:0 0 10px;font-size:20px;color:#ffb81c;text-transform:uppercase;letter-spacing:0.05em;">✅ link established</h2>
+    <p style="margin:0 0 12px;">welcome to the status underground.</p>
+    <p style="margin:0 0 18px;">you'll get alerts when providers wobble: cloudflare • aws • azure • google cloud • google workspace • slack • zscaler • qubeyond.</p>
+    <p style="margin:0 0 18px;"><a href="{$dashboard_url}" style="display:inline-block;padding:12px 18px;border-radius:999px;border:2px solid #ffb81c;background:#f04e23;color:#050505;font-weight:700;text-decoration:none;">OPEN LIVE DASHBOARD</a></p>
+    <blockquote style="margin:12px 0;padding:10px 14px;border-left:3px solid rgba(255,184,28,0.8);background:rgba(255,184,28,0.08);">
+      "Stay hungry. Stay foolish."<br>
+      — Steve Jobs
+    </blockquote>
+    <p style="margin:14px 0 0;font-size:13px;opacity:.85;">unsubscribe anytime: <a href="{$unsubscribe_url}" style="color:#ffb81c;">{$unsubscribe_url}</a></p>
+    <p style="margin:10px 0 0;font-size:12px;opacity:.85;">pro tip: add suzyeaston.ca to your safe senders so outage intel doesn’t get iced in spam.</p>
+  </div>
+</body>
+HTML;
+
+        Mailer::send($email, $subject, $text_body, $html_body);
+    }
+
+    private static function send_already_subscribed_email(string $email, string $token): void {
+        $dashboard_url      = home_url('/lousy-outages/');
+        $unsubscribe_url    = lo_unsubscribe_url_for($email);
+
+        $subject = 'you\'re already on the radar (all good)';
+
+        $text_body = <<<TEXT
+no double-hacking needed—your email is already subscribed.
+dashboard: {$dashboard_url}
+unsubscribe: <{$unsubscribe_url}>
+TEXT;
+
+        $html_body = <<<HTML
+<!doctype html>
+<meta charset="utf-8">
+<body style="font-family: ui-sans-serif,system-ui,Segoe UI,Roboto,Arial; background:#050505; color:#ffe9c4;">
+  <div style="max-width:560px;margin:24px auto;padding:20px;border:2px solid #ffb81c;border-radius:14px;background:linear-gradient(140deg,#0b0b0b,#1a0b00);box-shadow:0 18px 36px rgba(0,0,0,0.45);">
+    <h2 style="margin:0 0 8px;font-size:20px;color:#ffb81c;text-transform:uppercase;letter-spacing:0.05em;">already connected</h2>
+    <p style="margin:0 0 14px;">no double-hacking needed—your email is already subscribed.</p>
+    <p style="margin:0;font-weight:600;"><a href="{$dashboard_url}" style="color:#ffb81c;">open the dashboard</a> • <a href="{$unsubscribe_url}" style="color:#f04e23;">unsubscribe</a></p>
+  </div>
+</body>
+HTML;
+
+        Mailer::send($email, $subject, $text_body, $html_body);
+    }
+
+    private static function send_unsubscribed_email(string $email): void {
+        $resubscribe_url = home_url('/lousy-outages/?sub=check-email');
+
+        $subject = '🧹 wire cut. you\'re unsubscribed.';
+
+        $text_body = <<<TEXT
+you've been cleanly removed from Lousy Outages alerts.
+
+if this was a mistake, jack back in here:
+{$resubscribe_url}  (or just re-enter your email on the site)
+
+until next breach window—stay weird, stay patched.
+TEXT;
+
+        $html_body = <<<HTML
+<!doctype html>
+<meta charset="utf-8">
+<body style="font-family: ui-sans-serif,system-ui,Segoe UI,Roboto,Arial; background:#050505; color:#ffe9c4;">
+  <div style="max-width:560px;margin:24px auto;padding:20px;border:2px solid #ffb81c;border-radius:14px;background:linear-gradient(140deg,#0b0b0b,#1a0b00);box-shadow:0 18px 36px rgba(0,0,0,0.45);">
+    <h2 style="margin:0 0 10px;font-size:20px;color:#ffb81c;text-transform:uppercase;letter-spacing:0.05em;">🧹 wire cut</h2>
+    <p style="margin:0 0 12px;">you're unsubscribed and off the grid.</p>
+    <p style="margin:0 0 10px;opacity:.85;">if that was accidental, <a href="{$resubscribe_url}" style="color:#f04e23;">re-subscribe</a> any time.</p>
+    <p style="margin:0;font-size:12px;opacity:.7;">built in vancouver with coffee, riffs, and command-line confidence.</p>
+  </div>
+</body>
+HTML;
+
+        Mailer::send($email, $subject, $text_body, $html_body);
+    }
+}
+
+function lo_handle_subscribe(\WP_REST_Request $request) {
+    $responseParam  = $request->get_param('challenge_response');
+    $noscriptParam  = $request->get_param('lo_noscript_challenge');
+    $challengeReply = is_string($responseParam) ? trim((string) $responseParam) : '';
+    $noscriptFlag   = !empty($noscriptParam);
+
+    if (!lo_validate_lyric_captcha($challengeReply, $noscriptFlag)) {
+        return new \WP_Error(
+            'invalid_challenge',
+            'Please solve the human check to subscribe.',
+            [
+                'status' => 400,
+                'ok'     => false,
+            ]
+        );
+    }
+
+    $emailParam = $request->get_param('email');
+    $email      = is_string($emailParam) ? sanitize_email($emailParam) : '';
+    if (!$email || !is_email($email)) {
+        return new \WP_Error(
+            'invalid_email',
+            'Please provide a valid email address.',
+            [
+                'status' => 400,
+                'ok'     => false,
+            ]
+        );
+    }
+
+    $email = strtolower($email);
+    $providers = $request->get_param('providers');
+    if (!is_array($providers)) {
+        $providers = [];
+    }
+    $preferences = Subscriptions::normalize_preferences([
+        'providers' => $providers,
+        'realtime_alerts' => $request->get_param('realtime_alerts'),
+        'daily_digest' => $request->get_param('daily_digest'),
+        'newsletter' => $request->get_param('newsletter'),
+    ]);
+
+    $subscribers = get_option('suzy_newsletter', []);
+    if (!is_array($subscribers)) {
+        $subscribers = [];
+    }
+    if (!empty($preferences['newsletter']) && !in_array($email, $subscribers, true)) {
+        $subscribers[] = $email;
+        update_option('suzy_newsletter', array_values(array_unique($subscribers)), false);
+    }
+
+    $token   = lo_generate_subscribe_token($email);
+    $ip      = lo_detect_subscribe_ip($request);
+    $ip_hash = lo_hash_subscriber_ip($ip);
+    Subscriptions::save_pending_with_preferences($email, $token, $ip_hash, 'form', $preferences);
+
+    $domain = wp_parse_url(home_url(), PHP_URL_HOST);
+    if (!is_string($domain) || '' === $domain) {
+        $domain = (string) parse_url(site_url('/'), PHP_URL_HOST);
+    }
+    if ('' === $domain) {
+        $domain = 'example.com';
+    }
+    $domain = strtolower($domain);
+
+    $headers = [
+        'Content-Type: text/html; charset=UTF-8',
+    ];
+
+    $transport    = getenv('SMTP_HOST') ? 'smtp' : 'mail';
+    $sendmailPath = ini_get('sendmail_path') ?: '';
+    $debugParam   = $request->get_param('deliverability');
+    if (is_string($debugParam) && 'debug' === strtolower($debugParam)) {
+        return rest_ensure_response([
+            'transport'     => $transport,
+            'headers'       => $headers,
+            'mailer'        => 'SuzyEaston\\LousyOutages\\Mailer',
+            'domain'        => $domain,
+            'sendmail_path' => $sendmailPath,
+        ]);
+    }
+
+    $default_confirm_url = add_query_arg(
+        'token',
+        rawurlencode($token),
+        rest_url('lousy-outages/v1/confirm')
+    );
+
+    $confirm_url_filter = apply_filters('lo_subscribe_confirmation_url', '', $email, $request, $token);
+    if (!is_string($confirm_url_filter) || '' === trim($confirm_url_filter)) {
+        $confirm_url_filter = $default_confirm_url;
+    }
+
+    $sent = lo_send_confirmation($email, $confirm_url_filter, $preferences);
+
+    $admin_email = apply_filters('lo_admin_notification_email', 'admin@suzyeaston.ca', $email, $request);
+    $ok_admin    = false;
+    if ($admin_email && is_email($admin_email)) {
+        $subscriber_email   = esc_html($email);
+        $subscriber_count   = count($subscribers);
+        $subscriber_counter = number_format_i18n($subscriber_count);
+        $timestamp_display  = esc_html(wp_date('F j, Y g:i A T'));
+        $list_manage_url    = esc_url(admin_url('admin.php?page=lousy-outages'));
+
+        $admin_subject = '🌩️ Neon ping: a new Lousy Outages subscriber';
+        $admin_body    = <<<HTML
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"></head>
+<body style="margin:0;background:#0d0221;color:#f8f6ff;font-family:Helvetica,Arial,sans-serif;">
+    <div style="max-width:520px;margin:0 auto;padding:32px 28px;">
+        <div style="background:linear-gradient(135deg,#341671,#f72585);padding:24px 26px;border-radius:18px;box-shadow:0 14px 35px rgba(247,37,133,0.32);">
+            <h1 style="margin:0 0 12px;font-size:26px;letter-spacing:0.08em;text-transform:uppercase;color:#fdf8ff;">New Signal Locked</h1>
+            <p style="margin:0;font-size:15px;line-height:1.6;">A fresh human just hacked into the neon grid.</p>
+        </div>
+        <div style="background:#140631;padding:28px;border-radius:18px;margin-top:22px;border:1px solid rgba(255,184,28,0.28);">
+            <p style="margin:0 0 12px;font-size:14px;color:#ffb81c;letter-spacing:0.12em;text-transform:uppercase;">Subscriber Intel</p>
+            <p style="margin:0 0 10px;font-size:16px;font-weight:600;color:#fef4ff;">{$subscriber_email}</p>
+            <p style="margin:0 0 4px;font-size:13px;color:#d0c6ff;">Captured: {$timestamp_display}</p>
+            <p style="margin:0;font-size:13px;color:#d0c6ff;">Total crew on deck: <strong style="color:#ff4ecd;">{$subscriber_counter}</strong></p>
+        </div>
+        <p style="margin:22px 0 0;font-size:13px;line-height:1.6;color:#bfb6ff;">Need to audit the roster? <a href="{$list_manage_url}" style="color:#ffb81c;text-decoration:none;font-weight:600;">Beam into the dashboard</a> anytime.</p>
+        <p style="margin:18px 0 0;font-size:12px;color:#8c7dd6;text-transform:uppercase;letter-spacing:0.18em;">Stay rad &middot; Stay noisy</p>
+    </div>
+</body>
+</html>
+HTML;
+
+        $ok_admin = wp_mail($admin_email, $admin_subject, $admin_body, $headers);
+    }
+
+    do_action('lousy_outages_log', 'subscribe_confirmation_send', [
+        'email'        => $email,
+        'sent'         => $sent,
+        'admin_notice' => $ok_admin,
+    ]);
+
+    if (!$sent) {
+        return new \WP_Error(
+            'send_fail',
+            'Mail send failed — check SMTP or server mailer',
+            [
+                'status'     => 500,
+                'ok'         => false,
+                'transport'  => $transport,
+                'sendmail'   => $sendmailPath,
+                'ok_admin'   => (bool) $ok_admin,
+            ]
+        );
+    }
+
+    return rest_ensure_response(['ok' => true]);
+}
+
+if (!function_exists('lo_detect_subscribe_ip')) {
+    function lo_detect_subscribe_ip(\WP_REST_Request $request): string
+    {
+        $candidates = [];
+
+        foreach (['cf-connecting-ip', 'x-forwarded-for', 'x-real-ip'] as $header) {
+            $value = $request->get_header($header);
+            if (is_string($value) && '' !== trim($value)) {
+                $candidates[] = $value;
+            }
+        }
+
+        foreach (['HTTP_CF_CONNECTING_IP', 'HTTP_X_FORWARDED_FOR', 'HTTP_X_REAL_IP', 'REMOTE_ADDR'] as $serverKey) {
+            if (!empty($_SERVER[$serverKey])) {
+                $candidates[] = (string) $_SERVER[$serverKey];
+            }
+        }
+
+        foreach ($candidates as $candidate) {
+            $parts = explode(',', (string) $candidate);
+            foreach ($parts as $part) {
+                $ip = trim($part);
+                if ('' === $ip) {
+                    continue;
+                }
+                if (filter_var($ip, FILTER_VALIDATE_IP)) {
+                    return $ip;
+                }
+            }
+        }
+
+        return '';
+    }
+}
+
+if (!function_exists('lo_hash_subscriber_ip')) {
+    function lo_hash_subscriber_ip(string $ip): string
+    {
+        $payload = '' !== $ip ? $ip : 'unknown';
+
+        if (function_exists('wp_salt')) {
+            $salt = wp_salt('nonce');
+            return hash_hmac('sha256', $payload, $salt);
+        }
+
+        return hash('sha256', $payload);
+    }
+}
+
+if (!function_exists('lo_generate_subscribe_token')) {
+    function lo_generate_subscribe_token(string $email): string
+    {
+        if (function_exists('wp_rand')) {
+            $random = wp_rand();
+        } else {
+            $random = random_int(PHP_INT_MIN, PHP_INT_MAX);
+        }
+
+        if (function_exists('wp_generate_uuid4')) {
+            $uuid = wp_generate_uuid4();
+        } else {
+            $uuid = bin2hex(random_bytes(16));
+        }
+
+        $entropy = $email . '|' . microtime(true) . '|' . $random . '|' . $uuid;
+
+        return hash('sha256', $entropy);
+    }
+}
+
+if (!function_exists('lo_normalize_lyric_answer')) {
+    function lo_normalize_lyric_answer(string $value): string
+    {
+        $clean = preg_replace('/\W+/', '', $value);
+        if (null === $clean) {
+            $clean = '';
+        }
+
+        return strtolower($clean);
+    }
+}
+
+if (!function_exists('lo_lyric_fragment_bank')) {
+    function lo_lyric_fragment_bank(): array
+    {
+        return [
+            ['fragment' => 'Jobs says', 'answer' => 'stay hungry stay foolish'],
+            ['fragment' => 'Jobs says', 'answer' => 'real artists ship'],
+            ['fragment' => 'Jobs says', 'answer' => 'innovation distinguishes between a leader and a follower'],
+            ['fragment' => 'Jobs says', 'answer' => 'design is how it works'],
+            ['fragment' => 'Jobs says', 'answer' => 'the journey is the reward'],
+            ['fragment' => 'Jobs says', 'answer' => 'creativity is just connecting things'],
+            ['fragment' => 'Jobs says', 'answer' => 'deciding what not to do is as important as deciding what to do'],
+            ['fragment' => 'Jobs says', 'answer' => 'have the courage to follow your heart and intuition'],
+            ['fragment' => 'Jobs says', 'answer' => 'the only way to do great work is to love what you do'],
+            ['fragment' => 'Jobs says', 'answer' => 'the people who are crazy enough to think they can change the world are the ones who do'],
+            ['fragment' => 'Jobs says', 'answer' => 'simplicity is the ultimate sophistication'],
+            ['fragment' => 'Jobs says', 'answer' => 'dont let the noise of others opinions drown out your own inner voice'],
+            ['fragment' => 'Jobs says', 'answer' => 'be a yardstick of quality'],
+            ['fragment' => 'Jobs says', 'answer' => 'your time is limited so dont waste it living someone elses life'],
+            ['fragment' => 'Jobs says', 'answer' => 'great things in business are never done by one person'],
+        ];
+    }
+}
+
+if (!function_exists('lo_lyric_passphrases')) {
+    function lo_lyric_passphrases(): array
+    {
+        $bank = lo_lyric_fragment_bank();
+        $defaults = [];
+        foreach ($bank as $row) {
+            if (!is_array($row) || empty($row['answer'])) {
+                continue;
+            }
+            $defaults[] = (string) $row['answer'];
+        }
+
+        $custom = apply_filters('lo_subscribe_passphrases', $defaults);
+        if (!is_array($custom)) {
+            $custom = $defaults;
+        }
+
+        $filtered = [];
+        foreach ($custom as $phrase) {
+            if (!is_string($phrase)) {
+                continue;
+            }
+            $trimmed = trim($phrase);
+            if ('' === $trimmed) {
+                continue;
+            }
+            $filtered[] = $trimmed;
+        }
+
+        return array_values(array_unique($filtered));
+    }
+}
+
+if (!function_exists('lo_validate_lyric_captcha')) {
+    function lo_validate_lyric_captcha(string $response, bool $allowFallback = false): bool
+    {
+        $normalized = lo_normalize_lyric_answer($response);
+        if ('' === $normalized) {
+            return false;
+        }
+
+        $answers = array_map('lo_normalize_lyric_answer', lo_lyric_passphrases());
+        foreach ($answers as $answer) {
+            if ('' === $answer) {
+                continue;
+            }
+            if (hash_equals($answer, $normalized)) {
+                return true;
+            }
+        }
+
+        if ($allowFallback) {
+            $fallback = lo_normalize_lyric_answer(apply_filters('lo_subscribe_noscript_word', 'jobs'));
+            if ('' !== $fallback && hash_equals($fallback, $normalized)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+Lousy_Outages_Subscribe::bootstrap();

--- a/plugins/lousy-outages/includes/Subscriptions.php
+++ b/plugins/lousy-outages/includes/Subscriptions.php
@@ -1,0 +1,338 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+class Subscriptions {
+    public const TABLE = 'lousy_outages_subs';
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_SUBSCRIBED = 'subscribed';
+    public const STATUS_UNSUBSCRIBED = 'unsubscribed';
+
+    /** @var bool */
+    private static $schema_checked = false;
+
+    private static function ensure_schema(): void {
+        if (self::$schema_checked) {
+            return;
+        }
+
+        global $wpdb;
+
+        $table = self::table_name();
+        $needs_upgrade = false;
+
+        $like = $wpdb->esc_like($table);
+        $existing = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $like));
+        if (!$existing) {
+            $needs_upgrade = true;
+        } else {
+            $columns = $wpdb->get_col("SHOW COLUMNS FROM `{$table}`");
+            if (!is_array($columns)) {
+                $columns = [];
+            }
+
+            $columns = array_map('strtolower', $columns);
+            foreach (['email', 'status', 'token', 'created_at', 'updated_at', 'ip_hash', 'consent_source', 'providers', 'realtime_alerts', 'daily_digest', 'newsletter', 'consent_version', 'confirmed_at'] as $required) {
+                if (!in_array($required, $columns, true)) {
+                    $needs_upgrade = true;
+                    break;
+                }
+            }
+        }
+
+        if ($needs_upgrade) {
+            self::create_table();
+        }
+
+        self::$schema_checked = true;
+    }
+
+    public static function table_name(): string {
+        global $wpdb;
+        return $wpdb->prefix . self::TABLE;
+    }
+
+    public static function create_table(): void {
+        global $wpdb;
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+        $charset = $wpdb->get_charset_collate();
+        $table   = self::table_name();
+
+        $sql = "CREATE TABLE {$table} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            email VARCHAR(190) NOT NULL,
+            status VARCHAR(20) NOT NULL DEFAULT 'pending',
+            token CHAR(64) NOT NULL,
+            created_at DATETIME NOT NULL,
+            updated_at DATETIME NOT NULL,
+            ip_hash CHAR(64) NOT NULL,
+            consent_source VARCHAR(50) NOT NULL DEFAULT '',
+            providers LONGTEXT NULL,
+            realtime_alerts TINYINT(1) NOT NULL DEFAULT 1,
+            daily_digest TINYINT(1) NOT NULL DEFAULT 0,
+            newsletter TINYINT(1) NOT NULL DEFAULT 0,
+            consent_version VARCHAR(30) NOT NULL DEFAULT '2026-05',
+            confirmed_at DATETIME NULL,
+            PRIMARY KEY  (id),
+            UNIQUE KEY email (email),
+            UNIQUE KEY token (token)
+        ) {$charset};";
+
+        dbDelta($sql);
+    }
+
+    public static function schedule_purge(): void {
+        if (!wp_next_scheduled('lousy_outages_purge_pending')) {
+            wp_schedule_event(time() + DAY_IN_SECONDS, 'daily', 'lousy_outages_purge_pending');
+        }
+    }
+
+    public static function clear_schedule(): void {
+        wp_clear_scheduled_hook('lousy_outages_purge_pending');
+    }
+
+    public static function purge_stale_pending(): int {
+        global $wpdb;
+        $table = self::table_name();
+        $cutoff = gmdate('Y-m-d H:i:s', time() - 14 * DAY_IN_SECONDS);
+        return (int) $wpdb->query($wpdb->prepare("DELETE FROM {$table} WHERE status = %s AND created_at < %s", self::STATUS_PENDING, $cutoff));
+    }
+
+    public static function save_pending(string $email, string $token, string $ip_hash, string $source = 'form'): void {
+        self::save_pending_with_preferences($email, $token, $ip_hash, $source, []);
+    }
+
+
+    public static function normalize_provider_ids(array $ids): array {
+        $providers = Providers::list();
+        $allowed = array_fill_keys(array_keys($providers), true);
+        $normalized = [];
+
+        foreach ($ids as $id) {
+            $key = sanitize_key((string) $id);
+            if ('' === $key || !isset($allowed[$key])) {
+                continue;
+            }
+            $normalized[$key] = $key;
+        }
+
+        return array_values($normalized);
+    }
+
+    public static function normalize_preferences(array $input): array {
+        $providers = [];
+        if (isset($input['providers']) && is_array($input['providers'])) {
+            $providers = self::normalize_provider_ids($input['providers']);
+        }
+
+        $toBool = static function ($value, bool $default = false): bool {
+            if (is_bool($value)) {
+                return $value;
+            }
+            if (null === $value) {
+                return $default;
+            }
+            if (is_string($value)) {
+                $v = strtolower(trim($value));
+                if (in_array($v, ['1', 'true', 'yes', 'on'], true)) {
+                    return true;
+                }
+                if (in_array($v, ['0', 'false', 'no', 'off', ''], true)) {
+                    return false;
+                }
+            }
+
+            return !empty($value);
+        };
+
+        return [
+            'providers' => $providers,
+            'realtime_alerts' => $toBool($input['realtime_alerts'] ?? true, true),
+            'daily_digest' => $toBool($input['daily_digest'] ?? false, false),
+            'newsletter' => $toBool($input['newsletter'] ?? false, false),
+        ];
+    }
+
+    public static function save_pending_with_preferences(string $email, string $token, string $ip_hash, string $source, array $preferences): void {
+        global $wpdb;
+        self::ensure_schema();
+        $table = self::table_name();
+        $now = gmdate('Y-m-d H:i:s');
+        $prefs = self::normalize_preferences($preferences);
+
+        $data = [
+            'status' => self::STATUS_PENDING,
+            'token' => $token,
+            'created_at' => $now,
+            'updated_at' => $now,
+            'ip_hash' => $ip_hash,
+            'consent_source' => $source,
+            'providers' => wp_json_encode($prefs['providers']),
+            'realtime_alerts' => $prefs['realtime_alerts'] ? 1 : 0,
+            'daily_digest' => $prefs['daily_digest'] ? 1 : 0,
+            'newsletter' => $prefs['newsletter'] ? 1 : 0,
+            'consent_version' => '2026-05',
+        ];
+
+        $existing = $wpdb->get_row($wpdb->prepare("SELECT id FROM {$table} WHERE email = %s", $email));
+        if ($existing) {
+            $wpdb->update($table, $data, ['id' => (int) $existing->id]);
+            return;
+        }
+
+        $data['email'] = $email;
+        $wpdb->insert($table, $data);
+    }
+
+    public static function get_preferences_for_email(string $email): array {
+        global $wpdb;
+        self::ensure_schema();
+
+        $defaults = ['providers'=>[], 'realtime_alerts'=>true, 'daily_digest'=>false, 'newsletter'=>false];
+        $table = self::table_name();
+        $row = $wpdb->get_row($wpdb->prepare("SELECT providers,realtime_alerts,daily_digest,newsletter FROM {$table} WHERE email = %s", $email), ARRAY_A);
+        if (!is_array($row)) {
+            return $defaults;
+        }
+
+        $providers = [];
+        if (isset($row['providers']) && is_string($row['providers']) && '' !== trim($row['providers'])) {
+            $decoded = json_decode($row['providers'], true);
+            if (is_array($decoded)) {
+                $providers = self::normalize_provider_ids($decoded);
+            }
+        }
+
+        return [
+            'providers' => $providers,
+            'realtime_alerts' => !isset($row['realtime_alerts']) ? true : (int)$row['realtime_alerts'] === 1,
+            'daily_digest' => isset($row['daily_digest']) && (int)$row['daily_digest'] === 1,
+            'newsletter' => isset($row['newsletter']) && (int)$row['newsletter'] === 1,
+        ];
+    }
+
+    public static function subscriber_wants_provider(string $email, string $provider_id): bool {
+        $prefs = self::get_preferences_for_email($email);
+        if (empty($prefs['providers'])) {
+            return true;
+        }
+        return in_array(sanitize_key($provider_id), $prefs['providers'], true);
+    }
+
+    public static function subscriber_wants_realtime(string $email): bool { return (bool) self::get_preferences_for_email($email)['realtime_alerts']; }
+    public static function subscriber_wants_digest(string $email): bool { return (bool) self::get_preferences_for_email($email)['daily_digest']; }
+    public static function subscriber_wants_newsletter(string $email): bool { return (bool) self::get_preferences_for_email($email)['newsletter']; }
+    public static function find_by_token(string $token): ?array {
+        global $wpdb;
+
+        self::ensure_schema();
+
+        $table = self::table_name();
+        $row   = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$table} WHERE token = %s", $token), ARRAY_A);
+        return $row ?: null;
+    }
+
+    public static function update_status_by_token(string $token, string $status): bool {
+        global $wpdb;
+
+        self::ensure_schema();
+
+        $table = self::table_name();
+        $data = [
+            'status'     => $status,
+            'updated_at' => gmdate('Y-m-d H:i:s'),
+        ];
+        if (self::STATUS_SUBSCRIBED === $status) {
+            $data['confirmed_at'] = gmdate('Y-m-d H:i:s');
+        }
+
+        $updated = $wpdb->update(
+            $table,
+            $data,
+            ['token' => $token]
+        );
+
+        return false !== $updated && $updated > 0;
+    }
+
+    public static function update_token_for_email(string $email, string $token): bool {
+        global $wpdb;
+
+        self::ensure_schema();
+
+        $table = self::table_name();
+        $updated = $wpdb->update(
+            $table,
+            [
+                'token'      => $token,
+                'updated_at' => gmdate('Y-m-d H:i:s'),
+            ],
+            ['email' => $email],
+            ['%s', '%s'],
+            ['%s']
+        );
+
+        return false !== $updated && $updated > 0;
+    }
+
+    public static function mark_unsubscribed_by_email(string $email): bool {
+        global $wpdb;
+        $email = sanitize_email($email);
+        if (!$email) {
+            return false;
+        }
+
+        self::ensure_schema();
+
+        $table = self::table_name();
+        $updated = $wpdb->update(
+            $table,
+            [
+                'status'     => self::STATUS_UNSUBSCRIBED,
+                'updated_at' => gmdate('Y-m-d H:i:s'),
+            ],
+            ['email' => $email],
+            ['%s', '%s'],
+            ['%s']
+        );
+
+        return false !== $updated && $updated > 0;
+    }
+}
+
+add_action('template_redirect', static function (): void {
+    if (!isset($_GET['lo_unsub'])) {
+        return;
+    }
+
+    $raw_email = isset($_GET['email']) ? wp_unslash((string) $_GET['email']) : '';
+    if ('' !== $raw_email) {
+        $raw_email = rawurldecode($raw_email);
+    }
+    $raw_token = isset($_GET['token']) ? wp_unslash((string) $_GET['token']) : '';
+
+    $email = sanitize_email($raw_email);
+    $token = sanitize_text_field($raw_token);
+
+    if (!$email || !is_email($email) || '' === $token) {
+        wp_die('Invalid unsubscribe link.', 'Unsubscribe', ['response' => 400]);
+    }
+
+    $saved = IncidentAlerts::get_saved_unsubscribe_token($email);
+    if ('' === $saved) {
+        wp_die('Subscriber not found.', 'Unsubscribe', ['response' => 404]);
+    }
+
+    if (!hash_equals((string) $saved, (string) $token)) {
+        wp_die('Invalid or expired unsubscribe link.', 'Unsubscribe', ['response' => 403]);
+    }
+
+    IncidentAlerts::remove_subscriber($email);
+    Subscriptions::mark_unsubscribed_by_email($email);
+
+    $redirect = add_query_arg('lo_unsub_success', 1, home_url('/lousy-outages/'));
+    wp_safe_redirect($redirect);
+    exit;
+});

--- a/plugins/lousy-outages/includes/Summary.php
+++ b/plugins/lousy-outages/includes/Summary.php
@@ -1,0 +1,435 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+class Summary {
+    public static function current(): array {
+        $providers = self::providers();
+        $latestIncident = self::latest_incident($providers);
+        $latestSignal = self::latest_signal_provider($providers);
+        $outageCount = self::count_outages($providers);
+        $signalCount = self::count_signals($providers);
+
+        if ($latestIncident) {
+            $slug = sanitize_title($latestIncident['provider_id'] ?: $latestIncident['provider_name']);
+
+            return [
+                'kind'        => 'outage',
+                'hasIncident' => true,
+                'hasSignal'   => false,
+                'providerId'  => $latestIncident['provider_id'],
+                'provider'    => $latestIncident['provider_name'],
+                'title'       => $latestIncident['title'],
+                'status'      => $latestIncident['status'],
+                'relative'    => self::relative_time_from_timestamp(
+                    (int) ($latestIncident['started_timestamp'] ?? $latestIncident['sort_timestamp'])
+                ),
+                'started_at'  => $latestIncident['started_at'],
+                'href'        => $slug ? home_url('/lousy-outages/#provider-' . $slug) : home_url('/lousy-outages/'),
+                'outageCount' => $outageCount,
+                'signalCount' => $signalCount,
+            ];
+        }
+
+        // Degraded indicators without unresolved incidents are treated as signals.
+        if ($latestSignal) {
+            $slug = sanitize_title($latestSignal['provider_id'] ?: $latestSignal['provider_name']);
+
+            return [
+                'kind'        => 'signal',
+                'hasIncident' => false,
+                'hasSignal'   => true,
+                'providerId'  => $latestSignal['provider_id'],
+                'provider'    => $latestSignal['provider_name'],
+                'title'       => $latestSignal['title'],
+                'status'      => $latestSignal['status'],
+                'relative'    => self::relative_time_from_timestamp(
+                    (int) ($latestSignal['started_timestamp'] ?? $latestSignal['sort_timestamp'])
+                ),
+                'started_at'  => $latestSignal['started_at'],
+                'href'        => $slug ? home_url('/lousy-outages/#provider-' . $slug) : home_url('/lousy-outages/'),
+                'outageCount' => $outageCount,
+                'signalCount' => $signalCount,
+            ];
+        }
+
+        return [
+            'kind'        => 'clear',
+            'hasIncident' => false,
+            'hasSignal'   => false,
+            'providerId'  => '',
+            'provider'    => '',
+            'title'       => 'All systems operational.',
+            'status'      => 'Operational',
+            'relative'    => '',
+            'started_at'  => '',
+            'href'        => home_url('/lousy-outages/'),
+            'outageCount' => $outageCount,
+            'signalCount' => $signalCount,
+        ];
+    }
+
+    private static function providers(): array
+    {
+        $providers = [];
+
+        if (function_exists('lousy_outages_get_snapshot')) {
+            $snapshot = \lousy_outages_get_snapshot(false);
+            if (empty($snapshot['providers'])) {
+                $snapshot = \lousy_outages_get_snapshot(true);
+            }
+
+            if (!empty($snapshot['providers']) && is_array($snapshot['providers'])) {
+                $providers = array_values($snapshot['providers']);
+            }
+        }
+
+        if ($providers) {
+            return $providers;
+        }
+
+        $store  = new Store();
+        $states = $store->get_all();
+        if (!$states) {
+            return [];
+        }
+
+        $timestamp = get_option('lousy_outages_last_poll');
+        if (!$timestamp) {
+            $timestamp = gmdate('c');
+        }
+
+        foreach ($states as $id => $state) {
+            if (!is_array($state)) {
+                continue;
+            }
+
+            if (function_exists('lousy_outages_build_provider_payload')) {
+                $providers[] = \lousy_outages_build_provider_payload((string) $id, $state, (string) $timestamp);
+                continue;
+            }
+
+            $providers[] = [
+                'id'        => (string) $id,
+                'provider'  => (string) ($state['provider'] ?? $state['name'] ?? $id),
+                'name'      => (string) ($state['name'] ?? $state['provider'] ?? $id),
+                'stateCode' => (string) ($state['status'] ?? 'unknown'),
+                'updatedAt' => (string) ($state['updated_at'] ?? $state['updatedAt'] ?? $timestamp),
+                'incidents' => isset($state['incidents']) && is_array($state['incidents']) ? $state['incidents'] : [],
+                'summary'   => (string) ($state['summary'] ?? ''),
+            ];
+        }
+
+        return $providers;
+    }
+
+    private static function latest_incident(array $providers): ?array
+    {
+        $latest = null;
+        $recent_cutoff = time() - (2 * DAY_IN_SECONDS);
+
+        foreach ($providers as $provider) {
+            if (!is_array($provider)) {
+                continue;
+            }
+
+            $providerId = (string) ($provider['id'] ?? $provider['provider'] ?? '');
+            $providerName = (string) ($provider['name'] ?? $provider['provider'] ?? $providerId);
+            $incidents = isset($provider['incidents']) && is_array($provider['incidents']) ? $provider['incidents'] : [];
+
+            foreach ($incidents as $incident) {
+                if (!is_array($incident)) {
+                    continue;
+                }
+
+                if (!self::is_unresolved_incident($incident)) {
+                    continue;
+                }
+
+                $sortTimestamp = self::incident_timestamp($incident);
+                $startedTimestamp = self::incident_started_timestamp($incident);
+
+                if (null === $sortTimestamp || $sortTimestamp < $recent_cutoff) {
+                    continue;
+                }
+
+                if (null === $latest || $sortTimestamp > $latest['sort_timestamp']) {
+                    $startedIso = self::incident_start_iso($incident, $sortTimestamp);
+                    $statusCode = strtolower((string) ($incident['impact'] ?? $incident['status'] ?? ''));
+
+                    $latest = [
+                        'provider_id'        => $providerId,
+                        'provider_name'      => $providerName ?: $providerId,
+                        'title'              => (string) ($incident['title'] ?? $incident['name'] ?? 'Incident'),
+                        'status'             => Fetcher::status_label($statusCode ?: 'incident'),
+                        'started_at'         => $startedIso,
+                        'sort_timestamp'     => $sortTimestamp,
+                        'started_timestamp'  => $startedTimestamp ?? $sortTimestamp,
+                    ];
+                }
+            }
+        }
+
+        return $latest;
+    }
+
+    private static function latest_signal_provider(array $providers): ?array
+    {
+        $fallback = null;
+        $recent_cutoff = time() - (4 * HOUR_IN_SECONDS);
+        $eligibleFallbackStates = ['degraded', 'outage', 'major', 'partial', 'monitoring', 'investigating'];
+
+        foreach ($providers as $provider) {
+            if (!is_array($provider)) {
+                continue;
+            }
+
+            $tileKind = strtolower((string) ($provider['tile_kind'] ?? $provider['tileKind'] ?? ''));
+            $status = strtolower((string) ($provider['stateCode'] ?? $provider['status'] ?? 'unknown'));
+            $isSignal = $tileKind === 'signal' || in_array($status, $eligibleFallbackStates, true);
+
+            if (!$isSignal) {
+                continue;
+            }
+
+            $providerId = (string) ($provider['id'] ?? $provider['provider'] ?? '');
+            $providerName = (string) ($provider['name'] ?? $provider['provider'] ?? $providerId);
+            $incidents = isset($provider['incidents']) && is_array($provider['incidents']) ? $provider['incidents'] : [];
+
+            // Only treat degraded indicators as signals when there are no unresolved incidents.
+            if (self::has_unresolved_incident($incidents)) {
+                continue;
+            }
+
+            $updated = self::parse_time($provider['updatedAt'] ?? $provider['updated_at'] ?? null);
+            $sortTimestamp = $updated ?? time();
+            if ($updated && $updated < $recent_cutoff) {
+                continue;
+            }
+
+            if (null === $fallback || $sortTimestamp > $fallback['sort_timestamp']) {
+                $fallback = [
+                    'provider_id'        => $providerId,
+                    'provider_name'      => $providerName,
+                    'title'              => (string) ($provider['summary'] ?? Fetcher::status_label($status)),
+                    'status'             => Fetcher::status_label($status),
+                    'started_at'         => (string) ($provider['updatedAt'] ?? $provider['updated_at'] ?? ''),
+                    'sort_timestamp'     => $sortTimestamp,
+                    'started_timestamp'  => $updated ?? $sortTimestamp,
+                ];
+            }
+        }
+
+        return $fallback;
+    }
+
+    private static function count_outages(array $providers): int
+    {
+        $recent_cutoff = time() - (2 * DAY_IN_SECONDS);
+        $count = 0;
+
+        foreach ($providers as $provider) {
+            if (!is_array($provider)) {
+                continue;
+            }
+
+            $incidents = isset($provider['incidents']) && is_array($provider['incidents']) ? $provider['incidents'] : [];
+
+            foreach ($incidents as $incident) {
+                if (!is_array($incident)) {
+                    continue;
+                }
+
+                if (!self::is_unresolved_incident($incident)) {
+                    continue;
+                }
+
+                $sortTimestamp = self::incident_timestamp($incident);
+                if (null === $sortTimestamp || $sortTimestamp < $recent_cutoff) {
+                    continue;
+                }
+
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    private static function count_signals(array $providers): int
+    {
+        $recent_cutoff = time() - (4 * HOUR_IN_SECONDS);
+        $eligibleFallbackStates = ['degraded', 'outage', 'major', 'partial', 'monitoring', 'investigating'];
+        $count = 0;
+
+        foreach ($providers as $provider) {
+            if (!is_array($provider)) {
+                continue;
+            }
+
+            $tileKind = strtolower((string) ($provider['tile_kind'] ?? $provider['tileKind'] ?? ''));
+            $status = strtolower((string) ($provider['stateCode'] ?? $provider['status'] ?? 'unknown'));
+            $isSignal = $tileKind === 'signal' || in_array($status, $eligibleFallbackStates, true);
+            if (!$isSignal) {
+                continue;
+            }
+
+            $incidents = isset($provider['incidents']) && is_array($provider['incidents']) ? $provider['incidents'] : [];
+            if (self::has_unresolved_incident($incidents)) {
+                continue;
+            }
+
+            $updated = self::parse_time($provider['updatedAt'] ?? $provider['updated_at'] ?? null);
+            if ($updated && $updated < $recent_cutoff) {
+                continue;
+            }
+
+            $count++;
+        }
+
+        return $count;
+    }
+
+    private static function has_unresolved_incident(array $incidents): bool
+    {
+        foreach ($incidents as $incident) {
+            if (!is_array($incident)) {
+                continue;
+            }
+
+            if (self::is_unresolved_incident($incident)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function is_unresolved_incident(array $incident): bool
+    {
+        $statusCode = strtolower((string) ($incident['impact'] ?? $incident['status'] ?? ''));
+        if (in_array($statusCode, ['operational', 'resolved', 'maintenance'], true)) {
+            return false;
+        }
+
+        if (!empty($incident['resolved_at']) || !empty($incident['resolvedAt'])) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static function incident_timestamp(array $incident): ?int
+    {
+        // Effective time for sorting incidents (generally the last update time).
+        $candidates = [
+            $incident['timestamp'] ?? null,
+            $incident['updated_at'] ?? null,
+            $incident['updatedAt'] ?? null,
+            $incident['detected_at'] ?? null,
+            $incident['detectedAt'] ?? null,
+            $incident['started_at'] ?? null,
+            $incident['startedAt'] ?? null,
+        ];
+
+        foreach ($candidates as $value) {
+            $parsed = self::parse_time($value);
+            if (null !== $parsed) {
+                return $parsed;
+            }
+        }
+
+        return null;
+    }
+
+    private static function incident_started_timestamp(array $incident): ?int
+    {
+        // Prefer the earliest plausible "start" field.
+        $candidates = [
+            $incident['detected_at'] ?? null,
+            $incident['detectedAt'] ?? null,
+            $incident['started_at'] ?? null,
+            $incident['startedAt'] ?? null,
+            $incident['timestamp'] ?? null,
+            $incident['updated_at'] ?? null,
+            $incident['updatedAt'] ?? null,
+        ];
+
+        foreach ($candidates as $value) {
+            $parsed = self::parse_time($value);
+            if (null !== $parsed) {
+                return $parsed;
+            }
+        }
+
+        return null;
+    }
+
+    private static function incident_start_iso(array $incident, int $timestamp): string
+    {
+        $fields = [
+            $incident['detected_at'] ?? null,
+            $incident['detectedAt'] ?? null,
+            $incident['started_at'] ?? null,
+            $incident['startedAt'] ?? null,
+            $incident['updated_at'] ?? null,
+            $incident['updatedAt'] ?? null,
+        ];
+
+        foreach ($fields as $field) {
+            if (is_string($field) && '' !== trim($field)) {
+                return (string) $field;
+            }
+
+            if (is_numeric($field)) {
+                $ts = self::parse_time($field);
+                if ($ts) {
+                    return gmdate('c', $ts);
+                }
+            }
+        }
+
+        return gmdate('c', $timestamp);
+    }
+
+    private static function parse_time($value): ?int {
+        if (is_int($value)) {
+            return $value > 0 ? $value : null;
+        }
+
+        if (is_string($value) && ctype_digit($value)) {
+            $int = (int) $value;
+            return $int > 0 ? $int : null;
+        }
+
+        if (empty($value)) {
+            return null;
+        }
+
+        $timestamp = strtotime((string) $value);
+        if (false === $timestamp) {
+            return null;
+        }
+        return $timestamp;
+    }
+
+    private static function relative_time_from_timestamp(int $timestamp): string
+    {
+        if ($timestamp <= 0) {
+            return '';
+        }
+
+        $now = current_time('timestamp', true);
+        if (!is_int($now)) {
+            $now = time();
+        }
+
+        if ($timestamp > $now) {
+            $timestamp = $now;
+        }
+
+        $diff = human_time_diff($timestamp, $now);
+        return $diff ? sprintf('%s ago', $diff) : '';
+    }
+}

--- a/plugins/lousy-outages/includes/Trending.php
+++ b/plugins/lousy-outages/includes/Trending.php
@@ -1,0 +1,151 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+class Trending
+{
+    private const CLOUD_SLUGS = ['aws', 'azure', 'google_cloud'];
+    private const MAJOR_STATES = ['major', 'outage'];
+    private const DEGRADED_STATES = ['degraded', 'major', 'outage'];
+
+    public function evaluate(array $providers): array
+    {
+        $timestamp = time();
+        $degraded = [];
+        $major = [];
+        $cloudRecent = [];
+
+        foreach ($providers as $provider) {
+            if (!is_array($provider)) {
+                continue;
+            }
+
+            $slug = strtolower((string) ($provider['provider'] ?? $provider['id'] ?? ''));
+            if ('' === $slug) {
+                continue;
+            }
+
+            $status = strtolower((string) ($provider['status'] ?? $provider['overall'] ?? $provider['stateCode'] ?? 'unknown'));
+
+            if (in_array($status, self::DEGRADED_STATES, true)) {
+                $degraded[] = $slug;
+            }
+
+            if (in_array($status, self::MAJOR_STATES, true)) {
+                $major[] = $slug;
+            }
+
+            if (in_array($slug, self::CLOUD_SLUGS, true) && $this->has_recent_cloud_incident($provider, $timestamp)) {
+                $cloudRecent[] = $slug;
+            }
+        }
+
+        $degraded = array_values(array_unique($degraded));
+        $major = array_values(array_unique($major));
+        $cloudRecent = array_values(array_unique($cloudRecent));
+
+        $active = false;
+        $signals = [];
+
+        if (count($degraded) >= 2) {
+            $active = true;
+            $signals[] = 'Multiple providers impacted: ' . $this->format_list($degraded);
+        }
+
+        if ($major && $cloudRecent) {
+            if (!$active) {
+                $active = true;
+                $signals[] = 'Major outages: ' . $this->format_list($major);
+                $signals[] = 'Cloud incidents (last 6h): ' . $this->format_list($cloudRecent);
+            } else {
+                $signals[] = 'Major outages: ' . $this->format_list($major);
+                $signals[] = 'Cloud incidents (last 6h): ' . $this->format_list($cloudRecent);
+            }
+        } elseif ($active && $major) {
+            $signals[] = 'Major outages: ' . $this->format_list($major);
+        }
+
+        return [
+            'trending'     => $active,
+            'signals'      => array_slice(array_filter($signals), 0, 6),
+            'generated_at' => gmdate('c', $timestamp),
+        ];
+    }
+
+    private function has_recent_cloud_incident(array $provider, int $now): bool
+    {
+        if (empty($provider['incidents']) || !is_array($provider['incidents'])) {
+            return false;
+        }
+
+        $window = $this->cloud_window_seconds();
+
+        foreach ($provider['incidents'] as $incident) {
+            if (!is_array($incident)) {
+                continue;
+            }
+
+            $timestamps = [];
+            foreach (['updated_at', 'updatedAt', 'started_at', 'startedAt'] as $field) {
+                if (empty($incident[$field])) {
+                    continue;
+                }
+                $time = strtotime((string) $incident[$field]);
+                if ($time) {
+                    $timestamps[] = $time;
+                }
+            }
+
+            if (isset($incident['timestamp'])) {
+                $raw = (int) $incident['timestamp'];
+                if ($raw > 0) {
+                    $timestamps[] = $raw;
+                }
+            }
+
+            foreach ($timestamps as $time) {
+                if (($now - $time) <= $window) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function cloud_window_seconds(): int
+    {
+        $base = defined('HOUR_IN_SECONDS') ? (int) HOUR_IN_SECONDS : 3600;
+        return $base * 6;
+    }
+
+    private function format_list(array $slugs): string
+    {
+        $unique = array_values(array_unique($slugs));
+        $labels = array_map(
+            static function ($slug) {
+                $slug = (string) $slug;
+                if ('' === $slug) {
+                    return '';
+                }
+                $special = [
+                    'aws'   => 'AWS',
+                    'azure' => 'Azure',
+                    'google_cloud' => 'Google Cloud',
+                ];
+                if (isset($special[$slug])) {
+                    return $special[$slug];
+                }
+                return ucwords(str_replace(['-', '_'], ' ', $slug));
+            },
+            $unique
+        );
+
+        $labels = array_filter($labels, static function ($label) {
+            return '' !== $label;
+        });
+
+        return implode(', ', $labels);
+    }
+}

--- a/plugins/lousy-outages/includes/UserReports.php
+++ b/plugins/lousy-outages/includes/UserReports.php
@@ -1,0 +1,148 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+class UserReports {
+    public const TABLE = 'lo_user_reports';
+    public const ALLOWED_SYMPTOMS = ['login','checkout','payments','api','dashboard','dns','email','slow','full_outage','other'];
+    public const ALLOWED_SEVERITY = ['minor','degraded','major','unknown'];
+
+    public static function table_name(): string { global $wpdb; return $wpdb->prefix . self::TABLE; }
+
+    public static function install(): void {
+        global $wpdb;
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        $table = self::table_name();
+        $charset = $wpdb->get_charset_collate();
+        $sql = "CREATE TABLE {$table} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            provider_id VARCHAR(80) NOT NULL,
+            symptom VARCHAR(80) NOT NULL,
+            severity VARCHAR(40) NOT NULL DEFAULT 'unknown',
+            region VARCHAR(80) NOT NULL DEFAULT '',
+            source VARCHAR(40) NOT NULL DEFAULT 'public_form',
+            details TEXT NULL,
+            email_hash VARCHAR(128) NULL,
+            ip_hash VARCHAR(128) NULL,
+            user_agent_hash VARCHAR(128) NULL,
+            created_at DATETIME NOT NULL,
+            status VARCHAR(40) NOT NULL DEFAULT 'new',
+            PRIMARY KEY (id),
+            KEY provider_id (provider_id),
+            KEY created_at (created_at),
+            KEY provider_created_at (provider_id, created_at),
+            KEY ip_created_at (ip_hash, created_at)
+        ) {$charset};";
+        dbDelta($sql);
+    }
+
+    public static function hash_value(string $raw): string { return hash('sha256', wp_salt('auth') . '|' . trim($raw)); }
+
+    public static function normalize_input(array $input): array {
+        $provider = sanitize_key((string)($input['provider_id'] ?? ''));
+        $providers = Providers::list();
+        if (!isset($providers[$provider])) return ['ok'=>false,'error'=>'invalid_provider'];
+        $symptom = sanitize_key((string)($input['symptom'] ?? 'other'));
+        if (!in_array($symptom, self::ALLOWED_SYMPTOMS, true)) $symptom = 'other';
+        $severity = sanitize_key((string)($input['severity'] ?? 'unknown'));
+        if (!in_array($severity, self::ALLOWED_SEVERITY, true)) $severity = 'unknown';
+        $region = substr(sanitize_text_field((string)($input['region'] ?? '')), 0, 80);
+        $details = substr(sanitize_text_field((string)($input['details'] ?? '')), 0, 500);
+        $email = sanitize_email((string)($input['email'] ?? ''));
+        $email_hash = ($email && is_email($email)) ? self::hash_value(strtolower($email)) : null;
+        $ip = (string)($input['ip'] ?? ($_SERVER['REMOTE_ADDR'] ?? ''));
+        $ua = (string)($input['user_agent'] ?? ($_SERVER['HTTP_USER_AGENT'] ?? ''));
+        return ['ok'=>true,'provider_id'=>$provider,'symptom'=>$symptom,'severity'=>$severity,'region'=>$region,'details'=>$details,'email_hash'=>$email_hash,'ip_hash'=>self::hash_value($ip),'user_agent_hash'=>self::hash_value($ua),'source'=>'public_form','status'=>'new'];
+    }
+
+    public static function is_rate_limited(string $ipHash, string $provider_id): bool {
+        global $wpdb;
+        $cutoff = gmdate('Y-m-d H:i:s', time() - 5 * MINUTE_IN_SECONDS);
+        $count = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM " . self::table_name() . " WHERE ip_hash = %s AND provider_id = %s AND created_at >= %s", $ipHash, $provider_id, $cutoff));
+        return $count > 0;
+    }
+
+    public static function record_report(array $input): array {
+        global $wpdb;
+        $normalized = self::normalize_input($input);
+        if (empty($normalized['ok'])) return ['success'=>false,'error'=>'invalid_provider'];
+        if (self::is_rate_limited((string)$normalized['ip_hash'], (string)$normalized['provider_id'])) return ['success'=>false,'rate_limited'=>true,'message'=>'Thanks, we already logged a recent report for this provider. We’re watching it.'];
+        $now = gmdate('Y-m-d H:i:s');
+        $data = $normalized; unset($data['ok']); $data['created_at'] = $now;
+        $wpdb->insert(self::table_name(), $data);
+        return ['success'=>true,'provider_id'=>$data['provider_id'],'created_at'=>$now];
+    }
+
+    public static function get_recent_reports(array $args = []): array {
+        global $wpdb;
+        $window = max(1, (int)($args['windowMinutes'] ?? 60));
+        $limit = max(1, (int)($args['limit'] ?? 50));
+        $provider = sanitize_key((string)($args['provider_id'] ?? ''));
+        $source = sanitize_key((string)($args['source'] ?? ''));
+        $status = sanitize_key((string)($args['status'] ?? ''));
+        $cutoff = gmdate('Y-m-d H:i:s', time() - $window * MINUTE_IN_SECONDS);
+        $sql = 'SELECT * FROM ' . self::table_name() . ' WHERE created_at >= %s';
+        $params = [$cutoff];
+        if ($provider) { $sql .= ' AND provider_id = %s'; $params[] = $provider; }
+        if ($source) { $sql .= ' AND source = %s'; $params[] = $source; }
+        if ($status) { $sql .= ' AND status = %s'; $params[] = $status; }
+        $sql .= ' ORDER BY created_at DESC LIMIT %d';
+        $params[] = $limit;
+        return (array)$wpdb->get_results($wpdb->prepare($sql, ...$params), ARRAY_A);
+    }
+
+    public static function get_recent_report_count(int $windowMinutes = 60): int {
+        global $wpdb;
+        $cutoff = gmdate('Y-m-d H:i:s', time() - max(1, $windowMinutes) * MINUTE_IN_SECONDS);
+        return (int)$wpdb->get_var($wpdb->prepare('SELECT COUNT(*) FROM ' . self::table_name() . ' WHERE created_at >= %s', $cutoff));
+    }
+
+    public static function count_recent_reports(string $provider_id, int $windowMinutes = 60): int {
+        global $wpdb;
+        $cutoff = gmdate('Y-m-d H:i:s', time() - max(1,$windowMinutes) * MINUTE_IN_SECONDS);
+        return (int)$wpdb->get_var($wpdb->prepare('SELECT COUNT(*) FROM ' . self::table_name() . ' WHERE provider_id = %s AND created_at >= %s', sanitize_key($provider_id), $cutoff));
+    }
+
+    public static function get_recent_provider_counts(int $windowMinutes = 60): array {
+        global $wpdb;
+        $cutoff = gmdate('Y-m-d H:i:s', time() - max(1,$windowMinutes) * MINUTE_IN_SECONDS);
+        return (array)$wpdb->get_results($wpdb->prepare('SELECT provider_id, COUNT(*) AS report_count FROM ' . self::table_name() . ' WHERE created_at >= %s GROUP BY provider_id ORDER BY report_count DESC', $cutoff), ARRAY_A);
+    }
+
+    public static function get_admin_diagnostics(int $windowMinutes = 60): array {
+        return [
+            'window_minutes' => max(1, $windowMinutes),
+            'total_reports' => self::get_recent_report_count($windowMinutes),
+            'provider_counts' => self::get_recent_provider_counts($windowMinutes),
+            'signals' => SignalEngine::summarize_recent_signals($windowMinutes),
+            'recent_reports' => self::get_recent_reports(['windowMinutes' => $windowMinutes, 'limit' => 25]),
+        ];
+    }
+
+    public static function seed_demo_reports(array $options = []): array {
+        global $wpdb;
+        $providers = Providers::enabled();
+        if (empty($providers)) $providers = Providers::list();
+        $ids = array_values(array_keys($providers));
+        if (count($ids) < 3) return ['inserted' => 0, 'provider_ids' => []];
+        $plan = [[$ids[0], 5, 'api', 'major', 'us-east', 'Demo report: API timeout'],[$ids[1], 3, 'login', 'degraded', 'us-west', 'Demo report: login errors'],[$ids[2], 2, 'checkout', 'minor', 'ca-central', 'Demo report: checkout failures']];
+        $inserted = 0;
+        foreach ($plan as $idx => $rowPlan) {
+            [$providerId, $count, $symptom, $severity, $region, $details] = $rowPlan;
+            for ($i = 0; $i < $count; $i++) {
+                $now = gmdate('Y-m-d H:i:s', time() - (($idx * 2 + $i) * 60));
+                $seed = $providerId . '|' . $idx . '|' . $i;
+                $wpdb->insert(self::table_name(), ['provider_id' => sanitize_key((string)$providerId), 'symptom' => $symptom, 'severity' => $severity, 'region' => $region, 'source' => 'demo_seed', 'details' => $details, 'email_hash' => self::hash_value('demo-email-' . $seed), 'ip_hash' => self::hash_value('demo-ip-' . $seed), 'user_agent_hash' => self::hash_value('demo-ua-' . $seed), 'created_at' => $now, 'status' => 'new']);
+                $inserted++;
+            }
+        }
+        return ['inserted' => $inserted, 'provider_ids' => [$ids[0], $ids[1], $ids[2]]];
+    }
+
+    public static function clear_demo_reports(): int {
+        global $wpdb;
+        $sql = $wpdb->prepare('DELETE FROM ' . self::table_name() . ' WHERE source = %s', 'demo_seed');
+        return (int)$wpdb->query($sql);
+    }
+}

--- a/plugins/lousy-outages/includes/compat.php
+++ b/plugins/lousy-outages/includes/compat.php
@@ -1,0 +1,84 @@
+<?php
+// Legacy incident shim so older integrations keep working alongside the namespaced classes.
+if ( ! class_exists('LO_Incident') ) {
+    if ( ! class_exists('SuzyEaston\\LousyOutages\\Model\\Incident') ) {
+        require_once __DIR__ . '/Model/Incident.php';
+    }
+
+    if ( ! class_exists('LousyOutages\\Model\\Incident') && class_exists('SuzyEaston\\LousyOutages\\Model\\Incident') ) {
+        class_alias('SuzyEaston\\LousyOutages\\Model\\Incident', 'LousyOutages\\Model\\Incident');
+    }
+
+    class LO_Incident extends \SuzyEaston\LousyOutages\Model\Incident {
+        public function __construct($provider, $id, $title, $status, $url, $component = null, $impact = null, $detected_at = null, $resolved_at = null) {
+            $detected = (null === $detected_at || '' === $detected_at) ? time() : (int) $detected_at;
+            $resolved = (null === $resolved_at || '' === $resolved_at) ? null : (int) $resolved_at;
+
+            parent::__construct(
+                (string) $provider,
+                (string) $id,
+                (string) $title,
+                (string) $status,
+                (string) $url,
+                null !== $component ? (string) $component : null,
+                null !== $impact ? (string) $impact : null,
+                $detected,
+                $resolved
+            );
+        }
+
+        public static function create($provider, $id, $title, $status, $url, $component = null, $impact = null, $detected_at = null, $resolved_at = null) {
+            return new self($provider, $id, $title, $status, $url, $component, $impact, $detected_at, $resolved_at);
+        }
+
+        public static function operational($provider, $url) {
+            $now = time();
+            return new self(
+                $provider,
+                self::make_id($provider, 'operational', $now),
+                'All systems operational.',
+                'operational',
+                $url,
+                null,
+                null,
+                $now,
+                null
+            );
+        }
+
+        public static function make_id($provider, $title, $timestamp) {
+            $base = strtolower((string) $provider . '-' . (string) $title);
+            $base = preg_replace('/[^a-z0-9]+/', '-', $base);
+            $base = trim((string) $base, '-');
+            if ('' === $base) {
+                $base = 'incident';
+            }
+
+            return $base . '-' . (int) $timestamp;
+        }
+    }
+}
+
+// Allow legacy code referencing the old namespaced alias to continue working if needed.
+if ( ! class_exists('SuzyEaston\\LousyOutages\\Model\\LegacyIncident') ) {
+    class_alias('LO_Incident', 'SuzyEaston\\LousyOutages\\Model\\LegacyIncident');
+}
+
+if ( ! class_exists('LousyOutages\\Model\\LegacyIncident') ) {
+    class_alias('LO_Incident', 'LousyOutages\\Model\\LegacyIncident');
+}
+
+if ( ! class_exists('LousyOutages\\Fetcher') && class_exists('SuzyEaston\\LousyOutages\\Fetcher') ) {
+    // LO: keep legacy namespace compatibility for tests and old hooks.
+    class_alias('SuzyEaston\\LousyOutages\\Fetcher', 'LousyOutages\\Fetcher');
+}
+
+if ( ! class_exists('LousyOutages\\Summary') && class_exists('SuzyEaston\\LousyOutages\\Summary') ) {
+    // LO: surface incident summary data to legacy templates.
+    class_alias('SuzyEaston\\LousyOutages\\Summary', 'LousyOutages\\Summary');
+}
+
+if ( ! class_exists('LousyOutages\\I18n') && class_exists('SuzyEaston\\LousyOutages\\I18n') ) {
+    // LO: allow legacy front-end strings lookup.
+    class_alias('SuzyEaston\\LousyOutages\\I18n', 'LousyOutages\\I18n');
+}

--- a/plugins/lousy-outages/includes/email-templates.php
+++ b/plugins/lousy-outages/includes/email-templates.php
@@ -1,0 +1,463 @@
+<?php
+/**
+ * Email template helpers for Lousy Outages.
+ */
+
+declare(strict_types=1);
+
+if (!function_exists('lo_unsubscribe_url_for')) {
+    function lo_unsubscribe_url_for(string $email): string {
+        $email = sanitize_email($email);
+        if (!$email || !is_email($email)) {
+            return home_url('/lousy-outages/');
+        }
+
+        if (!class_exists('SuzyEaston\\LousyOutages\\IncidentAlerts')) {
+            return home_url('/lousy-outages/');
+        }
+
+        $token = \SuzyEaston\LousyOutages\IncidentAlerts::build_unsubscribe_token($email);
+
+        return add_query_arg(
+            [
+                'lo_unsub' => 1,
+                'email'    => rawurlencode($email),
+                'token'    => $token,
+            ],
+            home_url('/lousy-outages/')
+        );
+    }
+}
+
+if (!function_exists('lo_send_confirmation')) {
+    function lo_send_confirmation(string $email, ?string $confirm_url = null, array $preferences = []): bool {
+        $unsubscribe_url = lo_unsubscribe_url_for($email);
+
+        do_action('lousy_outages_log', 'confirm_email_unsub_url', [
+            'email' => sanitize_email($email),
+            'unsub' => $unsubscribe_url,
+        ]);
+
+        return send_lo_confirmation_email($email, $unsubscribe_url, $confirm_url, $preferences);
+    }
+}
+
+if (!function_exists('send_lo_confirmation_email')) {
+    /**
+     * Sends the Lousy Outages confirmation email.
+     */
+    function send_lo_confirmation_email(string $email, string $unsubscribe_url, ?string $confirm_url = null, array $preferences = []): bool {
+        $email = sanitize_email($email);
+        if (!$email || !is_email($email)) {
+            error_log('[lousy_outages] confirmation_email invalid recipient');
+            return false;
+        }
+
+        if ('' === trim((string) $unsubscribe_url)) {
+            $unsubscribe_url = lo_unsubscribe_url_for($email);
+        }
+        $unsubscribe_raw = esc_url_raw($unsubscribe_url);
+        $unsubscribe_html = esc_url($unsubscribe_url);
+
+        if (null === $confirm_url || '' === trim((string) $confirm_url)) {
+            $confirm_url = apply_filters('lo_confirmation_cta_url', '', $email, $unsubscribe_url);
+        }
+        if (null === $confirm_url || '' === trim((string) $confirm_url)) {
+            $confirm_url = add_query_arg(
+                'email',
+                rawurlencode($email),
+                home_url('/lousy-outages/')
+            );
+        }
+        $confirm_raw  = esc_url_raw($confirm_url);
+        $confirm_html = esc_url($confirm_url);
+
+
+        $prefs = class_exists('SuzyEaston\LousyOutages\Subscriptions')
+            ? \SuzyEaston\LousyOutages\Subscriptions::normalize_preferences($preferences)
+            : ['providers'=>[], 'realtime_alerts'=>true, 'daily_digest'=>false, 'newsletter'=>false];
+        $providerNames = [];
+        if (class_exists('SuzyEaston\LousyOutages\Providers')) {
+            $providerMap = \SuzyEaston\LousyOutages\Providers::list();
+            foreach ((array) ($prefs['providers'] ?? []) as $providerId) {
+                $providerId = sanitize_key((string) $providerId);
+                if (isset($providerMap[$providerId]['name'])) {
+                    $providerNames[] = (string) $providerMap[$providerId]['name'];
+                }
+            }
+        }
+        $providerSummary = empty($providerNames) ? 'All monitored providers' : implode(', ', $providerNames);
+        $realtimeSummary = !empty($prefs['realtime_alerts']) ? 'on' : 'off';
+        $digestSummary = !empty($prefs['daily_digest']) ? 'on' : 'off';
+
+        $subject = '🔔 Please confirm your subscription to Lousy Outages';
+
+        $text_body_lines = [
+            'Please confirm your subscription to Lousy Outages.',
+            '',
+            'Tap the link below to confirm and start receiving outage intel:',
+            $confirm_raw,
+            '',
+            'Dashboard anytime: ' . home_url('/lousy-outages/'),
+            '',
+            'You’re set for real-time alerts: ' . $realtimeSummary,
+            'Daily digest: ' . $digestSummary,
+            'Providers: ' . $providerSummary,
+            '',
+            'Unsubscribe instantly if this wasn’t you:',
+            $unsubscribe_raw,
+        ];
+        $text_body = implode("\n", $text_body_lines);
+
+        ob_start();
+        ?>
+        <!doctype html>
+        <html lang="en">
+        <head>
+            <meta charset="utf-8">
+            <title>Lousy Outages Confirmation</title>
+        </head>
+        <body style="margin:0;background:#05050a;color:#f7f4ff;font-family:Segoe UI,Roboto,system-ui,-apple-system,sans-serif;font-size:16px;line-height:1.5;">
+            <div style="max-width:640px;margin:0 auto;padding:32px 20px;">
+                <div style="border-radius:18px;border:1px solid rgba(119,85,255,0.4);background:linear-gradient(145deg,#0d0c1f,#1b1540);box-shadow:0 22px 46px rgba(26,17,68,0.45);padding:32px 30px;">
+                    <p style="margin:0 0 12px;font-size:14px;letter-spacing:0.12em;text-transform:uppercase;color:#8f80ff;">Confirm required</p>
+                    <h1 style="margin:0 0 16px;font-size:30px;color:#f9f7ff;letter-spacing:0.04em;">Please confirm your subscription to Lousy Outages</h1>
+                    <p style="margin:0 0 18px;font-size:16px;line-height:1.5;color:rgba(255,255,255,0.82);">Confirm your email to receive outage alerts, post-mortems, and status intel. One click keeps you in the loop.</p>
+                    <p style="margin:0 0 22px;">
+                        <a href="<?php echo esc_url($confirm_html); ?>" style="display:inline-block;padding:16px 28px;border-radius:999px;border:2px solid rgba(170,144,255,0.9);background:#6c5ce7;color:#fff;font-weight:700;text-decoration:none;letter-spacing:0.08em;">Confirm subscription</a>
+                    </p>
+                    <p style="margin:0 0 18px;font-size:14px;color:rgba(255,255,255,0.75);">Button sleepy? Copy this link instead:<br><span style="word-break:break-all;color:#b6a9ff;"><?php echo esc_html($confirm_raw); ?></span></p>
+                    <p style="margin:0 0 18px;font-size:14px;color:rgba(255,255,255,0.75);">Visit the live dashboard any time:<br><a href="<?php echo esc_url(home_url('/lousy-outages/')); ?>" style="color:#8f80ff;"><?php echo esc_html(home_url('/lousy-outages/')); ?></a></p>
+                    <div style="margin:24px 0 0;padding:16px 18px;border:1px dashed rgba(143,128,255,0.6);border-radius:14px;background:rgba(24,20,58,0.7);color:rgba(255,255,255,0.8);font-size:13px;">
+                        <strong style="display:block;font-size:11px;letter-spacing:0.16em;color:#d0c6ff;margin-bottom:6px;text-transform:uppercase;">Unsubscribe</strong>
+                        Leave immediately if this wasn’t you:<br><a style="color:#d0c6ff;text-decoration:none;" href="<?php echo esc_url($unsubscribe_html); ?>"><?php echo esc_html($unsubscribe_raw); ?></a>
+                    </div>
+                </div>
+            </div>
+        </body>
+        </html>
+        <?php
+        $html_body = trim((string) ob_get_clean());
+
+        $headers = [
+            'List-Unsubscribe: <' . $unsubscribe_raw . '>',
+            'List-Unsubscribe-Post: List-Unsubscribe=One-Click',
+        ];
+
+        $sent = \SuzyEaston\LousyOutages\Mailer::send($email, $subject, $text_body, $html_body, $headers);
+
+        if (!$sent) {
+            error_log('[lousy_outages] confirmation_email send failed for ' . $email);
+        } elseif (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log('Sent Lousy Outages confirmation to ' . $email . ' at ' . current_time('mysql'));
+        }
+
+        return (bool) $sent;
+    }
+}
+
+if (!function_exists('LO_compose_daily_digest')) {
+    /**
+     * Compose the daily digest email subject and bodies.
+     *
+     * @param array<int,array<string,mixed>> $incidents
+     * @return array{subject:string,html:string,text:string}
+     */
+    function LO_compose_daily_digest(array $incidents): array {
+        $items = [];
+        foreach ($incidents as $incident) {
+            if (!is_array($incident)) {
+                continue;
+            }
+
+            $provider = isset($incident['provider']) ? trim((string) $incident['provider']) : '';
+            $title    = isset($incident['title']) ? trim((string) $incident['title']) : '';
+            $status   = isset($incident['status']) ? trim((string) $incident['status']) : '';
+            $url      = isset($incident['url']) ? trim((string) $incident['url']) : '';
+
+            if ('' === $provider || '' === $title) {
+                continue;
+            }
+
+            if ('' === $status && isset($incident['statusRaw'])) {
+                $status = trim((string) $incident['statusRaw']);
+            }
+
+            if ('' !== $url) {
+                $url = esc_url_raw($url);
+            }
+
+            $items[] = [
+                'provider' => $provider,
+                'title'    => \SuzyEaston\LousyOutages\Email\Composer::shortTitle($title),
+                'status'   => $status ?: 'Status update',
+                'url'      => $url,
+            ];
+        }
+
+        if (empty($items)) {
+            return [];
+        }
+
+        $tz        = new \DateTimeZone('America/Vancouver');
+        $dateLabel = wp_date('Y-m-d', null, $tz);
+        $subject   = sprintf('[Outage Digest] Lousy Outages — %s (Local)', $dateLabel);
+        $subject   = (string) apply_filters('lo_daily_digest_subject', $subject, $items);
+
+        $intro = sprintf('Summary of outages and maintenance observed on %s (local time). Each provider is grouped below with the first detected timestamp.', $dateLabel);
+        $intro = (string) apply_filters('lo_daily_digest_intro', $intro, $items);
+
+        $heading = sprintf('Outage Digest — %s (Local)', $dateLabel);
+        $heading = (string) apply_filters('lo_daily_digest_heading', $heading, $items);
+
+        $signoff_text = (string) apply_filters('lo_daily_digest_signoff', 'Stay vigilant — Lousy Outages', $items);
+        $signoff_html = (string) apply_filters('lo_daily_digest_signoff_html', $signoff_text, $items);
+
+        $text_lines = [$heading, $intro, ''];
+        $rows_html  = '';
+        foreach ($items as $item) {
+            $provider = $item['provider'];
+            $title    = $item['title'];
+            $status   = $item['status'];
+            $url      = $item['url'];
+
+            $text_line = sprintf('%s — %s (%s)', $provider, $title, $status);
+            if ('' !== $url) {
+                $text_line .= ' → ' . $url;
+            }
+            $text_lines[] = $text_line;
+
+            $rows_html .= sprintf(
+                '<tr><td style="padding:14px 0;border-bottom:1px solid rgba(143,128,255,0.25);"><strong style="display:block;font-size:16px;color:#f7f4ff;">%s</strong><span style="display:block;font-size:14px;color:rgba(255,255,255,0.8);margin-top:4px;">%s</span><span style="display:block;font-size:13px;color:#8f80ff;margin-top:6px;">%s</span>%s</td></tr>',
+                esc_html($provider),
+                esc_html($title),
+                esc_html($status),
+                $url ? sprintf(' <a href="%s" style="display:inline-block;margin-top:10px;font-size:14px;color:#8f80ff;text-decoration:none;">%s</a>', esc_url($url), esc_html(apply_filters('lo_daily_digest_link_label', 'View incident', $item))) : ''
+            );
+        }
+
+        $text_lines[] = '';
+        $text_lines[] = $signoff_text;
+        $text_body = implode("\n", $text_lines);
+
+        ob_start();
+        ?>
+        <!doctype html>
+        <html lang="en">
+        <head>
+            <meta charset="utf-8">
+            <title><?php echo esc_html($heading); ?></title>
+        </head>
+        <body style="margin:0;background:#070412;color:#f7f4ff;font-family:Segoe UI,Roboto,system-ui,-apple-system,sans-serif;font-size:16px;line-height:1.5;">
+            <div style="max-width:680px;margin:0 auto;padding:36px 24px;">
+                <div style="border-radius:20px;border:1px solid rgba(143,128,255,0.35);background:linear-gradient(155deg,rgba(18,11,45,0.95),rgba(9,6,28,0.92));box-shadow:0 26px 48px rgba(20,14,46,0.6);padding:32px 28px;">
+                    <h1 style="margin:0 0 12px;font-size:26px;letter-spacing:0.04em;color:#d0c6ff;"><?php echo esc_html($heading); ?></h1>
+                    <p style="margin:0 0 20px;font-size:16px;line-height:1.5;color:rgba(255,255,255,0.85);"><?php echo esc_html($intro); ?></p>
+                    <table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;">
+                        <tbody>
+                            <?php echo $rows_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                        </tbody>
+                    </table>
+                    <p style="margin:24px 0 0;font-size:14px;line-height:1.5;color:#c5bfff;"><?php echo esc_html($signoff_html); ?></p>
+                </div>
+            </div>
+        </body>
+        </html>
+        <?php
+        $html_body = trim((string) ob_get_clean());
+
+        return [
+            'subject' => $subject,
+            'html'    => $html_body,
+            'text'    => $text_body,
+        ];
+    }
+}
+
+if (!function_exists('send_lo_outage_alert_email')) {
+    /**
+     * Sends a themed outage alert email.
+     *
+     * @param array<string,mixed> $incident_data
+     */
+    function send_lo_outage_alert_email(string $email, array $incident_data): bool {
+        $email = sanitize_email($email);
+        if (!$email || !is_email($email)) {
+            error_log('[lousy_outages] outage_email invalid recipient');
+            return false;
+        }
+
+        $service = isset($incident_data['service']) ? (string) $incident_data['service'] : 'Service';
+        $status  = isset($incident_data['status']) ? strtolower(trim((string) $incident_data['status'])) : 'degraded';
+        $summary = isset($incident_data['summary']) ? (string) $incident_data['summary'] : '';
+        $impact  = isset($incident_data['impact']) ? strtolower((string) $incident_data['impact']) : 'minor';
+        $timestamp_raw = isset($incident_data['timestamp']) ? (string) $incident_data['timestamp'] : '';
+        $components = isset($incident_data['components']) ? (string) $incident_data['components'] : '';
+        $status_url = isset($incident_data['url']) ? (string) $incident_data['url'] : '';
+        $extra_notes = isset($incident_data['notes']) ? (string) $incident_data['notes'] : '';
+
+        $service_label = trim($service) ?: 'Service';
+        $status_slug   = $status ?: 'degraded';
+        $status_map = [
+            'degraded'       => 'Degraded',
+            'partial_outage' => 'Partial Outage',
+            'major_outage'   => 'Major Outage',
+            'maintenance'    => 'Maintenance',
+            'resolved'       => 'Resolved',
+            'operational'    => 'Operational',
+        ];
+        $status_label  = $status_map[$status_slug] ?? ucfirst(str_replace('_', ' ', $status_slug));
+        $summary_text  = trim($summary) ?: trim($extra_notes);
+        $status_url    = $status_url ?: home_url('/lousy-outages/');
+        $status_url_raw  = esc_url_raw($status_url);
+        $status_url_html = esc_url($status_url);
+
+        $timestamp_display = $timestamp_raw;
+        if ('' !== $timestamp_raw) {
+            $time = strtotime($timestamp_raw);
+            if (false !== $time) {
+                $timestamp_display = wp_date('M j, Y g:i A T', $time);
+            }
+        }
+        $timestamp_display = $timestamp_display ?: wp_date('M j, Y g:i A T');
+
+        $component_line = trim($components);
+        if ('' === $component_line && isset($incident_data['components_list']) && is_array($incident_data['components_list'])) {
+            $component_line = implode(' • ', array_map('strval', $incident_data['components_list']));
+        }
+        if ('' === $component_line) {
+            $component_line = 'All monitored components';
+        }
+
+        $unsubscribe_url = '';
+        if (isset($incident_data['unsubscribe_url']) && '' !== trim((string) $incident_data['unsubscribe_url'])) {
+            $unsubscribe_url = (string) $incident_data['unsubscribe_url'];
+        } else {
+            $unsubscribe_url = lo_unsubscribe_url_for($email);
+        }
+        $unsubscribe_raw  = esc_url_raw($unsubscribe_url);
+        $unsubscribe_html = esc_url($unsubscribe_url);
+
+        $clean_summary = $summary_text ?: sprintf('%s status changed to %s.', $service_label, $status_label);
+
+        $impact_slug = in_array($impact, ['none', 'minor', 'major', 'critical'], true) ? $impact : 'minor';
+        $detected_epoch = strtotime($timestamp_raw) ?: time();
+        $resolved_epoch = ('resolved' === $status_slug) ? $detected_epoch : null;
+
+        $incident_object = new \SuzyEaston\LousyOutages\Model\Incident(
+            $service_label,
+            md5($service_label . '|' . $clean_summary . '|' . $status_slug . '|' . $timestamp_display),
+            $clean_summary,
+            $status_slug,
+            $status_url,
+            $components ?: null,
+            $impact_slug,
+            $detected_epoch,
+            $resolved_epoch
+        );
+
+        $subject = \SuzyEaston\LousyOutages\Email\Composer::subjectForIncident($incident_object, $status_slug);
+
+        $text_body_lines = [
+            sprintf('%s outage alert', strtoupper($service_label)),
+            sprintf('Status: %s', $status_label),
+            sprintf('Detected: %s', $timestamp_display),
+            '',
+            $clean_summary,
+            '',
+            'Impacted components: ' . $component_line,
+            '',
+            'Track live status: ' . $status_url_raw,
+            '',
+            'Unsubscribe: ' . $unsubscribe_raw,
+            '',
+            'Hold the line — Lousy Outages',
+        ];
+        $text_body = implode("\n", $text_body_lines);
+
+        ob_start();
+        ?>
+        <!doctype html>
+        <html lang="en">
+        <head>
+            <meta charset="utf-8">
+            <title>Lousy Outages Alert</title>
+        </head>
+        <body style="margin:0;background:#050607;color:#FFEB3B;font-family:'Courier New','Lucida Console',monospace;font-size:16px;line-height:1.5;">
+            <div style="max-width:720px;margin:0 auto;padding:40px 24px;">
+                <div style="border:3px solid #FFEB3B;border-radius:24px;padding:34px 30px;background:linear-gradient(160deg,rgba(7,12,20,0.95),rgba(20,6,40,0.92));box-shadow:0 0 32px rgba(255,235,59,0.35);">
+                    <p style="margin:0 0 10px;font-size:13px;letter-spacing:0.2em;text-transform:uppercase;color:#FF1744;">alert: <?php echo esc_html($service_label); ?></p>
+                    <h1 style="margin:0 0 14px;font-size:32px;color:#FFEB3B;text-transform:uppercase;letter-spacing:0.05em;"><?php echo esc_html($service_label); ?> status: <?php echo esc_html(strtoupper($status_label)); ?></h1>
+                    <p style="margin:0 0 18px;font-size:16px;line-height:1.5;color:#FFF59D;"><?php echo esc_html($clean_summary); ?></p>
+                    <dl style="margin:0 0 20px;color:#FFF59D;font-size:14px;line-height:1.5;">
+                        <div style="display:flex;flex-wrap:wrap;gap:6px 16px;margin-bottom:10px;">
+                            <dt style="width:120px;text-transform:uppercase;letter-spacing:0.08em;color:#80D8FF;">Status</dt>
+                            <dd style="margin:0;font-weight:700;"><?php echo esc_html($status_label); ?></dd>
+                        </div>
+                        <div style="display:flex;flex-wrap:wrap;gap:6px 16px;margin-bottom:10px;">
+                            <dt style="width:120px;text-transform:uppercase;letter-spacing:0.08em;color:#80D8FF;">Components</dt>
+                            <dd style="margin:0;"><?php echo esc_html($component_line); ?></dd>
+                        </div>
+                        <div style="display:flex;flex-wrap:wrap;gap:6px 16px;margin-bottom:10px;">
+                            <dt style="width:120px;text-transform:uppercase;letter-spacing:0.08em;color:#80D8FF;">Detected</dt>
+                            <dd style="margin:0;"><?php echo esc_html($timestamp_display); ?></dd>
+                        </div>
+                    </dl>
+                    <p style="margin:0 0 18px;font-size:14px;color:#FFCCBC;">Keep eyes on the incident console:</p>
+                    <p style="margin:0 0 24px;">
+                        <a href="<?php echo esc_url($status_url_html); ?>" style="display:inline-block;padding:16px 28px;border-radius:999px;border:2px solid #FF1744;background:#0A0418;color:#FFEB3B;font-weight:700;text-decoration:none;text-transform:uppercase;letter-spacing:0.14em;">View live status feed</a>
+                    </p>
+                    <?php
+                    $follow_line = apply_filters(
+                        'lo_incident_follow_line',
+                        'We won’t email every update. Follow the status page for the latest, and look for the daily digest tonight.',
+                        $incident_data
+                    );
+                    if (is_string($follow_line) && '' !== trim($follow_line)) :
+                    ?>
+                        <p style="margin:0 0 20px;font-size:14px;color:#FFE082;">
+                            <?php echo esc_html($follow_line); ?>
+                        </p>
+                    <?php endif; ?>
+                    <p style="margin:0 0 14px;font-size:13px;color:#FFF59D;">Backup link:<br><span style="color:#FFAB40;"><?php echo esc_html($status_url_raw); ?></span></p>
+                    <?php if ($extra_notes) : ?>
+                        <p style="margin:0 0 28px;font-size:13px;color:#FFCDD2;"><?php echo esc_html($extra_notes); ?></p>
+                    <?php endif; ?>
+                    <div style="margin:26px 0;padding:18px;border:1px dashed rgba(255,235,59,0.7);border-radius:16px;background:rgba(29,8,48,0.8);color:#FFEB3B;font-size:13px;">
+                        <strong style="display:block;font-size:11px;letter-spacing:0.18em;color:#FF1744;margin-bottom:6px;text-transform:uppercase;">Need to bail?</strong>
+                        Unsubscribe instantly: <a style="color:#FFAB40;text-decoration:none;" href="<?php echo esc_url($unsubscribe_html); ?>"><?php echo esc_html($unsubscribe_raw); ?></a>
+                    </div>
+                    <p style="margin:0;font-size:12px;color:rgba(255,235,59,0.75);">Stay patched &mdash; Lousy Outages monitoring team.</p>
+                </div>
+            </div>
+        </body>
+        </html>
+        <?php
+        $html_body = trim((string) ob_get_clean());
+
+        $headers = [
+            'List-Unsubscribe: <' . $unsubscribe_raw . '>',
+            'List-Unsubscribe-Post: List-Unsubscribe=One-Click',
+        ];
+
+        if (isset($incident_data['headers']) && is_array($incident_data['headers'])) {
+            foreach ($incident_data['headers'] as $header) {
+                if (!is_string($header)) {
+                    continue;
+                }
+                $headers[] = $header;
+            }
+        }
+
+        $sent = \SuzyEaston\LousyOutages\Mailer::send($email, $subject, $text_body, $html_body, $headers);
+
+        if (!$sent) {
+            error_log('[lousy_outages] outage_email send failed for ' . $email . ' subject=' . $subject);
+        } elseif (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log('Sent Lousy Outages alert to ' . $email . ' at ' . current_time('mysql'));
+        }
+
+        return (bool) $sent;
+    }
+}
+

--- a/plugins/lousy-outages/lousy-outages.php
+++ b/plugins/lousy-outages/lousy-outages.php
@@ -1,12 +1,11 @@
 <?php
 declare( strict_types=1 );
 /**
- * Legacy theme-bundled loader shim for Lousy Outages. Remove after standalone plugin is fully verified.
- *
  * Plugin Name: Lousy Outages
- * Description: Aggregates service status and sends SMS/email alerts on incidents.
- * Version: 0.1.0
+ * Description: WordPress-native outage intelligence, community reporting, and early-warning signals for third-party service dependencies.
+ * Version: 0.2.0
  * Author: Suzy Easton
+ * Text Domain: lousy-outages
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/lousy-outages/public/shortcode.php
+++ b/plugins/lousy-outages/public/shortcode.php
@@ -1,0 +1,1019 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+const LO_SHOW_WIDESPREAD = false;
+
+/**
+ * Determine the filesystem path and URL for the plugin assets.
+ *
+ * When the plugin is bundled with the theme (as it is on suzyeaston.ca),
+ * plugin_dir_url() incorrectly points to wp-content/plugins/, which results in
+ * 404s for front-end assets. This helper checks for copies that live alongside
+ * the active theme before falling back to the plugin directory.
+ *
+ * @return array{string, string} An array containing the absolute path and the
+ *                               public URL for the assets directory.
+ */
+function locate_assets_base(): array
+{
+    $candidates = [];
+
+    if (function_exists('get_stylesheet_directory') && function_exists('get_stylesheet_directory_uri')) {
+        $stylesheet_path = rtrim(get_stylesheet_directory(), '/\\') . '/lousy-outages/assets/';
+        $stylesheet_url  = rtrim(get_stylesheet_directory_uri(), '/\\') . '/lousy-outages/assets/';
+        $candidates[] = [$stylesheet_path, $stylesheet_url];
+    }
+
+    if (function_exists('get_template_directory') && function_exists('get_template_directory_uri')) {
+        $template_path = rtrim(get_template_directory(), '/\\') . '/lousy-outages/assets/';
+        $template_url  = rtrim(get_template_directory_uri(), '/\\') . '/lousy-outages/assets/';
+        $candidates[] = [$template_path, $template_url];
+    }
+
+    $plugin_path = rtrim(plugin_dir_path(__DIR__), '/\\') . '/assets/';
+    $plugin_url  = rtrim(plugin_dir_url(__DIR__), '/\\') . '/assets/';
+    $candidates[] = [$plugin_path, $plugin_url];
+
+    foreach ($candidates as $candidate) {
+        [$path, $url] = $candidate;
+        if ($path && file_exists($path)) {
+            return [$path, $url];
+        }
+    }
+
+    return [$plugin_path, $plugin_url];
+}
+
+add_shortcode('lousy_outages', __NAMESPACE__ . '\render_shortcode');
+add_shortcode('lousy_outages_subscribe', __NAMESPACE__ . '\render_subscribe_shortcode');
+add_shortcode('lousy_outages_report', __NAMESPACE__ . '\render_report_shortcode');
+
+function render_shortcode(): string {
+    [$base_path, $base_url] = locate_assets_base();
+
+    wp_enqueue_style(
+        'lousy-outages',
+        $base_url . 'lousy-outages.css',
+        [],
+        file_exists($base_path . 'lousy-outages.css') ? filemtime($base_path . 'lousy-outages.css') : null
+    );
+
+    wp_enqueue_style(
+        'lousy-outages-hud',
+        $base_url . 'hud.css',
+        ['lousy-outages'],
+        file_exists($base_path . 'hud.css') ? filemtime($base_path . 'hud.css') : null
+    );
+
+    wp_enqueue_script(
+        'lousy-outages',
+        $base_url . 'lousy-outages.js',
+        [],
+        file_exists($base_path . 'lousy-outages.js') ? filemtime($base_path . 'lousy-outages.js') : null,
+        true
+    );
+
+    wp_enqueue_script(
+        'lousy-outages-hud',
+        $base_url . 'hud.js',
+        ['lousy-outages'],
+        file_exists($base_path . 'hud.js') ? filemtime($base_path . 'hud.js') : null,
+        true
+    );
+
+    if (file_exists($base_path . 'js/outages.js')) {
+        wp_enqueue_script(
+            'lousy-outages-auto-refresh',
+            $base_url . 'js/outages.js',
+            [],
+            filemtime($base_path . 'js/outages.js'),
+            true
+        );
+    }
+
+    $cache_key = is_user_logged_in() ? null : 'lousy_outages_fragment_public';
+    $cached    = ($cache_key) ? get_transient($cache_key) : null;
+    $snapshot_endpoint = esc_url_raw(rest_url('lousy/v1/snapshot'));
+
+    $fetcher      = new Lousy_Outages_Fetcher();
+    $provider_map = $fetcher->get_provider_map();
+
+    $providers_config = Providers::enabled();
+    if (is_array($provider_map) && $provider_map) {
+        foreach ($provider_map as $slug => $info) {
+            if (!isset($providers_config[$slug]) && is_array($info)) {
+                $providers_config[$slug] = [
+                    'id'         => $slug,
+                    'name'       => isset($info['name']) ? (string) $info['name'] : ucfirst((string) $slug),
+                    'status_url' => isset($info['status_url']) ? (string) $info['status_url'] : '',
+                ];
+            }
+        }
+    }
+
+    $fetched_at = '';
+    $last_fetched_iso = \function_exists('lousy_outages_get_last_fetched_iso')
+        ? \lousy_outages_get_last_fetched_iso()
+        : '';
+    $tiles      = [];
+    $config     = null;
+    $refresh_interval = 60000;
+    $initial_trending = [
+        'trending'     => false,
+        'signals'      => [],
+        'generated_at' => gmdate('c'),
+    ];
+    $source = 'live';
+    $snapshot_errors = [];
+
+    if (is_array($cached) && isset($cached['config'])) {
+        $config = $cached['config'];
+        if (isset($config['initial']['providers']) && is_array($config['initial']['providers'])) {
+            foreach ($config['initial']['providers'] as $tile) {
+                if (!is_array($tile)) {
+                    continue;
+                }
+                $slug = (string) ($tile['provider'] ?? '');
+                if ('' === $slug) {
+                    continue;
+                }
+                $tiles[] = $tile;
+            }
+        }
+        $fetched_at = $config['initial']['fetched_at'] ?? $config['initial']['fetchedAt'] ?? $fetched_at;
+        if (isset($config['initial']['trending']) && is_array($config['initial']['trending'])) {
+            $initial_trending = $config['initial']['trending'];
+        }
+        if (isset($config['initial']['source'])) {
+            $source = (string) $config['initial']['source'];
+        }
+        if (isset($config['initial']['errors']) && is_array($config['initial']['errors'])) {
+            $snapshot_errors = $config['initial']['errors'];
+        }
+    }
+
+    if (!$config) {
+        $snapshot = \lousy_outages_get_snapshot(false);
+        if (!isset($snapshot['providers']) || !is_array($snapshot['providers']) || !$snapshot['providers']) {
+            $stored_snapshot = get_option('lousy_outages_snapshot', []);
+            if (isset($stored_snapshot['providers']) && is_array($stored_snapshot['providers']) && $stored_snapshot['providers']) {
+                $snapshot = $stored_snapshot;
+            }
+        }
+
+        if (isset($snapshot['providers']) && is_array($snapshot['providers']) && $snapshot['providers']) {
+            $tiles = array_values($snapshot['providers']);
+            if (isset($snapshot['fetched_at'])) {
+                $fetched_at = (string) $snapshot['fetched_at'];
+            }
+            if (isset($snapshot['trending']) && is_array($snapshot['trending'])) {
+                $initial_trending = $snapshot['trending'];
+            }
+            if (!empty($snapshot['errors']) && is_array($snapshot['errors'])) {
+                $snapshot_errors = $snapshot['errors'];
+            }
+            $source = isset($snapshot['source']) ? (string) $snapshot['source'] : 'snapshot';
+        } else {
+            $normalized_snapshot = \lo_snapshot_get_cached();
+            if (!empty($normalized_snapshot['services'])) {
+                foreach ($normalized_snapshot['services'] as $service) {
+                    if (!is_array($service)) {
+                        continue;
+                    }
+                    $service_id = (string) ($service['id'] ?? '');
+                    if ('' === $service_id) {
+                        continue;
+                    }
+                    $tiles[] = [
+                        'id'          => $service_id,
+                        'provider'    => $service_id,
+                        'name'        => $service['name'] ?? $service_id,
+                        'status'      => $service['status'] ?? 'unknown',
+                        'status_label'=> $service['status_text'] ?? ucfirst((string) ($service['status'] ?? 'unknown')),
+                        'state'       => $service['status_text'] ?? '',
+                        'stateCode'   => $service['status'] ?? 'unknown',
+                        'summary'     => $service['summary'] ?? '',
+                        'url'         => $service['url'] ?? '',
+                        'updated_at'  => $service['updated_at'] ?? $normalized_snapshot['updated_at'],
+                        'incidents'   => [],
+                    ];
+                }
+                $fetched_at = $normalized_snapshot['updated_at'];
+                $snapshot_errors = [];
+                $source = $normalized_snapshot['stale'] ? 'stale' : 'snapshot';
+            }
+        }
+
+        $config = [
+            'endpoint'          => esc_url_raw(rest_url('lousy-outages/v1/summary')),
+            'pollInterval'      => $refresh_interval,
+            'refreshEndpoint'   => esc_url_raw(rest_url('lousy-outages/v1/refresh')),
+            'refreshNonce'      => wp_create_nonce('wp_rest'),
+            'subscribeEndpoint' => esc_url_raw(rest_url('lousy-outages/v1/subscribe')),
+            'snapshotEndpoint'  => $snapshot_endpoint,
+            'historyEndpoint'   => esc_url_raw(rest_url('lousy-outages/v1/history')),
+            'initial'           => [
+                'providers'  => $tiles,
+                'fetched_at' => $fetched_at,
+                'trending'   => $initial_trending,
+                'source'     => $source,
+                'errors'     => $snapshot_errors,
+            ],
+        ];
+    } else {
+        if (!isset($config['initial']['trending']) || !is_array($config['initial']['trending'])) {
+            $config['initial']['trending'] = $initial_trending;
+        } else {
+            $initial_trending = $config['initial']['trending'];
+        }
+        if (isset($config['initial']['source'])) {
+            $source = (string) $config['initial']['source'];
+        } else {
+            $config['initial']['source'] = $source;
+        }
+        if (isset($config['initial']['errors']) && is_array($config['initial']['errors'])) {
+            $snapshot_errors = $config['initial']['errors'];
+        } else {
+            $config['initial']['errors'] = $snapshot_errors;
+        }
+
+        if (!isset($config['snapshotEndpoint'])) {
+            $config['snapshotEndpoint'] = $snapshot_endpoint;
+        }
+        if (!isset($config['historyEndpoint'])) {
+            $config['historyEndpoint'] = esc_url_raw(rest_url('lousy-outages/v1/history'));
+        }
+    }
+
+    if ($last_fetched_iso) {
+        if ('' === $fetched_at) {
+            $fetched_at = $last_fetched_iso;
+        }
+        if (isset($config['initial']['fetched_at'])) {
+            $config['initial']['fetched_at'] = $last_fetched_iso;
+        }
+    }
+
+    if ('' === $fetched_at) {
+        $fetched_at = $last_fetched_iso ?: gmdate('c');
+    }
+
+    $tiles_by_slug = [];
+    foreach ($tiles as $tile) {
+        if (!is_array($tile)) {
+            continue;
+        }
+        $slug = (string) ($tile['provider'] ?? '');
+        if ('' === $slug) {
+            continue;
+        }
+        $tiles_by_slug[$slug] = $tile;
+    }
+
+    $ordered_tiles = [];
+    foreach ($tiles as $tile) {
+        if (!is_array($tile)) {
+            continue;
+        }
+        $slug = (string) ($tile['provider'] ?? '');
+        if ('' === $slug) {
+            continue;
+        }
+        if (!empty($providers_config) && !isset($providers_config[$slug])) {
+            continue;
+        }
+        $ordered_tiles[] = $tile;
+    }
+
+    $operational_placeholders = apply_filters('lo_operational_placeholder_providers', ['openai', 'twilio']);
+    if (!is_array($operational_placeholders)) {
+        $operational_placeholders = ['openai', 'twilio'];
+    }
+    $operational_placeholders = array_map('sanitize_key', $operational_placeholders);
+
+    $placeholder_label = apply_filters('lo_operational_placeholder_label', 'OPERATIONAL');
+    if (!is_string($placeholder_label) || '' === trim($placeholder_label)) {
+        $placeholder_label = 'OPERATIONAL';
+    }
+
+    $placeholder_summary = apply_filters('lo_operational_placeholder_summary', 'Assuming operational — awaiting the next live sync.');
+    if (!is_string($placeholder_summary) || '' === trim($placeholder_summary)) {
+        $placeholder_summary = 'Assuming operational — awaiting the next live sync.';
+    }
+
+    $placeholder_message = apply_filters('lo_operational_placeholder_message', 'Live status feed quiet; placeholder set to operational.');
+    if (!is_string($placeholder_message) || '' === trim($placeholder_message)) {
+        $placeholder_message = 'Live status feed quiet; placeholder set to operational.';
+    }
+
+    foreach ($providers_config as $slug => $provider_config) {
+        if (isset($tiles_by_slug[$slug])) {
+            continue;
+        }
+        $provider_key = sanitize_key($slug);
+        $is_operational_placeholder = in_array($provider_key, $operational_placeholders, true);
+        $status_slug = $is_operational_placeholder ? 'operational' : 'unknown';
+        $tile_kind = $is_operational_placeholder ? 'operational' : 'unknown';
+        $sort_key = $is_operational_placeholder ? 70 : 90;
+        $status_label = $is_operational_placeholder ? $placeholder_label : 'UNKNOWN';
+        $status_class = $is_operational_placeholder ? 'status--operational' : 'status--unknown';
+        $summary_text = $is_operational_placeholder ? '' : 'Can’t verify status right now.';
+        $message_text = $is_operational_placeholder ? 'All systems operational.' : 'Can’t verify status right now.';
+
+        $ordered_tiles[] = [
+            'id'           => $slug,
+            'provider'     => $slug,
+            'name'         => $provider_config['name'] ?? ucfirst($slug),
+            'status'       => $status_slug,
+            'status_label' => $status_label,
+            'status_class' => $status_class,
+            'overall'      => $status_slug,
+            'message'      => $message_text,
+            'summary'      => $summary_text,
+            'components'   => [],
+            'incidents'    => [],
+            'fetched_at'   => $fetched_at,
+            'http_code'    => 0,
+            'indicator'    => null,
+            'link'         => $provider_config['status_url'] ?? '',
+            'url'          => $provider_config['status_url'] ?? '',
+            'error'        => null,
+            'tile_kind'    => $tile_kind,
+            'sort_key'     => $sort_key,
+        ];
+    }
+
+    if (!$ordered_tiles && $provider_map) {
+        foreach ($provider_map as $slug => $provider_info) {
+            $provider_key = sanitize_key($slug);
+            $is_operational_placeholder = in_array($provider_key, $operational_placeholders, true);
+            $status_slug = $is_operational_placeholder ? 'operational' : 'unknown';
+            $tile_kind = $is_operational_placeholder ? 'operational' : 'unknown';
+            $sort_key = $is_operational_placeholder ? 70 : 90;
+            $status_label = $is_operational_placeholder ? $placeholder_label : 'UNKNOWN';
+            $status_class = $is_operational_placeholder ? 'status--operational' : 'status--unknown';
+            $summary_text = $is_operational_placeholder ? '' : 'Can’t verify status right now.';
+            $message_text = $is_operational_placeholder ? 'All systems operational.' : 'Can’t verify status right now.';
+
+            $ordered_tiles[] = [
+                'provider'     => $slug,
+                'name'         => $provider_info['name'],
+                'status'       => $status_slug,
+                'status_label' => $status_label,
+                'status_class' => $status_class,
+                'overall'      => $status_slug,
+                'message'      => $message_text,
+                'summary'      => $summary_text,
+                'components'   => [],
+                'incidents'    => [],
+                'fetched_at'   => $fetched_at,
+                'http_code'    => 0,
+                'indicator'    => null,
+                'link'         => $provider_info['status_url'],
+                'url'          => $provider_info['status_url'],
+                'error'        => null,
+                'tile_kind'    => $tile_kind,
+                'sort_key'     => $sort_key,
+            ];
+        }
+    }
+
+    $config['initial']['providers'] = array_values($ordered_tiles);
+    $config['initial']['source']    = $source;
+    $config['initial']['errors']    = $snapshot_errors;
+
+    $build_meta_counts = static function (array $providers): array {
+        $counts = [
+            'active_outage_count' => 0,
+            'signal_count'        => 0,
+            'unverified_count'    => 0,
+            'generated_at'        => gmdate('c'),
+        ];
+
+        foreach ($providers as $provider) {
+            if (!is_array($provider)) {
+                continue;
+            }
+            $tile_kind = strtolower((string) ($provider['tile_kind'] ?? $provider['tileKind'] ?? ''));
+            if ('' === $tile_kind) {
+                $status = strtolower((string) ($provider['status'] ?? $provider['stateCode'] ?? 'unknown'));
+                if ('operational' === $status) {
+                    $tile_kind = 'operational';
+                } elseif ('unknown' === $status) {
+                    $tile_kind = 'unknown';
+                } elseif (!empty($provider['incidents'])) {
+                    $tile_kind = 'outage';
+                } else {
+                    $tile_kind = 'signal';
+                }
+            }
+
+            if ('outage' === $tile_kind) {
+                $counts['active_outage_count'] += 1;
+            } elseif ('signal' === $tile_kind) {
+                $counts['signal_count'] += 1;
+            } elseif ('unknown' === $tile_kind || 'manual' === $tile_kind) {
+                $counts['unverified_count'] += 1;
+            }
+        }
+
+        return $counts;
+    };
+
+    $meta_counts = $build_meta_counts($config['initial']['providers']);
+    $config['meta'] = $meta_counts;
+    $config['initial']['meta'] = $meta_counts;
+
+    $rss_url = home_url('/?feed=lousy_outages_status'); // Pretty /feed/lousy_outages_status/ works after a permalink flush, but the query form is safer.
+
+    wp_localize_script('lousy-outages', 'LousyOutagesConfig', $config);
+    wp_localize_script(
+        'lousy-outages',
+        'LOUSY_OUTAGES',
+        [
+            'restUrl' => esc_url_raw(rest_url('lousy/v1/refresh')),
+            'nonce'   => $config['refreshNonce'] ?? wp_create_nonce('wp_rest'),
+        ]
+    );
+
+    $format_datetime = static function (?string $iso): string {
+        if (empty($iso)) {
+            return '—';
+        }
+        $timestamp = strtotime($iso);
+        if (!$timestamp) {
+            return '—';
+        }
+        $format = get_option('date_format') . ' ' . get_option('time_format');
+        return wp_date($format, $timestamp);
+    };
+    $is_no_incidents_message = static function (string $text): bool {
+        $needle = strtolower(trim($text));
+        if ('' === $needle) {
+            return false;
+        }
+        $phrases = [
+            'no active incidents',
+            'no incidents',
+            'no current incidents',
+            'no known incidents',
+            'no reported incidents',
+            'all systems operational',
+        ];
+        foreach ($phrases as $phrase) {
+            if (false !== strpos($needle, $phrase)) {
+                return true;
+            }
+        }
+        return false;
+    };
+    $is_generic_degraded_message = static function (string $text): bool {
+        $needle = strtolower(trim($text));
+        if ('' === $needle) {
+            return true;
+        }
+        $phrases = [
+            'service degradation reported.',
+            'major outage reported.',
+            'maintenance in progress.',
+            'status temporarily unavailable.',
+            'can’t verify status right now.',
+        ];
+        return in_array($needle, $phrases, true);
+    };
+
+    $fetched_label = ('snapshot' === strtolower((string) $source))
+        ? 'Outage info last refreshed:'
+        : 'Outage info fetched:';
+    $external_query = rawurlencode('service outage');
+    $external_links = [
+        [
+            'label' => 'Twitter/X search',
+            'url'   => 'https://x.com/search?q=' . $external_query,
+        ],
+        [
+            'label' => 'Reddit search',
+            'url'   => 'https://www.reddit.com/search/?q=' . $external_query,
+        ],
+        [
+            'label' => 'Web search',
+            'url'   => 'https://duckduckgo.com/?q=' . $external_query,
+        ],
+    ];
+
+    ob_start();
+    ?>
+    <?php
+    $trending_active = !empty($initial_trending['trending']);
+    $trending_signals = isset($initial_trending['signals']) && is_array($initial_trending['signals'])
+        ? array_filter(array_map('strval', $initial_trending['signals']))
+        : [];
+    $trending_generated = isset($initial_trending['generated_at']) ? (string) $initial_trending['generated_at'] : '';
+    ?>
+    <div
+        class="lousy-outages"
+        data-lo-endpoint="<?php echo esc_url($config['endpoint']); ?>"
+        data-lo-source="<?php echo esc_attr($source); ?>"
+        data-lo-snapshot="<?php echo esc_url($config['snapshotEndpoint'] ?? $snapshot_endpoint); ?>"
+        data-lo-refresh-interval="<?php echo esc_attr((string) $refresh_interval); ?>"
+    >
+        <div class="lo-header">
+            <div class="lo-actions">
+                <span class="lo-meta" aria-live="polite">
+                    <span data-lo-fetched-label><?php echo esc_html($fetched_label); ?></span>
+                    <strong data-lo-fetched><?php echo esc_html($format_datetime($fetched_at)); ?></strong>
+                    <span data-lo-countdown>Auto-refresh ready</span>
+                </span>
+                <span class="lo-pill lo-pill--degraded" data-lo-degraded hidden>Auto-refresh degraded</span>
+                <button type="button" class="lo-link" data-lo-refresh>Refresh now</button>
+                <button type="button" class="lo-link" data-lo-export-csv>Export CSV</button>
+                <button type="button" class="lo-link" data-lo-export-pdf>Save PDF</button>
+                <a class="lo-link" href="<?php echo esc_url($rss_url); ?>" target="_blank" rel="noopener">Subscribe (RSS)</a>
+            </div>
+        </div>
+        <div class="lo-mode-toggle" data-lo-mode-toggle>
+            <button type="button" class="lo-mode-toggle__button is-active" data-lo-mode="incidents" aria-pressed="true">Incidents (0)</button>
+            <button type="button" class="lo-mode-toggle__button" data-lo-mode="all" aria-pressed="false">All providers</button>
+        </div>
+        <div class="lo-incidents" data-lo-incidents>
+            <section class="lo-section lo-section--incidents" data-lo-section="incidents">
+                <div class="lo-section__head">
+                    <h3 class="lo-block-title">Active incidents</h3>
+                </div>
+                <div class="lo-grid lo-grid--section" data-lo-section-grid="incidents"></div>
+            </section>
+            <section class="lo-section lo-section--collapsible" data-lo-section="signals">
+                <div class="lo-section__head">
+                    <button type="button" class="lo-section__toggle" data-lo-section-toggle="signals" aria-expanded="false">Signals (0)</button>
+                </div>
+                <div class="lo-grid lo-grid--section" data-lo-section-grid="signals" hidden></div>
+            </section>
+            <section class="lo-section lo-section--collapsible" data-lo-section="unverified">
+                <div class="lo-section__head">
+                    <button type="button" class="lo-section__toggle" data-lo-section-toggle="unverified" aria-expanded="false">Can’t verify (0)</button>
+                </div>
+                <div class="lo-grid lo-grid--section" data-lo-section-grid="unverified" hidden></div>
+            </section>
+        </div>
+        <?php if (LO_SHOW_WIDESPREAD) : ?>
+        <div class="lo-trending" data-lo-trending<?php echo $trending_active ? '' : ' hidden'; ?> data-lo-trending-generated="<?php echo esc_attr($trending_generated); ?>" aria-live="assertive">
+            <span class="lo-trending__icon" aria-hidden="true">⚡</span>
+            <div class="lo-trending__body">
+                <strong data-lo-trending-text>Potential widespread issues detected — check affected providers</strong>
+                <span class="lo-trending__reasons" data-lo-trending-reasons<?php echo $trending_signals ? '' : ' hidden'; ?>><?php echo esc_html($trending_signals ? 'Signals: ' . implode(', ', array_slice($trending_signals, 0, 6)) : ''); ?></span>
+            </div>
+        </div>
+        <?php endif; ?>
+        <div class="lo-hero" data-lo-hero hidden>
+            <article class="lo-card lo-card--hero">
+                <div class="lo-head">
+                    <h3 class="lo-title">No active incidents</h3>
+                </div>
+                <p class="lo-summary">Signals and verification issues are hidden by default.</p>
+                <p class="lo-card-meta">Last checked: <span data-lo-hero-time>—</span></p>
+            </article>
+        </div>
+        <section class="lo-history" data-lo-history>
+            <div class="lo-history__heading">
+                <div>
+                    <h3 class="lo-block-title">Recent incidents (Status feeds + community)</h3>
+                    <p class="lo-history__meta">Last 30 days of non-operational blips.</p>
+                </div>
+                <div class="lo-history__controls">
+                    <label>
+                        <input type="checkbox" data-lo-history-important checked>
+                        <span>Show only major incidents</span>
+                    </label>
+                    <label>
+                        <span class="sr-only">History window</span>
+                        <select data-lo-history-window>
+                            <option value="1">24h</option>
+                            <option value="7">7d</option>
+                            <option value="30" selected>30d</option>
+                        </select>
+                    </label>
+                </div>
+            </div>
+            <div class="lo-history__body">
+                <div class="lo-history__charts" data-lo-history-charts hidden></div>
+                <ol class="lo-history__list" data-lo-history-list>
+                    <li class="lo-history__item lo-history__item--placeholder">Loading incidents…</li>
+                </ol>
+                <p class="lo-history__empty" data-lo-history-empty hidden>No incidents in the past 30 days.</p>
+                <p class="lo-history__error" data-lo-history-error hidden>Unable to load incident history right now.</p>
+            </div>
+        </section>
+        <?php echo render_subscribe_shortcode(); ?>
+        <div class="lo-external" data-lo-external>
+            <article class="lo-card lo-card--external" data-provider-id="external-signals">
+                <div class="lo-head">
+                    <h3 class="lo-title">External signals (unconfirmed)</h3>
+                </div>
+                <p class="lo-summary">Quick links to community chatter and third-party status hints.</p>
+                <ul class="lo-links">
+                    <?php foreach ($external_links as $external_link) : ?>
+                        <li>
+                            <a class="lo-link" href="<?php echo esc_url($external_link['url']); ?>" target="_blank" rel="noopener">
+                                <?php echo esc_html($external_link['label']); ?>
+                            </a>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            </article>
+        </div>
+        <div class="lo-settings" data-lo-settings>
+            <h3 class="lo-block-title">Customize view</h3>
+            <p class="lo-settings__hint">Pick which providers appear below. Preferences stay on this browser only.</p>
+            <div class="lo-settings__actions">
+                <button type="button" class="lo-settings__button" data-lo-provider-select="all">Select all</button>
+                <button type="button" class="lo-settings__button lo-settings__button--ghost" data-lo-provider-select="none">Select none</button>
+            </div>
+            <div class="lo-settings__options">
+                <?php foreach ($ordered_tiles as $tile) :
+                    $slug = (string) ($tile['provider'] ?? '');
+                    if ('' === $slug) {
+                        continue;
+                    }
+                    $provider_label = $tile['name'] ?? ucfirst($slug);
+                    ?>
+                    <label class="lo-checkbox">
+                        <input type="checkbox" data-lo-provider-toggle value="<?php echo esc_attr($slug); ?>" checked>
+                        <span><?php echo esc_html($provider_label); ?></span>
+                    </label>
+                <?php endforeach; ?>
+            </div>
+        </div>
+        <div class="lo-loading" data-lo-loading<?php echo $ordered_tiles ? ' hidden' : ''; ?> role="status">
+            <span class="lo-loading__spinner" aria-hidden="true"></span>
+            <span class="lo-loading__text">Dialing interstellar relays…</span>
+        </div>
+        <div class="lo-all" data-lo-all>
+            <div class="lo-grid" data-lo-grid>
+                <?php foreach ($ordered_tiles as $tile) :
+                    $slug = (string) ($tile['provider'] ?? '');
+                    $status = strtolower((string) ($tile['status'] ?? 'unknown'));
+                    $status_class = $tile['status_class'] ?? ('status--' . (preg_replace('/[^a-z0-9_-]+/i', '-', $status) ?: 'unknown'));
+                    $label = $tile['status_label'] ?? ucfirst($status);
+                    $components = array_filter(
+                        is_array($tile['components'] ?? null) ? $tile['components'] : [],
+                        static fn($component) => is_array($component) && strtolower((string) ($component['status'] ?? '')) !== 'operational'
+                    );
+                    $incidents = is_array($tile['incidents'] ?? null) ? $tile['incidents'] : [];
+                    $resolved_states = ['resolved', 'completed', 'postmortem'];
+                    $active_incidents = array_values(
+                        array_filter(
+                            $incidents,
+                            static function ($incident) use ($resolved_states): bool {
+                                if (!is_array($incident)) {
+                                    return false;
+                                }
+                                $status = strtolower((string) ($incident['status'] ?? ''));
+                                return !in_array($status, $resolved_states, true);
+                            }
+                        )
+                    );
+                    $last_checked = $format_datetime(
+                        $tile['fetched_at']
+                        ?? $tile['fetchedAt']
+                        ?? $tile['updated_at']
+                        ?? $tile['updatedAt']
+                        ?? null
+                    );
+                    $debug_mode = isset($_GET['lo_debug']) && '1' === $_GET['lo_debug'];
+                    $debug_line = '';
+                    if ($debug_mode) {
+                        $http_code = isset($tile['http_code']) ? (int) $tile['http_code'] : 0;
+                        $error_text = isset($tile['error']) ? trim((string) $tile['error']) : '';
+                        if ($http_code > 0) {
+                            $debug_line = 'debug: HTTP ' . $http_code;
+                            if ('' !== $error_text) {
+                                $debug_line .= ' (' . $error_text . ')';
+                            }
+                        } elseif ('' !== $error_text) {
+                            $debug_line = 'debug: ' . $error_text;
+                        }
+                    }
+                    ?>
+                    <article class="lo-card" data-provider-id="<?php echo esc_attr($slug ?: 'provider'); ?>">
+                        <div class="lo-head">
+                            <h3 class="lo-title"><?php echo esc_html($tile['name'] ?? ucfirst($slug)); ?></h3>
+                            <span class="lo-pill <?php echo esc_attr($status_class); ?>" data-lo-badge><?php echo esc_html($label); ?></span>
+                        </div>
+                        <?php
+                        $message_text = trim((string) ($tile['message'] ?? ''));
+                        $summary_text = trim((string) ($tile['summary'] ?? ''));
+                        if (!empty($tile['error'])) {
+                            if ('' === $message_text) {
+                                $message_text = 'Can’t verify status right now.';
+                            }
+                            $summary_text = '';
+                        }
+                        if ('' === $message_text) {
+                            if (!empty($active_incidents)) {
+                                $lead_incident = $active_incidents[0]['name'] ?? ($active_incidents[0]['title'] ?? ($active_incidents[0]['summary'] ?? 'Incident'));
+                                $message_text = $lead_incident;
+                            } elseif ($status === 'operational') {
+                                $message_text = 'All systems operational.';
+                            } elseif ($status === 'unknown') {
+                                $message_text = 'Can’t verify status right now.';
+                            } else {
+                                $message_text = $summary_text ?: ($label ?: 'Status update');
+                            }
+                        }
+                        if (
+                            empty($tile['error'])
+                            && 'cloudflare' === $slug
+                            && !in_array($status, ['operational', 'unknown'], true)
+                            && empty($active_incidents)
+                            && $is_generic_degraded_message($summary_text)
+                            && $is_generic_degraded_message($message_text)
+                        ) {
+                            $message_text = 'Degraded signal detected';
+                            $summary_text = 'No active incident listed yet — may be transient. Click \'View status\' or hit Refresh.';
+                        }
+
+                        $summary_display = '';
+                        if ('' !== $summary_text && strcasecmp($summary_text, $message_text) !== 0) {
+                            $summary_display = $summary_text;
+                        }
+                        if ($summary_display && $status === 'operational' && $is_no_incidents_message($summary_display)) {
+                            $summary_display = '';
+                        }
+                        if ($summary_display && $status === 'unknown' && $is_no_incidents_message($summary_display)) {
+                            $summary_display = '';
+                        }
+                        ?>
+                        <p class="lo-message" data-lo-message><?php echo esc_html($message_text); ?></p>
+                        <?php if ('' !== $summary_display) : ?>
+                            <p class="lo-summary" data-lo-summary><?php echo esc_html($summary_display); ?></p>
+                        <?php endif; ?>
+                        <div class="lo-card-meta-wrap" data-lo-meta>
+                            <p class="lo-card-meta" data-lo-last-checked>Last checked: <?php echo esc_html($last_checked); ?></p>
+                            <p class="lo-card-meta lo-card-meta--hint" data-lo-last-known hidden></p>
+                            <p class="lo-card-meta lo-card-meta--hint" data-lo-unknown-hint<?php echo $status === 'unknown' ? '' : ' hidden'; ?>>
+                                Provider page may still be operational — click ‘View status’.
+                            </p>
+                            <p class="lo-card-debug" data-lo-debug<?php echo '' !== $debug_line ? '' : ' hidden'; ?>><?php echo esc_html($debug_line); ?></p>
+                        </div>
+                        <div class="lo-components" data-lo-components>
+                            <?php if (!empty($components)) : ?>
+                                <h4 class="lo-components__title">Impacted components</h4>
+                                <ul class="lo-components__list">
+                                    <?php foreach ($components as $component) :
+                                        $component_status = strtolower((string) ($component['status'] ?? 'unknown'));
+                                        $component_label  = $component['status_label'] ?? ucfirst($component_status);
+                                        ?>
+                                        <li>
+                                            <span class="lo-component-name"><?php echo esc_html($component['name'] ?? 'Component'); ?></span>
+                                            <span class="lo-component-status"><?php echo esc_html($component_label); ?></span>
+                                        </li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            <?php endif; ?>
+                        </div>
+                        <?php if (!empty($active_incidents)) : ?>
+                            <div class="lo-inc" data-lo-incidents>
+                                <ul class="lo-inc-list">
+                                    <?php foreach ($active_incidents as $incident) :
+                                        $impact  = isset($incident['status']) ? ucfirst((string) $incident['status']) : 'Unknown';
+                                        $updated = $format_datetime($incident['updated_at'] ?? null);
+                                        $summary = isset($incident['summary']) ? (string) $incident['summary'] : '';
+                                        $url     = isset($incident['url']) ? (string) $incident['url'] : '';
+                                        ?>
+                                        <li class="lo-inc-item">
+                                            <p class="lo-inc-title"><?php echo esc_html($incident['name'] ?? 'Incident'); ?></p>
+                                            <p class="lo-inc-meta"><?php echo esc_html(trim($impact . ($updated ? ' • ' . $updated : ''))); ?></p>
+                                            <?php if ($summary) : ?>
+                                                <p class="lo-inc-summary"><?php echo esc_html($summary); ?></p>
+                                            <?php endif; ?>
+                                            <?php if ($url) : ?>
+                                                <a class="lo-status-link" href="<?php echo esc_url($url); ?>" target="_blank" rel="noopener">View incident</a>
+                                            <?php endif; ?>
+                                        </li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            </div>
+                        <?php endif; ?>
+                        <?php if (!empty($tile['url'])) : ?>
+                            <a class="lo-status-link" data-lo-status-url href="<?php echo esc_url($tile['url']); ?>" target="_blank" rel="noopener">View status →</a>
+                        <?php endif; ?>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    </div>
+    <?php
+    $output = (string) ob_get_clean();
+
+    if ($cache_key) {
+        set_transient($cache_key, [
+            'html'   => $output,
+            'config' => $config,
+        ], 90);
+    }
+
+    return $output;
+}
+
+
+
+
+function render_subscribe_shortcode(): string {
+    $endpoint = esc_url_raw(rest_url('lousy-outages/v1/subscribe'));
+    $nonce    = wp_create_nonce('lousy_outages_subscribe');
+    $rss_url  = esc_url(home_url('/?feed=lousy_outages_status'));
+    $lyric_lines = [];
+    foreach (\lo_lyric_fragment_bank() as $entry) {
+        if (!is_array($entry)) {
+            continue;
+        }
+        $fragment = isset($entry['fragment']) ? trim((string) $entry['fragment']) : '';
+        $answer   = isset($entry['answer']) ? trim((string) $entry['answer']) : '';
+        if ('' === $fragment && '' === $answer) {
+            continue;
+        }
+        $lyric_lines[] = [
+            'fragment' => $fragment,
+            'answer'   => $answer,
+        ];
+    }
+
+    $lyric_lines = apply_filters('lo_subscribe_lyric_lines', $lyric_lines);
+    if (!is_array($lyric_lines)) {
+        $lyric_lines = [];
+    }
+
+    $challenge_phrase = '';
+    $challenge_choices = [];
+    foreach ($lyric_lines as $line) {
+        if (!is_array($line)) {
+            continue;
+        }
+        $answer = isset($line['answer']) ? trim((string) $line['answer']) : '';
+        if ('' === $answer) {
+            continue;
+        }
+        $challenge_choices[] = $answer;
+    }
+
+    if (!empty($challenge_choices)) {
+        $random_key = array_rand($challenge_choices);
+        if (isset($challenge_choices[$random_key])) {
+            $challenge_phrase = $challenge_choices[$random_key];
+        }
+    }
+    $form_uid  = uniqid('lo-subscribe-');
+    $email_id  = $form_uid . '-email';
+    $challenge_id = $form_uid . '-challenge';
+    $challenge_hint_id = $challenge_id . '-hint';
+    $providers = Providers::enabled();
+    if (empty($providers)) {
+        $providers = Providers::list();
+    }
+
+    ob_start();
+    ?>
+    <div class="lo-subscribe" data-lo-subscribe>
+        <h2 class="lo-subscribe__title">Subscribe by email or RSS</h2>
+        <p class="lo-subscribe__intro">Get outage alerts in your inbox or follow the <a href="<?php echo $rss_url; ?>" target="_blank" rel="noopener">RSS feed</a>.</p>
+        <form class="lo-subscribe__form" method="post" action="<?php echo esc_url($endpoint); ?>" data-lo-subscribe-form>
+            <label class="lo-subscribe__label" for="<?php echo esc_attr($email_id); ?>">
+                <span>Email</span>
+                <input
+                    id="<?php echo esc_attr($email_id); ?>"
+                    class="lo-subscribe__input"
+                    type="email"
+                    name="email"
+                    placeholder="you@example.com"
+                    required
+                    autocomplete="email"
+                />
+            </label>
+            <fieldset class="lo-subscribe__fieldset">
+                <legend class="lo-subscribe__legend">Choose your outage alerts</legend>
+                <p class="lo-subscribe__note">Pick the services you care about. Leave everything checked if you want the full chaos feed.</p>
+                <div class="lo-subscribe__provider-grid">
+                    <?php foreach ($providers as $provider) : $provider_id = sanitize_key((string) ($provider['id'] ?? '')); if ('' === $provider_id) { continue; } ?>
+                        <label class="lo-subscribe__checkbox">
+                            <input type="checkbox" name="providers[]" value="<?php echo esc_attr($provider_id); ?>" checked />
+                            <span><?php echo esc_html((string) ($provider['name'] ?? $provider_id)); ?></span>
+                        </label>
+                    <?php endforeach; ?>
+                </div>
+            </fieldset>
+            <fieldset class="lo-subscribe__fieldset lo-subscribe__prefs">
+                <legend class="lo-subscribe__legend">Delivery preferences</legend>
+                <label class="lo-subscribe__checkbox"><input type="checkbox" name="realtime_alerts" value="1" checked /> <span>Real-time incident alerts</span></label>
+                <label class="lo-subscribe__checkbox"><input type="checkbox" name="daily_digest" value="1" /> <span>Daily digest</span></label>
+                <label class="lo-subscribe__checkbox"><input type="checkbox" name="newsletter" value="1" /> <span>Product updates / newsletter</span></label>
+                <p class="lo-subscribe__note">We’ll only use this to send the outage updates you request. You can unsubscribe anytime.</p>
+            </fieldset>
+            <div class="lo-subscribe__label lo-subscribe__challenge">
+                <p class="lo-subscribe__prompt">Type the Steve Jobs line shown below to prove you&rsquo;re not a bot.</p>
+                <?php if ($challenge_phrase) : ?>
+                    <p class="lo-subscribe__challenge-quote" aria-live="polite"><?php echo esc_html($challenge_phrase); ?></p>
+                <?php endif; ?>
+                <label for="<?php echo esc_attr($challenge_id); ?>" class="lo-subscribe__challenge-label">
+                    <span class="screen-reader-text">Type the sentence</span>
+                    <input
+                        id="<?php echo esc_attr($challenge_id); ?>"
+                        class="lo-subscribe__input"
+                        type="text"
+                        name="challenge_response"
+                        placeholder="Copy the sentence above"
+                        autocomplete="off"
+                        aria-describedby="<?php echo esc_attr($challenge_hint_id); ?>"
+                        required
+                        data-lo-captcha-input
+                    />
+                </label>
+                <p class="lo-subscribe__note" id="<?php echo esc_attr($challenge_hint_id); ?>">Case doesn&rsquo;t matter, punctuation optional.</p>
+                  <noscript>
+                      <p class="lo-subscribe__noscript">No JavaScript? Type the word <strong>jobs</strong> above.</p>
+                    <input type="hidden" name="lo_noscript_challenge" value="1" />
+                </noscript>
+            </div>
+            <input type="text" name="website" class="lo-hp" autocomplete="off" tabindex="-1" aria-hidden="true" style="position:absolute;left:-9999px" />
+            <input type="hidden" name="_wpnonce" value="<?php echo esc_attr($nonce); ?>" />
+            <button type="submit" class="lo-subscribe__button">Subscribe</button>
+            <p class="lo-subscribe__status" data-lo-subscribe-status aria-live="polite"></p>
+        </form>
+        <p class="lo-subscribe__help">Watch for the confirmation email (check spam if it’s missing). Every briefing ships with a one-click unsubscribe link, and we rotate a Steve Jobs quote to stop spam bots.</p>
+    </div>
+    <?php
+    return (string) ob_get_clean();
+}
+
+
+function render_report_shortcode(): string {
+    [$base_path, $base_url] = locate_assets_base();
+
+    wp_enqueue_style(
+        'lousy-outages',
+        $base_url . 'lousy-outages.css',
+        [],
+        file_exists($base_path . 'lousy-outages.css') ? filemtime($base_path . 'lousy-outages.css') : null
+    );
+
+    wp_enqueue_script(
+        'lousy-outages',
+        $base_url . 'lousy-outages.js',
+        [],
+        file_exists($base_path . 'lousy-outages.js') ? filemtime($base_path . 'lousy-outages.js') : null,
+        true
+    );
+
+    $providers = Providers::enabled();
+    if (empty($providers)) {
+        $providers = Providers::list();
+    }
+
+    $report_endpoint = rest_url('lousy-outages/v1/report');
+    $signals_endpoint = rest_url('lousy-outages/v1/signals');
+    $signals = class_exists('\\SuzyEaston\\LousyOutages\\SignalEngine') ? SignalEngine::summarize_recent_signals(60) : [];
+
+    ob_start();
+    ?>
+    <section class="lo-report" data-lo-report>
+        <h3>Seeing an issue?</h3>
+        <p>Report what you’re seeing. We’ll treat it as an unconfirmed community signal unless the provider confirms it.</p>
+        <form class="lo-report__form" method="post" action="<?php echo esc_url($report_endpoint); ?>" data-lo-report-form>
+            <label class="lo-report__field">Provider
+                <select name="provider_id" data-lo-report-provider required>
+                    <option value="">Select a provider…</option>
+                    <?php foreach ($providers as $provider) : $provider_id = sanitize_key((string) ($provider['id'] ?? '')); if (!$provider_id) continue; ?>
+                    <option value="<?php echo esc_attr($provider_id); ?>"><?php echo esc_html((string) ($provider['name'] ?? $provider_id)); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </label>
+            <label class="lo-report__field">Symptom
+                <select name="symptom" data-lo-report-summary required><option value="login">Login</option><option value="checkout">Checkout</option><option value="payments">Payments</option><option value="api">API</option><option value="dashboard">Dashboard</option><option value="dns">DNS</option><option value="email">Email</option><option value="slow">Slow</option><option value="full_outage">Full outage</option><option value="other">Other</option></select>
+            </label>
+            <label class="lo-report__field">Severity
+                <select name="severity"><option value="unknown">Unknown</option><option value="minor">Minor</option><option value="degraded">Degraded</option><option value="major">Major</option></select>
+            </label>
+            <label class="lo-report__field">Region <input type="text" name="region" maxlength="80" placeholder="Canada / BC / Vancouver"></label>
+            <label class="lo-report__field">Details (optional)<textarea name="details" maxlength="500"></textarea></label>
+            <label class="lo-report__field">Email (optional)<input type="email" name="email" data-lo-report-contact></label>
+            <button type="submit" class="lo-subscribe__button" data-lo-report-submit>Report issue</button>
+            <p class="lo-report__status" data-lo-report-status aria-live="polite"></p>
+        </form>
+        <div class="lo-signals" data-lo-signals data-lo-signals-endpoint="<?php echo esc_url($signals_endpoint); ?>">
+            <h4>Community signals</h4>
+            <div data-lo-signals-list>
+            <?php foreach (array_slice($signals, 0, 5) as $signal) : $class = strtolower((string) ($signal['classification'] ?? 'quiet')); if (!in_array($class, ['watch','trending','hot'], true)) { continue; } ?>
+                <div class="lo-signal lo-signal--<?php echo esc_attr($class); ?>">
+                    <span class="lo-signal__badge"><?php echo esc_html(ucfirst($class)); ?></span>
+                    <strong><?php echo esc_html((string) ($signal['provider_name'] ?? $signal['provider_id'] ?? 'Provider')); ?></strong>
+                    <span><?php echo esc_html((string) ($signal['message'] ?? 'Unconfirmed community signal.')); ?></span>
+                </div>
+            <?php endforeach; ?>
+            </div>
+            <p data-lo-signals-empty<?php echo !empty($signals) ? ' hidden' : ''; ?>>No unusual community reports.</p>
+        </div>
+    </section>
+    <?php
+    return (string) ob_get_clean();
+}

--- a/plugins/lousy-outages/readme.txt
+++ b/plugins/lousy-outages/readme.txt
@@ -1,0 +1,23 @@
+=== Lousy Outages ===
+Contributors: suzyeaston
+Tags: status, incidents, monitoring, alerts
+Requires at least: 6.0
+Tested up to: 6.6
+Stable tag: 0.2.0
+
+WordPress-native outage intelligence, community reporting, and early-warning signals for third-party service dependencies.
+
+== Installation ==
+1. Copy `plugins/lousy-outages` to `wp-content/plugins/lousy-outages`.
+2. Activate **Lousy Outages** in **WordPress Admin → Plugins**.
+3. Open **Lousy Outages** in the admin sidebar.
+
+== Emergency disable ==
+Add this to `wp-config.php`:
+`define( 'LOUSY_OUTAGES_DISABLE', true );`
+
+== Notes ==
+- Cloudflare Radar token is optional.
+- SMS/Twilio is optional.
+- Synthetic checks are lightweight public URL checks only.
+- Community signals are unconfirmed until official provider data confirms them.

--- a/plugins/lousy-outages/wp-cli/class-wp-cli-lousy.php
+++ b/plugins/lousy-outages/wp-cli/class-wp-cli-lousy.php
@@ -1,0 +1,151 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages\CLI;
+
+use SuzyEaston\LousyOutages\Fetcher;
+use SuzyEaston\LousyOutages\IncidentAlerts;
+use SuzyEaston\LousyOutages\Providers;
+use WP_CLI;
+use function WP_CLI\Utils\format_items;
+
+if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+    return;
+}
+
+class ProbeCommand {
+    public function __invoke( array $args, array $assoc_args ): void {
+        $id       = isset( $assoc_args['id'] ) ? (string) $assoc_args['id'] : '';
+        $timeout  = (int) apply_filters( 'lousy_outages_fetch_timeout', 10 );
+        $fetcher  = new Fetcher( $timeout );
+
+        if ( '' !== $id ) {
+            $providers = Providers::list();
+            if ( ! isset( $providers[ $id ] ) ) {
+                WP_CLI::error( sprintf( 'Provider "%s" not found.', $id ) );
+            }
+
+            $provider = $providers[ $id ];
+            $state    = $fetcher->fetch( $provider );
+            $line     = sprintf(
+                '%s | %s | %s | updated:%s | error:%s',
+                $state['name'] ?? $id,
+                $state['status_label'] ?? $state['status'] ?? 'Unknown',
+                preg_replace('/\s+/', ' ', (string) ( $state['summary'] ?? '' )),
+                $state['updated_at'] ?? '-',
+                $state['error'] ?? '-'
+            );
+            WP_CLI::line( $line );
+            return;
+        }
+
+        $rows      = [];
+        $providers = Providers::enabled();
+        foreach ( $providers as $provider ) {
+            $state      = $fetcher->fetch( $provider );
+            $rows[] = [
+                'id'      => $state['id'] ?? ( $provider['id'] ?? '' ),
+                'name'    => $state['name'] ?? ( $provider['name'] ?? '' ),
+                'status'  => $state['status_label'] ?? $state['status'] ?? 'Unknown',
+                'summary' => preg_replace('/\s+/', ' ', (string) ( $state['summary'] ?? '' )),
+                'updated' => $state['updated_at'] ?? '-',
+                'error'   => $state['error'] ?? '-',
+            ];
+        }
+
+        if ( empty( $rows ) ) {
+            WP_CLI::warning( 'No enabled providers were found.' );
+            return;
+        }
+
+        format_items( 'table', $rows, [ 'id', 'name', 'status', 'summary', 'updated', 'error' ] );
+    }
+}
+
+WP_CLI::add_command( 'lousy:probe', ProbeCommand::class );
+
+class RefreshCommand {
+    /**
+     * Run the full Lousy Outages refresh pipeline once.
+     *
+     * ## OPTIONS
+     *
+     * [--bypass-cache=<bool>]
+     * : Whether to bypass any internal caching. Defaults to true.
+     *
+     * ## EXAMPLES
+     *
+     *     wp lousy:refresh
+     *     wp lousy:refresh --bypass-cache=false
+     */
+    public function __invoke( array $args, array $assoc_args ): void {
+        $bypass = true;
+        if ( isset( $assoc_args['bypass-cache'] ) ) {
+            $value  = strtolower( (string) $assoc_args['bypass-cache'] );
+            $bypass = ! in_array( $value, [ '0', 'false', 'no' ], true );
+        }
+
+        if ( ! function_exists( '\lousy_outages_refresh_data' ) ) {
+            WP_CLI::error( 'lousy_outages_refresh_data() not available.' );
+        }
+
+        $result = \lousy_outages_refresh_data( $bypass );
+
+        $ok      = ! empty( $result['ok'] );
+        $skipped = ! empty( $result['skipped'] );
+        $msg     = isset( $result['message'] ) ? (string) $result['message'] : '';
+
+        $refreshedAt = isset( $result['refreshedAt'] ) ? (string) $result['refreshedAt'] : gmdate( 'c' );
+
+        if ( $ok ) {
+            WP_CLI::success( sprintf( 'Refresh completed. skipped=%s refreshedAt=%s %s', $skipped ? 'true' : 'false', $refreshedAt, $msg ) );
+        } elseif ( $skipped ) {
+            WP_CLI::warning( sprintf( 'Refresh skipped. refreshedAt=%s %s', $refreshedAt, $msg ) );
+        } else {
+            WP_CLI::error( sprintf( 'Refresh failed. refreshedAt=%s %s', $refreshedAt, $msg ) );
+        }
+    }
+}
+
+WP_CLI::add_command( 'lousy:refresh', RefreshCommand::class );
+
+class AlertTestCommand {
+    public function __invoke( array $args, array $assoc_args ): void {
+        $recipient = isset( $assoc_args['recipient'] ) ? sanitize_email( (string) $assoc_args['recipient'] ) : '';
+        $dry_run   = isset( $assoc_args['dry-run'] ) && in_array( strtolower( (string) $assoc_args['dry-run'] ), [ '1', 'true', 'yes' ], true );
+        $fixed_id  = isset( $assoc_args['fixed-id'] ) ? (string) $assoc_args['fixed-id'] : '';
+        $overrides = [];
+        if ( '' !== $fixed_id ) {
+            $overrides['id'] = $fixed_id;
+        }
+        if ( '' !== $recipient ) {
+            update_option( 'lousy_outages_email', $recipient, false );
+        }
+        $incident = IncidentAlerts::make_synthetic_incident( $overrides );
+        $result = IncidentAlerts::process_incidents( [ $incident ], [ 'synthetic' => true, 'mode' => 'cli_alert_test', 'notification_only' => true, 'dry_run' => $dry_run ] );
+        WP_CLI::line( wp_json_encode( $result ) ?: '{}' );
+        if ( (int) ( $result['failed'] ?? 0 ) > 0 ) {
+            WP_CLI::warning( 'Synthetic alert test had failures.' );
+        } else {
+            WP_CLI::success( 'Synthetic alert test completed.' );
+        }
+    }
+}
+WP_CLI::add_command( 'lousy:alert-test', AlertTestCommand::class );
+
+class AlertHealthCommand {
+    public function __invoke( array $args, array $assoc_args ): void {
+        $subscribers = get_option( 'lo_subscribers', [] );
+        $rows = [
+            [ 'key' => 'configured_notification_email', 'value' => (string) get_option( 'lousy_outages_email', get_option( 'admin_email' ) ) ],
+            [ 'key' => 'subscriber_count', 'value' => is_array( $subscribers ) ? (string) count( $subscribers ) : '0' ],
+            [ 'key' => 'last_modern_success', 'value' => wp_json_encode( get_option( 'lousy_outages_last_alert_success', [] ) ) ?: '{}' ],
+            [ 'key' => 'last_modern_failure', 'value' => wp_json_encode( get_option( 'lousy_outages_last_alert_failure', [] ) ) ?: '{}' ],
+            [ 'key' => 'last_synthetic_test', 'value' => wp_json_encode( get_option( 'lousy_outages_last_synthetic_alert', [] ) ) ?: '{}' ],
+            [ 'key' => 'cron_lo_check_statuses_scheduled', 'value' => wp_next_scheduled( 'lo_check_statuses' ) ? 'yes' : 'no' ],
+            [ 'key' => 'recent_failure_exists', 'value' => get_option( 'lousy_outages_alert_delivery_failure' ) ? 'yes' : 'no' ],
+        ];
+        format_items( 'table', $rows, [ 'key', 'value' ] );
+    }
+}
+WP_CLI::add_command( 'lousy:alert-health', AlertHealthCommand::class );


### PR DESCRIPTION
### Motivation
- Provide a standalone, installable WordPress plugin for Lousy Outages so the feature can be shipped/demonstrated independently of the theme. 
- Prevent fatal load-order issues and double-registration when both theme-bundled and plugin copies coexist. 
- Keep the live site working during migration and make admin UX product-like with a top-level menu.

### Description
- Added a full plugin package at `plugins/lousy-outages/` by copying and reshaping the existing theme module into a plugin layout and adding `readme.txt`/packaging docs and assets. 
- Introduced a safe plugin root loader (`plugins/lousy-outages/lousy-outages.php`) with a proper plugin header, emergency disable check, safe constants (`LOUSY_OUTAGES_VERSION`, `LOUSY_OUTAGES_FILE`, `LOUSY_OUTAGES_PATH`, `LOUSY_OUTAGES_URL`), activation/deactivation hooks, and `LOUSY_OUTAGES_LOADED` guard to avoid double-loading. 
- Added a small include helper `lousy_outages_require( string $relative, bool $required = true )` used for ordered includes and error-logged missing files; enforced external-signal load order (SignalSourceInterface → ExternalSignals → concrete Sources → SignalCollector → public/shortcode) in both plugin and theme-bundled loaders to prevent interface-not-found fatals. 
- Preserved and hardened the theme-bundled loader (`lousy-outages/lousy-outages.php`) as a migration shim that uses the same `LOUSY_OUTAGES_LOADED` guard and ordered require helper so the live site does not break while migrating. 
- Added a top-level admin menu and submenus (Dashboard, Providers, Subscribers, Community Signals, External Signals, Settings) with lightweight dashboard/providers/subscribers/diagnostics scaffolds and backward-compatible Settings alias; updated admin-post redirect targets to the new admin page slugs. 
- Copied and adapted core modules into the plugin includes (fetching/adapters, SignalEngine, ExternalSignals, SignalCollector, Snapshot/Feed/Api layers, storage, email/sms/mailer/transport, CLI, public shortcode UI, synthetic canary and Cloudflare Radar sources, and compatibility shims) while preserving REST routes, shortcodes, cron hooks, option/table names and public behavior.

### Testing
- Ran PHP lint on key files and both loaders: `php -l` on `lousy-outages/lousy-outages.php`, `plugins/lousy-outages/lousy-outages.php`, `plugins/lousy-outages/includes/SignalSourceInterface.php`, `plugins/lousy-outages/includes/ExternalSignals.php`, `plugins/lousy-outages/includes/SignalCollector.php`, `plugins/lousy-outages/includes/Sources/SyntheticCanarySource.php`, `plugins/lousy-outages/includes/Sources/CloudflareRadarSource.php`, `plugins/lousy-outages/includes/SignalEngine.php`, `plugins/lousy-outages/includes/UserReports.php`, `plugins/lousy-outages/includes/Subscribe.php`, `plugins/lousy-outages/public/shortcode.php`, and `page-lousy-outages.php` — all returned “No syntax errors detected.”
- Ran targeted PHP unit tests: `php tests/SignalEngineTest.php`, `php tests/UserReportsTest.php`, `php tests/SubscriptionsTest.php`, and `php tests/IncidentStoreCloudflareSuppressionTest.php` — all tests executed and passed in this environment.
- Confirmed the codebase remains backward-compatible with the theme workflow via the shim guard and that REST endpoints/shortcodes remain available from the copied plugin.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7fbef3760832ea8192f2018ab3f07)