### PR TITLE
Harden Intel Conduit sources, schema gating, and preflight checks

### DIFF
--- a/lousy-outages/includes/ExternalSignals.php
+++ b/lousy-outages/includes/ExternalSignals.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace SuzyEaston\LousyOutages;
 
 class ExternalSignals {
-    private const SCHEMA_VERSION = '2026-05-05.1';
+    public const SCHEMA_VERSION = '2026-05-05.1';
     public static function table_name(): string { global $wpdb; return $wpdb->prefix . 'lo_external_signals'; }
     private static function table_exists(): bool {
         global $wpdb;
@@ -12,6 +12,23 @@ class ExternalSignals {
         $like = $wpdb->esc_like($table);
         $existing = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $like));
         return (string) $existing === $table;
+    }
+
+
+    public static function expected_columns(): array {
+        return ['source_type','adapter_id','source_id','snippets','domains','source_urls','confidence_reason','evidence_quality','official_confirmed','unconfirmed_note','metadata_json'];
+    }
+
+    public static function schema_diagnostics(): array {
+        global $wpdb;
+        $table=self::table_name();
+        $existing=[];
+        if (self::table_exists()) {
+            $rows=$wpdb->get_results("SHOW COLUMNS FROM {$table}", ARRAY_A) ?: [];
+            foreach($rows as $r){ $existing[]=(string)($r['Field']??''); }
+        }
+        $missing=array_values(array_diff(self::expected_columns(), $existing));
+        return ['schema_version'=>self::SCHEMA_VERSION,'table'=>$table,'expected_columns'=>self::expected_columns(),'existing_columns'=>$existing,'missing_columns'=>$missing,'table_exists'=>self::table_exists()];
     }
 
     public static function install(): void {
@@ -29,6 +46,7 @@ class ExternalSignals {
             $schemaDiagnostics['status'] = 'error';
             $schemaDiagnostics['error'] = $e->getMessage();
         }
+        $schemaDiagnostics['external_signals']=self::schema_diagnostics();
         update_option('lousy_outages_schema_diagnostics', $schemaDiagnostics, false);
     }
 

--- a/lousy-outages/includes/SignalCollector.php
+++ b/lousy-outages/includes/SignalCollector.php
@@ -14,16 +14,16 @@ use SuzyEaston\LousyOutages\Sources\SyntheticCanarySource;
 class SignalCollector {
     public static function sources(): array { return [new StatuspageIntelSource(), new ProviderFeedSource(), new HackerNewsChatterSource(), new CommunityReportIntelSource(), new SyntheticCanarySource(), new PublicChatterSource(), new CloudflareRadarSource()]; }
     public static function collect(array $options=[]): array {
-        $started=microtime(true); $sources=self::sources();
-        $result=['started_at'=>gmdate('c'),'finished_at'=>'','sources'=>[],'total_collected'=>0,'total_stored'=>0,'providers_checked'=>0,'queries_attempted'=>0,'diagnostics'=>[],'errors'=>[]];
-        foreach($sources as $source){ $r=self::collect_source($source->id(),$options); $result['sources'][]=$r; $result['total_collected']+=(int)$r['collected_count']; $result['total_stored']+=(int)$r['stored_count']; $result['providers_checked']+=(int)($r['providers_checked']??0); $result['queries_attempted']+=(int)($r['queries_attempted']??0); $result['diagnostics'][]=['source'=>$source->id(),'status'=>$r['attempted']?'attempted':'skipped','reason'=>(string)($r['reason']??'')]; }
+        $sources=self::sources();
+        $result=['started_at'=>gmdate('c'),'finished_at'=>'','sources'=>[],'total_collected'=>0,'total_stored'=>0,'diagnostics'=>[],'errors'=>[]];
+        foreach($sources as $source){ $r=self::collect_source($source->id(),$options); $result['sources'][]=$r; $result['total_collected']+=(int)$r['collected_count']; $result['total_stored']+=(int)$r['stored_count']; $result['diagnostics'][]=['source'=>$source->id(),'status'=>$r['attempted']?'attempted':'skipped','reason'=>(string)($r['reason']??''),'detail'=>$r['diagnostics']??[]]; }
         $result['finished_at']=gmdate('c'); self::mark_last_collection_result($result); return $result;
     }
     public static function collect_source(string $sourceId, array $options=[]): array {
-        foreach(self::sources() as $source){ if($source->id()!==$sourceId) continue; $configured=$source->is_configured(); if(!$configured) return ['source'=>$source->id(),'configured'=>false,'attempted'=>false,'reason'=>'not_configured','collected_count'=>0,'stored_count'=>0,'errors'=>[]];
-            $signals=$source->collect($options); $stored=ExternalSignals::record_many($signals);
-            return ['source'=>$source->id(),'configured'=>true,'attempted'=>true,'collected_count'=>count($signals),'stored_count'=>(int)($stored['inserted']??0),'providers_checked'=>$source->id()==='provider_feed'?count((array)\SuzyEaston\LousyOutages\Sources\SourcePack::provider_feed_urls()):0,'queries_attempted'=>$source->id()==='hacker_news_chatter'?(int)get_option('lo_last_hn_attempted',0):0,'errors'=>[]]; }
-        return ['source'=>$sourceId,'configured'=>false,'attempted'=>false,'collected_count'=>0,'stored_count'=>0,'errors'=>['unknown source']];
+        foreach(self::sources() as $source){ if($source->id()!==$sourceId) continue; $configured=$source->is_configured(); if(!$configured) return ['source'=>$source->id(),'configured'=>false,'attempted'=>false,'reason'=>'not_configured','collected_count'=>0,'stored_count'=>0,'diagnostics'=>['configured'=>false,'attempted'=>false,'skipped_reasons'=>['not_configured']],'errors'=>[]];
+            $signals=$source->collect($options); $stored=ExternalSignals::record_many($signals); $diag=get_option('lo_diag_'.$source->id(),[]); if(!is_array($diag)) $diag=[];
+            return ['source'=>$source->id(),'configured'=>true,'attempted'=>true,'collected_count'=>count($signals),'stored_count'=>(int)($stored['inserted']??0),'diagnostics'=>$diag,'errors'=>[]]; }
+        return ['source'=>$sourceId,'configured'=>false,'attempted'=>false,'collected_count'=>0,'stored_count'=>0,'diagnostics'=>['configured'=>false,'attempted'=>false],'errors'=>['unknown source']];
     }
     public static function get_last_collection_result(): array { $r=get_option('lousy_outages_last_external_collection',[]); return is_array($r)?$r:[]; }
     public static function mark_last_collection_result(array $result): void { update_option('lousy_outages_last_external_collection',$result,false); }

--- a/lousy-outages/includes/Sources/HackerNewsChatterSource.php
+++ b/lousy-outages/includes/Sources/HackerNewsChatterSource.php
@@ -8,12 +8,37 @@ class HackerNewsChatterSource implements SignalSourceInterface {
     public function id(): string { return 'hacker_news_chatter'; }
     public function label(): string { return 'Hacker News Chatter'; }
     public function is_configured(): bool { return SourcePack::enabled() && (bool) apply_filters('lo_hn_chatter_enabled', get_option('lo_hn_chatter_enabled', '1') === '1'); }
+    private function issue(string $t): bool { return (bool) preg_match('/\b(outage|down|incident|degrad|latency|error|unavailable|disruption)\b/i',$t); }
     public function collect(array $options = []): array {
         if(!$this->is_configured()) return [];
         $queries=SourcePack::early_warning_queries(); $cursor=(int)get_option('lo_hn_query_cursor',0); $take=array_slice(array_merge($queries,$queries),$cursor,2); update_option('lo_hn_query_cursor',($cursor+2)%max(1,count($queries)),false);
-        $out=[]; $attempted=0;
-        foreach($take as $q){ $budget=SourceBudgetManager::can_attempt($this->id(),'hn.algolia.com',20); if(empty($budget['ok'])) break; $attempted++; $url=add_query_arg(['query'=>$q,'tags'=>'story','hitsPerPage'=>5],'https://hn.algolia.com/api/v1/search_by_date'); $r=wp_remote_get($url,['timeout'=>7]); SourceBudgetManager::mark_attempt($this->id(),'hn.algolia.com',10); if(is_wp_error($r)) { SourceBudgetManager::mark_result($this->id(),false,0); continue; } $code=(int)wp_remote_retrieve_response_code($r); if($code===429){SourceBudgetManager::mark_result($this->id(),false,429); break;} if($code<200||$code>=300){SourceBudgetManager::mark_result($this->id(),false,$code); continue;} $json=json_decode((string)wp_remote_retrieve_body($r),true); $hits=(array)($json['hits']??[]); if(empty($hits)) continue; SourceBudgetManager::mark_result($this->id(),true,$code); $out[]=['source'=>'hacker_news_chatter','provider_id'=>'','provider_name'=>'Tech Pulse','category'=>'public_chatter','region'=>'global','signal_type'=>'public_chatter','severity'=>'watch','confidence'=>25,'title'=>'HN chatter: '.$q,'message'=>'Unconfirmed chatter from Hacker News search results.','url'=>'https://hn.algolia.com/?q='.rawurlencode((string)$q),'observed_at'=>gmdate('Y-m-d H:i:s'),'metadata'=>['query'=>$q,'mentions'=>min(5,count($hits)),'evidence_quality'=>'weak']]; }
-        update_option('lo_last_hn_attempted',$attempted,false);
+        $diag=['configured'=>true,'attempted'=>false,'queries_available'=>count($queries),'queries_attempted'=>0,'queries_skipped_budget'=>0,'raw_results_seen'=>0,'usable_results'=>0,'rows_stored'=>0,'skipped_reasons'=>[],'cooldown_active'=>false];
+        $out=[];
+        foreach($take as $q){
+            $budget=SourceBudgetManager::can_attempt($this->id(),'hn.algolia.com',20); if(empty($budget['ok'])){ $diag['queries_skipped_budget']++; $diag['cooldown_active']=true; continue; }
+            $diag['queries_attempted']++; $diag['attempted']=true;
+            $url=add_query_arg(['query'=>$q,'tags'=>'story','hitsPerPage'=>5],'https://hn.algolia.com/api/v1/search_by_date');
+            $cache='lo_hn_'.md5($url); $hits=get_transient($cache);
+            if(!is_array($hits)){
+                $r=wp_remote_get($url,['timeout'=>7]); SourceBudgetManager::mark_attempt($this->id(),'hn.algolia.com',10);
+                if(is_wp_error($r)) { SourceBudgetManager::mark_result($this->id(),false,0); $diag['skipped_reasons'][]='http_error'; continue; }
+                $code=(int)wp_remote_retrieve_response_code($r); if($code===429){SourceBudgetManager::mark_result($this->id(),false,429); $diag['cooldown_active']=true; continue;}
+                if($code<200||$code>=300){SourceBudgetManager::mark_result($this->id(),false,$code); continue;}
+                SourceBudgetManager::mark_result($this->id(),true,$code);
+                $json=json_decode((string)wp_remote_retrieve_body($r),true); $hits=(array)($json['hits']??[]); set_transient($cache,$hits,10*MINUTE_IN_SECONDS);
+            }
+            $diag['raw_results_seen']+=count($hits);
+            foreach(array_slice($hits,0,5) as $hit){
+                $title=sanitize_text_field((string)($hit['title']??$hit['story_title']??'')); $txt=sanitize_textarea_field((string)($hit['comment_text']??''));
+                if($title==='' || !$this->issue($title.' '.$txt.' '.$q)) continue;
+                $diag['usable_results']++;
+                $storyUrl=esc_url_raw((string)($hit['url']??$hit['story_url']??'')); $hnUrl='https://news.ycombinator.com/item?id='.(int)($hit['objectID']??0);
+                $urls=array_values(array_filter([$hnUrl,$storyUrl]));
+                $out[]=['source'=>'hacker_news_chatter','source_type'=>'public_chatter','adapter_id'=>'hacker_news_chatter','source_id'=>sanitize_text_field((string)($hit['objectID']??md5($title.$hnUrl))),'provider_id'=>'','provider_name'=>'Tech Pulse','category'=>'public_chatter','region'=>'global','signal_type'=>'public_chatter','severity'=>'watch','confidence'=>$storyUrl?40:25,'title'=>'HN chatter: '.$title,'message'=>'Unconfirmed developer chatter from Hacker News search results.','url'=>$hnUrl,'observed_at'=>gmdate('Y-m-d H:i:s'),'snippets'=>[$title],'source_urls'=>$urls,'domains'=>array_values(array_unique(array_filter([wp_parse_url($storyUrl,PHP_URL_HOST),'news.ycombinator.com']))),'confidence_reason'=>'Developer chatter with issue-language match; requires corroboration.','evidence_quality'=>$storyUrl?'moderate':'weak','official_confirmed'=>false,'unconfirmed_note'=>'Unconfirmed developer chatter.'];
+                $diag['rows_stored']++;
+            }
+        }
+        update_option('lo_diag_'.$this->id(),$diag,false);
         return $out;
     }
 }

--- a/lousy-outages/includes/Sources/IntelConduitSources.php
+++ b/lousy-outages/includes/Sources/IntelConduitSources.php
@@ -3,52 +3,5 @@ declare(strict_types=1);
 
 namespace SuzyEaston\LousyOutages\Sources;
 
-use SuzyEaston\LousyOutages\SignalSourceInterface;
-use SuzyEaston\LousyOutages\UserReports;
-
-trait IntelConduitHelpers {
-    private function has_issue_language(string $text): bool {
-        return (bool) preg_match('/\b(down|outage|incident|degraded|error|failure|unavailable|latency|disruption)\b/i', $text);
-    }
-    private function host(string $url): string { return (string) wp_parse_url($url, PHP_URL_HOST); }
-}
-
-class StatuspageIntelSource implements SignalSourceInterface {
-    use IntelConduitHelpers;
-
-    public function id(): string { return 'statuspage_intel'; }
-    public function label(): string { return 'Statuspage Intel'; }
-    public function is_configured(): bool { return true; }
-    public function collect(array $options = []): array {
-        $bases = (array) apply_filters('lo_statuspage_base_urls', []);
-        $out=[];
-        foreach($bases as $provider=>$base){ $base=rtrim((string)$base,'/'); if(!$base) continue; $incidentUrl=$base.'/api/v2/incidents/unresolved.json'; $r=wp_remote_get($incidentUrl,['timeout'=>6]); if(is_wp_error($r)) continue; $json=json_decode((string)wp_remote_retrieve_body($r),true); foreach((array)($json['incidents']??[]) as $inc){ $name=sanitize_text_field((string)($inc['name']??'Statuspage incident')); $body=sanitize_text_field((string)($inc['status']??'')); if(!$this->has_issue_language($name.' '.$body)) continue; $url=esc_url_raw((string)($inc['shortlink']??$base)); $out[]=['source'=>'statuspage','source_type'=>'official_status','adapter_id'=>'statuspage_public','source_id'=>sanitize_text_field((string)($inc['id']??md5($url.$name))),'provider_id'=>sanitize_key((string)$provider),'provider_name'=>sanitize_text_field((string)$provider),'category'=>'service','region'=>'global','signal_type'=>'status_incident','severity'=>'major','confidence'=>95,'title'=>$name,'message'=>$body,'url'=>$url,'source_urls'=>[$url,$incidentUrl],'domains'=>[$this->host($base)],'snippets'=>[$name,$body],'confidence_reason'=>'Official provider statuspage incident','evidence_quality'=>'official','official_confirmed'=>true,'observed_at'=>gmdate('Y-m-d H:i:s')]; }
-        }
-        return $out;
-    }
-}
-
-class ProviderFeedSource implements SignalSourceInterface { use IntelConduitHelpers;
-    public function id(): string { return 'provider_feed'; }
-    public function label(): string { return 'Provider/RSS Feed Intel'; }
-    public function is_configured(): bool { return true; }
-    public function collect(array $options = []): array {
-        $feeds=(array)apply_filters('lo_provider_feed_urls',[]); $max=max(1,min(20,(int)apply_filters('lo_provider_feed_max_items',8))); $timeout=max(2,min(12,(int)apply_filters('lo_provider_feed_timeout',6))); $out=[];
-        include_once ABSPATH . WPINC . '/feed.php';
-        foreach($feeds as $provider=>$url){ $cache='lo_feed_'.md5((string)$url); $items=get_transient($cache); if(!is_array($items)){ $rss=fetch_feed((string)$url); if(is_wp_error($rss)) continue; $items=$rss->get_items(0,$max); set_transient($cache,$items,5*MINUTE_IN_SECONDS);} foreach((array)$items as $item){ $title=sanitize_text_field((string)$item->get_title()); $summary=sanitize_textarea_field((string)$item->get_description()); if(!$this->has_issue_language($title.' '.$summary)) continue; $link=esc_url_raw((string)$item->get_link()); $out[]=['source'=>'provider_feed','source_type'=>'provider_rss','adapter_id'=>'provider_rss_atom','source_id'=>sanitize_text_field((string)$item->get_id()),'provider_id'=>sanitize_key((string)$provider),'provider_name'=>sanitize_text_field((string)$provider),'category'=>'service','region'=>'global','signal_type'=>'feed_incident','severity'=>'degraded','confidence'=>65,'title'=>$title,'message'=>mb_substr($summary,0,280),'url'=>$link,'domains'=>[$this->host($link)],'source_urls'=>[$link,(string)$url],'snippets'=>[$title,mb_substr($summary,0,120)],'confidence_reason'=>'Provider feed reported potential issue language','evidence_quality'=>'moderate','official_confirmed'=>false,'unconfirmed_note'=>'Feed item is not a direct official incident confirmation.','metadata_json'=>['published_at'=>(string)$item->get_date('c')],'observed_at'=>gmdate('Y-m-d H:i:s')]; }} return $out;
-    }
-}
-
-class HackerNewsChatterSource implements SignalSourceInterface { use IntelConduitHelpers;
-    public function id(): string { return 'hacker_news_chatter'; }
-    public function label(): string { return 'Hacker News Chatter'; }
-    public function is_configured(): bool { return (bool) apply_filters('lo_hn_chatter_enabled', false); }
-    public function collect(array $options = []): array { $queries=['GitHub Actions down','npm outage','Cloudflare outage','AWS outage','OpenAI API down','Vercel outage','Docker Hub outage']; $out=[]; $limit=3; foreach($queries as $q){ $u='https://hn.algolia.com/api/v1/search?tags=story&hitsPerPage='.$limit.'&query='.rawurlencode($q); $cache='lo_hn_'.md5($u); $hits=get_transient($cache); if(!is_array($hits)){ $r=wp_remote_get($u,['timeout'=>5]); if(is_wp_error($r)) continue; $hits=(array)(json_decode((string)wp_remote_retrieve_body($r),true)['hits']??[]); set_transient($cache,$hits,10*MINUTE_IN_SECONDS);} foreach($hits as $h){ $title=sanitize_text_field((string)($h['title']??$h['story_title']??'')); if(!$this->has_issue_language($title.' '.$q)) continue; $url=esc_url_raw((string)($h['url']??$h['story_url']??'https://news.ycombinator.com/item?id='.(int)($h['objectID']??0))); $provider=preg_split('/\s+/',trim((string)$q))[0] ?? 'unknown'; $out[]=['source'=>'hacker_news','source_type'=>'developer_chatter','adapter_id'=>'hn_algolia','source_id'=>sanitize_text_field((string)($h['objectID']??md5($title.$url))),'provider_id'=>sanitize_key((string)$provider),'provider_name'=>sanitize_text_field((string)$provider),'category'=>'developer_chatter','region'=>'global','signal_type'=>'hn_chatter','severity'=>'watch','confidence'=>35,'title'=>$title,'message'=>'Unconfirmed developer chatter from Hacker News.','url'=>$url,'domains'=>[$this->host($url)],'source_urls'=>[$url,$u],'snippets'=>[$title],'confidence_reason'=>'Developer chatter only, requires corroboration.','evidence_quality'=>'weak','official_confirmed'=>false,'unconfirmed_note'=>'HN chatter alone should not create HOT signals.','metadata_json'=>['points'=>(int)($h['points']??0),'comments'=>(int)($h['num_comments']??0),'created_at'=>(string)($h['created_at']??'')],'observed_at'=>gmdate('Y-m-d H:i:s')]; }} return $out; }
-}
-
-class CommunityReportIntelSource implements SignalSourceInterface { use IntelConduitHelpers;
-    public function id(): string { return 'community_report_intel'; }
-    public function label(): string { return 'Community Report Intel'; }
-    public function is_configured(): bool { return true; }
-    public function collect(array $options = []): array { $rows=UserReports::recent(60,100); $out=[]; foreach($rows as $r){ $txt=sanitize_text_field((string)($r['issue_text']??$r['symptom']??'')); if(!$this->has_issue_language($txt)) continue; $out[]=['source'=>'community_reports','source_type'=>'community_report','adapter_id'=>'community_report_normalizer','source_id'=>sanitize_text_field((string)($r['id']??md5(wp_json_encode($r)))),'provider_id'=>sanitize_key((string)($r['provider_id']??'')),'provider_name'=>sanitize_text_field((string)($r['provider_name']??$r['provider_id']??'Unknown')),'category'=>sanitize_key((string)($r['category']??'community')),'region'=>sanitize_text_field((string)($r['region']??'')),'signal_type'=>'user_report','severity'=>'watch','confidence'=>45,'title'=>'Community report: '.sanitize_text_field((string)($r['provider_name']??$r['provider_id']??'provider')),'message'=>mb_substr($txt,0,220),'evidence_quality'=>'weak','official_confirmed'=>false,'unconfirmed_note'=>'Community reports are unconfirmed unless corroborated.','observed_at'=>sanitize_text_field((string)($r['reported_at']??gmdate('Y-m-d H:i:s')))]; } return $out; }
-}
+// Compatibility placeholder retained for legacy include paths.
+// Canonical source classes live in dedicated files under includes/Sources/.

--- a/lousy-outages/includes/Sources/ProviderFeedSource.php
+++ b/lousy-outages/includes/Sources/ProviderFeedSource.php
@@ -7,8 +7,34 @@ class ProviderFeedSource implements SignalSourceInterface {
     public function id(): string { return 'provider_feed'; }
     public function label(): string { return 'Provider Feed Intel'; }
     public function is_configured(): bool { return SourcePack::enabled() && count(SourcePack::provider_feed_urls()) > 0; }
+    private function issue(string $t): bool { return (bool) preg_match('/\b(outage|down|incident|degrad|latency|error|unavailable|disruption)\b/i', $t); }
+    private function host(string $url): string { return (string) wp_parse_url($url, PHP_URL_HOST); }
     public function collect(array $options = []): array {
-        $feeds=SourcePack::provider_feed_urls(); $out=[]; $counts=['feeds_checked'=>0,'items_seen'=>0,'items_matched'=>0,'items_stored'=>0];
-        foreach(array_slice($feeds,0,8) as $feed){ $counts['feeds_checked']++; $cache='lo_feed_'.md5($feed); $items=get_transient($cache); if(!is_array($items)){ $r=wp_remote_get($feed,['timeout'=>8]); if(is_wp_error($r)) continue; $xml=simplexml_load_string((string)wp_remote_retrieve_body($r)); $items=[]; if($xml&&isset($xml->entry)){ foreach($xml->entry as $e){$items[]=['title'=>sanitize_text_field((string)$e->title),'url'=>esc_url_raw((string)$e->link['href'])];}} set_transient($cache,$items,10*MINUTE_IN_SECONDS);} foreach(array_slice($items,0,5) as $it){ $counts['items_seen']++; $title=strtolower((string)($it['title']??'')); if(strpos($title,'outage')===false && strpos($title,'degrad')===false && strpos($title,'incident')===false) continue; $counts['items_matched']++; $out[]=['source'=>'provider_feed','provider_id'=>'','provider_name'=>'Provider Feed','category'=>'official_status','region'=>'global','signal_type'=>'official_feed','severity'=>'trending','confidence'=>65,'title'=>(string)$it['title'],'message'=>'Provider status feed indicates service issue.','url'=>(string)($it['url']??$feed),'observed_at'=>gmdate('Y-m-d H:i:s'),'metadata'=>['evidence_quality'=>'moderate','source_url'=>$feed]]; $counts['items_stored']++; }} update_option('lo_last_provider_feed_counts',$counts,false); return $out;
+        $feeds=SourcePack::provider_feed_urls(); $out=[]; $diag=['configured'=>$this->is_configured(),'attempted'=>false,'feeds_checked'=>0,'items_seen'=>0,'items_matched'=>0,'items_stored'=>0,'skipped_reasons'=>[]];
+        foreach(array_slice($feeds,0,12,true) as $key=>$feed){
+            $diag['feeds_checked']++; $diag['attempted']=true;
+            $cache='lo_feed_'.md5((string)$feed); $items=get_transient($cache);
+            if(!is_array($items)){
+                $r=wp_remote_get((string)$feed,['timeout'=>8]);
+                if(is_wp_error($r)){ $diag['skipped_reasons'][]='http_error:'.$feed; continue; }
+                $body=(string)wp_remote_retrieve_body($r);
+                $xml=@simplexml_load_string($body); $items=[];
+                if($xml && isset($xml->entry)){ foreach($xml->entry as $e){ $items[]=['title'=>(string)$e->title,'url'=>(string)$e->link['href'],'description'=>(string)($e->summary??$e->content??'')]; } }
+                if($xml && isset($xml->channel->item)){ foreach($xml->channel->item as $i){ $items[]=['title'=>(string)$i->title,'url'=>(string)$i->link,'description'=>(string)$i->description]; } }
+                set_transient($cache,$items,10*MINUTE_IN_SECONDS);
+            }
+            foreach(array_slice($items,0,8) as $it){
+                $diag['items_seen']++;
+                $title=sanitize_text_field((string)($it['title']??'')); $desc=sanitize_textarea_field((string)($it['description']??''));
+                if(!$this->issue($title.' '.$desc)) continue;
+                $diag['items_matched']++;
+                $url=esc_url_raw((string)($it['url']??$feed)); if($url==='') $url=(string)$feed;
+                $providerHost=$this->host((string)$feed);
+                $official=(bool) preg_match('/statuspage\.io$|status\./i',$providerHost);
+                $out[]=['source'=>'provider_feed','source_type'=>'provider_rss','adapter_id'=>'provider_feed','source_id'=>md5($url.$title),'provider_id'=>sanitize_key(is_string($key)?$key:$providerHost),'provider_name'=>sanitize_text_field(is_string($key)?$key:$providerHost),'category'=>'service','region'=>'global','signal_type'=>'official_feed','severity'=>'trending','confidence'=>$official?70:55,'title'=>$title,'message'=>mb_substr($desc ?: 'Provider feed indicates service issue.',0,280),'url'=>$url,'observed_at'=>gmdate('Y-m-d H:i:s'),'snippets'=>array_values(array_filter([$title,mb_substr($desc,0,120)])),'domains'=>array_values(array_unique(array_filter([$this->host($url),$providerHost]))),'source_urls'=>array_values(array_unique([$url,(string)$feed])),'confidence_reason'=>$official?'Official provider status feed issue language detected.':'Provider/public feed issue language detected.','evidence_quality'=>$official?'moderate':'weak','official_confirmed'=>$official];
+                $diag['items_stored']++;
+            }
+        }
+        update_option('lo_diag_'.$this->id(),$diag,false); return $out;
     }
 }

--- a/lousy-outages/includes/Sources/PublicChatterSource.php
+++ b/lousy-outages/includes/Sources/PublicChatterSource.php
@@ -12,7 +12,7 @@ class PublicChatterSource implements SignalSourceInterface {
     public function is_configured(): bool { return (bool) get_option('lousy_outages_public_chatter_enabled', false); }
 
     public function collect(array $options = []): array {
-        if (!$this->is_configured()) return [];
+        if (!$this->is_configured()) { update_option('lo_diag_'.$this->id(), ['configured'=>false,'attempted'=>false,'skipped_reasons'=>['not_configured']], false); return []; }
         $window = max(10, min(180, (int) apply_filters('lo_public_chatter_window_minutes', 30)));
         $thresholds = [
             'watch' => (int) apply_filters('lo_public_chatter_watch_threshold', 3),
@@ -23,9 +23,9 @@ class PublicChatterSource implements SignalSourceInterface {
         $queries = (array) apply_filters('lo_public_chatter_queries', $this->default_queries($providers), $providers);
         $signals = [];
         $sources = [
-            'public_chatter_bluesky' => !empty(get_option('lousy_outages_public_chatter_bluesky_enabled', true)),
+            'public_chatter_bluesky' => !empty(get_option('lousy_outages_public_chatter_bluesky_enabled', false)),
             'public_chatter_mastodon' => !empty(get_option('lousy_outages_public_chatter_mastodon_enabled', false)),
-            'public_chatter_gdelt' => !empty(get_option('lousy_outages_public_chatter_gdelt_enabled', true)),
+            'public_chatter_gdelt' => !empty(get_option('lousy_outages_public_chatter_gdelt_enabled', false)),
         ];
         foreach ($queries as $providerId => $providerQueries) {
             $provider = (array)($providers[$providerId] ?? ['name' => ucfirst((string)$providerId), 'category'=>'general']);
@@ -38,6 +38,7 @@ class PublicChatterSource implements SignalSourceInterface {
                 $signals[] = $this->build_signal($sourceId, (string)$providerId, (string)($provider['name'] ?? $providerId), (string)($provider['category'] ?? 'general'), $severity, $count, $window, $mentions);
             }
         }
+        update_option('lo_diag_'.$this->id(), ['configured'=>true,'attempted'=>true,'queries_attempted'=>count($queries),'usable_results'=>count($signals),'rows_stored'=>count($signals)], false);
         return $signals;
     }
 

--- a/lousy-outages/includes/Sources/StatuspageIntelSource.php
+++ b/lousy-outages/includes/Sources/StatuspageIntelSource.php
@@ -9,31 +9,61 @@ class StatuspageIntelSource implements SignalSourceInterface {
     public function id(): string { return 'statuspage_intel'; }
     public function label(): string { return 'Statuspage Intel'; }
     public function is_configured(): bool { return SourcePack::enabled() && count(SourcePack::statuspage_base_urls()) > 0; }
-    private function has_issue_language(string $text): bool { return (bool) preg_match('/\b(down|outage|incident|degraded|error|failure|unavailable|latency|disruption)\b/i', $text); }
     private function host(string $url): string { return (string) wp_parse_url($url, PHP_URL_HOST); }
+    private function issue(string $text): bool { return (bool) preg_match('/\b(down|outage|incident|degraded|error|failure|unavailable|latency|disruption|maintenance)\b/i', $text); }
 
     public function collect(array $options = []): array {
+        $endpoints=['/api/v2/status.json','/api/v2/summary.json','/api/v2/components.json','/api/v2/incidents/unresolved.json','/api/v2/incidents.json','/api/v2/scheduled-maintenances/active.json'];
+        $diag=['configured'=>$this->is_configured(),'attempted'=>false,'providers_checked'=>0,'endpoints_attempted'=>0,'incidents_found'=>0,'components_degraded'=>0,'rows_stored'=>0,'rows_suppressed'=>0,'skipped_reasons'=>[],'cooldown_active'=>false];
         $out=[];
-        foreach(SourcePack::statuspage_base_urls() as $base){
+        foreach (SourcePack::statuspage_base_urls() as $base) {
             $base=rtrim((string)$base,'/'); if(!$base) continue;
-            $can=SourceBudgetManager::can_attempt($this->id(), $this->host($base), 30);
-            if(empty($can['ok'])) continue;
-            $incidentUrl=$base.'/api/v2/incidents/unresolved.json';
-            $r=wp_remote_get($incidentUrl,['timeout'=>6]);
-            SourceBudgetManager::mark_attempt($this->id(), $this->host($base), 10);
-            if(is_wp_error($r)){ SourceBudgetManager::mark_result($this->id(), false, 0); continue; }
-            $code=(int) wp_remote_retrieve_response_code($r);
-            SourceBudgetManager::mark_result($this->id(), $code >= 200 && $code < 300, $code);
-            if($code < 200 || $code >= 300) continue;
-            $json=json_decode((string)wp_remote_retrieve_body($r),true);
-            foreach((array)($json['incidents']??[]) as $inc){
-                $name=sanitize_text_field((string)($inc['name']??'Statuspage incident'));
-                $body=sanitize_text_field((string)($inc['status']??''));
-                if(!$this->has_issue_language($name.' '.$body)) continue;
-                $url=esc_url_raw((string)($inc['shortlink']??$base));
-                $out[]=['source'=>'statuspage','source_type'=>'official_status','adapter_id'=>'statuspage_public','source_id'=>sanitize_text_field((string)($inc['id']??md5($url.$name))),'provider_id'=>sanitize_key($this->host($base)),'provider_name'=>sanitize_text_field($this->host($base)),'category'=>'service','region'=>'global','signal_type'=>'status_incident','severity'=>'major','confidence'=>95,'title'=>$name,'message'=>$body,'url'=>$url,'source_urls'=>[$url,$incidentUrl],'domains'=>[$this->host($base)],'snippets'=>[$name,$body],'confidence_reason'=>'Official provider statuspage incident','evidence_quality'=>'official','official_confirmed'=>true,'observed_at'=>gmdate('Y-m-d H:i:s')];
+            $diag['providers_checked']++;
+            $host=$this->host($base);
+            $bucket=[];
+            foreach($endpoints as $ep){
+                $can=SourceBudgetManager::can_attempt($this->id(),$host,30);
+                if(empty($can['ok'])){ $diag['cooldown_active']=true; $diag['skipped_reasons'][]='budget:'.$host; break; }
+                $diag['attempted']=true; $diag['endpoints_attempted']++;
+                $url=$base.$ep;
+                $cache='lo_statuspage_'.md5($url);
+                $json=get_transient($cache);
+                if(!is_array($json)){
+                    $r=wp_remote_get($url,['timeout'=>6]);
+                    SourceBudgetManager::mark_attempt($this->id(),$host,8);
+                    if(is_wp_error($r)){ SourceBudgetManager::mark_result($this->id(),false,0); $diag['skipped_reasons'][]='http_error:'.$host; continue; }
+                    $code=(int)wp_remote_retrieve_response_code($r);
+                    SourceBudgetManager::mark_result($this->id(), $code>=200&&$code<300, $code);
+                    if($code<200||$code>=300){ if($code===429){$diag['cooldown_active']=true;} continue; }
+                    $json=json_decode((string)wp_remote_retrieve_body($r),true);
+                    if(!is_array($json)) $json=[];
+                    set_transient($cache,$json,5*MINUTE_IN_SECONDS);
+                }
+                $bucket[$ep]=$json;
             }
+            $incidents=array_merge((array)($bucket['/api/v2/incidents/unresolved.json']['incidents']??[]),(array)($bucket['/api/v2/incidents.json']['incidents']??[]),(array)($bucket['/api/v2/summary.json']['incidents']??[]));
+            $hasIssue=false; $snips=[]; $urls=[];
+            foreach($incidents as $inc){
+                $name=sanitize_text_field((string)($inc['name']??'')); $status=sanitize_text_field((string)($inc['status']??''));
+                if($name==='' && $status==='') continue;
+                if(in_array($status,['investigating','identified','monitoring','in_progress'],true) || $this->issue($name.' '.$status)){
+                    $hasIssue=true; $diag['incidents_found']++;
+                    $snips[]=$name.($status?" ({$status})":'');
+                    $urls[]=esc_url_raw((string)($inc['shortlink']??$base.'/api/v2/incidents.json'));
+                }
+            }
+            foreach((array)($bucket['/api/v2/components.json']['components']??$bucket['/api/v2/summary.json']['components']??[]) as $component){
+                $st=(string)($component['status']??'');
+                if($st!=='' && $st!=='operational'){ $hasIssue=true; $diag['components_degraded']++; $snips[]=sanitize_text_field((string)($component['name']??'component')).' '.$st; }
+            }
+            foreach((array)($bucket['/api/v2/scheduled-maintenances/active.json']['scheduled_maintenances']??[]) as $m){
+                $hasIssue=true; $snips[]='Maintenance: '.sanitize_text_field((string)($m['name']??'active maintenance'));
+            }
+            if(!$hasIssue){ $diag['rows_suppressed']++; continue; }
+            $diag['rows_stored']++;
+            $out[]=['source'=>'statuspage','source_type'=>'official_status','adapter_id'=>'statuspage_public','source_id'=>md5($base.implode('|',$snips)),'provider_id'=>sanitize_key($host),'provider_name'=>sanitize_text_field($host),'category'=>'service','region'=>'global','signal_type'=>'status_incident','severity'=>'major','confidence'=>95,'title'=>'Statuspage issue detected: '.$host,'message'=>implode(' | ',array_slice($snips,0,3)),'url'=>$base,'source_urls'=>array_values(array_unique(array_merge([$base],$urls))),'domains'=>[$host],'snippets'=>array_slice($snips,0,6),'confidence_reason'=>'Official provider statuspage indicates incident/degradation/maintenance.','evidence_quality'=>'official','official_confirmed'=>true,'observed_at'=>gmdate('Y-m-d H:i:s')];
         }
+        update_option('lo_diag_'.$this->id(),$diag,false);
         return $out;
     }
 }

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -180,16 +180,21 @@ function lousy_outages_activate() {
 register_activation_hook( __FILE__, 'lousy_outages_activate' );
 
 function lousy_outages_maybe_install_schema( bool $force = false ): void {
-    $schema_version = '2026-05-04.1';
+    $schema_version = ExternalSignals::SCHEMA_VERSION;
     $option_key = 'lousy_outages_schema_version';
     $current = (string) get_option( $option_key, '' );
-    if ( ! $force && version_compare( $current, $schema_version, '>=' ) ) {
+    $diag = ExternalSignals::schema_diagnostics();
+    $needs_external = ! empty( $diag['missing_columns'] ) || empty( $diag['table_exists'] );
+    if ( ! $force && version_compare( $current, $schema_version, '>=' ) && ! $needs_external ) {
         return;
     }
 
     Subscriptions::create_table();
     UserReports::install();
-    ExternalSignals::install();
+    if ( $needs_external || $force || version_compare( $current, $schema_version, '<' ) ) {
+        ExternalSignals::install();
+    }
+    update_option( 'lousy_outages_external_schema_diagnostic', ExternalSignals::schema_diagnostics(), false );
     update_option( $option_key, $schema_version, false );
 }
 add_action( 'admin_init', 'lousy_outages_maybe_install_schema' );

--- a/lousy-outages/scripts/smoke-production-preflight.php
+++ b/lousy-outages/scripts/smoke-production-preflight.php
@@ -4,20 +4,25 @@ declare(strict_types=1);
 if ($argc < 2) { fwrite(STDERR, "Usage: php scripts/smoke-production-preflight.php /path/to/wp-load.php\n"); exit(2);} 
 $wpLoad=$argv[1]; if(!is_file($wpLoad)){ fwrite(STDERR,"wp-load.php not found at: {$wpLoad}\n"); exit(2);} require_once $wpLoad;
 
+use SuzyEaston\LousyOutages\ExternalSignals;
 use SuzyEaston\LousyOutages\SignalCollector;
 use SuzyEaston\LousyOutages\SignalSourceInterface;
 use SuzyEaston\LousyOutages\Sources\SourcePack;
 
-$errors=[]; $sources=SignalCollector::sources();
+$errors=[]; $sources=SignalCollector::sources(); $ids=[];
 foreach($sources as $i=>$source){
  if(!$source instanceof SignalSourceInterface){$errors[]="Source $i is not SignalSourceInterface"; continue;}
- if(trim((string)$source->id())==='') $errors[] = get_class($source).' empty id';
- if(trim((string)$source->label())==='') $errors[] = get_class($source).' empty label';
+ $id=trim((string)$source->id()); $label=trim((string)$source->label());
+ if($id==='') $errors[] = get_class($source).' empty id';
+ if($label==='') $errors[] = get_class($source).' empty label';
+ if(isset($ids[$id])) $errors[] = 'Duplicate source id: '.$id; else $ids[$id]=true;
 }
-if(count(SourcePack::statuspage_base_urls())===0) $errors[]='SourcePack statuspage list empty';
-if(count(SourcePack::provider_feed_urls())===0) $errors[]='SourcePack feed list empty';
-if(count(SourcePack::early_warning_queries())===0) $errors[]='SourcePack queries empty';
+if(count(SourcePack::statuspage_base_urls()) < 5) $errors[]='SourcePack statuspage list <5';
+if(count(SourcePack::provider_feed_urls()) < 5) $errors[]='SourcePack feed list <5';
+if(count(SourcePack::early_warning_queries()) < 20) $errors[]='SourcePack queries <20';
+$schemaDiag=ExternalSignals::schema_diagnostics();
+if(!empty($schemaDiag['missing_columns']) && !is_callable([ExternalSignals::class,'install'])) $errors[]='ExternalSignals expected columns missing and install not callable';
 
-$result = SignalCollector::collect(['dry_run'=>true,'suppress_notifications'=>true]);
-if (!is_array($result) || !isset($result['sources'])) $errors[]='dry-run collect did not return expected diagnostics';
+$result = SignalCollector::collect(['dry_run'=>true,'suppress_notifications'=>true,'no_email'=>true]);
+if (!is_array($result) || !isset($result['sources']) || !isset($result['diagnostics'])) $errors[]='dry-run collect did not return expected diagnostics';
 if($errors){ fwrite(STDERR, "Preflight FAILED:\n- ".implode("\n- ",$errors)."\n"); exit(1);} echo "Preflight passed with ".count($sources)." sources.\n";


### PR DESCRIPTION
### Motivation
- Prevent schema drift and runtime failures by aligning plugin install gating with the authoritative external-signal schema and reporting missing evidence columns.
- Remove duplicate legacy source class risk and ensure canonical source implementations are safe for production polling.
- Reduce noisy/weak signals and improve evidence quality for Statuspage, provider feeds, and Hacker News while adding budget/caching to avoid provider overload. 
- Make pre-deploy smoke checks and quiet/dry runs informative so production dry-runs explain what was checked and why nothing was stored.

### Description
- Aligned install gate in `lousy-outages.php` with `ExternalSignals::SCHEMA_VERSION`, added conditional `ExternalSignals::install()` invocation, and recorded external-signal schema diagnostics via `ExternalSignals::schema_diagnostics()`. 
- Added `ExternalSignals::expected_columns()` and `schema_diagnostics()` and surfaced those diagnostics in `install()` to detect missing evidence columns (e.g. `source_type`, `adapter_id`, `snippets`, `domains`, `source_urls`, `confidence_reason`, `evidence_quality`, `official_confirmed`, `unconfirmed_note`, `metadata_json`). 
- Neutralized `includes/Sources/IntelConduitSources.php` by replacing it with a harmless compatibility placeholder to eliminate duplicate-class declarations. 
- Reworked `StatuspageIntelSource` to query a structured set of Statuspage endpoints, respect `SourceBudgetManager` per host, cache responses briefly, emit official evidence only when incidents/degraded components/active maintenances are present, populate first-class evidence fields, and write detailed per-provider diagnostics. 
- Reworked `ProviderFeedSource` to support Atom and RSS parsing, preserve provider identity from configured key or host, populate evidence fields and metadata, cache feeds (≈10 minutes), apply issue-language filtering, and record feed diagnostics. 
- Reworked `HackerNewsChatterSource` to use budget-aware bounded queries (2 queries/run, 5 hits/query), per-query caching, issue-language filtering, stronger evidence-or-silence behavior, full evidence fields including `unconfirmed_note`, and per-run diagnostics. 
- Tightened `PublicChatterSource` defaults to keep direct Bluesky/Mastodon/GDELT calls disabled by default for this deploy and added baseline diagnostics when disabled or run. 
- Enhanced `SignalCollector` to include per-source diagnostics (reads `lo_diag_<source>` and returns diagnostics in dry runs) so quiet runs explain configured/attempted work and skip reasons. 
- Hardened `scripts/smoke-production-preflight.php` to accept a `/path/to/wp-load.php`, validate instantiation/IDs/duplicates, check `SourcePack` minimum counts, ensure external-signal columns exist or that `ExternalSignals::install()` is callable, and validate dry-run diagnostics without sending email. 

### Testing
- Ran PHP lint on the changed files with `php -l` for `lousy-outages.php`, `includes/ExternalSignals.php`, `includes/SignalCollector.php`, `includes/Sources/StatuspageIntelSource.php`, `includes/Sources/ProviderFeedSource.php`, `includes/Sources/HackerNewsChatterSource.php`, `includes/Sources/PublicChatterSource.php`, `includes/Sources/IntelConduitSources.php`, and `scripts/smoke-production-preflight.php` and all reported no syntax errors. 
- Attempted smoke scripts (`smoke-signal-sources.php` / `smoke-intel-source-pack.php`) in this environment but they require a WordPress bootstrap path (`/path/to/wp-load.php`) so a full smoke-run must be executed on the target WP bootstrap during deploy. 
- Committed changes and created this PR after local lint checks succeeded; full smoke preflight and runtime collection tests should be run against the production WP bootstrap before activating polling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f958df75dc832e9e69a26c9eca3907)