### PR TITLE
Tighten public chatter credibility and lane routing

### DIFF
--- a/lousy-outages/includes/SignalEngine.php
+++ b/lousy-outages/includes/SignalEngine.php
@@ -72,8 +72,10 @@ class SignalEngine {
         }
         foreach ($external as $row) {
             $key = ($row['provider_id'] ?? '') . '|' . ($row['category'] ?? '') . '|' . ($row['region'] ?? '');
-            if (!isset($buckets[$key])) { $buckets[$key]=['provider_id'=>(string)($row['provider_id']??''),'provider_name'=>(string)($row['provider_name']??'Unknown'),'category'=>(string)($row['category']??''),'region'=>(string)($row['region']??''),'report_count'=>0,'external_signal_count'=>0,'synthetic_failure_count'=>0,'sources'=>[],'official_status_known'=>false,'confirmed'=>false,'last_observed_at'=>(string)($row['observed_at']??''),'base_confidence'=>0,'sample_observations'=>[],'domains'=>[],'source_urls'=>[],'adapter_ids'=>[],'official_confirmed'=>false]; }
+            if (!isset($buckets[$key])) { $buckets[$key]=['provider_id'=>(string)($row['provider_id']??''),'provider_name'=>(string)($row['provider_name']??'Unknown'),'category'=>(string)($row['category']??''),'region'=>(string)($row['region']??''),'report_count'=>0,'external_signal_count'=>0,'synthetic_failure_count'=>0,'sources'=>[],'official_status_known'=>false,'confirmed'=>false,'last_observed_at'=>(string)($row['observed_at']??''),'base_confidence'=>0,'sample_observations'=>[],'domains'=>[],'source_urls'=>[],'adapter_ids'=>[],'official_confirmed'=>false,'source_type'=>'','signal_lane'=>'']; }
             $buckets[$key]['external_signal_count']++;
+            if (($buckets[$key]['source_type'] ?? '') === '' && !empty($row['source_type'])) { $buckets[$key]['source_type'] = (string)$row['source_type']; }
+            if (($buckets[$key]['signal_lane'] ?? '') === '' && !empty($row['signal_lane'])) { $buckets[$key]['signal_lane'] = sanitize_key((string)$row['signal_lane']); }
             if (($row['signal_type'] ?? '') === 'public_chatter') { $buckets[$key]['public_chatter_confidence'] = max((int)($buckets[$key]['public_chatter_confidence'] ?? 0),(int)($row['confidence'] ?? 0)); }
             $src=(string)($row['source']??'external'); if(!in_array($src,$buckets[$key]['sources'],true)) $buckets[$key]['sources'][]=$src;
             $adapter = (string)($row['adapter_id'] ?? $src); if($adapter!=='' && !in_array($adapter,$buckets[$key]['adapter_ids'],true)) $buckets[$key]['adapter_ids'][]=$adapter;
@@ -89,8 +91,33 @@ class SignalEngine {
         foreach($buckets as $b){ $conf=(int)$b['base_confidence']; $evidenceQuality=self::evidence_quality_for_bucket($b); if($evidenceQuality==='none') continue; $chatter=(int)($b['public_chatter_confidence'] ?? 0); if($chatter>0){ $conf=max($conf,$chatter); } if($chatter>0 && $b['report_count']>0){ $conf += 10; } if($chatter>0 && $b['external_signal_count']>0){ $conf += 15; } if(count($b['sources'])>=2) $conf += 15; if(!$b['confirmed']) $conf=min($conf,($chatter>0?85:95)); $class=$conf>=70?'hot':($conf>=45?'trending':($conf>=25?'watch':'quiet')); if($class==='hot' && !$b['official_confirmed'] && $evidenceQuality!=='strong'){ $class='trending'; } $msg='Community reports are trending for this provider. Official incident not confirmed.'; if(!empty($b['official_confirmed']) || $evidenceQuality==='official'){ $hasMaintenance=in_array('maintenance',$b['adapter_ids'],true) || in_array('statuspage',$b['sources'],true) && (str_contains(strtolower(implode(' ', (array)$b['sample_observations'])),'maintenance:')); $hasIndicator=in_array('statuspage',$b['sources'],true) && (str_contains(strtolower(implode(' ', (array)$b['sample_observations'])),'status indicator:')); if($hasMaintenance){ $msg='Official status page reports active maintenance.'; } elseif($hasIndicator){ $msg='Official status indicator reports degraded service.'; } else { $msg='Official status evidence indicates current provider impact.'; } } elseif($chatter>0 && $b['report_count']===0){$msg='Public chatter has increased for this provider. This is unconfirmed.';} if(empty($b['official_confirmed']) && $evidenceQuality!=='official' && $chatter>0 && $b['report_count']>0){$msg='Public chatter and community reports both suggest a possible issue.';} if(empty($b['official_confirmed']) && $evidenceQuality!=='official' && $chatter>0 && $b['external_signal_count']>0){$msg='Public chatter and external telemetry both suggest a possible issue.';} if(empty($b['official_confirmed']) && $evidenceQuality!=='official' && $b['report_count']>0 && $b['external_signal_count']>0 && $chatter===0){$msg='External internet-health signals and community reports both suggest a possible issue.';} elseif(empty($b['official_confirmed']) && $evidenceQuality!=='official' && $b['external_signal_count']>0 && $b['synthetic_failure_count']===0 && $b['report_count']===0){$msg='External internet-health telemetry suggests a possible issue. Official incident not confirmed.';} elseif(empty($b['official_confirmed']) && $evidenceQuality!=='official' && $b['synthetic_failure_count']>0 && $b['report_count']===0){$msg='A lightweight public canary check failed. This is an unconfirmed signal.';}
             $snippets=array_slice(array_values(array_unique($b['sample_observations'])),0,4);
             $urls=array_slice(array_keys($b['source_urls']),0,6);
-            $sourceType=(in_array('statuspage',$b['sources'],true)||!empty($b['official_confirmed']))?'official_status':'public_chatter';
-            $lane = !empty($b['official_confirmed']) || $sourceType === 'official_status' ? 'official' : ($sourceType === 'public_chatter' ? 'chatter' : 'feed');
+            $sourceType=(string)($b['source_type'] ?? '');
+            $source=(string)($b['sources'][0] ?? 'external');
+            $rowLane = sanitize_key((string)($b['signal_lane'] ?? ''));
+            if ($rowLane !== '') {
+                $lane = $rowLane;
+            } elseif ($sourceType === 'public_chatter' || $source === 'hacker_news_chatter') {
+                $lane = 'chatter';
+            } elseif (!empty($b['official_confirmed']) || $source === 'statuspage' || $sourceType === 'official_status') {
+                $lane = 'official';
+            } elseif ($sourceType === 'provider_rss' || $source === 'provider_feed') {
+                $lane = 'feed';
+            } elseif ($source === 'synthetic_canary') {
+                $lane = 'synthetic';
+            } else {
+                $lane = 'feed';
+            }
+            if ($sourceType === '') {
+                if ($lane === 'official') {
+                    $sourceType = 'official_status';
+                } elseif ($lane === 'chatter') {
+                    $sourceType = 'public_chatter';
+                } elseif ($lane === 'synthetic') {
+                    $sourceType = 'synthetic';
+                } else {
+                    $sourceType = 'provider_rss';
+                }
+            }
             $sourceLabel=!empty($b['official_confirmed'])?'Official Statuspage':(in_array('hacker_news_chatter',$b['sources'],true)?'Hacker News':'Provider RSS/Public');
             $signals[]=$b + ['confidence'=>$conf,'classification'=>$class,'message'=>$msg,'evidence_quality'=>$evidenceQuality,'confidence_reason'=>$b['official_confirmed']?'Official source confirms incident':(count($b['sources'])>=2?'Multiple sources corroborate':'Single-source unconfirmed observation'),'snippets'=>$snippets,'domains'=>array_slice(array_keys($b['domains']),0,6),'source_urls'=>$urls,'official_confirmed'=>!empty($b['official_confirmed']),'evidence_quote'=>isset($snippets[0])?(string)substr((string)$snippets[0],0,180):'','evidence_source_label'=>$sourceLabel,'evidence_url'=>isset($urls[0])?(string)$urls[0]:'','evidence_urls'=>$urls,'evidence_platform'=>(in_array('hacker_news_chatter',$b['sources'],true)?'Hacker News':($lane==='official'?'Statuspage':'Public Web')),'evidence_observed_at'=>(string)($b['last_observed_at']??''),'observed_at'=>(string)($b['last_observed_at']??''),'source_type'=>$sourceType,'adapter_id'=>isset($b['adapter_ids'][0])?(string)$b['adapter_ids'][0]:'','signal_lane'=>$lane,'detected_provider'=>$b['provider_name'],'detected_category'=>$b['category'],'id'=>md5($b['provider_id'].'|'.$b['category'].'|'.$b['region'])];
         }

--- a/lousy-outages/includes/Sources/HackerNewsChatterSource.php
+++ b/lousy-outages/includes/Sources/HackerNewsChatterSource.php
@@ -49,7 +49,7 @@ class HackerNewsChatterSource implements SignalSourceInterface {
         $minTs = time() - ($windowMinutes * 60);
         $lookbackMinTs = time() - ($lookbackHours * HOUR_IN_SECONDS);
         $skipBudgetMutation = $this->should_skip_budget_mutation($options);
-        $diag=['configured'=>true,'attempted'=>false,'queries_available'=>count($queries),'queries_attempted'=>0,'queries_skipped_budget'=>0,'raw_results_seen'=>0,'usable_results'=>0,'rows_stored'=>0,'rows_attempted'=>0,'results_old_skipped'=>0,'results_missing_date'=>0,'rows_inserted'=>null,'skipped_reasons'=>[],'cooldown_active'=>false,'chatter_queries_attempted'=>0,'chatter_raw_results_seen'=>0,'chatter_recent_results'=>0,'chatter_old_skipped'=>0,'chatter_rows_attempted'=>0,'chatter_rows_inserted'=>0,'chatter_rows_skipped'=>0,'chatter_sources_enabled'=>['hacker_news'],'chatter_sources_disabled'=>[],'first_chatter_error'=>''];
+        $diag=['configured'=>true,'attempted'=>false,'queries_available'=>count($queries),'queries_attempted'=>0,'queries_skipped_budget'=>0,'raw_results_seen'=>0,'usable_results'=>0,'rows_stored'=>0,'rows_attempted'=>0,'results_old_skipped'=>0,'results_missing_date'=>0,'rows_inserted'=>null,'skipped_reasons'=>[],'cooldown_active'=>false,'chatter_queries_attempted'=>0,'chatter_raw_results_seen'=>0,'chatter_recent_results'=>0,'chatter_old_skipped'=>0,'chatter_rows_attempted'=>0,'chatter_rows_output'=>0,'chatter_rows_skipped'=>0,'chatter_rows_skipped_no_issue_language'=>0,'chatter_rows_skipped_empty_quote'=>0,'chatter_rows_skipped_old'=>0,'chatter_sources_enabled'=>['hacker_news'],'chatter_sources_disabled'=>[],'first_chatter_error'=>''];
         $out=[];
         foreach($take as $q){
             $budget=['ok'=>true];
@@ -72,22 +72,24 @@ class HackerNewsChatterSource implements SignalSourceInterface {
             foreach(array_slice($hits,0,10) as $hit){
                 $title=sanitize_text_field((string)($hit['title']??$hit['story_title']??'')); $txt=wp_strip_all_tags((string)($hit['comment_text']??''));
                 $quote = sanitize_text_field(substr(trim($txt !== '' ? $txt : $title), 0, 180));
-                if($quote==='' || !$this->issue($title.' '.$txt.' '.$q)) { $diag['chatter_rows_skipped']++; continue; }
+                if($quote==='') { $diag['chatter_rows_skipped']++; $diag['chatter_rows_skipped_empty_quote']=($diag['chatter_rows_skipped_empty_quote']??0)+1; continue; }
+                $evidenceText = trim($title . ' ' . $txt);
+                if(!$this->issue($evidenceText)) { $diag['chatter_rows_skipped']++; $diag['chatter_rows_skipped_no_issue_language']=($diag['chatter_rows_skipped_no_issue_language']??0)+1; continue; }
                 $parsed = $this->parse_observed_at($hit);
                 if (empty($parsed['ok'])) { $diag['results_missing_date']++; continue; }
-                if ((int)$parsed['ts'] < $lookbackMinTs) { $diag['results_old_skipped']++; $diag['chatter_old_skipped']++; continue; }
+                if ((int)$parsed['ts'] < $lookbackMinTs) { $diag['results_old_skipped']++; $diag['chatter_old_skipped']++; $diag['chatter_rows_skipped_old']=($diag['chatter_rows_skipped_old']??0)+1; continue; }
                 $diag['usable_results']++;
                 $diag['chatter_recent_results']++;
                 $storyUrl=esc_url_raw((string)($hit['url']??$hit['story_url']??'')); $hnUrl='https://news.ycombinator.com/item?id='.(int)($hit['objectID']??0);
                 $urls=array_values(array_filter([$hnUrl,$storyUrl]));
-                $provider=$this->detect_provider($title.' '.$q);
+                $provider=$this->detect_provider($title.' '.$txt);
                 $isRecentCurrent = ((int)$parsed['ts'] >= $minTs);
                 $message = $isRecentCurrent ? 'Public chatter reports possible user impact.' : 'Recent chatter mentions outage symptoms. Needs corroboration from official/synthetic signals.';
                 $out[]=['source'=>'hacker_news_chatter','source_type'=>'public_chatter','adapter_id'=>'hacker_news_chatter','source_id'=>sanitize_text_field((string)($hit['objectID']??md5($title.$hnUrl))),'provider_id'=>$provider['provider_id'],'provider_name'=>$provider['provider_name'],'category'=>$isRecentCurrent ? 'public_chatter' : 'rumour_radar','region'=>'global','signal_type'=>'public_chatter','severity'=>'watch','confidence'=>$storyUrl?40:25,'title'=>'HN chatter: '.$title,'message'=>$message,'url'=>$hnUrl,'observed_at'=>(string)$parsed['value'],'snippets'=>[$quote],'source_urls'=>$urls,'domains'=>array_values(array_unique(array_filter([wp_parse_url($storyUrl,PHP_URL_HOST),'news.ycombinator.com']))),'confidence_reason'=>'Developer chatter with issue-language match; requires corroboration.','evidence_quality'=>$storyUrl?'moderate':'weak','official_confirmed'=>false,'unconfirmed_note'=>'UNCONFIRMED / RECENT CHATTER','signal_lane'=>'chatter','evidence_platform'=>'Hacker News','evidence_source_label'=>'Hacker News','evidence_quote'=>$quote,'evidence_url'=>$hnUrl,'evidence_urls'=>$urls,'evidence_observed_at'=>(string)$parsed['value']];
                 $diag['rows_stored']++;
                 $diag['rows_attempted']++;
                 $diag['chatter_rows_attempted']++;
-                $diag['chatter_rows_inserted']++;
+                $diag['chatter_rows_output']=($diag['chatter_rows_output']??0)+1;
             }
         }
         update_option('lo_diag_'.$this->id(),$diag,false);

--- a/lousy-outages/includes/Subscribe.php
+++ b/lousy-outages/includes/Subscribe.php
@@ -95,14 +95,13 @@ class Lousy_Outages_Subscribe {
             $lane = sanitize_key((string)($signal['signal_lane'] ?? ''));
             if ($lane === '') { $lane = !empty($signal['official_confirmed']) ? 'official' : 'chatter'; }
             $safeSignals[] = [
-                'provider_id' => (string)($signal['provider_id'] ?? ''),
-                'provider_name' => (string)($signal['provider_name'] ?? ''),
-                'classification' => (string)($signal['classification'] ?? 'quiet'),
+                'provider_id' => sanitize_key((string)($signal['provider_id'] ?? '')),
+                'provider_name' => sanitize_text_field((string)($signal['provider_name'] ?? '')),
+                'classification' => sanitize_key((string)($signal['classification'] ?? 'quiet')),
                 'report_count' => (int)($signal['report_count'] ?? 0),
-                                'region' => (string)($signal['region'] ?? ''),
-                'message' => (string)($signal['message'] ?? ''),
-                'category' => (string)($signal['category'] ?? ''),
-                'region' => (string)($signal['region'] ?? ''),
+                                'region' => sanitize_text_field((string)($signal['region'] ?? '')),
+                'message' => sanitize_text_field((string)($signal['message'] ?? '')),
+                'category' => sanitize_key((string)($signal['category'] ?? '')),
                 'confidence' => (int)($signal['confidence'] ?? 0),
                 'external_signal_count' => (int)($signal['external_signal_count'] ?? 0),
                 'synthetic_failure_count' => (int)($signal['synthetic_failure_count'] ?? 0),
@@ -119,6 +118,8 @@ class Lousy_Outages_Subscribe {
                 'observed_at' => sanitize_text_field((string)($signal['observed_at'] ?? '')),
                 'source_type' => sanitize_key((string)($signal['source_type'] ?? '')),
                 'adapter_id' => sanitize_key((string)($signal['adapter_id'] ?? '')),
+                'evidence_platform' => sanitize_text_field((string)($signal['evidence_platform'] ?? '')),
+                'evidence_observed_at' => sanitize_text_field((string)($signal['evidence_observed_at'] ?? '')),
                 'signal_lane' => $lane,
             ];
         }

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -537,7 +537,9 @@ function render_shortcode(): string {
             <button type="button" class="lo-mode-toggle__button is-active" data-lo-mode="incidents" aria-pressed="true">Incidents (0)</button>
             <button type="button" class="lo-mode-toggle__button" data-lo-mode="all" aria-pressed="false">All providers</button>
         </div>
-        <?php $fused_public = SignalEngine::summarize_fused_signals(120); $fused_public = is_array($fused_public) ? array_values(array_filter($fused_public, static function($r){ $c = strtolower((string)($r['classification'] ?? 'quiet')); return in_array($c,['watch','trending','hot'], true); })) : []; $official_signals=array_values(array_filter($fused_public, static fn($s)=>!empty($s['official_confirmed']) || (($s['signal_lane'] ?? '') === 'official'))); $public_chatter=array_values(array_filter($fused_public, static fn($s)=>(($s['signal_lane'] ?? '') === 'chatter' || empty($s['official_confirmed'])))); ?>
+        <?php $fused_public = SignalEngine::summarize_fused_signals(120); $fused_public = is_array($fused_public) ? array_values(array_filter($fused_public, static function($r){ $c = strtolower((string)($r['classification'] ?? 'quiet')); return in_array($c,['watch','trending','hot'], true); })) : []; $official_signals=array_values(array_filter($fused_public, static fn($s)=>!empty($s['official_confirmed']) || (($s['signal_lane'] ?? '') === 'official'))); // Public chatter must stay quote-backed human/public reports only.
+        // Feed/synthetic/watch telemetry lanes should render in dedicated sections later.
+        $public_chatter=array_values(array_filter($fused_public, static fn($s)=>(($s['signal_lane'] ?? '') === 'chatter'))); ?>
         <section class="lo-signals-panel" data-lo-signals-panel<?php echo $fused_public ? '' : ' hidden'; ?>>
             <div class="lo-section__head">
                 <h3 class="lo-block-title">OFFICIAL STATUS SIGNALS</h3>
@@ -559,7 +561,7 @@ function render_shortcode(): string {
                 <p class="lo-history__meta">Unconfirmed posts from public dev/social channels. Useful smoke, not fire.</p>
             </div>
             <div class="lo-grid">
-            <?php if (!$public_chatter) : ?><p class="lo-history__meta">No fresh field reports found. Official radar only.</p><?php endif; ?>
+            <?php if (!$public_chatter) : ?><p class="lo-history__meta">No fresh field reports intercepted. Official radar only.</p><?php endif; ?>
             <?php foreach (array_slice($public_chatter, 0, 6) as $sig) : $quote = trim((string)($sig['evidence_quote'] ?? '')); $sourceLabel = trim((string)($sig['evidence_source_label'] ?? '')); $sourceUrl = trim((string)($sig['evidence_url'] ?? '')); ?>
                 <article class="lo-card">
                     <div class="lo-head"><h4 class="lo-title"><?php echo esc_html((string)($sig['provider_name'] ?? $sig['provider_id'] ?? 'Provider')); ?></h4><span class="lo-pill">RUMOUR RADAR</span></div>


### PR DESCRIPTION
### Motivation
- Reduce false-positive Hacker News chatter by requiring issue-language to appear in actual result evidence text rather than the search query. 
- Prevent provider feeds, telemetry, and synthetic signals from being misclassified as public chatter while preserving official Statuspage evidence as official. 
- Keep REST and frontend outputs backward-compatible while improving signal sanitization and diagnostics for debugging.

### Description
- HackerNewsChatterSource now checks issue-language only against `title` + comment/story text and uses the comment/story text for provider detection, and it adds explicit diagnostic counters for skipped rows (`no_issue_language`, `empty_quote`, `old`) and switches source-level accounting to `chatter_rows_output` (no in-source inserted count). 
- SignalEngine now preserves `source_type`/`signal_lane` from external rows and applies explicit lane mapping rules: honor `signal_lane` when present, map HN/public to `chatter`, statuspage/official to `official`, provider feed/rss to `feed`, synthetic canary to `synthetic`, and default to `feed` (not chatter). 
- Frontend `shortcode.php` narrows PUBLIC CHATTER / FIELD REPORTS to only render rows where `signal_lane === 'chatter'`, adds comments for future feed/synthetic sections, and updates the empty-state copy to “No fresh field reports intercepted. Official radar only.” 
- REST output hardens sanitization for key string fields (`provider_id`, `provider_name`, `classification`, `region`, `message`, `category`, and evidence fields) while retaining the `signals`, `official_signals`, and `public_chatter` arrays and ensuring `public_chatter` only contains `signal_lane === 'chatter'` items.

### Testing
- Ran `php -l` syntax checks on `lousy-outages/includes/Sources/HackerNewsChatterSource.php`, `lousy-outages/includes/SignalEngine.php`, `lousy-outages/includes/Subscribe.php`, `lousy-outages/public/shortcode.php`, `lousy-outages/scripts/smoke-signal-sources.php`, `lousy-outages/scripts/smoke-intel-source-pack.php`, `lousy-outages/scripts/smoke-external-signal-insert.php`, and `lousy-outages/scripts/smoke-production-preflight.php` and all returned “No syntax errors detected.” 
- Attempted to run smoke scripts end-to-end but the smoke runners require a WordPress bootstrap (`wp-load.php`) path in this environment, so full end-to-end smoke execution was not performed here (scripts exited with usage message). 
- Local static checks and the included smoke script invocation attempts completed without producing emails or other side effects.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97283384c832e8ea5a89e4c792555)