### PR TITLE
Fix Intel Conduit source interface fatal and add WP-bootstrap smoke test

### DIFF
--- a/lousy-outages/README.md
+++ b/lousy-outages/README.md
@@ -103,3 +103,21 @@ Use these shell snippets on hosts where WP-CLI is unavailable:
 - Check adapter options and diagnostics payloads:
   - `mysql -e "SELECT option_name,LENGTH(option_value) FROM wp_options WHERE option_name LIKE 'lousy_outages_%external%' OR option_name LIKE 'lousy_outages_%signal%';"`
 
+
+## Deployment preflight (required)
+
+`php -l` only validates syntax. It does **not** verify runtime interface compatibility or class instantiation during WordPress bootstrap.
+
+Before replacing the production plugin, run:
+
+- `php -l wp-content/plugins/lousy-outages/includes/Sources/IntelConduitSources.php`
+- `php wp-content/plugins/lousy-outages/scripts/smoke-signal-sources.php /var/www/html/wp-load.php`
+
+The smoke script bootstraps WordPress (`require wp-load.php`), calls `\SuzyEaston\LousyOutages\SignalCollector::sources()`, and validates for each source:
+
+- instance of `SignalSourceInterface`
+- non-empty `id()` string
+- non-empty `label()` string
+- boolean return from `is_configured()`
+
+If this check fails, do not deploy.

--- a/lousy-outages/includes/Sources/IntelConduitSources.php
+++ b/lousy-outages/includes/Sources/IntelConduitSources.php
@@ -15,7 +15,9 @@ trait IntelConduitHelpers {
 
 class StatuspageIntelSource implements SignalSourceInterface {
     use IntelConduitHelpers;
-    
+
+    public function id(): string { return 'statuspage_intel'; }
+    public function label(): string { return 'Statuspage Intel'; }
     public function is_configured(): bool { return true; }
     public function collect(array $options = []): array {
         $bases = (array) apply_filters('lo_statuspage_base_urls', []);
@@ -28,7 +30,7 @@ class StatuspageIntelSource implements SignalSourceInterface {
 
 class ProviderFeedSource implements SignalSourceInterface { use IntelConduitHelpers;
     public function id(): string { return 'provider_feed'; }
-    public function label(): string { return 'Provider Feed'; }
+    public function label(): string { return 'Provider/RSS Feed Intel'; }
     public function is_configured(): bool { return true; }
     public function collect(array $options = []): array {
         $feeds=(array)apply_filters('lo_provider_feed_urls',[]); $max=max(1,min(20,(int)apply_filters('lo_provider_feed_max_items',8))); $timeout=max(2,min(12,(int)apply_filters('lo_provider_feed_timeout',6))); $out=[];
@@ -38,15 +40,15 @@ class ProviderFeedSource implements SignalSourceInterface { use IntelConduitHelp
 }
 
 class HackerNewsChatterSource implements SignalSourceInterface { use IntelConduitHelpers;
-    public function id(): string { return 'hn_chatter'; }
+    public function id(): string { return 'hacker_news_chatter'; }
     public function label(): string { return 'Hacker News Chatter'; }
     public function is_configured(): bool { return (bool) apply_filters('lo_hn_chatter_enabled', false); }
     public function collect(array $options = []): array { $queries=['GitHub Actions down','npm outage','Cloudflare outage','AWS outage','OpenAI API down','Vercel outage','Docker Hub outage']; $out=[]; $limit=3; foreach($queries as $q){ $u='https://hn.algolia.com/api/v1/search?tags=story&hitsPerPage='.$limit.'&query='.rawurlencode($q); $cache='lo_hn_'.md5($u); $hits=get_transient($cache); if(!is_array($hits)){ $r=wp_remote_get($u,['timeout'=>5]); if(is_wp_error($r)) continue; $hits=(array)(json_decode((string)wp_remote_retrieve_body($r),true)['hits']??[]); set_transient($cache,$hits,10*MINUTE_IN_SECONDS);} foreach($hits as $h){ $title=sanitize_text_field((string)($h['title']??$h['story_title']??'')); if(!$this->has_issue_language($title.' '.$q)) continue; $url=esc_url_raw((string)($h['url']??$h['story_url']??'https://news.ycombinator.com/item?id='.(int)($h['objectID']??0))); $provider=preg_split('/\s+/',trim((string)$q))[0] ?? 'unknown'; $out[]=['source'=>'hacker_news','source_type'=>'developer_chatter','adapter_id'=>'hn_algolia','source_id'=>sanitize_text_field((string)($h['objectID']??md5($title.$url))),'provider_id'=>sanitize_key((string)$provider),'provider_name'=>sanitize_text_field((string)$provider),'category'=>'developer_chatter','region'=>'global','signal_type'=>'hn_chatter','severity'=>'watch','confidence'=>35,'title'=>$title,'message'=>'Unconfirmed developer chatter from Hacker News.','url'=>$url,'domains'=>[$this->host($url)],'source_urls'=>[$url,$u],'snippets'=>[$title],'confidence_reason'=>'Developer chatter only, requires corroboration.','evidence_quality'=>'weak','official_confirmed'=>false,'unconfirmed_note'=>'HN chatter alone should not create HOT signals.','metadata_json'=>['points'=>(int)($h['points']??0),'comments'=>(int)($h['num_comments']??0),'created_at'=>(string)($h['created_at']??'')],'observed_at'=>gmdate('Y-m-d H:i:s')]; }} return $out; }
 }
 
 class CommunityReportIntelSource implements SignalSourceInterface { use IntelConduitHelpers;
-    public function id(): string { return 'community_reports_intel'; }
-    public function label(): string { return 'Community Reports Intel'; }
+    public function id(): string { return 'community_report_intel'; }
+    public function label(): string { return 'Community Report Intel'; }
     public function is_configured(): bool { return true; }
     public function collect(array $options = []): array { $rows=UserReports::recent(60,100); $out=[]; foreach($rows as $r){ $txt=sanitize_text_field((string)($r['issue_text']??$r['symptom']??'')); if(!$this->has_issue_language($txt)) continue; $out[]=['source'=>'community_reports','source_type'=>'community_report','adapter_id'=>'community_report_normalizer','source_id'=>sanitize_text_field((string)($r['id']??md5(wp_json_encode($r)))),'provider_id'=>sanitize_key((string)($r['provider_id']??'')),'provider_name'=>sanitize_text_field((string)($r['provider_name']??$r['provider_id']??'Unknown')),'category'=>sanitize_key((string)($r['category']??'community')),'region'=>sanitize_text_field((string)($r['region']??'')),'signal_type'=>'user_report','severity'=>'watch','confidence'=>45,'title'=>'Community report: '.sanitize_text_field((string)($r['provider_name']??$r['provider_id']??'provider')),'message'=>mb_substr($txt,0,220),'evidence_quality'=>'weak','official_confirmed'=>false,'unconfirmed_note'=>'Community reports are unconfirmed unless corroborated.','observed_at'=>sanitize_text_field((string)($r['reported_at']??gmdate('Y-m-d H:i:s')))]; } return $out; }
 }

--- a/lousy-outages/scripts/smoke-signal-sources.php
+++ b/lousy-outages/scripts/smoke-signal-sources.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+if ($argc < 2) {
+    fwrite(STDERR, "Usage: php scripts/smoke-signal-sources.php /path/to/wp-load.php\n");
+    exit(2);
+}
+
+$wpLoad = $argv[1];
+if (!is_file($wpLoad)) {
+    fwrite(STDERR, "wp-load.php not found at: {$wpLoad}\n");
+    exit(2);
+}
+
+require_once $wpLoad;
+
+use SuzyEaston\LousyOutages\SignalCollector;
+use SuzyEaston\LousyOutages\SignalSourceInterface;
+
+$sources = SignalCollector::sources();
+$errors = [];
+
+foreach ($sources as $index => $source) {
+    if (!$source instanceof SignalSourceInterface) {
+        $errors[] = sprintf('Source index %d (%s) is not a SignalSourceInterface instance.', $index, is_object($source) ? get_class($source) : gettype($source));
+        continue;
+    }
+
+    $id = $source->id();
+    if (!is_string($id) || trim($id) === '') {
+        $errors[] = sprintf('%s::id() returned an empty/non-string value.', get_class($source));
+    }
+
+    $label = $source->label();
+    if (!is_string($label) || trim($label) === '') {
+        $errors[] = sprintf('%s::label() returned an empty/non-string value.', get_class($source));
+    }
+
+    $configured = $source->is_configured();
+    if (!is_bool($configured)) {
+        $errors[] = sprintf('%s::is_configured() did not return bool.', get_class($source));
+    }
+}
+
+if ($errors !== []) {
+    fwrite(STDERR, "Signal source smoke test FAILED:\n- " . implode("\n- ", $errors) . "\n");
+    exit(1);
+}
+
+fwrite(STDOUT, sprintf("Signal source smoke test passed (%d sources).\n", count($sources)));
+exit(0);


### PR DESCRIPTION
### Motivation
- A production fatal occurred because `StatuspageIntelSource` did not implement the required `id()` and `label()` methods, causing PHP 8.3 runtime interface validation to fail.
- New Intel Conduit source classes are instantiated from `SignalCollector::sources()` and must fully satisfy `SignalSourceInterface` to avoid plugin load failures.
- `php -l` only checks syntax and does not detect runtime bootstrap/interface issues, so a lightweight WP-bootstrap smoke check is needed before deployment.

### Description
- Implemented `id()` and `label()` on `StatuspageIntelSource` and normalized IDs/labels for Intel Conduit sources to stable values (`statuspage_intel`, `provider_feed`, `hacker_news_chatter`, `community_report_intel`) and readable labels. 
- Updated `ProviderFeedSource`, `HackerNewsChatterSource`, and `CommunityReportIntelSource` to use the requested stable IDs/labels. 
- Added a runtime smoke script at `lousy-outages/scripts/smoke-signal-sources.php` that `require`s `wp-load.php`, calls `SignalCollector::sources()`, and validates that each source implements `SignalSourceInterface` and returns non-empty `id()`/`label()` and a boolean from `is_configured()`. 
- Documented the required deployment preflight in `lousy-outages/README.md` and explicitly recommend running the WP-bootstrap smoke test prior to replacing production plugin files.

### Testing
- Ran `php -l lousy-outages/includes/Sources/IntelConduitSources.php` and the check reported no syntax errors. 
- Ran `php -l lousy-outages/scripts/smoke-signal-sources.php` and the script passed syntax validation. 
- Verified presence of the new/updated methods with `rg` (search for `class ...` and `function id|function label`) to confirm the interface implementations exist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94ee184c4832e9734703425bc2a63)