### PR TITLE
Canonicalize top-level lousy-outages tree and merge #473 source-pack pipeline

### DIFF
--- a/lousy-outages/README.md
+++ b/lousy-outages/README.md
@@ -110,8 +110,10 @@ Use these shell snippets on hosts where WP-CLI is unavailable:
 
 Before replacing the production plugin, run:
 
-- `php -l wp-content/plugins/lousy-outages/includes/Sources/IntelConduitSources.php`
+- `php -l wp-content/plugins/lousy-outages/lousy-outages.php`
 - `php wp-content/plugins/lousy-outages/scripts/smoke-signal-sources.php /var/www/html/wp-load.php`
+- `php wp-content/plugins/lousy-outages/scripts/smoke-intel-source-pack.php`
+- `php wp-content/plugins/lousy-outages/scripts/smoke-production-preflight.php /var/www/html/wp-load.php`
 
 The smoke script bootstraps WordPress (`require wp-load.php`), calls `\SuzyEaston\LousyOutages\SignalCollector::sources()`, and validates for each source:
 
@@ -121,3 +123,11 @@ The smoke script bootstraps WordPress (`require wp-load.php`), calls `\SuzyEasto
 - boolean return from `is_configured()`
 
 If this check fails, do not deploy.
+
+
+## Canonical deployment path
+
+- **Deploy only from `lousy-outages/` (top-level).**
+- `plugins/lousy-outages/` is deprecated/non-deployable and exists only for merge history until cleanup.
+- Before deploy, run `./scripts/check-lousy-outages-tree-drift.sh` from repo root; if it fails, reconcile top-level first.
+- Swap plugin folder with rollback copy ready; do not deploy if smoke scripts fail.

--- a/lousy-outages/includes/Api.php
+++ b/lousy-outages/includes/Api.php
@@ -79,6 +79,16 @@ class Api {
 
         register_rest_route(
             'lousy-outages/v1',
+            '/intel-health',
+            [
+                'methods'             => 'GET',
+                'permission_callback' => static function (): bool { return current_user_can('manage_options'); },
+                'callback'            => [self::class, 'handle_intel_health'],
+            ]
+        );
+
+        register_rest_route(
+            'lousy-outages/v1',
             '/summary',
             [
                 'methods'             => 'GET',
@@ -189,6 +199,20 @@ class Api {
             ]
         );
 
+    }
+
+    public static function handle_intel_health(): WP_REST_Response {
+        $last = SignalCollector::get_last_collection_result();
+        $sources = [];
+        foreach (SignalCollector::sources() as $source) {
+            $state = \SuzyEaston\LousyOutages\Sources\SourceBudgetManager::source_state($source->id());
+            $sources[] = [
+                'source_id' => $source->id(), 'label' => $source->label(), 'configured' => $source->is_configured(), 'enabled' => $source->is_configured(),
+                'cooldown_until' => !empty($state['next_allowed_at']) ? gmdate('c', (int)$state['next_allowed_at']) : null,
+                'last_status' => $source->is_configured() ? 'ready' : 'disabled', 'last_error' => '', 'last_counts' => [], 'last_skipped_reasons' => [],
+            ];
+        }
+        return new WP_REST_Response(['sources'=>$sources,'last_collection'=>$last], 200);
     }
 
     public static function verify_nonce(): bool {

--- a/lousy-outages/includes/SignalCollector.php
+++ b/lousy-outages/includes/SignalCollector.php
@@ -4,22 +4,25 @@ declare(strict_types=1);
 namespace SuzyEaston\LousyOutages;
 
 use SuzyEaston\LousyOutages\Sources\CloudflareRadarSource;
-use SuzyEaston\LousyOutages\Sources\SyntheticCanarySource;
+use SuzyEaston\LousyOutages\Sources\CommunityReportIntelSource;
+use SuzyEaston\LousyOutages\Sources\HackerNewsChatterSource;
+use SuzyEaston\LousyOutages\Sources\ProviderFeedSource;
 use SuzyEaston\LousyOutages\Sources\PublicChatterSource;
 use SuzyEaston\LousyOutages\Sources\StatuspageIntelSource;
-use SuzyEaston\LousyOutages\Sources\ProviderFeedSource;
-use SuzyEaston\LousyOutages\Sources\HackerNewsChatterSource;
-use SuzyEaston\LousyOutages\Sources\CommunityReportIntelSource;
+use SuzyEaston\LousyOutages\Sources\SyntheticCanarySource;
 
 class SignalCollector {
     public static function sources(): array { return [new StatuspageIntelSource(), new ProviderFeedSource(), new HackerNewsChatterSource(), new CommunityReportIntelSource(), new SyntheticCanarySource(), new PublicChatterSource(), new CloudflareRadarSource()]; }
     public static function collect(array $options=[]): array {
-        $result=['started_at'=>gmdate('c'),'finished_at'=>'','sources'=>[],'total_collected'=>0,'total_stored'=>0,'providers_checked'=>0,'queries_attempted'=>0,'errors'=>[]];
-        foreach(self::sources() as $source){ $r=self::collect_source($source->id(),$options); $result['sources'][]=$r; $result['total_collected']+=(int)$r['collected_count']; $result['total_stored']+=(int)$r['stored_count']; $result['providers_checked']+=(int)($r['providers_checked']??0); $result['queries_attempted']+=(int)($r['queries_attempted']??0); $result['errors']=array_merge($result['errors'], (array)($r['errors']??[])); }
+        $started=microtime(true); $sources=self::sources();
+        $result=['started_at'=>gmdate('c'),'finished_at'=>'','sources'=>[],'total_collected'=>0,'total_stored'=>0,'providers_checked'=>0,'queries_attempted'=>0,'diagnostics'=>[],'errors'=>[]];
+        foreach($sources as $source){ $r=self::collect_source($source->id(),$options); $result['sources'][]=$r; $result['total_collected']+=(int)$r['collected_count']; $result['total_stored']+=(int)$r['stored_count']; $result['providers_checked']+=(int)($r['providers_checked']??0); $result['queries_attempted']+=(int)($r['queries_attempted']??0); $result['diagnostics'][]=['source'=>$source->id(),'status'=>$r['attempted']?'attempted':'skipped','reason'=>(string)($r['reason']??'')]; }
         $result['finished_at']=gmdate('c'); self::mark_last_collection_result($result); return $result;
     }
     public static function collect_source(string $sourceId, array $options=[]): array {
-        foreach(self::sources() as $source){ if($source->id()!==$sourceId) continue; $configured=$source->is_configured(); if(!$configured) return ['source'=>$source->id(),'configured'=>false,'attempted'=>false,'collected_count'=>0,'stored_count'=>0,'errors'=>[]]; $signals=$source->collect($options); $stored=ExternalSignals::record_many($signals); return ['source'=>$source->id(),'configured'=>true,'attempted'=>true,'collected_count'=>count($signals),'stored_count'=>(int)($stored['inserted']??0),'providers_checked'=>(int)($options['providers_checked']??0),'queries_attempted'=>(int)($options['queries_attempted']??0),'errors'=>[]]; }
+        foreach(self::sources() as $source){ if($source->id()!==$sourceId) continue; $configured=$source->is_configured(); if(!$configured) return ['source'=>$source->id(),'configured'=>false,'attempted'=>false,'reason'=>'not_configured','collected_count'=>0,'stored_count'=>0,'errors'=>[]];
+            $signals=$source->collect($options); $stored=ExternalSignals::record_many($signals);
+            return ['source'=>$source->id(),'configured'=>true,'attempted'=>true,'collected_count'=>count($signals),'stored_count'=>(int)($stored['inserted']??0),'providers_checked'=>$source->id()==='provider_feed'?count((array)\SuzyEaston\LousyOutages\Sources\SourcePack::provider_feed_urls()):0,'queries_attempted'=>$source->id()==='hacker_news_chatter'?(int)get_option('lo_last_hn_attempted',0):0,'errors'=>[]]; }
         return ['source'=>$sourceId,'configured'=>false,'attempted'=>false,'collected_count'=>0,'stored_count'=>0,'errors'=>['unknown source']];
     }
     public static function get_last_collection_result(): array { $r=get_option('lousy_outages_last_external_collection',[]); return is_array($r)?$r:[]; }

--- a/lousy-outages/includes/Sources/CommunityReportIntelSource.php
+++ b/lousy-outages/includes/Sources/CommunityReportIntelSource.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages\Sources;
+
+use SuzyEaston\LousyOutages\SignalSourceInterface;
+use SuzyEaston\LousyOutages\UserReports;
+
+class CommunityReportIntelSource implements SignalSourceInterface {
+    public function id(): string { return 'community_report_intel'; }
+    public function label(): string { return 'Community Report Intel'; }
+    public function is_configured(): bool { return true; }
+    private function has_issue_language(string $text): bool { return (bool) preg_match('/\b(down|outage|incident|degraded|error|failure|unavailable|latency|disruption)\b/i', $text); }
+    public function collect(array $options = []): array { $rows=UserReports::recent(60,100); $out=[]; foreach($rows as $r){ $txt=sanitize_text_field((string)($r['issue_text']??$r['symptom']??'')); if(!$this->has_issue_language($txt)) continue; $out[]=['source'=>'community_reports','source_type'=>'community_report','adapter_id'=>'community_report_normalizer','source_id'=>sanitize_text_field((string)($r['id']??md5(wp_json_encode($r)))),'provider_id'=>sanitize_key((string)($r['provider_id']??'')),'provider_name'=>sanitize_text_field((string)($r['provider_name']??$r['provider_id']??'Unknown')),'category'=>sanitize_key((string)($r['category']??'community')),'region'=>sanitize_text_field((string)($r['region']??'')),'signal_type'=>'user_report','severity'=>'watch','confidence'=>45,'title'=>'Community report: '.sanitize_text_field((string)($r['provider_name']??$r['provider_id']??'provider')),'message'=>mb_substr($txt,0,220),'evidence_quality'=>'weak','official_confirmed'=>false,'unconfirmed_note'=>'Community reports are unconfirmed unless corroborated.','observed_at'=>sanitize_text_field((string)($r['reported_at']??gmdate('Y-m-d H:i:s')))]; } return $out; }
+}

--- a/lousy-outages/includes/Sources/HackerNewsChatterSource.php
+++ b/lousy-outages/includes/Sources/HackerNewsChatterSource.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+namespace SuzyEaston\LousyOutages\Sources;
+
+use SuzyEaston\LousyOutages\SignalSourceInterface;
+
+class HackerNewsChatterSource implements SignalSourceInterface {
+    public function id(): string { return 'hacker_news_chatter'; }
+    public function label(): string { return 'Hacker News Chatter'; }
+    public function is_configured(): bool { return SourcePack::enabled() && (bool) apply_filters('lo_hn_chatter_enabled', get_option('lo_hn_chatter_enabled', '1') === '1'); }
+    public function collect(array $options = []): array {
+        if(!$this->is_configured()) return [];
+        $queries=SourcePack::early_warning_queries(); $cursor=(int)get_option('lo_hn_query_cursor',0); $take=array_slice(array_merge($queries,$queries),$cursor,2); update_option('lo_hn_query_cursor',($cursor+2)%max(1,count($queries)),false);
+        $out=[]; $attempted=0;
+        foreach($take as $q){ $budget=SourceBudgetManager::can_attempt($this->id(),'hn.algolia.com',20); if(empty($budget['ok'])) break; $attempted++; $url=add_query_arg(['query'=>$q,'tags'=>'story','hitsPerPage'=>5],'https://hn.algolia.com/api/v1/search_by_date'); $r=wp_remote_get($url,['timeout'=>7]); SourceBudgetManager::mark_attempt($this->id(),'hn.algolia.com',10); if(is_wp_error($r)) { SourceBudgetManager::mark_result($this->id(),false,0); continue; } $code=(int)wp_remote_retrieve_response_code($r); if($code===429){SourceBudgetManager::mark_result($this->id(),false,429); break;} if($code<200||$code>=300){SourceBudgetManager::mark_result($this->id(),false,$code); continue;} $json=json_decode((string)wp_remote_retrieve_body($r),true); $hits=(array)($json['hits']??[]); if(empty($hits)) continue; SourceBudgetManager::mark_result($this->id(),true,$code); $out[]=['source'=>'hacker_news_chatter','provider_id'=>'','provider_name'=>'Tech Pulse','category'=>'public_chatter','region'=>'global','signal_type'=>'public_chatter','severity'=>'watch','confidence'=>25,'title'=>'HN chatter: '.$q,'message'=>'Unconfirmed chatter from Hacker News search results.','url'=>'https://hn.algolia.com/?q='.rawurlencode((string)$q),'observed_at'=>gmdate('Y-m-d H:i:s'),'metadata'=>['query'=>$q,'mentions'=>min(5,count($hits)),'evidence_quality'=>'weak']]; }
+        update_option('lo_last_hn_attempted',$attempted,false);
+        return $out;
+    }
+}

--- a/lousy-outages/includes/Sources/ProviderFeedSource.php
+++ b/lousy-outages/includes/Sources/ProviderFeedSource.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+namespace SuzyEaston\LousyOutages\Sources;
+use SuzyEaston\LousyOutages\SignalSourceInterface;
+
+class ProviderFeedSource implements SignalSourceInterface {
+    public function id(): string { return 'provider_feed'; }
+    public function label(): string { return 'Provider Feed Intel'; }
+    public function is_configured(): bool { return SourcePack::enabled() && count(SourcePack::provider_feed_urls()) > 0; }
+    public function collect(array $options = []): array {
+        $feeds=SourcePack::provider_feed_urls(); $out=[]; $counts=['feeds_checked'=>0,'items_seen'=>0,'items_matched'=>0,'items_stored'=>0];
+        foreach(array_slice($feeds,0,8) as $feed){ $counts['feeds_checked']++; $cache='lo_feed_'.md5($feed); $items=get_transient($cache); if(!is_array($items)){ $r=wp_remote_get($feed,['timeout'=>8]); if(is_wp_error($r)) continue; $xml=simplexml_load_string((string)wp_remote_retrieve_body($r)); $items=[]; if($xml&&isset($xml->entry)){ foreach($xml->entry as $e){$items[]=['title'=>sanitize_text_field((string)$e->title),'url'=>esc_url_raw((string)$e->link['href'])];}} set_transient($cache,$items,10*MINUTE_IN_SECONDS);} foreach(array_slice($items,0,5) as $it){ $counts['items_seen']++; $title=strtolower((string)($it['title']??'')); if(strpos($title,'outage')===false && strpos($title,'degrad')===false && strpos($title,'incident')===false) continue; $counts['items_matched']++; $out[]=['source'=>'provider_feed','provider_id'=>'','provider_name'=>'Provider Feed','category'=>'official_status','region'=>'global','signal_type'=>'official_feed','severity'=>'trending','confidence'=>65,'title'=>(string)$it['title'],'message'=>'Provider status feed indicates service issue.','url'=>(string)($it['url']??$feed),'observed_at'=>gmdate('Y-m-d H:i:s'),'metadata'=>['evidence_quality'=>'moderate','source_url'=>$feed]]; $counts['items_stored']++; }} update_option('lo_last_provider_feed_counts',$counts,false); return $out;
+    }
+}

--- a/lousy-outages/includes/Sources/SourceBudgetManager.php
+++ b/lousy-outages/includes/Sources/SourceBudgetManager.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+namespace SuzyEaston\LousyOutages\Sources;
+
+class SourceBudgetManager {
+    private const KEY = 'lo_source_budget_state';
+    public static function can_attempt(string $source, string $host = '', int $dailyCap = 0): array {
+        $s = self::state(); $now=time(); $row=(array)($s[$source]??[]);
+        if (!empty($row['next_allowed_at']) && $now < (int)$row['next_allowed_at']) return ['ok'=>false,'reason'=>'cooldown_active'];
+        if ($dailyCap>0) { $day=gmdate('Y-m-d'); $used=(int)(($row['daily'][$day]??0)); if($used>=$dailyCap) return ['ok'=>false,'reason'=>'daily_budget_exhausted']; }
+        if ($host !== '') { $h=(array)($row['hosts'][$host]??[]); if(!empty($h['next_allowed_at']) && $now < (int)$h['next_allowed_at']) return ['ok'=>false,'reason'=>'per_host_throttle']; }
+        return ['ok'=>true];
+    }
+    public static function mark_attempt(string $source, string $host = '', int $hostCooldown = 0): void { $s=self::state(); $day=gmdate('Y-m-d'); $s[$source]['daily'][$day]=(int)($s[$source]['daily'][$day]??0)+1; if($host!==''&&$hostCooldown>0){$s[$source]['hosts'][$host]['next_allowed_at']=time()+$hostCooldown*60;} self::save($s); }
+    public static function mark_result(string $source, bool $ok, int $httpCode = 200): void { $s=self::state(); $now=time(); $row=(array)($s[$source]??[]); if($ok){$row['last_success_at']=$now;$row['consecutive_failures']=0;} else { $row['last_error_at']=$now; $fails=(int)($row['consecutive_failures']??0)+1; $row['consecutive_failures']=$fails; $row['next_allowed_at']=$now+min(3600, (int)pow(2,min($fails,8))*30); } if($httpCode===429){$row['last_429_at']=$now;$row['next_allowed_at']=$now+1800;} $s[$source]=$row; self::save($s); }
+    public static function source_state(string $source): array { return (array)(self::state()[$source]??[]); }
+    private static function state(): array { $v=get_option(self::KEY,[]); return is_array($v)?$v:[]; }
+    private static function save(array $s): void { update_option(self::KEY,$s,false); }
+}

--- a/lousy-outages/includes/Sources/SourcePack.php
+++ b/lousy-outages/includes/Sources/SourcePack.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages\Sources;
+
+class SourcePack {
+    private static function opt(string $k, $d){ return function_exists('get_option') ? get_option($k,$d) : $d; }
+    private static function filt(string $k, $v){ return function_exists('apply_filters') ? apply_filters($k,$v) : $v; }
+    public static function enabled(): bool { return (bool) self::filt('lo_intel_source_pack_enabled', self::opt('lo_intel_source_pack_enabled', '1') === '1'); }
+    public static function statuspage_base_urls(): array { return (array) self::filt('lo_statuspage_base_urls', self::opt('lo_statuspage_base_urls', [
+        'https://www.githubstatus.com','https://status.atlassian.com','https://www.cloudflarestatus.com','https://status.openai.com','https://status.slack.com','https://www.vercel-status.com','https://www.netlifystatus.com','https://status.npmjs.org','https://www.dockerstatus.com','https://status.zoom.us',
+    ])); }
+    public static function provider_feed_urls(): array { return (array) self::filt('lo_provider_feed_urls', self::opt('lo_provider_feed_urls', [
+        'https://www.githubstatus.com/history.atom','https://status.atlassian.com/history.atom','https://www.cloudflarestatus.com/history.atom','https://status.openai.com/history.atom','https://www.vercel-status.com/history.atom','https://www.netlifystatus.com/history.atom','https://status.npmjs.org/history.atom','https://www.dockerstatus.com/history.atom',
+    ])); }
+    public static function early_warning_queries(): array { return (array) self::filt('lo_early_warning_queries', self::opt('lo_early_warning_queries', [
+        'GitHub Actions failing','GitHub down','npm outage','npm install failing','Docker Hub outage','Docker pull errors','PyPI outage','Vercel outage','Netlify outage','CI/CD outage','package registry outage','deploy failures','webhook delays','AWS outage','AWS API errors','Azure outage','Google Cloud outage','Cloudflare outage','Cloudflare Workers issue','API outage','API latency','elevated errors','status page incident','OpenAI API down','ChatGPT down','ChatGPT login error','Claude down','Anthropic API outage','SSO outage','authentication outage','login errors','MFA failure','Entra outage','Okta outage','Auth0 outage','Interac e-Transfer outage','Canadian bank outage','Rogers outage','Telus internet outage','Bell outage','Freedom Mobile outage','BC Services Card login issue','TransLink Compass outage'
+    ])); }
+}

--- a/lousy-outages/includes/Sources/StatuspageIntelSource.php
+++ b/lousy-outages/includes/Sources/StatuspageIntelSource.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages\Sources;
+
+use SuzyEaston\LousyOutages\SignalSourceInterface;
+
+class StatuspageIntelSource implements SignalSourceInterface {
+    public function id(): string { return 'statuspage_intel'; }
+    public function label(): string { return 'Statuspage Intel'; }
+    public function is_configured(): bool { return SourcePack::enabled() && count(SourcePack::statuspage_base_urls()) > 0; }
+    private function has_issue_language(string $text): bool { return (bool) preg_match('/\b(down|outage|incident|degraded|error|failure|unavailable|latency|disruption)\b/i', $text); }
+    private function host(string $url): string { return (string) wp_parse_url($url, PHP_URL_HOST); }
+
+    public function collect(array $options = []): array {
+        $out=[];
+        foreach(SourcePack::statuspage_base_urls() as $base){
+            $base=rtrim((string)$base,'/'); if(!$base) continue;
+            $can=SourceBudgetManager::can_attempt($this->id(), $this->host($base), 30);
+            if(empty($can['ok'])) continue;
+            $incidentUrl=$base.'/api/v2/incidents/unresolved.json';
+            $r=wp_remote_get($incidentUrl,['timeout'=>6]);
+            SourceBudgetManager::mark_attempt($this->id(), $this->host($base), 10);
+            if(is_wp_error($r)){ SourceBudgetManager::mark_result($this->id(), false, 0); continue; }
+            $code=(int) wp_remote_retrieve_response_code($r);
+            SourceBudgetManager::mark_result($this->id(), $code >= 200 && $code < 300, $code);
+            if($code < 200 || $code >= 300) continue;
+            $json=json_decode((string)wp_remote_retrieve_body($r),true);
+            foreach((array)($json['incidents']??[]) as $inc){
+                $name=sanitize_text_field((string)($inc['name']??'Statuspage incident'));
+                $body=sanitize_text_field((string)($inc['status']??''));
+                if(!$this->has_issue_language($name.' '.$body)) continue;
+                $url=esc_url_raw((string)($inc['shortlink']??$base));
+                $out[]=['source'=>'statuspage','source_type'=>'official_status','adapter_id'=>'statuspage_public','source_id'=>sanitize_text_field((string)($inc['id']??md5($url.$name))),'provider_id'=>sanitize_key($this->host($base)),'provider_name'=>sanitize_text_field($this->host($base)),'category'=>'service','region'=>'global','signal_type'=>'status_incident','severity'=>'major','confidence'=>95,'title'=>$name,'message'=>$body,'url'=>$url,'source_urls'=>[$url,$incidentUrl],'domains'=>[$this->host($base)],'snippets'=>[$name,$body],'confidence_reason'=>'Official provider statuspage incident','evidence_quality'=>'official','official_confirmed'=>true,'observed_at'=>gmdate('Y-m-d H:i:s')];
+            }
+        }
+        return $out;
+    }
+}

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -69,7 +69,6 @@ lousy_outages_require( 'includes/Subscriptions.php' );
 lousy_outages_require( 'includes/UserReports.php' );
 lousy_outages_require( 'includes/SignalEngine.php' );
 lousy_outages_require( 'includes/Subscribe.php' );
-lousy_outages_require( 'includes/Api.php' );
 lousy_outages_require( 'includes/Feeds.php' );
 lousy_outages_require( 'includes/Summary.php' );
 lousy_outages_require( 'includes/IncidentAlerts.php' );
@@ -87,11 +86,17 @@ lousy_outages_require( 'includes/Cron/Refresh.php' );
 // External signal infrastructure must load before concrete source classes.
 lousy_outages_require( 'includes/SignalSourceInterface.php' );
 lousy_outages_require( 'includes/ExternalSignals.php' );
+lousy_outages_require( 'includes/Sources/SourcePack.php' );
+lousy_outages_require( 'includes/Sources/SourceBudgetManager.php' );
+lousy_outages_require( 'includes/Sources/StatuspageIntelSource.php' );
+lousy_outages_require( 'includes/Sources/ProviderFeedSource.php' );
+lousy_outages_require( 'includes/Sources/HackerNewsChatterSource.php' );
+lousy_outages_require( 'includes/Sources/CommunityReportIntelSource.php' );
 lousy_outages_require( 'includes/Sources/SyntheticCanarySource.php' );
-lousy_outages_require( 'includes/Sources/CloudflareRadarSource.php' );
 lousy_outages_require( 'includes/Sources/PublicChatterSource.php' );
-lousy_outages_require( 'includes/Sources/IntelConduitSources.php' );
+lousy_outages_require( 'includes/Sources/CloudflareRadarSource.php' );
 lousy_outages_require( 'includes/SignalCollector.php' );
+lousy_outages_require( 'includes/Api.php' );
 
 lousy_outages_require( 'public/shortcode.php' );
 

--- a/lousy-outages/scripts/smoke-intel-source-pack.php
+++ b/lousy-outages/scripts/smoke-intel-source-pack.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+require_once dirname(__DIR__) . '/includes/Sources/SourcePack.php';
+require_once dirname(__DIR__) . '/includes/Sources/SourceBudgetManager.php';
+require_once dirname(__DIR__) . '/includes/SignalSourceInterface.php';
+require_once dirname(__DIR__) . '/includes/Sources/HackerNewsChatterSource.php';
+require_once dirname(__DIR__) . '/includes/Sources/ProviderFeedSource.php';
+
+use SuzyEaston\LousyOutages\Sources\SourcePack;
+
+$errors=[];
+if(count(SourcePack::statuspage_base_urls()) < 5) $errors[]='statuspage urls <5';
+if(count(SourcePack::provider_feed_urls()) < 5) $errors[]='feed urls <5';
+if(count(SourcePack::early_warning_queries()) < 20) $errors[]='queries <20';
+if(!empty($errors)){ fwrite(STDERR, implode("\n",$errors)."\n"); exit(1);} echo "ok\n";

--- a/lousy-outages/scripts/smoke-production-preflight.php
+++ b/lousy-outages/scripts/smoke-production-preflight.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+if ($argc < 2) { fwrite(STDERR, "Usage: php scripts/smoke-production-preflight.php /path/to/wp-load.php\n"); exit(2);} 
+$wpLoad=$argv[1]; if(!is_file($wpLoad)){ fwrite(STDERR,"wp-load.php not found at: {$wpLoad}\n"); exit(2);} require_once $wpLoad;
+
+use SuzyEaston\LousyOutages\SignalCollector;
+use SuzyEaston\LousyOutages\SignalSourceInterface;
+use SuzyEaston\LousyOutages\Sources\SourcePack;
+
+$errors=[]; $sources=SignalCollector::sources();
+foreach($sources as $i=>$source){
+ if(!$source instanceof SignalSourceInterface){$errors[]="Source $i is not SignalSourceInterface"; continue;}
+ if(trim((string)$source->id())==='') $errors[] = get_class($source).' empty id';
+ if(trim((string)$source->label())==='') $errors[] = get_class($source).' empty label';
+}
+if(count(SourcePack::statuspage_base_urls())===0) $errors[]='SourcePack statuspage list empty';
+if(count(SourcePack::provider_feed_urls())===0) $errors[]='SourcePack feed list empty';
+if(count(SourcePack::early_warning_queries())===0) $errors[]='SourcePack queries empty';
+
+$result = SignalCollector::collect(['dry_run'=>true,'suppress_notifications'=>true]);
+if (!is_array($result) || !isset($result['sources'])) $errors[]='dry-run collect did not return expected diagnostics';
+if($errors){ fwrite(STDERR, "Preflight FAILED:\n- ".implode("\n- ",$errors)."\n"); exit(1);} echo "Preflight passed with ".count($sources)." sources.\n";

--- a/scripts/check-lousy-outages-tree-drift.sh
+++ b/scripts/check-lousy-outages-tree-drift.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CANON="$ROOT/lousy-outages"
+ALT="$ROOT/plugins/lousy-outages"
+if [[ ! -d "$CANON" || ! -d "$ALT" ]]; then
+  echo "OK: one plugin tree present or alternate missing"; exit 0
+fi
+KEYS=(
+  "includes/Api.php"
+  "includes/SignalCollector.php"
+  "includes/Sources/SourcePack.php"
+  "includes/Sources/SourceBudgetManager.php"
+  "includes/Sources/ProviderFeedSource.php"
+  "includes/Sources/HackerNewsChatterSource.php"
+  "lousy-outages.php"
+)
+status=0
+for f in "${KEYS[@]}"; do
+  if ! cmp -s "$CANON/$f" "$ALT/$f"; then echo "DRIFT: $f differs between canonical and deprecated tree"; status=1; fi
+done
+if [[ $status -ne 0 ]]; then
+  echo "Canonical deploy path is top-level lousy-outages/. Do not deploy plugins/lousy-outages/." >&2
+fi
+exit $status


### PR DESCRIPTION
### Motivation
- Production deploys from the top-level `lousy-outages/` but #473 source-pack work landed under `plugins/lousy-outages/`, creating tree drift and an ambiguous deploy path. 
- The change consolidates the new source-pack, budget, HN/feed, and intel-health diagnostics into the canonical production tree while preserving the working #471/#472 sources. 
- The deployment path and runtime loading order must be safe for PHP 8.3 (no WP-CLI required) and include smoke checks to avoid the previous 500 caused by runtime interface validation.

### Description
- Added `SourcePack` and `SourceBudgetManager` to `lousy-outages/includes/Sources/` and ported `ProviderFeedSource` and `HackerNewsChatterSource` as standalone classes to avoid duplicate declarations. 
- Split Intel Conduit sources out of the single file by adding `StatuspageIntelSource.php` and `CommunityReportIntelSource.php`, and updated `SignalCollector::sources()` to include all intended sources (statuspage, provider feed, HN chatter, community reports, synthetic canary, public chatter, Cloudflare radar) and to emit collection diagnostics. 
- Reordered bootstrap requires in `lousy-outages/lousy-outages.php` so external signal interfaces and `SourcePack`/`SourceBudgetManager` load before all source classes, then `SignalCollector`, then `Api` to ensure runtime interface safety. 
- Added smoke scripts and drift protection: `lousy-outages/scripts/smoke-intel-source-pack.php`, `lousy-outages/scripts/smoke-production-preflight.php`, and `scripts/check-lousy-outages-tree-drift.sh`, and updated `README.md` deployment guidance to make the canonical path unambiguous.

### Testing
- Ran `php -l` syntax checks for `lousy-outages/lousy-outages.php`, `lousy-outages/includes/Sources/*`, `lousy-outages/includes/SignalCollector.php`, and `lousy-outages/includes/Api.php`, all of which reported no syntax errors. 
- Executed the source-pack smoke check `php lousy-outages/scripts/smoke-intel-source-pack.php`, which returned `ok`. 
- Executed the repo drift guard `./scripts/check-lousy-outages-tree-drift.sh`, which correctly reported drift between `lousy-outages/` and `plugins/lousy-outages/` on key files (this is the intended behavior until the deprecated tree is cleaned up). 
- Created `lousy-outages/scripts/smoke-production-preflight.php` for runtime preflight (requires a real `wp-load.php` path) but did not run it against a live WP bootstrap in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f95660c320832ebe623b08ea969d6e)