### PR TITLE
Harden Intel Conduit pre-deploy safety checks

### DIFF
--- a/lousy-outages/includes/Sources/HackerNewsChatterSource.php
+++ b/lousy-outages/includes/Sources/HackerNewsChatterSource.php
@@ -9,6 +9,24 @@ class HackerNewsChatterSource implements SignalSourceInterface {
     public function label(): string { return 'Hacker News Chatter'; }
     public function is_configured(): bool { return SourcePack::enabled() && (bool) apply_filters('lo_hn_chatter_enabled', get_option('lo_hn_chatter_enabled', '1') === '1'); }
     private function issue(string $t): bool { return (bool) preg_match('/\b(outage|down|incident|degrad|latency|error|unavailable|disruption)\b/i',$t); }
+    private function detect_provider(string $text): array {
+        $map=[
+            ['/(github actions|github)/i','github','GitHub','developer_tooling'],
+            ['/(\bnpm\b)/i','npm','npm','package_registry'],
+            ['/(docker hub|docker pull|\bdocker\b)/i','docker','Docker','package_registry'],
+            ['/(cloudflare|workers)/i','cloudflare','Cloudflare','dns_cdn'],
+            ['/(openai|chatgpt)/i','openai','OpenAI','ai_api'],
+            ['/(vercel)/i','vercel','Vercel','developer_tooling'],
+            ['/(netlify)/i','netlify','Netlify','developer_tooling'],
+            ['/(\baws\b)/i','aws','AWS','cloud_api'],
+            ['/(azure|entra)/i','azure','Azure','cloud_identity'],
+            ['/(google cloud|\bgcp\b)/i','google_cloud','Google Cloud','cloud_api'],
+            ['/(interac|e-?transfer)/i','interac','Interac','canadian_payments'],
+            ['/(rogers|shaw|telus|bell|freedom)/i','canadian_telecom','Canadian Telecom','canadian_telecom'],
+        ];
+        foreach($map as $row){ if(preg_match($row[0],$text)){ return ['provider_id'=>$row[1],'provider_name'=>$row[2],'category'=>$row[3]]; }}
+        return ['provider_id'=>'','provider_name'=>'Tech Pulse','category'=>'public_chatter'];
+    }
     public function collect(array $options = []): array {
         if(!$this->is_configured()) return [];
         $queries=SourcePack::early_warning_queries(); $cursor=(int)get_option('lo_hn_query_cursor',0); $take=array_slice(array_merge($queries,$queries),$cursor,2); update_option('lo_hn_query_cursor',($cursor+2)%max(1,count($queries)),false);
@@ -34,7 +52,8 @@ class HackerNewsChatterSource implements SignalSourceInterface {
                 $diag['usable_results']++;
                 $storyUrl=esc_url_raw((string)($hit['url']??$hit['story_url']??'')); $hnUrl='https://news.ycombinator.com/item?id='.(int)($hit['objectID']??0);
                 $urls=array_values(array_filter([$hnUrl,$storyUrl]));
-                $out[]=['source'=>'hacker_news_chatter','source_type'=>'public_chatter','adapter_id'=>'hacker_news_chatter','source_id'=>sanitize_text_field((string)($hit['objectID']??md5($title.$hnUrl))),'provider_id'=>'','provider_name'=>'Tech Pulse','category'=>'public_chatter','region'=>'global','signal_type'=>'public_chatter','severity'=>'watch','confidence'=>$storyUrl?40:25,'title'=>'HN chatter: '.$title,'message'=>'Unconfirmed developer chatter from Hacker News search results.','url'=>$hnUrl,'observed_at'=>gmdate('Y-m-d H:i:s'),'snippets'=>[$title],'source_urls'=>$urls,'domains'=>array_values(array_unique(array_filter([wp_parse_url($storyUrl,PHP_URL_HOST),'news.ycombinator.com']))),'confidence_reason'=>'Developer chatter with issue-language match; requires corroboration.','evidence_quality'=>$storyUrl?'moderate':'weak','official_confirmed'=>false,'unconfirmed_note'=>'Unconfirmed developer chatter.'];
+                $provider=$this->detect_provider($title.' '.$q);
+                $out[]=['source'=>'hacker_news_chatter','source_type'=>'public_chatter','adapter_id'=>'hacker_news_chatter','source_id'=>sanitize_text_field((string)($hit['objectID']??md5($title.$hnUrl))),'provider_id'=>$provider['provider_id'],'provider_name'=>$provider['provider_name'],'category'=>$provider['category'],'region'=>'global','signal_type'=>'public_chatter','severity'=>'watch','confidence'=>$storyUrl?40:25,'title'=>'HN chatter: '.$title,'message'=>'Unconfirmed developer chatter from Hacker News search results.','url'=>$hnUrl,'observed_at'=>gmdate('Y-m-d H:i:s'),'snippets'=>[$title],'source_urls'=>$urls,'domains'=>array_values(array_unique(array_filter([wp_parse_url($storyUrl,PHP_URL_HOST),'news.ycombinator.com']))),'confidence_reason'=>'Developer chatter with issue-language match; requires corroboration.','evidence_quality'=>$storyUrl?'moderate':'weak','official_confirmed'=>false,'unconfirmed_note'=>'Unconfirmed developer chatter.'];
                 $diag['rows_stored']++;
             }
         }

--- a/lousy-outages/includes/Sources/PublicChatterSource.php
+++ b/lousy-outages/includes/Sources/PublicChatterSource.php
@@ -13,6 +13,7 @@ class PublicChatterSource implements SignalSourceInterface {
 
     public function collect(array $options = []): array {
         if (!$this->is_configured()) { update_option('lo_diag_'.$this->id(), ['configured'=>false,'attempted'=>false,'skipped_reasons'=>['not_configured']], false); return []; }
+        $directEnabled = $this->direct_sources_enabled();
         $window = max(10, min(180, (int) apply_filters('lo_public_chatter_window_minutes', 30)));
         $thresholds = [
             'watch' => (int) apply_filters('lo_public_chatter_watch_threshold', 3),
@@ -27,6 +28,9 @@ class PublicChatterSource implements SignalSourceInterface {
             'public_chatter_mastodon' => !empty(get_option('lousy_outages_public_chatter_mastodon_enabled', false)),
             'public_chatter_gdelt' => !empty(get_option('lousy_outages_public_chatter_gdelt_enabled', false)),
         ];
+        if (!$directEnabled) {
+            $sources = ['public_chatter_bluesky'=>false,'public_chatter_mastodon'=>false,'public_chatter_gdelt'=>false];
+        }
         foreach ($queries as $providerId => $providerQueries) {
             $provider = (array)($providers[$providerId] ?? ['name' => ucfirst((string)$providerId), 'category'=>'general']);
             foreach ($sources as $sourceId => $enabled) {
@@ -38,8 +42,13 @@ class PublicChatterSource implements SignalSourceInterface {
                 $signals[] = $this->build_signal($sourceId, (string)$providerId, (string)($provider['name'] ?? $providerId), (string)($provider['category'] ?? 'general'), $severity, $count, $window, $mentions);
             }
         }
-        update_option('lo_diag_'.$this->id(), ['configured'=>true,'attempted'=>true,'queries_attempted'=>count($queries),'usable_results'=>count($signals),'rows_stored'=>count($signals)], false);
+        update_option('lo_diag_'.$this->id(), ['configured'=>true,'attempted'=>true,'queries_attempted'=>count($queries),'usable_results'=>count($signals),'rows_stored'=>count($signals),'direct_sources_enabled'=>$directEnabled,'direct_sources_disabled_by_safe_default'=>!$directEnabled], false);
         return $signals;
+    }
+
+    private function direct_sources_enabled(): bool {
+        $flag = defined('LOUSY_OUTAGES_ENABLE_DIRECT_PUBLIC_CHATTER') ? (bool) LOUSY_OUTAGES_ENABLE_DIRECT_PUBLIC_CHATTER : false;
+        return (bool) apply_filters('lo_public_chatter_direct_sources_enabled', $flag);
     }
 
     private function default_queries(array $providers): array {

--- a/lousy-outages/includes/Sources/StatuspageIntelSource.php
+++ b/lousy-outages/includes/Sources/StatuspageIntelSource.php
@@ -14,16 +14,16 @@ class StatuspageIntelSource implements SignalSourceInterface {
 
     public function collect(array $options = []): array {
         $endpoints=['/api/v2/status.json','/api/v2/summary.json','/api/v2/components.json','/api/v2/incidents/unresolved.json','/api/v2/incidents.json','/api/v2/scheduled-maintenances/active.json'];
-        $diag=['configured'=>$this->is_configured(),'attempted'=>false,'providers_checked'=>0,'endpoints_attempted'=>0,'incidents_found'=>0,'components_degraded'=>0,'rows_stored'=>0,'rows_suppressed'=>0,'skipped_reasons'=>[],'cooldown_active'=>false];
+        $diag=['configured'=>$this->is_configured(),'attempted'=>false,'providers_checked'=>0,'endpoints_attempted'=>0,'endpoints_skipped_budget'=>0,'incidents_found'=>0,'components_degraded'=>0,'rows_stored'=>0,'rows_suppressed'=>0,'skipped_reasons'=>[],'cooldown_active'=>false];
         $out=[];
-        foreach (SourcePack::statuspage_base_urls() as $base) {
+        foreach (array_slice(SourcePack::statuspage_base_urls(),0,20) as $base) {
             $base=rtrim((string)$base,'/'); if(!$base) continue;
             $diag['providers_checked']++;
             $host=$this->host($base);
+            $can=SourceBudgetManager::can_attempt($this->id(),$host,30);
+            if(empty($can['ok'])){ $diag['cooldown_active']=true; $diag['skipped_reasons'][]='budget:'.$host; $diag['endpoints_skipped_budget']+=count($endpoints); continue; }
             $bucket=[];
-            foreach($endpoints as $ep){
-                $can=SourceBudgetManager::can_attempt($this->id(),$host,30);
-                if(empty($can['ok'])){ $diag['cooldown_active']=true; $diag['skipped_reasons'][]='budget:'.$host; break; }
+            foreach(array_slice($endpoints,0,6) as $ep){
                 $diag['attempted']=true; $diag['endpoints_attempted']++;
                 $url=$base.$ep;
                 $cache='lo_statuspage_'.md5($url);
@@ -41,8 +41,11 @@ class StatuspageIntelSource implements SignalSourceInterface {
                 }
                 $bucket[$ep]=$json;
             }
+            SourceBudgetManager::mark_attempt($this->id(),$host,8);
             $incidents=array_merge((array)($bucket['/api/v2/incidents/unresolved.json']['incidents']??[]),(array)($bucket['/api/v2/incidents.json']['incidents']??[]),(array)($bucket['/api/v2/summary.json']['incidents']??[]));
             $hasIssue=false; $snips=[]; $urls=[];
+            $indicator=(string)($bucket['/api/v2/status.json']['status']['indicator']??'');
+            if(in_array($indicator,['minor','major','critical'],true)){ $hasIssue=true; $snips[]='Status indicator: '.$indicator; }
             foreach($incidents as $inc){
                 $name=sanitize_text_field((string)($inc['name']??'')); $status=sanitize_text_field((string)($inc['status']??''));
                 if($name==='' && $status==='') continue;
@@ -59,7 +62,7 @@ class StatuspageIntelSource implements SignalSourceInterface {
             foreach((array)($bucket['/api/v2/scheduled-maintenances/active.json']['scheduled_maintenances']??[]) as $m){
                 $hasIssue=true; $snips[]='Maintenance: '.sanitize_text_field((string)($m['name']??'active maintenance'));
             }
-            if(!$hasIssue){ $diag['rows_suppressed']++; continue; }
+            if(!$hasIssue){ $diag['rows_suppressed']++; $diag['skipped_reasons'][]='all_operational:'.$host; continue; }
             $diag['rows_stored']++;
             $out[]=['source'=>'statuspage','source_type'=>'official_status','adapter_id'=>'statuspage_public','source_id'=>md5($base.implode('|',$snips)),'provider_id'=>sanitize_key($host),'provider_name'=>sanitize_text_field($host),'category'=>'service','region'=>'global','signal_type'=>'status_incident','severity'=>'major','confidence'=>95,'title'=>'Statuspage issue detected: '.$host,'message'=>implode(' | ',array_slice($snips,0,3)),'url'=>$base,'source_urls'=>array_values(array_unique(array_merge([$base],$urls))),'domains'=>[$host],'snippets'=>array_slice($snips,0,6),'confidence_reason'=>'Official provider statuspage indicates incident/degradation/maintenance.','evidence_quality'=>'official','official_confirmed'=>true,'observed_at'=>gmdate('Y-m-d H:i:s')];
         }

--- a/lousy-outages/scripts/smoke-production-preflight.php
+++ b/lousy-outages/scripts/smoke-production-preflight.php
@@ -25,4 +25,14 @@ if(!empty($schemaDiag['missing_columns']) && !is_callable([ExternalSignals::clas
 
 $result = SignalCollector::collect(['dry_run'=>true,'suppress_notifications'=>true,'no_email'=>true]);
 if (!is_array($result) || !isset($result['sources']) || !isset($result['diagnostics'])) $errors[]='dry-run collect did not return expected diagnostics';
+$statusDiag=(array)get_option('lo_diag_statuspage_intel',[]);
+if(!empty($statusDiag)){
+    $attempted=(int)($statusDiag['endpoints_attempted']??0);
+    $cooldown=!empty($statusDiag['cooldown_active']);
+    if($attempted<=0 && !$cooldown){ $errors[]='Statuspage diagnostics: endpoints_attempted=0 without cooldown'; }
+}
+$chatterDiag=(array)get_option('lo_diag_public_chatter',[]);
+if(!empty($chatterDiag) && !empty($chatterDiag['direct_sources_enabled'])){ $errors[]='Public chatter direct sources enabled (expected safe-default disabled)'; }
+$hnDiag=(array)get_option('lo_diag_hacker_news_chatter',[]);
+if(!empty($hnDiag) && !array_key_exists('queries_attempted',$hnDiag)){ $errors[]='HN diagnostics missing queries_attempted'; }
 if($errors){ fwrite(STDERR, "Preflight FAILED:\n- ".implode("\n- ",$errors)."\n"); exit(1);} echo "Preflight passed with ".count($sources)." sources.\n";


### PR DESCRIPTION
### Motivation
- Prevent blind spots and self-throttling when sweeping multiple Statuspage endpoints per provider so we don't miss official evidence during a run. 
- Ensure direct public chatter sources (Bluesky/Mastodon/GDELT) remain disabled by safe default in production unless explicitly enabled. 
- Improve Hacker News result classification so obvious provider/category matches (GitHub, npm, Docker, Cloudflare, OpenAI, etc.) produce more useful signals. 
- Strengthen the production preflight to surface these safety/diagnostic issues before rollout. 

### Description
- Updated `StatuspageIntelSource` to perform a provider-scoped budget check and allow a single provider sweep of multiple structured endpoints, added `endpoints_skipped_budget`, capped providers/endpoints per run, applied `mark_attempt` at sweep level, and parse `status.json` indicators (`minor|major|critical`) to generate official evidence or record `all_operational` suppression reasons. 
- Added a safe-default gate to `PublicChatterSource` via the constant `LOUSY_OUTAGES_ENABLE_DIRECT_PUBLIC_CHATTER` and an `lo_public_chatter_direct_sources_enabled` filter so Bluesky/Mastodon/GDELT are disabled unless explicitly enabled, and exposed `direct_sources_enabled` diagnostics. 
- Added `detect_provider()` in `HackerNewsChatterSource` with simple alias mapping to set `provider_id`, `provider_name`, and `category` for common targets (GitHub, npm, Docker, Cloudflare, OpenAI, Vercel, Netlify, AWS, Azure/Entra, Google Cloud/GCP, Interac/e-Transfer, major Canadian ISPs) and preserved `Tech Pulse/public_chatter` when unmatched. 
- Hardened `scripts/smoke-production-preflight.php` to check `lo_diag_statuspage_intel` for `endpoints_attempted` (unless cooldown applies), enforce that public chatter direct sources are disabled by safe default, and validate Hacker News diagnostics shape. 
- Files changed: `lousy-outages/includes/Sources/StatuspageIntelSource.php`, `lousy-outages/includes/Sources/PublicChatterSource.php`, `lousy-outages/includes/Sources/HackerNewsChatterSource.php`, and `lousy-outages/scripts/smoke-production-preflight.php`. 

### Testing
- `php -l` passed on all modified PHP files (`StatuspageIntelSource.php`, `PublicChatterSource.php`, `HackerNewsChatterSource.php`, `smoke-production-preflight.php`). 
- `php lousy-outages/scripts/smoke-intel-source-pack.php /workspace/suzyeastonca/wp-load.php` executed successfully in this environment (returned `ok`). 
- `php lousy-outages/scripts/smoke-signal-sources.php /workspace/suzyeastonca/wp-load.php` and `php lousy-outages/scripts/smoke-production-preflight.php /workspace/suzyeastonca/wp-load.php` could not complete here because `wp-load.php` was not available at the provided path, so those smoke runs need a real WordPress environment to validate end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f95b362c88832e9491221f230d68e2)