### PR TITLE
Refocus homepage around Lousy Outages and simplify content hierarchy

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -3,66 +3,20 @@
 get_header();
 ?>
 
-<main id="homepage-content">
-    <?php
-    $hero_eyebrow = apply_filters('se_home_hero_eyebrow', 'Vancouver, BC • QA automation • IT operations • Creative AI');
-    $hero_headline = apply_filters('se_home_hero_headline', 'I build strange, useful things.');
-    $hero_logo_label = apply_filters('se_home_hero_title', 'Suzy Easton');
-    $hero_logo_top = apply_filters('se_home_hero_logo_top', 'Suzy');
-    $hero_logo_mid = apply_filters('se_home_hero_logo_mid', '');
-    $hero_logo_bottom = apply_filters('se_home_hero_logo_bottom', 'Easton');
-    $hero_logo_top_text = function_exists('mb_strtoupper') ? mb_strtoupper($hero_logo_top, 'UTF-8') : strtoupper($hero_logo_top);
-    $hero_logo_mid_text = function_exists('mb_strtoupper') ? mb_strtoupper($hero_logo_mid, 'UTF-8') : strtoupper($hero_logo_mid);
-    $hero_logo_bottom_text = function_exists('mb_strtoupper') ? mb_strtoupper($hero_logo_bottom, 'UTF-8') : strtoupper($hero_logo_bottom);
-    ?>
-
-    <div class="hero hero-section">
+<main id="homepage-content" class="home-layout">
+    <section class="home-hero hero hero-section crt-block" aria-labelledby="home-hero-title">
         <div class="hero-grid">
             <div class="hero-main">
-                <?php if (!empty($hero_eyebrow)) : ?>
-                    <p class="hero-eyebrow pixel-font"><?php echo esc_html($hero_eyebrow); ?></p>
-                <?php endif; ?>
-
-                <h1 class="hero-core-headline"><?php echo esc_html($hero_headline); ?></h1>
-
-                <p class="hero-copy">
-                    <?php echo esc_html('I’m Suzy Easton — a senior technical generalist, musician, and creative technologist who turns messy workflows, flaky systems, and half-formed ideas into practical outcomes. My work spans QA automation, IT operations, AI prototypes, civic/open-data experiments, music tech, and public projects like Lousy Outages.'); ?>
-                </p>
-
-                <p class="hero-availability">
-                    <?php echo esc_html('Available for senior technical roles, contract QA/automation work, practical AI prototypes, and useful weird builds.'); ?>
-                </p>
-
-                <div class="hero-status-chips" aria-label="Current status">
-                    <span class="hero-status-chip"><strong><?php echo esc_html('BUILD MODE:'); ?></strong> <?php echo esc_html('SHIPPING'); ?></span>
-                    <span class="hero-status-chip"><strong><?php echo esc_html('LOCATION:'); ?></strong> <?php echo esc_html('VANCOUVER'); ?></span>
-                    <span class="hero-status-chip"><strong><?php echo esc_html('STATUS:'); ?></strong> <?php echo esc_html('OPEN TO WORK'); ?></span>
+                <p class="hero-eyebrow pixel-font"><?php echo esc_html('Vancouver, BC • QA automation • IT operations • Creative AI'); ?></p>
+                <h1 id="home-hero-title" class="hero-core-headline"><?php echo esc_html('Creative technologist building outage intelligence, AI-assisted tools, and weird useful web things.'); ?></h1>
+                <p class="hero-copy"><?php echo esc_html('I’m Suzy Easton, a Vancouver-based IT operations analyst, QA automation builder, musician, and WordPress/plugin tinkerer turning messy systems into useful products.'); ?></p>
+                <div class="home-cta-row hero-cta-group">
+                    <a href="<?php echo esc_url(home_url('/lousy-outages/')); ?>" class="pixel-button hero-primary-cta"><?php echo esc_html('View Lousy Outages'); ?></a>
+                    <a href="<?php echo esc_url(home_url('/resume/')); ?>" class="pixel-button hero-secondary-cta"><?php echo esc_html('View Resume'); ?></a>
                 </div>
-
-                <div class="hero-cta-group">
-                    <a href="<?php echo esc_url(home_url('/page-gastown-sim/')); ?>" class="pixel-button hero-primary-cta">Enter Gastown Simulator</a>
-                    <a href="<?php echo esc_url(home_url('/work-with-suzy/')); ?>" class="pixel-button hero-secondary-cta">Work with Suzy</a>
-                    <a href="<?php echo esc_url('https://www.linkedin.com/in/suzyeaston/'); ?>" class="pixel-button hero-tertiary-cta" target="_blank" rel="noopener noreferrer">LinkedIn</a>
-                </div>
-                <p class="hero-collab-link"><a href="<?php echo esc_url(home_url('/bio/')); ?>"><?php echo esc_html('Read bio →'); ?></a></p>
+                <p class="hero-collab-link"><a href="<?php echo esc_url(home_url('/projects/')); ?>"><?php echo esc_html('See projects →'); ?></a></p>
             </div>
-
-            <button class="hero-deco hero-ship hero-ship--autopilot" type="button" aria-label="Drag the spaceship" title="Drag me" tabindex="0"></button>
-
-            <aside class="hero-side hero-photo-card" aria-label="Hero wordmark and portrait">
-                <div class="hero-wordmark-wrap">
-                    <div class="hero-badge">
-                        <p class="hero-wordmark" aria-label="<?php echo esc_attr($hero_logo_label); ?>">
-                            <span class="line1">
-                                <?php echo esc_html($hero_logo_top_text); ?>
-                                <?php if (!empty($hero_logo_mid_text)) : ?>
-                                    <small><?php echo esc_html($hero_logo_mid_text); ?></small>
-                                <?php endif; ?>
-                            </span>
-                            <span class="line2"><?php echo esc_html($hero_logo_bottom_text); ?></span>
-                        </p>
-                    </div>
-                </div>
+            <aside class="hero-side hero-photo-card" aria-label="Hero portrait">
                 <div class="hero-photo-frame">
                     <a class="hero-photo-link hero-photo-link-block" href="<?php echo esc_url(home_url('/bio/')); ?>">
                         <img class="hero-photo" src="<?php echo esc_url(home_url('/wp-content/uploads/2026/01/IMG_9003.jpg')); ?>" alt="<?php echo esc_attr('Suzy Easton smiling with a guitar'); ?>" loading="lazy" decoding="async">
@@ -71,90 +25,59 @@ get_header();
                 <p class="hero-photo-caption pixel-font"><a class="hero-photo-link" href="<?php echo esc_url(home_url('/bio/')); ?>"><?php echo esc_html('Vancouver, BC / Read bio →'); ?></a></p>
             </aside>
         </div>
+    </section>
 
-        <div class="hero-game-stage" tabindex="0" aria-label="Pacific Static mini arcade game">
-            <p class="hero-game-stage__header pixel-font"><?php echo esc_html('PACIFIC STATIC'); ?></p>
-            <div class="hero-game-stage__screen" role="region" aria-label="Pacific Static game screen">
-                <p class="hero-game-stage__idle pixel-font"><?php echo esc_html('PACIFIC STATIC'); ?><br><?php echo esc_html('Vessel: LIONS GATE'); ?><br><?php echo esc_html('Defend the Vancouver signal.'); ?><br><?php echo esc_html('Press G to play.'); ?><br><?php echo esc_html('WASD move // Space fire // Esc quit'); ?></p>
-            </div>
-            <p class="hero-game-stage__mobile-note"><?php echo esc_html('Mini arcade available on keyboard screens.'); ?></p>
+    <section class="home-featured-build home-lousy-outages crt-block" aria-labelledby="home-featured-title">
+        <p class="pixel-font home-section-kicker"><?php echo esc_html('PRIMARY BUILD'); ?></p>
+        <h2 id="home-featured-title" class="pixel-font"><?php echo esc_html('Featured Build: Lousy Outages'); ?></h2>
+        <p class="home-featured-subtitle"><?php echo esc_html('WordPress-native outage intelligence for third-party services.'); ?></p>
+        <p><?php echo esc_html('Lousy Outages tracks provider status, community reports, external signals, and lightweight synthetic checks to surface possible issues before they become everyone’s problem. It’s built as a standalone WordPress plugin with public REST endpoints, subscriber preferences, admin diagnostics, and demo-safe early-warning logic.'); ?></p>
+        <ul class="home-feature-list">
+            <li><?php echo esc_html('Status monitoring for cloud/SaaS providers'); ?></li>
+            <li><?php echo esc_html('Subscriber preferences for provider-specific alerts'); ?></li>
+            <li><?php echo esc_html('Community issue reporting with cautious/unconfirmed language'); ?></li>
+            <li><?php echo esc_html('Fused signal engine combining official, community, external, and synthetic checks'); ?></li>
+            <li><?php echo esc_html('Plugin-style admin dashboard and ZIP packaging'); ?></li>
+        </ul>
+        <div class="home-badge-list" aria-label="Lousy Outages badges">
+            <span>WordPress Plugin</span><span>Outage Intelligence</span><span>Community Signals</span><span>QA/Ops Automation</span><span>Built in Vancouver</span>
         </div>
-
-        <p class="arcade-subtext">Retro-futurist lab mode: online</p>
-    </div>
-
-    <?php
-    $ai_film_club_watch_url = 'https://www.youtube.com/watch?v=f2MdY3qcxt8';
-    $ai_film_club_embed_url = 'https://www.youtube-nocookie.com/embed/f2MdY3qcxt8';
-    $ai_film_club_repo_url = 'https://github.com/suzyeaston/suzyeastonca';
-    ?>
-    <section class="ai-film-feature crt-block" aria-labelledby="ai-film-feature-title">
-        <div class="ai-film-feature__media">
-            <p class="ai-film-feature__badge pixel-font"><?php echo esc_html('FEATURED CONVERSATION // ON AIR'); ?></p>
-            <div class="ai-film-feature__embed-wrap">
-                <iframe
-                    src="<?php echo esc_url($ai_film_club_embed_url); ?>"
-                    title="<?php echo esc_attr('AI Film Club fireside chat with Mayumi Rollings'); ?>"
-                    loading="lazy"
-                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                    referrerpolicy="strict-origin-when-cross-origin"
-                    allowfullscreen>
-                </iframe>
-            </div>
-        </div>
-        <div class="ai-film-feature__copy">
-            <p class="ai-film-feature__kicker pixel-font"><?php echo esc_html('LATEST SIGNAL // AI FILM CLUB'); ?></p>
-            <h2 id="ai-film-feature-title" class="pixel-font"><?php echo esc_html('AI Film Club fireside chat: building tools, not just prompts'); ?></h2>
-            <p><?php echo esc_html('I joined Mayumi Rollings for an AI Film Club fireside chat about the middle ground between prompting and building: ASMR Lab, Gastown/Vancouver scene experiments, procedural audio, creator control, and why I started making my own tools instead of waiting for a platform to fit.'); ?></p>
-            <p class="ai-film-feature__note"><?php echo esc_html('Part film experiment, part product prototype, part “fine, I’ll build it myself.”'); ?></p>
-            <div class="ai-film-feature__actions" aria-label="AI Film Club and lab links">
-                <a class="pixel-button" href="<?php echo esc_url($ai_film_club_watch_url); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html('Watch the fireside chat'); ?></a>
-                <a class="pixel-button" href="<?php echo esc_url(home_url('/asmr-lab/')); ?>"><?php echo esc_html('Explore ASMR Lab'); ?></a>
-                <a class="pixel-button" href="<?php echo esc_url($ai_film_club_repo_url); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html('View source on GitHub'); ?></a>
-            </div>
+        <div class="home-cta-row">
+            <a class="pixel-button" href="<?php echo esc_url(home_url('/lousy-outages/')); ?>"><?php echo esc_html('Open Lousy Outages'); ?></a>
+            <a class="pixel-button" href="<?php echo esc_url('https://github.com/suzyeaston/suzyeastonca'); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html('View GitHub'); ?></a>
         </div>
     </section>
 
-    <section class="selected-work crt-block" aria-labelledby="selected-work-title">
-        <h2 id="selected-work-title" class="pixel-font">Featured builds</h2>
-        <p class="selected-work__intro">Projects with a practical point of view: experiments that ship, teach, and stay useful.</p>
+    <section class="home-project-grid crt-block" aria-labelledby="selected-projects-title">
+        <h2 id="selected-projects-title" class="pixel-font"><?php echo esc_html('Selected Projects'); ?></h2>
+        <p class="selected-work__intro"><?php echo esc_html('A compact view of the builds I use most in interviews and consulting conversations.'); ?></p>
         <div class="selected-work__grid">
-            <article class="selected-work__card">
-                <h3 class="pixel-font">Gastown Simulator</h3>
-                <p>First-person Vancouver prototype using browser rendering, civic/open-data world files, route anchors, weather/time-of-day controls, and iterative product design.</p>
-                <a class="pixel-button" href="<?php echo esc_url(home_url('/page-gastown-sim/')); ?>">Enter Gastown</a>
+            <article class="home-project-card selected-work__card">
+                <h3 class="pixel-font"><?php echo esc_html('Lousy Outages'); ?></h3>
+                <p><?php echo esc_html('A productizing plugin build for outage monitoring, alert preferences, and fused incident signals.'); ?></p>
+                <a class="pixel-button" href="<?php echo esc_url(home_url('/lousy-outages/')); ?>"><?php echo esc_html('Open project'); ?></a>
             </article>
-            <article class="selected-work__card">
-                <h3 class="pixel-font">VanOps Radar</h3>
-                <p>Vancouver operations intelligence for storefronts, venues, offices, and local teams — a practical disruption board for road access, transit, weather, utility issues, event-day risks, and business continuity signals.</p>
-                <a class="pixel-button" href="<?php echo esc_url(home_url('/vanops-radar/')); ?>">Open VanOps Radar</a>
+            <article class="home-project-card selected-work__card">
+                <h3 class="pixel-font"><?php echo esc_html('Gastown Simulator'); ?></h3>
+                <p><?php echo esc_html('A Vancouver browser-sim prototype blending civic data, world-building, and game-like UX.'); ?></p>
+                <a class="pixel-button" href="<?php echo esc_url(home_url('/page-gastown-sim/')); ?>"><?php echo esc_html('Enter Gastown'); ?></a>
             </article>
-            <article class="selected-work__card">
-                <h3 class="pixel-font">Track Analyzer</h3>
-                <p>AI feedback tool for musicians: upload a track, get practical mix notes, and move faster from “something&rsquo;s off” to “that&rsquo;s the problem.”</p>
-                <a class="pixel-button" href="<?php echo esc_url(home_url('/suzys-track-analyzer/')); ?>">Analyze a Track</a>
+            <article class="home-project-card selected-work__card">
+                <h3 class="pixel-font"><?php echo esc_html('Track Analyzer'); ?></h3>
+                <p><?php echo esc_html('AI-assisted music feedback that helps creators get from vague friction to actionable mix changes.'); ?></p>
+                <a class="pixel-button" href="<?php echo esc_url(home_url('/suzys-track-analyzer/')); ?>"><?php echo esc_html('Analyze a track'); ?></a>
             </article>
-            <article class="selected-work__card">
-                <h3 class="pixel-font">Lousy Outages</h3>
-                <p>Retro internet/provider outage tracker and status-page experiment — the weird monitoring lab behind some of the signal ideas.</p>
-                <a class="pixel-button" href="<?php echo esc_url(home_url('/lousy-outages/')); ?>">View Lousy Outages</a>
-            </article>
-            <article class="selected-work__card">
-                <h3 class="pixel-font">ASMR Lab / Rain City Experiments</h3>
-                <p>Procedural audio-visual experiments where storyboards, synths, browser visuals, and AI prompts meet in the weird part of the lab.</p>
-                <a class="pixel-button" href="<?php echo esc_url(home_url('/asmr-lab/')); ?>">Explore the Lab</a>
-            </article>
-            <article class="selected-work__card">
-                <h3 class="pixel-font">Albini Q&amp;A</h3>
-                <p>An experimental voice-and-attitude-driven creative app inspired by Steve Albini: part tribute, part interactive web experiment, part chaos-tested music-tech artifact.</p>
-                <a class="pixel-button" href="<?php echo esc_url(home_url('/albini-qa/')); ?>">Open Albini Q&amp;A</a>
+            <article class="home-project-card selected-work__card">
+                <h3 class="pixel-font"><?php echo esc_html('AI/Audio Experiments'); ?></h3>
+                <p><?php echo esc_html('ASMR Lab and related creative-tech experiments in procedural sound, visuals, and AI-assisted prototyping.'); ?></p>
+                <a class="pixel-button" href="<?php echo esc_url(home_url('/asmr-lab/')); ?>"><?php echo esc_html('Explore experiments'); ?></a>
             </article>
         </div>
     </section>
 
     <section class="music-world crt-block" aria-labelledby="music-world-title">
-        <h2 id="music-world-title" class="pixel-font">The other signal chain</h2>
-        <p>The same brain behind the systems also writes songs, makes noisy little films, talks shop, and occasionally turns Vancouver rain into a production aesthetic.</p>
+        <h2 id="music-world-title" class="pixel-font"><?php echo esc_html('Music + Creative Tech'); ?></h2>
+        <p><?php echo esc_html('I still build in public as a musician: songs, audio tools, and weird web narratives feed the same product instincts as my ops and QA work.'); ?></p>
         <p class="home-section-legend-links" aria-label="Music and media links">
             <a href="https://suzyeaston.bandcamp.com" target="_blank" rel="noopener noreferrer">Bandcamp</a>
             <span aria-hidden="true">//</span>
@@ -162,31 +85,19 @@ get_header();
             <span aria-hidden="true">//</span>
             <a href="https://www.youtube.com/@suzyeaston" target="_blank" rel="noopener noreferrer">YouTube</a>
             <span aria-hidden="true">//</span>
-            <a href="https://instagram.com/officialsuzyeaston" target="_blank" rel="noopener noreferrer">Instagram</a>
-            <span aria-hidden="true">//</span>
             <a href="<?php echo esc_url(home_url('/podcast/')); ?>">Podcast</a>
         </p>
     </section>
 
-    <section class="collab-invite-home crt-block" aria-labelledby="collab-invite-title">
-        <h2 id="collab-invite-title" class="pixel-font">Available for senior roles, contract work, and strange useful builds</h2>
-        <p>I’m open to senior technical roles, contract QA/automation work, practical AI prototypes, and debugging projects where the system is messy and someone needs to make the thing make sense.</p>
-        <div class="collab-invite-home__actions">
-            <a href="<?php echo esc_url(home_url('/work-with-suzy/')); ?>" class="pixel-button">Work with Suzy</a>
-            <a href="<?php echo esc_url('https://www.linkedin.com/in/suzyeaston/'); ?>" target="_blank" rel="noopener noreferrer" class="pixel-button">LinkedIn</a>
-            <a href="mailto:suzyeaston@icloud.com?subject=Work%20Inquiry" class="pixel-button">Email Suzy</a>
+    <section class="collab-invite-home crt-block" aria-labelledby="work-pain-title">
+        <h2 id="work-pain-title" class="pixel-font"><?php echo esc_html('Built from real operations pain'); ?></h2>
+        <p><?php echo esc_html('My work sits where QA, IT operations, cloud tooling, automation, and creative product thinking overlap. I build tools that make noisy systems easier to understand.'); ?></p>
+        <p><?php echo esc_html('I’m available for QA automation, cloud/IT operations support, WordPress/plugin engineering, AI-assisted development, and creative-tech collaborations.'); ?></p>
+        <div class="home-cta-row collab-invite-home__actions">
+            <a href="<?php echo esc_url(home_url('/work-with-suzy/')); ?>" class="pixel-button"><?php echo esc_html('Work With Me'); ?></a>
+            <a href="<?php echo esc_url(home_url('/contact/')); ?>" class="pixel-button"><?php echo esc_html('Contact'); ?></a>
+            <a href="<?php echo esc_url(home_url('/bio/')); ?>" class="pixel-button"><?php echo esc_html('Read Bio'); ?></a>
         </div>
-    </section>
-
-    <?php
-    $visitor_data = include get_template_directory() . '/visitor-tracker.php';
-    $total = isset($visitor_data['count']) ? (int) $visitor_data['count'] : 0;
-    $total = max(0, $total);
-    ?>
-    <section class="utility-nav-home crt-block" aria-labelledby="utility-nav-title">
-        <h2 id="utility-nav-title" class="pixel-font">Lab activity</h2>
-        <p class="utility-nav-home__counter"><?php echo esc_html(sprintf('👁️ %d lab visits logged.', $total)); ?></p>
-        <p class="utility-nav-home__mini-links"><a href="<?php echo esc_url(home_url('/projects/')); ?>">Projects</a> // <a href="<?php echo esc_url(home_url('/work-with-suzy/')); ?>">Work with Suzy</a> // <a href="<?php echo esc_url(home_url('/bio/')); ?>">Bio</a></p>
     </section>
 </main>
 

--- a/style.css
+++ b/style.css
@@ -4913,3 +4913,20 @@ body {
         grid-template-columns: 1fr;
     }
 }
+
+/* Homepage clarity refresh */
+.home-layout section { margin-block: 1.5rem; }
+.home-featured-build { border: 2px solid rgba(95, 247, 205, 0.45); box-shadow: 0 0 0 1px rgba(95, 247, 205, 0.2), 0 12px 30px rgba(0,0,0,0.35); }
+.home-featured-subtitle { font-weight: 700; color: #9bf7dc; margin-top: 0.35rem; }
+.home-feature-list { margin: 1rem 0; padding-left: 1.25rem; }
+.home-feature-list li { margin-bottom: 0.45rem; }
+.home-badge-list { display: flex; flex-wrap: wrap; gap: 0.45rem; margin: 1rem 0; }
+.home-badge-list span { border: 1px solid rgba(155,247,220,0.5); padding: 0.25rem 0.6rem; border-radius: 999px; font-size: 0.78rem; letter-spacing: 0.03em; text-transform: uppercase; }
+.home-cta-row { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-top: 1rem; }
+.home-project-grid .selected-work__grid { gap: 1rem; }
+.home-project-card { min-height: 100%; }
+.home-section-kicker { color: #8fd5ff; letter-spacing: 0.08em; margin-bottom: 0.35rem; }
+@media (max-width: 782px) {
+  .home-layout section { margin-block: 1.1rem; }
+  .home-hero .hero-grid { gap: 1rem; }
+}


### PR DESCRIPTION
### Motivation
- The homepage was overly busy and competing for attention with many experiments and embeds, making it hard for recruiters/clients to see primary product work.  
- The intent is to present a clearer narrative: Suzy builds practical, creative tech with Lousy Outages as the primary product-style build.  

### Description
- Rewrote the homepage template `page-home.php` to a focused flow with five sections: Hero, Featured Build (Lousy Outages), Selected Projects, Music + Creative Tech, and Work/Contact, and removed several large above‑the‑fold embeds and decorative game panels.  
- Added a prominent `Featured Build: Lousy Outages` panel with prototype-safe copy, capability bullets, badge row, and primary CTAs to `/lousy-outages/` and GitHub.  
- Collapsed the project list into four compact cards (Lousy Outages, Gastown Simulator, Track Analyzer, AI/Audio Experiments) with one-sentence descriptions and single CTAs.  
- Added lightweight homepage-specific CSS rules to `style.css` (new `.home-*` classes) to improve spacing, visual hierarchy, and a console-style treatment for the featured build without introducing new JS or external libraries.  

### Testing
- Ran `php -l page-home.php`, `php -l functions.php`, and `php -l page-lousy-outages.php` and received "No syntax errors detected" for each file.  
- Verified `front-page.php` and `home.php` are not present in the repo using directory checks.  
- Produced a diff summary showing `page-home.php` and `style.css` were modified (2 files changed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f81f8fe5d0832ea8ebfa42b7e9dada)