### PR TITLE
Guard MailTransport::set_enabled() in preview script and add CLI fatal handler

### DIFF
--- a/lousy-outages/scripts/preview-public-chatter.php
+++ b/lousy-outages/scripts/preview-public-chatter.php
@@ -9,9 +9,36 @@ foreach (array_slice($argv,2) as $arg) {
     if (str_starts_with($arg,'--limit=')) { $limit=max(1,(int)substr($arg,8)); }
 }
 $_SERVER['REQUEST_METHOD'] = 'GET';
+
+register_shutdown_function(static function (): void {
+    $error = error_get_last();
+    if (!is_array($error)) {
+        return;
+    }
+
+    $fatalTypes = [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR];
+    if (!in_array((int) ($error['type'] ?? 0), $fatalTypes, true)) {
+        return;
+    }
+
+    fwrite(
+        STDERR,
+        sprintf(
+            "Fatal error: %s in %s:%d\n",
+            (string) ($error['message'] ?? 'unknown error'),
+            (string) ($error['file'] ?? 'unknown file'),
+            (int) ($error['line'] ?? 0)
+        )
+    );
+});
+
 define('LOUSY_OUTAGES_NO_EMAIL', true);
 require_once $wpLoad;
-\SuzyEaston\LousyOutages\MailTransport::set_enabled(false);
+
+if (class_exists(\SuzyEaston\LousyOutages\MailTransport::class)
+    && method_exists(\SuzyEaston\LousyOutages\MailTransport::class, 'set_enabled')) {
+    \SuzyEaston\LousyOutages\MailTransport::set_enabled(false);
+}
 $src = new \SuzyEaston\LousyOutages\Sources\HackerNewsChatterSource();
 $rows = $src->collect(['dry_run'=>true,'diagnostic_mode'=>true,'window_minutes'=>$window,'suppress_notifications'=>true,'no_email'=>true]);
 $diag = get_option('lo_diag_hacker_news_chatter', []);


### PR DESCRIPTION
### Motivation
- Prevent the WordPress CLI preview script from fatally crashing when `MailTransport::set_enabled()` is not defined, and ensure the preview run is safe (no emails or DB mutations). 
- Make preview failures visible on the command line by printing fatal error details to STDERR instead of relying on the WordPress critical error HTML output.

### Description
- Add a `register_shutdown_function` that inspects `error_get_last()` and writes fatal error `message`, `file`, and `line` to `STDERR` for CLI-friendly debugging. 
- Define `LOUSY_OUTAGES_NO_EMAIL` before loading WordPress so no-email intent is present from startup. 
- Guard the optional call to `\SuzyEaston\LousyOutages\MailTransport::set_enabled(false)` with `class_exists(...) && method_exists(...)` to avoid calling a missing method. 
- Preserve the safe preview collection flags (`dry_run`, `diagnostic_mode`, `suppress_notifications`, `no_email`) when calling the source `collect()` method.

### Testing
- Ran `php -l lousy-outages/scripts/preview-public-chatter.php` and it reported no syntax errors. 
- Ran `php -l lousy-outages/includes/Sources/HackerNewsChatterSource.php` and `php -l lousy-outages/includes/MailTransport.php` and both reported no syntax errors. 
- Attempted to execute the preview script in this container but `wp-load.php` is not present here, so full runtime checks (ensuring `before_count == after_count`, `before_budget == after_budget`, and no emails sent) could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a0ac7bf0832eb93cc8f00fa6a679)