### PR TITLE
Update homepage hero Resume CTA to LinkedIn

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -12,7 +12,7 @@ get_header();
                 <p class="hero-copy"><?php echo esc_html('I’m Suzy Easton. I work in IT operations and QA automation, and I build WordPress plugins, outage tools, and AI-assisted music projects on the side. I like projects where the logs are messy, the problem is real, and the fix needs to be clear.'); ?></p>
                 <div class="home-cta-row hero-cta-group">
                     <a href="<?php echo esc_url(home_url('/lousy-outages/')); ?>" class="pixel-button hero-primary-cta"><?php echo esc_html('See Lousy Outages'); ?></a>
-                    <a href="<?php echo esc_url(home_url('/resume/')); ?>" class="pixel-button hero-secondary-cta"><?php echo esc_html('Resume'); ?></a>
+                    <a href="<?php echo esc_url('https://www.linkedin.com/in/suzyeaston/'); ?>" class="pixel-button hero-secondary-cta" target="_blank" rel="noopener noreferrer"><?php echo esc_html('Resume'); ?></a>
                     <a href="<?php echo esc_url(home_url('/projects/')); ?>" class="pixel-button hero-secondary-cta"><?php echo esc_html('Projects'); ?></a>
                 </div>
             </div>


### PR DESCRIPTION
### Motivation
- Replace the homepage hero "Resume" button link so it opens the LinkedIn profile directly in a new tab for a clearer external resume destination.

### Description
- Updated `page-home.php` to change the hero `Resume` anchor from `home_url('/resume/')` to `https://www.linkedin.com/in/suzyeaston/` and added `target="_blank"` and `rel="noopener noreferrer"`, leaving other hero buttons unchanged.

### Testing
- Ran `php -l page-home.php` and `php -l functions.php`, both reported no syntax errors, and ran `git diff --stat`, which shows `page-home.php` updated (1 insertion, 1 deletion).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f84fffec28832eb45a23a9f3ba1bbd)