### PR TITLE
Fix Lousy Outages activation safety and cross-platform ZIP packaging

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -422,8 +422,38 @@ function suzyeaston_is_lousy_outages_plugin_active(): bool {
         && is_plugin_active( 'lousy-outages/lousy-outages.php' );
 }
 
+function suzyeaston_is_activating_lousy_outages_plugin(): bool {
+    if ( ! is_admin() ) {
+        return false;
+    }
+
+    $action = isset( $_REQUEST['action'] ) ? sanitize_key( wp_unslash( (string) $_REQUEST['action'] ) ) : '';
+    if ( 'activate' !== $action && 'activate-selected' !== $action ) {
+        return false;
+    }
+
+    $target_plugin = '';
+    if ( isset( $_REQUEST['plugin'] ) ) {
+        $target_plugin = sanitize_text_field( wp_unslash( (string) $_REQUEST['plugin'] ) );
+    } elseif ( isset( $_REQUEST['checked'] ) && is_array( $_REQUEST['checked'] ) ) {
+        $checked = array_map(
+            static function ( $plugin ): string {
+                return sanitize_text_field( wp_unslash( (string) $plugin ) );
+            },
+            $_REQUEST['checked']
+        );
+        $target_plugin = implode( ',', $checked );
+    }
+
+    return false !== strpos( $target_plugin, 'lousy-outages/lousy-outages.php' );
+}
+
 $lousy_outages = get_template_directory() . '/lousy-outages/lousy-outages.php';
-if ( file_exists( $lousy_outages ) && ! suzyeaston_is_lousy_outages_plugin_active() ) {
+if (
+    file_exists( $lousy_outages )
+    && ! suzyeaston_is_lousy_outages_plugin_active()
+    && ! suzyeaston_is_activating_lousy_outages_plugin()
+) {
     require_once $lousy_outages;
 }
 

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -61,15 +61,17 @@ if ( ! defined( 'LOUSY_OUTAGES_URL' ) ) {
     define( 'LOUSY_OUTAGES_URL', plugin_dir_url( __FILE__ ) );
 }
 
-function lousy_outages_require( string $relative, bool $required = true ): void {
-    $path = LOUSY_OUTAGES_PATH . ltrim( $relative, '/' );
-    if ( file_exists( $path ) ) {
-        require_once $path;
-        return;
-    }
-    error_log( '[LO] missing include: ' . $relative );
-    if ( $required ) {
-        return;
+if ( ! function_exists( 'lousy_outages_require' ) ) {
+    function lousy_outages_require( string $relative, bool $required = true ): void {
+        $path = LOUSY_OUTAGES_PATH . ltrim( $relative, '/' );
+        if ( file_exists( $path ) ) {
+            require_once $path;
+            return;
+        }
+        error_log( '[LO] missing include: ' . $relative );
+        if ( $required ) {
+            return;
+        }
     }
 }
 
@@ -182,9 +184,7 @@ function lousy_outages_activate() {
         lo_cron_activate();
     }
     lousy_outages_create_page();
-    Subscriptions::create_table();
-    UserReports::install();
-    ExternalSignals::install();
+    lousy_outages_maybe_install_schema( true );
     Subscriptions::schedule_purge();
     $default_email = 'suzyeaston@gmail.com';
     $stored_email  = get_option( 'lousy_outages_email' );
@@ -196,6 +196,22 @@ function lousy_outages_activate() {
     }
 }
 register_activation_hook( __FILE__, 'lousy_outages_activate' );
+
+function lousy_outages_maybe_install_schema( bool $force = false ): void {
+    $schema_version = '2026-05-04';
+    $option_key = 'lousy_outages_schema_version';
+    $current = (string) get_option( $option_key, '' );
+    if ( ! $force && version_compare( $current, $schema_version, '>=' ) ) {
+        return;
+    }
+
+    Subscriptions::create_table();
+    UserReports::install();
+    ExternalSignals::install();
+    update_option( $option_key, $schema_version, false );
+}
+add_action( 'admin_init', 'lousy_outages_maybe_install_schema' );
+add_action( 'init', 'lousy_outages_maybe_install_schema' );
 
 /**
  * Clear cron on deactivation.

--- a/plugins/lousy-outages/includes/ExternalSignals.php
+++ b/plugins/lousy-outages/includes/ExternalSignals.php
@@ -5,6 +5,13 @@ namespace SuzyEaston\LousyOutages;
 
 class ExternalSignals {
     public static function table_name(): string { global $wpdb; return $wpdb->prefix . 'lo_external_signals'; }
+    private static function table_exists(): bool {
+        global $wpdb;
+        $table = self::table_name();
+        $like = $wpdb->esc_like($table);
+        $existing = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $like));
+        return (string) $existing === $table;
+    }
 
     public static function install(): void {
         global $wpdb;
@@ -65,7 +72,7 @@ class ExternalSignals {
         return ['inserted'=>true,'id'=>(int)$wpdb->insert_id,'signal'=>$s];
     }
     public static function record_many(array $signals): array { $out=['inserted'=>0,'skipped'=>0,'rows'=>[]]; foreach($signals as $sig){$r=self::record_signal((array)$sig);$out['rows'][]=$r; $out[$r['inserted']?'inserted':'skipped']++;} return $out; }
-    public static function get_recent_signals(array $args=[]): array { global $wpdb; $limit=max(1,min(200,(int)($args['limit']??50))); return $wpdb->get_results($wpdb->prepare('SELECT * FROM '.self::table_name().' WHERE observed_at >= %s ORDER BY observed_at DESC LIMIT %d', gmdate('Y-m-d H:i:s', time()-((int)($args['windowMinutes']??60))*60), $limit), ARRAY_A) ?: []; }
+    public static function get_recent_signals(array $args=[]): array { global $wpdb; if (!self::table_exists()) { return []; } $limit=max(1,min(200,(int)($args['limit']??50))); return $wpdb->get_results($wpdb->prepare('SELECT * FROM '.self::table_name().' WHERE observed_at >= %s ORDER BY observed_at DESC LIMIT %d', gmdate('Y-m-d H:i:s', time()-((int)($args['windowMinutes']??60))*60), $limit), ARRAY_A) ?: []; }
     public static function get_recent_counts(int $windowMinutes=60): array { global $wpdb; $rows=$wpdb->get_results($wpdb->prepare('SELECT source, COUNT(*) as signal_count FROM '.self::table_name().' WHERE observed_at >= %s GROUP BY source', gmdate('Y-m-d H:i:s', time()-$windowMinutes*60)), ARRAY_A) ?: []; return $rows; }
     public static function clear_expired(): int { global $wpdb; $wpdb->query($wpdb->prepare('DELETE FROM '.self::table_name().' WHERE expires_at IS NOT NULL AND expires_at < %s', gmdate('Y-m-d H:i:s'))); return (int)$wpdb->rows_affected; }
     public static function clear_demo_signals(): int { global $wpdb; $wpdb->query($wpdb->prepare('DELETE FROM '.self::table_name().' WHERE source = %s', 'demo_external')); return (int)$wpdb->rows_affected; }

--- a/plugins/lousy-outages/includes/UserReports.php
+++ b/plugins/lousy-outages/includes/UserReports.php
@@ -9,6 +9,13 @@ class UserReports {
     public const ALLOWED_SEVERITY = ['minor','degraded','major','unknown'];
 
     public static function table_name(): string { global $wpdb; return $wpdb->prefix . self::TABLE; }
+    private static function table_exists(): bool {
+        global $wpdb;
+        $table = self::table_name();
+        $like = $wpdb->esc_like($table);
+        $existing = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $like));
+        return (string) $existing === $table;
+    }
 
     public static function install(): void {
         global $wpdb;
@@ -76,6 +83,7 @@ class UserReports {
 
     public static function get_recent_reports(array $args = []): array {
         global $wpdb;
+        if (!self::table_exists()) { return []; }
         $window = max(1, (int)($args['windowMinutes'] ?? 60));
         $limit = max(1, (int)($args['limit'] ?? 50));
         $provider = sanitize_key((string)($args['provider_id'] ?? ''));
@@ -94,18 +102,21 @@ class UserReports {
 
     public static function get_recent_report_count(int $windowMinutes = 60): int {
         global $wpdb;
+        if (!self::table_exists()) { return 0; }
         $cutoff = gmdate('Y-m-d H:i:s', time() - max(1, $windowMinutes) * MINUTE_IN_SECONDS);
         return (int)$wpdb->get_var($wpdb->prepare('SELECT COUNT(*) FROM ' . self::table_name() . ' WHERE created_at >= %s', $cutoff));
     }
 
     public static function count_recent_reports(string $provider_id, int $windowMinutes = 60): int {
         global $wpdb;
+        if (!self::table_exists()) { return 0; }
         $cutoff = gmdate('Y-m-d H:i:s', time() - max(1,$windowMinutes) * MINUTE_IN_SECONDS);
         return (int)$wpdb->get_var($wpdb->prepare('SELECT COUNT(*) FROM ' . self::table_name() . ' WHERE provider_id = %s AND created_at >= %s', sanitize_key($provider_id), $cutoff));
     }
 
     public static function get_recent_provider_counts(int $windowMinutes = 60): array {
         global $wpdb;
+        if (!self::table_exists()) { return []; }
         $cutoff = gmdate('Y-m-d H:i:s', time() - max(1,$windowMinutes) * MINUTE_IN_SECONDS);
         return (array)$wpdb->get_results($wpdb->prepare('SELECT provider_id, COUNT(*) AS report_count FROM ' . self::table_name() . ' WHERE created_at >= %s GROUP BY provider_id ORDER BY report_count DESC', $cutoff), ARRAY_A);
     }

--- a/plugins/lousy-outages/lousy-outages.php
+++ b/plugins/lousy-outages/lousy-outages.php
@@ -36,15 +36,17 @@ if ( ! defined( 'LOUSY_OUTAGES_URL' ) ) {
     define( 'LOUSY_OUTAGES_URL', plugin_dir_url( __FILE__ ) );
 }
 
-function lousy_outages_require( string $relative, bool $required = true ): void {
-    $path = LOUSY_OUTAGES_PATH . ltrim( $relative, '/' );
-    if ( file_exists( $path ) ) {
-        require_once $path;
-        return;
-    }
-    error_log( '[LO] missing include: ' . $relative );
-    if ( $required ) {
-        return;
+if ( ! function_exists( 'lousy_outages_require' ) ) {
+    function lousy_outages_require( string $relative, bool $required = true ): void {
+        $path = LOUSY_OUTAGES_PATH . ltrim( $relative, '/' );
+        if ( file_exists( $path ) ) {
+            require_once $path;
+            return;
+        }
+        error_log( '[LO] missing include: ' . $relative );
+        if ( $required ) {
+            return;
+        }
     }
 }
 
@@ -157,9 +159,7 @@ function lousy_outages_activate() {
         lo_cron_activate();
     }
     lousy_outages_create_page();
-    Subscriptions::create_table();
-    UserReports::install();
-    ExternalSignals::install();
+    lousy_outages_maybe_install_schema( true );
     Subscriptions::schedule_purge();
     $default_email = 'suzyeaston@gmail.com';
     $stored_email  = get_option( 'lousy_outages_email' );
@@ -171,6 +171,22 @@ function lousy_outages_activate() {
     }
 }
 register_activation_hook( __FILE__, 'lousy_outages_activate' );
+
+function lousy_outages_maybe_install_schema( bool $force = false ): void {
+    $schema_version = '2026-05-04';
+    $option_key = 'lousy_outages_schema_version';
+    $current = (string) get_option( $option_key, '' );
+    if ( ! $force && version_compare( $current, $schema_version, '>=' ) ) {
+        return;
+    }
+
+    Subscriptions::create_table();
+    UserReports::install();
+    ExternalSignals::install();
+    update_option( $option_key, $schema_version, false );
+}
+add_action( 'admin_init', 'lousy_outages_maybe_install_schema' );
+add_action( 'init', 'lousy_outages_maybe_install_schema' );
 
 /**
  * Clear cron on deactivation.

--- a/scripts/build-lousy-outages-plugin.ps1
+++ b/scripts/build-lousy-outages-plugin.ps1
@@ -1,17 +1,85 @@
 $ErrorActionPreference = 'Stop'
+
 $root = Split-Path -Parent $PSScriptRoot
 $dist = Join-Path $root 'dist'
 $out = Join-Path $dist 'lousy-outages.zip'
 $src = Join-Path $root 'plugins/lousy-outages'
+
+if (-not (Test-Path $src)) {
+    throw "Source plugin directory not found: $src"
+}
+
 New-Item -ItemType Directory -Force -Path $dist | Out-Null
 if (Test-Path $out) { Remove-Item $out -Force }
+
+Add-Type -AssemblyName System.IO.Compression
 Add-Type -AssemblyName System.IO.Compression.FileSystem
-$tmp = Join-Path $dist 'lousy-outages'
-if (Test-Path $tmp) { Remove-Item $tmp -Recurse -Force }
-Copy-Item $src $tmp -Recurse
-Get-ChildItem $tmp -Recurse -Force | Where-Object {
-  $_.FullName -match '\\.git\\|\\tests\\|\\node_modules\\|\\secrets\\|wp-config.php|\\.env|\\.bak$|~$|backup'
-} | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
-[System.IO.Compression.ZipFile]::CreateFromDirectory($tmp, $out)
-Remove-Item $tmp -Recurse -Force
-Write-Output "Built: $out"
+
+$excludeDirNames = @('.git', 'tests', 'node_modules', 'secrets')
+$requiredEntries = @(
+    'lousy-outages/lousy-outages.php',
+    'lousy-outages/includes/ExternalSignals.php',
+    'lousy-outages/public/shortcode.php'
+)
+
+$files = Get-ChildItem -Path $src -File -Recurse -Force | Where-Object {
+    $rel = $_.FullName.Substring($src.Length).TrimStart('\\','/')
+    if ([string]::IsNullOrWhiteSpace($rel)) { return $false }
+
+    $segments = $rel -split '[\\/]'
+    foreach ($segment in $segments) {
+        if ($excludeDirNames -contains $segment) { return $false }
+    }
+
+    $name = $_.Name
+    if ($name -eq 'wp-config.php') { return $false }
+    if ($name -eq '.env') { return $false }
+    if ($name -like '.env.*') { return $false }
+    if ($name -like '*.bak') { return $false }
+    if ($name -like '*.backup') { return $false }
+    if ($name -like '*.tmp') { return $false }
+    if ($name -eq '.DS_Store') { return $false }
+
+    return $true
+}
+
+$zip = [System.IO.Compression.ZipFile]::Open($out, [System.IO.Compression.ZipArchiveMode]::Create)
+try {
+    foreach ($file in $files) {
+        $rel = $file.FullName.Substring($src.Length).TrimStart('\\','/')
+        $normalized = $rel -replace '\\','/'
+        $entryName = "lousy-outages/$normalized"
+        [System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile($zip, $file.FullName, $entryName, [System.IO.Compression.CompressionLevel]::Optimal) | Out-Null
+    }
+}
+finally {
+    $zip.Dispose()
+}
+
+$zipCheck = [System.IO.Compression.ZipFile]::OpenRead($out)
+try {
+    $entries = @($zipCheck.Entries | ForEach-Object { $_.FullName })
+
+    if ($entries.Count -eq 0) {
+        throw 'ZIP is empty.'
+    }
+
+    if ($entries | Where-Object { $_ -like '*\\*' }) {
+        throw 'ZIP contains backslash path separators.'
+    }
+
+    if ($entries | Where-Object { $_ -notlike 'lousy-outages/*' }) {
+        throw 'ZIP contains entries outside lousy-outages/ root.'
+    }
+
+    foreach ($required in $requiredEntries) {
+        if (-not ($entries -contains $required)) {
+            throw "ZIP missing required entry: $required"
+        }
+    }
+}
+finally {
+    $zipCheck.Dispose()
+}
+
+Write-Output "Built and validated: $out"

--- a/scripts/build-lousy-outages-plugin.sh
+++ b/scripts/build-lousy-outages-plugin.sh
@@ -8,5 +8,25 @@ mkdir -p "$DIST"
 rm -f "$OUT"
 cd "$ROOT/plugins"
 zip -r "$OUT" lousy-outages \
-  -x '*/.git/*' '*/tests/*' '*/node_modules/*' '*/.env*' '*/secrets/*' '*/wp-config.php' '*/backup*' '*.bak' '*~'
-echo "Built: $OUT"
+  -x '*/.git/*' '*/tests/*' '*/node_modules/*' '*/.env' '*/.env.*' '*/secrets/*' '*/wp-config.php' '*.bak' '*.backup' '*.tmp' '*/.DS_Store'
+
+LISTING="$(unzip -Z -1 "$OUT")"
+if echo "$LISTING" | rg '\\' >/dev/null; then
+  echo "ERROR: ZIP contains backslash path separators" >&2
+  exit 1
+fi
+if echo "$LISTING" | rg -v '^lousy-outages/' >/dev/null; then
+  echo "ERROR: ZIP contains entries outside lousy-outages/ root" >&2
+  exit 1
+fi
+for req in \
+  'lousy-outages/lousy-outages.php' \
+  'lousy-outages/includes/ExternalSignals.php' \
+  'lousy-outages/public/shortcode.php'; do
+  if ! echo "$LISTING" | rg -x "$req" >/dev/null; then
+    echo "ERROR: ZIP missing required entry: $req" >&2
+    exit 1
+  fi
+done
+
+echo "Built and validated: $OUT"


### PR DESCRIPTION
### Motivation
- Prevent plugin activation failures caused by duplicate global helper declarations when the theme-bundled loader and standalone plugin are both present.  
- Ensure the Windows PowerShell build produces portable ZIPs (forward-slash paths) that extract correctly on Linux/WordPress.  
- Make table/schema access resilient so admin/public requests do not error if plugin tables are not yet created.  

### Description
- Add an activation-detection guard in `functions.php` (`suzyeaston_is_activating_lousy_outages_plugin`) and skip the theme-bundled loader during wp-admin activation requests to avoid double-loading during activation.  
- Wrap `lousy_outages_require()` in `function_exists()` in both loaders and keep the `LOUSY_OUTAGES_LOADED` early-return guard so the helper cannot be redeclared when theme and plugin code run together.  
- Add `lousy_outages_maybe_install_schema()` and call it from the activation path; hook it to `admin_init` and `init` and use a versioned option `lousy_outages_schema_version` to avoid repeated work.  
- Add defensive table-existence checks to `plugins/lousy-outages/includes/UserReports.php` and `plugins/lousy-outages/includes/ExternalSignals.php` so reads return empty/0 when tables are missing.  
- Rewrite `scripts/build-lousy-outages-plugin.ps1` to create ZIP entries with forward slashes using .NET `System.IO.Compression`, normalize paths, exclude unwanted files, and validate the archive (no backslashes, correct root prefix, required files present).  
- Add equivalent validation to `scripts/build-lousy-outages-plugin.sh` so the zip shape is checked on non-Windows builds.  

Files primarily changed: `functions.php`, `lousy-outages/lousy-outages.php`, `plugins/lousy-outages/lousy-outages.php`, `plugins/lousy-outages/includes/UserReports.php`, `plugins/lousy-outages/includes/ExternalSignals.php`, `scripts/build-lousy-outages-plugin.ps1`, and `scripts/build-lousy-outages-plugin.sh`.  

### Testing
- Ran `php -l` on the modified files and there were no syntax errors.  
- Ran unit/integration tests `php tests/SignalEngineTest.php`, `php tests/UserReportsTest.php`, `php tests/SubscriptionsTest.php`, and `php tests/IncidentStoreCloudflareSuppressionTest.php` and all tests passed.  
- Ran the bash build `bash scripts/build-lousy-outages-plugin.sh` which produced `dist/lousy-outages.zip`, listed entries, and validated shape (root `lousy-outages/`, required files present, no backslashes).  
- Attempted to run the PowerShell build (`powershell -ExecutionPolicy Bypass -File scripts/build-lousy-outages-plugin.ps1`) but the container lacked `powershell`; the script was updated and should be executed on Windows to validate end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f802c45d18832ebf0ef127c253a198)