### PR TITLE
Fix public chatter lane propagation and tighten HN outage relevance

### DIFF
--- a/lousy-outages/includes/SignalEngine.php
+++ b/lousy-outages/includes/SignalEngine.php
@@ -93,17 +93,22 @@ class SignalEngine {
             $urls=array_slice(array_keys($b['source_urls']),0,6);
             $sourceType=(string)($b['source_type'] ?? '');
             $source=(string)($b['sources'][0] ?? 'external');
+            $adapterIds = (array)($b['adapter_ids'] ?? []);
             $rowLane = sanitize_key((string)($b['signal_lane'] ?? ''));
+            $hasOfficialSource = !empty($b['official_confirmed']) || in_array('statuspage', $adapterIds, true) || in_array('official_status', $adapterIds, true) || in_array('statuspage', (array)$b['sources'], true) || $sourceType === 'official_status';
+            $hasChatterSource = $sourceType === 'public_chatter' || $source === 'hacker_news_chatter' || in_array('hacker_news_chatter', (array)$b['sources'], true) || in_array('hacker_news_chatter', $adapterIds, true);
             if ($rowLane !== '') {
                 $lane = $rowLane;
-            } elseif ($sourceType === 'public_chatter' || $source === 'hacker_news_chatter') {
-                $lane = 'chatter';
-            } elseif (!empty($b['official_confirmed']) || $source === 'statuspage' || $sourceType === 'official_status') {
+            } elseif ($hasOfficialSource) {
                 $lane = 'official';
+            } elseif ($hasChatterSource) {
+                $lane = 'chatter';
             } elseif ($sourceType === 'provider_rss' || $source === 'provider_feed') {
                 $lane = 'feed';
-            } elseif ($source === 'synthetic_canary') {
+            } elseif ($source === 'synthetic_canary' || in_array('synthetic_canary', (array)$b['sources'], true)) {
                 $lane = 'synthetic';
+            } elseif ($sourceType === 'public_chatter' || $source === 'hacker_news_chatter') {
+                $lane = 'chatter';
             } else {
                 $lane = 'feed';
             }

--- a/lousy-outages/includes/Sources/HackerNewsChatterSource.php
+++ b/lousy-outages/includes/Sources/HackerNewsChatterSource.php
@@ -8,24 +8,53 @@ class HackerNewsChatterSource implements SignalSourceInterface {
     public function id(): string { return 'hacker_news_chatter'; }
     public function label(): string { return 'Hacker News Chatter'; }
     public function is_configured(): bool { return SourcePack::enabled() && (bool) apply_filters('lo_hn_chatter_enabled', get_option('lo_hn_chatter_enabled', '1') === '1'); }
-    private function issue(string $t): bool { return (bool) preg_match('/\b(outage|down|incident|degrad|latency|error|unavailable|disruption)\b/i',$t); }
-    private function detect_provider(string $text): array {
-        $map=[
-            ['/(github actions|github)/i','github','GitHub','developer_tooling'],
-            ['/(\bnpm\b)/i','npm','npm','package_registry'],
-            ['/(docker hub|docker pull|\bdocker\b)/i','docker','Docker','package_registry'],
-            ['/(cloudflare|workers)/i','cloudflare','Cloudflare','dns_cdn'],
-            ['/(openai|chatgpt)/i','openai','OpenAI','ai_api'],
-            ['/(vercel)/i','vercel','Vercel','developer_tooling'],
-            ['/(netlify)/i','netlify','Netlify','developer_tooling'],
-            ['/(\baws\b)/i','aws','AWS','cloud_api'],
-            ['/(azure|entra)/i','azure','Azure','cloud_identity'],
-            ['/(google cloud|\bgcp\b)/i','google_cloud','Google Cloud','cloud_api'],
-            ['/(interac|e-?transfer)/i','interac','Interac','canadian_payments'],
-            ['/(rogers|shaw|telus|bell|freedom)/i','canadian_telecom','Canadian Telecom','canadian_telecom'],
+    private function issue(string $t): bool {
+        return (bool) preg_match('/\b(outage|is down|down\b|incident|degrad(?:ed|ing)?|latency(?: spike)?|errors?|failing|failed|not working|unavailable|disruption|returning 5\d\d|stuck)\b/i', $t);
+    }
+    private function provider_aliases(): array {
+        return [
+            'github' => ['name'=>'GitHub','category'=>'developer_tooling','aliases'=>['github','github actions']],
+            'npm' => ['name'=>'npm','category'=>'package_registry','aliases'=>['npm','npmjs']],
+            'docker' => ['name'=>'Docker','category'=>'package_registry','aliases'=>['docker','docker hub','docker pull']],
+            'cloudflare' => ['name'=>'Cloudflare','category'=>'dns_cdn','aliases'=>['cloudflare','cloudflare workers','workers']],
+            'openai' => ['name'=>'OpenAI','category'=>'ai_api','aliases'=>['openai','chatgpt','openai api']],
+            'vercel' => ['name'=>'Vercel','category'=>'developer_tooling','aliases'=>['vercel']],
+            'netlify' => ['name'=>'Netlify','category'=>'developer_tooling','aliases'=>['netlify']],
+            'aws' => ['name'=>'AWS','category'=>'cloud_api','aliases'=>['aws','amazon web services']],
+            'azure' => ['name'=>'Azure','category'=>'cloud_identity','aliases'=>['azure','entra']],
+            'google_cloud' => ['name'=>'Google Cloud','category'=>'cloud_api','aliases'=>['google cloud','gcp']],
+            'interac' => ['name'=>'Interac','category'=>'canadian_payments','aliases'=>['interac','e-transfer','etransfer']],
+            'canadian_telecom' => ['name'=>'Canadian Telecom','category'=>'canadian_telecom','aliases'=>['rogers','shaw','telus','bell','freedom']],
         ];
-        foreach($map as $row){ if(preg_match($row[0],$text)){ return ['provider_id'=>$row[1],'provider_name'=>$row[2],'category'=>$row[3]]; }}
-        return ['provider_id'=>'','provider_name'=>'Tech Pulse','category'=>'public_chatter'];
+    }
+    private function detect_provider_from_evidence(string $evidenceText): array {
+        foreach ($this->provider_aliases() as $id => $meta) {
+            foreach ((array)($meta['aliases'] ?? []) as $alias) {
+                if ((bool) preg_match('/\b' . preg_quote((string) $alias, '/') . '\b/i', $evidenceText)) {
+                    return ['provider_id'=>$id,'provider_name'=>(string)$meta['name'],'category'=>(string)$meta['category'],'aliases'=>(array)$meta['aliases']];
+                }
+            }
+        }
+        return ['provider_id'=>'','provider_name'=>'','category'=>'public_chatter','aliases'=>[]];
+    }
+    private function has_outage_phrase_near_provider(string $evidenceText, array $providerAliases): bool {
+        if ($providerAliases === []) { return false; }
+        $issuePattern = '(?:outage|incident|degraded|degrading|latency(?: spike)?|errors?|failing|failed|not working|unavailable|stuck|returning 5\d\d|is down|down)';
+        foreach ($providerAliases as $alias) {
+            $aliasPattern = preg_quote((string)$alias, '/');
+            if ((bool) preg_match('/\b' . $aliasPattern . '\b(?:.{0,50})\b' . $issuePattern . '\b/iu', $evidenceText)) { return true; }
+            if ((bool) preg_match('/\b' . $issuePattern . '\b(?:.{0,50})\b' . $aliasPattern . '\b/iu', $evidenceText)) { return true; }
+        }
+        return false;
+    }
+    private function is_generic_noise(string $evidenceText): bool {
+        return (bool) preg_match('/\b(down\s+\d+%|traffic is down|killing your vibe|port(ed|ing).+rust|job postings|rebuilt my blog|cache|welcome to gas city|pricing)\b/i', $evidenceText);
+    }
+    private function clean_quote(string $text): string {
+        $decoded = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $stripped = wp_strip_all_tags($decoded);
+        $normalized = trim((string) preg_replace('/\s+/u', ' ', $stripped));
+        return sanitize_text_field(mb_substr($normalized, 0, 180));
     }
     private function should_skip_budget_mutation(array $options): bool {
         return !empty($options['dry_run']) || !empty($options['preflight']) || !empty($options['suppress_notifications']) || !empty($options['no_email']);
@@ -49,7 +78,7 @@ class HackerNewsChatterSource implements SignalSourceInterface {
         $minTs = time() - ($windowMinutes * 60);
         $lookbackMinTs = time() - ($lookbackHours * HOUR_IN_SECONDS);
         $skipBudgetMutation = $this->should_skip_budget_mutation($options);
-        $diag=['configured'=>true,'attempted'=>false,'queries_available'=>count($queries),'queries_attempted'=>0,'queries_skipped_budget'=>0,'raw_results_seen'=>0,'usable_results'=>0,'rows_stored'=>0,'rows_attempted'=>0,'results_old_skipped'=>0,'results_missing_date'=>0,'rows_inserted'=>null,'skipped_reasons'=>[],'cooldown_active'=>false,'chatter_queries_attempted'=>0,'chatter_raw_results_seen'=>0,'chatter_recent_results'=>0,'chatter_old_skipped'=>0,'chatter_rows_attempted'=>0,'chatter_rows_output'=>0,'chatter_rows_skipped'=>0,'chatter_rows_skipped_no_issue_language'=>0,'chatter_rows_skipped_empty_quote'=>0,'chatter_rows_skipped_old'=>0,'chatter_sources_enabled'=>['hacker_news'],'chatter_sources_disabled'=>[],'first_chatter_error'=>''];
+        $diag=['configured'=>true,'attempted'=>false,'queries_available'=>count($queries),'queries_attempted'=>0,'queries_skipped_budget'=>0,'raw_results_seen'=>0,'usable_results'=>0,'rows_stored'=>0,'rows_attempted'=>0,'results_old_skipped'=>0,'results_missing_date'=>0,'rows_inserted'=>null,'skipped_reasons'=>[],'cooldown_active'=>false,'chatter_queries_attempted'=>0,'chatter_raw_results_seen'=>0,'chatter_recent_results'=>0,'chatter_old_skipped'=>0,'chatter_rows_attempted'=>0,'chatter_rows_output'=>0,'chatter_rows_skipped'=>0,'chatter_rows_skipped_no_issue_language'=>0,'chatter_rows_skipped_empty_quote'=>0,'chatter_rows_skipped_old'=>0,'chatter_rows_skipped_no_provider_match'=>0,'chatter_rows_skipped_weak_issue_language'=>0,'chatter_rows_skipped_generic_noise'=>0,'chatter_sources_enabled'=>['hacker_news'],'chatter_sources_disabled'=>[],'first_chatter_error'=>''];
         $out=[];
         foreach($take as $q){
             $budget=['ok'=>true];
@@ -70,11 +99,17 @@ class HackerNewsChatterSource implements SignalSourceInterface {
             $diag['raw_results_seen']+=count($hits);
             $diag['chatter_raw_results_seen']+=count($hits);
             foreach(array_slice($hits,0,10) as $hit){
-                $title=sanitize_text_field((string)($hit['title']??$hit['story_title']??'')); $txt=wp_strip_all_tags((string)($hit['comment_text']??''));
-                $quote = sanitize_text_field(substr(trim($txt !== '' ? $txt : $title), 0, 180));
+                $diag['chatter_rows_attempted']=($diag['chatter_rows_attempted']??0)+1;
+                $title=$this->clean_quote((string)($hit['title']??$hit['story_title']??''));
+                $txt=$this->clean_quote((string)($hit['comment_text']??''));
+                $quote = $this->clean_quote(trim($txt !== '' ? $txt : $title));
                 if($quote==='') { $diag['chatter_rows_skipped']++; $diag['chatter_rows_skipped_empty_quote']=($diag['chatter_rows_skipped_empty_quote']??0)+1; continue; }
                 $evidenceText = trim($title . ' ' . $txt);
+                if($this->is_generic_noise($evidenceText)) { $diag['chatter_rows_skipped']++; $diag['chatter_rows_skipped_generic_noise']=($diag['chatter_rows_skipped_generic_noise']??0)+1; $this->maybe_log_rejection($options, $quote, 'generic_noise'); continue; }
                 if(!$this->issue($evidenceText)) { $diag['chatter_rows_skipped']++; $diag['chatter_rows_skipped_no_issue_language']=($diag['chatter_rows_skipped_no_issue_language']??0)+1; continue; }
+                $provider=$this->detect_provider_from_evidence($evidenceText);
+                if(empty($provider['provider_id'])) { $diag['chatter_rows_skipped']++; $diag['chatter_rows_skipped_no_provider_match']=($diag['chatter_rows_skipped_no_provider_match']??0)+1; $this->maybe_log_rejection($options, $quote, 'no_provider_match'); continue; }
+                if(!$this->has_outage_phrase_near_provider($evidenceText, (array)($provider['aliases'] ?? []))) { $diag['chatter_rows_skipped']++; $diag['chatter_rows_skipped_weak_issue_language']=($diag['chatter_rows_skipped_weak_issue_language']??0)+1; $this->maybe_log_rejection($options, $quote, 'weak_issue_language'); continue; }
                 $parsed = $this->parse_observed_at($hit);
                 if (empty($parsed['ok'])) { $diag['results_missing_date']++; continue; }
                 if ((int)$parsed['ts'] < $lookbackMinTs) { $diag['results_old_skipped']++; $diag['chatter_old_skipped']++; $diag['chatter_rows_skipped_old']=($diag['chatter_rows_skipped_old']??0)+1; continue; }
@@ -82,17 +117,19 @@ class HackerNewsChatterSource implements SignalSourceInterface {
                 $diag['chatter_recent_results']++;
                 $storyUrl=esc_url_raw((string)($hit['url']??$hit['story_url']??'')); $hnUrl='https://news.ycombinator.com/item?id='.(int)($hit['objectID']??0);
                 $urls=array_values(array_filter([$hnUrl,$storyUrl]));
-                $provider=$this->detect_provider($title.' '.$txt);
                 $isRecentCurrent = ((int)$parsed['ts'] >= $minTs);
                 $message = $isRecentCurrent ? 'Public chatter reports possible user impact.' : 'Recent chatter mentions outage symptoms. Needs corroboration from official/synthetic signals.';
                 $out[]=['source'=>'hacker_news_chatter','source_type'=>'public_chatter','adapter_id'=>'hacker_news_chatter','source_id'=>sanitize_text_field((string)($hit['objectID']??md5($title.$hnUrl))),'provider_id'=>$provider['provider_id'],'provider_name'=>$provider['provider_name'],'category'=>$isRecentCurrent ? 'public_chatter' : 'rumour_radar','region'=>'global','signal_type'=>'public_chatter','severity'=>'watch','confidence'=>$storyUrl?40:25,'title'=>'HN chatter: '.$title,'message'=>$message,'url'=>$hnUrl,'observed_at'=>(string)$parsed['value'],'snippets'=>[$quote],'source_urls'=>$urls,'domains'=>array_values(array_unique(array_filter([wp_parse_url($storyUrl,PHP_URL_HOST),'news.ycombinator.com']))),'confidence_reason'=>'Developer chatter with issue-language match; requires corroboration.','evidence_quality'=>$storyUrl?'moderate':'weak','official_confirmed'=>false,'unconfirmed_note'=>'UNCONFIRMED / RECENT CHATTER','signal_lane'=>'chatter','evidence_platform'=>'Hacker News','evidence_source_label'=>'Hacker News','evidence_quote'=>$quote,'evidence_url'=>$hnUrl,'evidence_urls'=>$urls,'evidence_observed_at'=>(string)$parsed['value']];
                 $diag['rows_stored']++;
                 $diag['rows_attempted']++;
-                $diag['chatter_rows_attempted']++;
                 $diag['chatter_rows_output']=($diag['chatter_rows_output']??0)+1;
             }
         }
         update_option('lo_diag_'.$this->id(),$diag,false);
         return $out;
+    }
+    private function maybe_log_rejection(array $options, string $quote, string $reason): void {
+        if (empty($options['dry_run']) || empty($options['diagnostic_mode'])) { return; }
+        error_log(sprintf('[HN chatter dry-run] skipped=%s quote="%s"', $reason, $quote));
     }
 }


### PR DESCRIPTION
### Motivation
- Signal buckets were producing blank `signal_lane` for Hacker News / public chatter rows which prevented HN chatter from appearing in PUBLIC CHATTER / FIELD REPORTS. 
- Hacker News chatter was noisy and often matched query terms rather than true outage evidence, producing many false positives. 
- Need safe defaults that preserve official/statuspage precedence and keep feeds/synthetic rows mapped appropriately while tightening HN relevance.

### Description
- Ensure fused buckets with HN/public chatter are classified as `signal_lane=chatter` when appropriate and preserve official/statuspage precedence, `feed` for provider RSS, and `synthetic` for synthetic checks by updating `SignalEngine` lane resolution logic in `lousy-outages/includes/SignalEngine.php`.
- Harden `HackerNewsChatterSource` in `lousy-outages/includes/Sources/HackerNewsChatterSource.php` by replacing the loose `issue()` regex with a stricter outage-language pattern and adding `provider_aliases()`, `detect_provider_from_evidence()`, `has_outage_phrase_near_provider()`, `is_generic_noise()`, and `clean_quote()` helpers to require provider-specific outage language in the actual evidence text.
- Remove fallback assignment of a generic provider for weak chatter and skip generic/noisy posts (e.g., job posts, blog cache, metaphorical "DDOSing", porting to Rust), and add `maybe_log_rejection()` to optionally emit dry-run diagnostic messages without inserting rows or sending email.
- Improve evidence handling by decoding HTML entities, stripping tags, normalizing whitespace, and capping evidence snippets to ~180 characters so public output no longer contains encoded entities (e.g., `You&#x27;re` -> `You're`), and expand diagnostics counters to include `chatter_rows_skipped_no_provider_match`, `chatter_rows_skipped_weak_issue_language`, `chatter_rows_skipped_generic_noise`, `chatter_rows_output`, and `chatter_rows_attempted`.

### Testing
- Ran syntax checks with `php -l` on `lousy-outages/includes/Sources/HackerNewsChatterSource.php`, `lousy-outages/includes/SignalEngine.php`, `lousy-outages/includes/Subscribe.php`, `lousy-outages/public/shortcode.php`, `lousy-outages/scripts/smoke-signal-sources.php`, `lousy-outages/scripts/smoke-intel-source-pack.php`, `lousy-outages/scripts/smoke-external-signal-insert.php`, and `lousy-outages/scripts/smoke-production-preflight.php` and all returned no syntax errors. 
- Smoke scripts and preflight lint targets were verified as part of the validation step and reported no issues on syntax checks. 
- Diagnostic counters and optional dry-run logging were added to facilitate further runtime validation in staging without sending emails or inserting rows during preflight/dry-run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f977f1f13c832e9d9c28446e077688)