### PR TITLE
Refine homepage work/contact copy for a more direct voice

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -37,7 +37,7 @@
             <p>&copy; <?php echo date('Y'); ?> Suzy Easton. All rights reserved.</p>
         </div>
         <div class="footer-marquee">
-            <span>Made in Vancouver &middot; Built with coffee, riffs, and command line confidence.</span>
+            <span>Made in Vancouver &middot; Built with coffee, riffs, and practical tooling.</span>
         </div>
     </div>
 </footer>

--- a/page-home.php
+++ b/page-home.php
@@ -89,9 +89,9 @@ get_header();
     </section>
 
     <section class="collab-invite-home crt-block" aria-labelledby="work-pain-title">
-        <h2 id="work-pain-title" class="pixel-font"><?php echo esc_html('What I’m good at'); ?></h2>
-        <p><?php echo esc_html('I’m useful when a problem crosses support, QA, operations, and development. I can investigate what is going wrong, write tests, automate repetitive work, clean up handoffs, and turn a rough idea into a working demo.'); ?></p>
-        <p><?php echo esc_html('I’m open to QA automation, IT/cloud operations, WordPress/plugin work, AI-assisted prototyping, and practical automation projects.'); ?></p>
+        <h2 id="work-pain-title" class="pixel-font"><?php echo esc_html('The stuff I’m useful for'); ?></h2>
+        <p><?php echo esc_html('I’m good at taking a confusing technical problem and making it smaller. That might mean tracing an alert, testing a workflow, writing automation, cleaning up a handoff, or turning a rough idea into a demo people can actually try.'); ?></p>
+        <p><?php echo esc_html('I’m open to QA automation, IT and cloud operations, WordPress plugin work, AI-assisted prototyping, and practical automation projects.'); ?></p>
         <div class="home-cta-row collab-invite-home__actions">
             <a href="<?php echo esc_url(home_url('/work-with-suzy/')); ?>" class="pixel-button"><?php echo esc_html('Work with me'); ?></a>
             <a href="<?php echo esc_url(home_url('/contact/')); ?>" class="pixel-button"><?php echo esc_html('Contact'); ?></a>


### PR DESCRIPTION
### Motivation
- Make the homepage work/contact section sound more like Suzy: practical, warm, direct, and human while removing banned / overused phrases and keeping the existing retro style and CTAs.

### Description
- Updated the collaboration section in `page-home.php` to change the heading to “The stuff I’m useful for”, replaced the main body and availability lines with the requested copy, and left the CTA buttons unchanged, and updated the footer marquee in `footer.php` to remove the banned phrase `command line confidence` and replace it with plainer wording.

### Testing
- Ran `php -l page-home.php`, `php -l functions.php`, and `php -l page-lousy-outages.php` which reported no syntax errors, and inspected `git diff --stat` to confirm the intended changes were the only modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f83f2bdb88832e8082b6c08ccbd366)