### PR TITLE
Refine Projects page readability and feature Lousy Outages

### DIFF
--- a/page-projects.php
+++ b/page-projects.php
@@ -22,190 +22,87 @@ $project_url = static function (string $slug, string $fallback_path = ''): strin
 <main id="main-content" class="projects-page">
     <div class="projects-shell">
         <section class="projects-hero projects-section" aria-labelledby="projects-title">
-            <p class="projects-eyebrow projects-hero__eyebrow pixel-font">Build log // useful weird systems</p>
+            <p class="projects-eyebrow projects-hero__eyebrow pixel-font">Build log</p>
             <h1 id="projects-title" class="projects-hero__title">Projects</h1>
-            <p class="projects-lead projects-hero__lead">A field guide to the tools, prototypes, dashboards, music-tech experiments, civic builds, and strange useful systems I&rsquo;m building in public.</p>
-            <p class="projects-hero__support">Some are polished enough to use. Some are live prototypes. Some are weird little labs that teach me what to build next. The common thread: practical systems, creative taste, and enough technical grit to make the thing actually work.</p>
+            <p class="projects-lead projects-hero__lead">Things I&rsquo;m building, testing, breaking, fixing, and slowly turning into something useful. Some are polished enough to show. Some are still experiments. That is kind of the point.</p>
             <div class="projects-actions" role="group" aria-label="Projects page jumps and primary links">
-                <a class="pixel-button" href="#featured-projects">Featured builds</a>
-                <a class="pixel-button" href="#creative-labs">Creative labs</a>
-                <a class="pixel-button" href="<?php echo esc_url(home_url('/work-with-suzy/')); ?>">Work with Suzy</a>
+                <a class="pixel-button" href="#featured-projects">Featured</a>
+                <a class="pixel-button" href="#interactive-projects">Interactive</a>
+                <a class="pixel-button" href="#music-ai-projects">Music / AI</a>
             </div>
         </section>
 
         <section id="featured-projects" class="projects-section" aria-labelledby="featured-projects-title">
             <div class="projects-section-header">
-                <h2 id="featured-projects-title" class="pixel-font">Featured builds</h2>
-                <p>The main projects I&rsquo;d point a recruiter, client, collaborator, or curious Vancouver human toward first.</p>
+                <h2 id="featured-projects-title" class="pixel-font">Featured</h2>
+                <p>The lead build I want people to see first.</p>
             </div>
             <div class="projects-grid projects-grid--featured">
                 <article class="projects-card projects-card--featured">
-                    <h3 class="pixel-font">VanOps Radar</h3>
-                    <p class="projects-card__status"><strong>Status:</strong> Current product experiment</p>
-                    <p>A Vancouver-first operations dashboard concept for small and medium businesses that need clearer signals around road access, transit, weather, utilities, events, and business continuity.</p>
-                    <p class="projects-card__proof"><strong>What it proves:</strong> Civic product thinking, dashboards, local operations, SMB positioning, and practical web development.</p>
-                    <div class="projects-card__actions">
-                        <a class="pixel-button" href="<?php echo esc_url($project_url('vanops-radar')); ?>">Open VanOps Radar</a>
-                    </div>
-                </article>
-
-                <article class="projects-card projects-card--featured">
-                    <h3 class="pixel-font">Gastown Simulator</h3>
-                    <p class="projects-card__status"><strong>Status:</strong> Live prototype / desktop-first</p>
-                    <p>A first-person Vancouver corridor prototype from Waterfront Station toward Water Street and the Steam Clock, using browser rendering, civic/open-data world files, route anchors, weather/time-of-day controls, and iterative product design.</p>
-                    <p class="projects-card__proof"><strong>What it proves:</strong> Three.js-style worldbuilding, civic data pipelines, browser interaction, debugging, and build-in-public persistence.</p>
-                    <div class="projects-card__actions">
-                        <a class="pixel-button" href="<?php echo esc_url($project_url('page-gastown-sim', '/page-gastown-sim/')); ?>">Enter Gastown</a>
-                    </div>
-                </article>
-
-                <article class="projects-card projects-card--featured">
                     <h3 class="pixel-font">Lousy Outages</h3>
-                    <p class="projects-card__status"><strong>Status:</strong> Active monitoring lab</p>
-                    <p>A retro internet/provider outage tracker and status-page experiment with provider feeds, alert ideas, public utility energy, and chaos-monitoring personality.</p>
-                    <p class="projects-card__proof"><strong>What it proves:</strong> Status dashboards, monitoring UX, REST/plugin architecture, provider signal handling, and operational thinking.</p>
+                    <p>A WordPress plugin I&rsquo;m building for outage monitoring, alert preferences, community reports, and early-warning signals.</p>
+                    <ul class="projects-badges" aria-label="Lousy Outages details">
+                        <li>WordPress plugin</li><li>IT ops</li><li>REST API</li><li>Early warning</li><li>Subscriber alerts</li>
+                    </ul>
                     <div class="projects-card__actions">
-                        <a class="pixel-button" href="<?php echo esc_url($project_url('lousy-outages')); ?>">View Lousy Outages</a>
-                    </div>
-                </article>
-
-                <article class="projects-card projects-card--featured">
-                    <h3 class="pixel-font">Track Analyzer</h3>
-                    <p class="projects-card__status"><strong>Status:</strong> Live music-tech tool</p>
-                    <p>An AI-assisted feedback tool for musicians: upload a track, get practical mix notes, and move faster from &ldquo;something feels off&rdquo; to &ldquo;that is probably the problem.&rdquo;</p>
-                    <p class="projects-card__proof"><strong>What it proves:</strong> AI-assisted workflows, audio/product thinking, upload UX, OpenAI integration, and musician-first design.</p>
-                    <div class="projects-card__actions">
-                        <a class="pixel-button" href="<?php echo esc_url($project_url('suzys-track-analyzer', '/suzys-track-analyzer/')); ?>">Analyze a Track</a>
+                        <a class="pixel-button" href="<?php echo esc_url($project_url('lousy-outages')); ?>">Open project</a>
+                        <a class="pixel-button" href="https://github.com/suzyeaston/suzyeastonca" target="_blank" rel="noopener noreferrer">View GitHub</a>
                     </div>
                 </article>
             </div>
         </section>
 
-        <section id="creative-labs" class="projects-section" aria-labelledby="creative-labs-title">
+        <section id="interactive-projects" class="projects-section" aria-labelledby="interactive-projects-title">
             <div class="projects-section-header">
-                <h2 id="creative-labs-title" class="pixel-font">Creative labs</h2>
-                <p>Experiments where music, AI, browser visuals, retro interfaces, and Vancouver rain all start yelling into the same effects pedal.</p>
+                <h2 id="interactive-projects-title" class="pixel-font">Interactive</h2>
             </div>
             <div class="projects-grid">
                 <article class="projects-card">
-                    <h3 class="pixel-font">ASMR Lab / Rain City Experiments</h3>
-                    <p class="projects-card__status"><strong>Status:</strong> Rebuild in progress</p>
-                    <p>Procedural audio-visual experiments for storyboarded micro-scenes, browser foley, synchronized timelines, Vancouver route presets, and AI-assisted creative control.</p>
-                    <p class="projects-card__proof"><strong>What it proves:</strong> Audio engines, visual timelines, prompt-to-structure workflows, creative tooling, and experimental UX.</p>
+                    <h3 class="pixel-font">Gastown Simulator</h3>
+                    <p>A browser-based Vancouver prototype with maps, routes, civic data, and game-style navigation.</p>
                     <div class="projects-card__actions">
-                        <a class="pixel-button" href="<?php echo esc_url($project_url('asmr-lab')); ?>">Explore ASMR Lab</a>
+                        <a class="pixel-button" href="<?php echo esc_url($project_url('page-gastown-sim', '/page-gastown-sim/')); ?>">Open project</a>
                     </div>
                 </article>
 
                 <article class="projects-card">
-                    <h3 class="pixel-font">Albini Q&amp;A</h3>
-                    <p class="projects-card__status"><strong>Status:</strong> Music-tech experiment</p>
-                    <p>An interactive creative app inspired by Steve Albini&rsquo;s public voice and engineering ethos: part tribute, part music-technology playground, part quote-grounded interface experiment.</p>
-                    <p class="projects-card__proof"><strong>What it proves:</strong> Voice, archives, UI personality, quote handling, and creative AI boundaries.</p>
+                    <h3 class="pixel-font">Track Analyzer</h3>
+                    <p>An AI-assisted music feedback tool for rough mixes and songwriting notes.</p>
                     <div class="projects-card__actions">
-                        <a class="pixel-button" href="<?php echo esc_url($project_url('albini-qa')); ?>">Open Albini Q&amp;A</a>
+                        <a class="pixel-button" href="<?php echo esc_url($project_url('suzys-track-analyzer', '/suzys-track-analyzer/')); ?>">Open project</a>
                     </div>
                 </article>
+            </div>
+        </section>
 
+        <section id="music-ai-projects" class="projects-section" aria-labelledby="music-ai-projects-title">
+            <div class="projects-section-header">
+                <h2 id="music-ai-projects-title" class="pixel-font">Music / AI</h2>
+            </div>
+            <div class="projects-grid">
                 <article class="projects-card">
                     <h3 class="pixel-font">Riff Generator</h3>
-                    <p class="projects-card__status"><strong>Status:</strong> Small creative utility</p>
-                    <p>A quick creative prompt machine for music ideas, riffs, and songwriting sparks.</p>
-                    <p class="projects-card__proof"><strong>What it proves:</strong> Small-tool thinking, playful UX, and musician-focused utility.</p>
+                    <p>A small music idea generator for quick prompts, riffs, and creative nudges.</p>
                     <div class="projects-card__actions">
-                        <a class="pixel-button" href="<?php echo esc_url($project_url('riff-generator')); ?>">Generate a Riff</a>
+                        <a class="pixel-button" href="<?php echo esc_url($project_url('riff-generator')); ?>">Open project</a>
                     </div>
                 </article>
 
                 <article class="projects-card">
-                    <h3 class="pixel-font">Arcade / Canucks Puck Bash</h3>
-                    <p class="projects-card__status"><strong>Status:</strong> Playable web toy</p>
-                    <p>Retro arcade energy, hockey chaos, and browser-game experimentation living inside the same custom WordPress universe.</p>
-                    <p class="projects-card__proof"><strong>What it proves:</strong> Canvas/game UI thinking, interaction loops, fun as product glue, and Vancouver sports nonsense in the best way.</p>
+                    <h3 class="pixel-font">ASMR Lab</h3>
+                    <p>A playful audio experiment for generated sound textures and web-based ambience.</p>
                     <div class="projects-card__actions">
-                        <a class="pixel-button" href="<?php echo esc_url($project_url('arcade')); ?>">Open Arcade</a>
-                    </div>
-                </article>
-            </div>
-        </section>
-
-        <section id="vancouver-builds" class="projects-section" aria-labelledby="vancouver-builds-title">
-            <div class="projects-section-header">
-                <h2 id="vancouver-builds-title" class="pixel-font">Vancouver, civic, and community builds</h2>
-                <p>Local-first experiments and pages connected to Vancouver, civic life, community, advocacy, events, and useful public information.</p>
-            </div>
-            <div class="projects-grid">
-                <article class="projects-card">
-                    <h3 class="pixel-font">VanOps Radar</h3>
-                    <p class="projects-card__status"><strong>Status:</strong> Local disruption intelligence</p>
-                    <p>A Vancouver SMB operations dashboard concept for local disruption intelligence and business continuity.</p>
-                    <div class="projects-card__actions">
-                        <a class="pixel-button" href="<?php echo esc_url($project_url('vanops-radar')); ?>">Open VanOps Radar</a>
+                        <a class="pixel-button" href="<?php echo esc_url($project_url('asmr-lab')); ?>">Open project</a>
                     </div>
                 </article>
 
                 <article class="projects-card">
-                    <h3 class="pixel-font">Gastown Simulator</h3>
-                    <p class="projects-card__status"><strong>Status:</strong> Browser world prototype</p>
-                    <p>A browser-based Vancouver worldbuilding prototype using local route logic and civic/open-data thinking.</p>
+                    <h3 class="pixel-font">AI/Audio Experiments</h3>
+                    <p>Small experiments with generated sound, web visuals, and AI-assisted storytelling.</p>
                     <div class="projects-card__actions">
-                        <a class="pixel-button" href="<?php echo esc_url($project_url('page-gastown-sim', '/page-gastown-sim/')); ?>">Enter Gastown</a>
+                        <a class="pixel-button" href="<?php echo esc_url($project_url('albini-qa')); ?>">Open project</a>
                     </div>
                 </article>
-
-                <article class="projects-card">
-                    <h3 class="pixel-font">Advocacy updates</h3>
-                    <p class="projects-card__status"><strong>Status:</strong> Civic notebook</p>
-                    <p>A place for tenant-rights, DTES, city council, and civic advocacy notes as Suzy keeps building a stronger public voice in Vancouver.</p>
-                    <div class="projects-card__actions">
-                        <a class="pixel-button" href="<?php echo esc_url($project_url('advocacy')); ?>">Read advocacy updates</a>
-                    </div>
-                </article>
-
-                <article class="projects-card">
-                    <h3 class="pixel-font">Coffee for Builders</h3>
-                    <p class="projects-card__status"><strong>Status:</strong> Community experiment</p>
-                    <p>A lightweight invitation for local builders, makers, founders, musicians, technologists, and practical weirdos to connect without networking-event cosplay.</p>
-                    <div class="projects-card__actions">
-                        <a class="pixel-button" href="<?php echo esc_url($project_url('coffee-for-builders')); ?>">Coffee for Builders</a>
-                    </div>
-                </article>
-            </div>
-        </section>
-
-        <section class="projects-section" aria-labelledby="more-signals-title">
-            <div class="projects-section-header">
-                <h2 id="more-signals-title" class="pixel-font">More signals</h2>
-            </div>
-            <div class="projects-mini-grid">
-                <a class="projects-card" href="<?php echo esc_url($project_url('music-releases')); ?>"><strong>Music Releases</strong></a>
-                <a class="projects-card" href="<?php echo esc_url($project_url('podcast')); ?>"><strong>Podcast</strong></a>
-                <a class="projects-card" href="<?php echo esc_url(home_url('/bio/')); ?>"><strong>Bio</strong></a>
-                <a class="projects-card" href="<?php echo esc_url(home_url('/work-with-suzy/')); ?>"><strong>Work With Suzy</strong></a>
-                <a class="projects-card" href="https://github.com/suzyeaston/suzyeastonca" target="_blank" rel="noopener noreferrer"><strong>GitHub source</strong></a>
-            </div>
-        </section>
-
-        <section class="projects-section" aria-labelledby="how-i-build-title">
-            <div class="projects-section-header">
-                <h2 id="how-i-build-title" class="pixel-font">How I build</h2>
-                <p>I build in public, use the site as a working lab, and treat prototypes as proof. A project does not need to be perfect to be useful &mdash; it needs to reveal the next problem clearly.</p>
-            </div>
-            <div class="projects-method-grid">
-                <article class="projects-card"><h3 class="pixel-font">Practical first</h3><p>Tools should solve a real workflow or teach something concrete.</p></article>
-                <article class="projects-card"><h3 class="pixel-font">Weird is allowed</h3><p>Personality is not a bug. It helps people remember the thing.</p></article>
-                <article class="projects-card"><h3 class="pixel-font">Systems matter</h3><p>The fun layer still needs sane data, caching, APIs, fallbacks, and debugging.</p></article>
-                <article class="projects-card"><h3 class="pixel-font">Ship, learn, revise</h3><p>The point is momentum: build the smallest useful version, test it, then make it sharper.</p></article>
-            </div>
-        </section>
-
-        <section class="projects-final-cta projects-section" aria-labelledby="projects-cta-title">
-            <h2 id="projects-cta-title" class="pixel-font">Want to build something useful and memorable?</h2>
-            <p>I&rsquo;m open to senior technical roles, contract web development, QA/automation work, custom WordPress builds, dashboards, practical AI prototypes, and weird bug triage.</p>
-            <div class="projects-actions" role="group" aria-label="Work with Suzy and contact links">
-                <a class="pixel-button" href="<?php echo esc_url(home_url('/work-with-suzy/')); ?>">Work with Suzy</a>
-                <a class="pixel-button" href="mailto:suzyeaston@icloud.com?subject=Project%20Inquiry">Email Suzy</a>
-                <a class="pixel-button" href="https://github.com/suzyeaston/suzyeastonca" target="_blank" rel="noopener noreferrer">View GitHub</a>
             </div>
         </section>
     </div>

--- a/style.css
+++ b/style.css
@@ -4673,17 +4673,17 @@ body {
 .page-template-page-projects .projects-hero {
     border-color: rgba(57, 245, 255, 0.52);
     background: linear-gradient(160deg, rgba(8, 18, 45, 0.95), rgba(9, 20, 54, 0.9));
-    padding: clamp(24px, 4.2vw, 42px);
+    padding: clamp(18px, 3vw, 30px);
 }
 
 .page-template-page-projects .projects-eyebrow,
 .page-template-page-projects .projects-hero__eyebrow {
-    margin: 0 0 12px;
-    letter-spacing: 0.04em;
+    margin: 0 0 8px;
+    letter-spacing: 0.03em;
     text-transform: uppercase;
     color: var(--projects-teal);
-    font-size: clamp(0.72rem, 1.4vw, 0.86rem);
-    line-height: 1.55;
+    font-size: clamp(0.66rem, 1vw, 0.78rem);
+    line-height: 1.4;
     background: transparent;
     display: inline-flex;
     padding: 0;
@@ -4702,8 +4702,8 @@ body {
 .page-template-page-projects .projects-hero__title {
     font-family: "Press Start 2P", cursive;
     font-size: clamp(3rem, 8vw, 6rem);
-    line-height: 1.03;
-    letter-spacing: 0.02em;
+    line-height: 0.95;
+    letter-spacing: 0.01em;
     color: #71f7ff;
     text-shadow: 0 0 20px rgba(57, 245, 255, 0.25);
     padding: 0;
@@ -4716,10 +4716,10 @@ body {
 
 .page-template-page-projects .projects-lead,
 .page-template-page-projects .projects-hero__lead {
-    margin: 0 0 10px;
-    max-width: 78ch;
-    font-size: clamp(1.2rem, 2.4vw, 1.75rem);
-    line-height: 1.5;
+    margin: 0 0 8px;
+    max-width: 850px;
+    font-size: clamp(1rem, 2vw, 1.35rem);
+    line-height: 1.55;
     color: var(--projects-text);
     background: transparent;
 }
@@ -4740,7 +4740,7 @@ body {
 }
 
 .page-template-page-projects .projects-actions {
-    margin-top: 16px;
+    margin-top: 12px;
     display: flex;
     flex-wrap: wrap;
     gap: 10px;
@@ -4830,6 +4830,26 @@ body {
 
 .page-template-page-projects .projects-card__actions .pixel-button {
     min-height: 40px;
+}
+
+.page-template-page-projects .projects-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    list-style: none;
+    margin: 10px 0 0;
+    padding: 0;
+}
+
+.page-template-page-projects .projects-badges li {
+    margin: 0;
+    border: 1px solid rgba(57, 245, 255, 0.36);
+    border-radius: 999px;
+    padding: 3px 9px;
+    background: rgba(4, 12, 29, 0.86);
+    color: #dff9ff;
+    font-size: 0.74rem;
+    letter-spacing: 0.01em;
 }
 
 .page-template-page-projects .projects-mini-grid {


### PR DESCRIPTION
### Motivation
- Reduce the poster-like visual weight of the Projects page while keeping the retro/pixel/terminal aesthetic so the page reads like an index rather than a landing hero.  
- Improve hierarchy and scanability so visitors see content (project cards) above the fold on desktop.  
- Surface one clear lead project (Lousy Outages) and make project copy concise and usable for portfolio browsing.  

### Description
- Replaced oversized hero copy and support lines in `page-projects.php` with the requested eyebrow `Build log`, H1 `Projects`, and the concise intro paragraph.  
- Reorganized project listings into light groups (`Featured`, `Interactive`, `Music / AI`) and tightened every card to one-sentence descriptions using the existing `project_url` resolver.  
- Made **Lousy Outages** the featured lead card with the requested description, a compact badges list, a primary CTA (`Open project` → `/lousy-outages/`) and a secondary `View GitHub` CTA.  
- Tuned hero styling in `style.css` to reduce dominance: decreased hero padding, scaled eyebrow down, tightened H1 line-height while keeping `font-size: clamp(3rem, 8vw, 6rem)` for prominence, changed intro to `font-size: clamp(1rem, 2vw, 1.35rem)` with `max-width: 850px`, and added compact badge styles.  
- Removed or collapsed several slogan-like / repetitive sections to reduce clutter and let project cards surface earlier without changing global theme header/footer or the retro look.  

### Testing
- Ran `php -l page-projects.php` and the file reports no syntax errors.  
- Ran `php -l functions.php`, `php -l page-home.php`, and `php -l page-lousy-outages.php` and each reported no syntax errors.  
- Ran `git diff --stat` to confirm the change summary includes updates to `page-projects.php` and `style.css` (files modified and diff size).  
- No automated visual tests were run; CSS changes were limited and scoped to the projects template to preserve site-wide styles.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f83c2bbc9c832eaf05bbe1e919540d)