### PR TITLE
Add human-friendly public-chatter rejection reason map and expose diagnostics

### DIFF
--- a/lousy-outages/includes/Api.php
+++ b/lousy-outages/includes/Api.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace SuzyEaston\LousyOutages;
 
 use SuzyEaston\LousyOutages\Storage\IncidentStore;
+use SuzyEaston\LousyOutages\Sources\ChatterRejectionReasons;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -412,6 +413,20 @@ class Api {
             if (!empty($errors)) {
                 $payload['errors'] = $errors;
             }
+            $diag = (array) get_option('lo_diag_hacker_news_chatter', []);
+            $reasonCounts = (array) ($diag['chatter_rejected_by_reason'] ?? []);
+            if ($reasonCounts === [] && !empty($diag['chatter_candidates_preview_sample']) && is_array($diag['chatter_candidates_preview_sample'])) {
+                foreach ((array) $diag['chatter_candidates_preview_sample'] as $item) {
+                    $reason = (string) ($item['reject_reason'] ?? '');
+                    if ($reason === '' || $reason === 'accepted') { continue; }
+                    $reasonCounts[$reason] = (int) ($reasonCounts[$reason] ?? 0) + 1;
+                }
+            }
+            $payload['public_chatter_diagnostics'] = [
+                'rejected_by_reason' => ChatterRejectionReasons::summarize_counts($reasonCounts),
+                'reason_definitions' => array_values(ChatterRejectionReasons::definitions()),
+                'raw_rejected_codes' => $reasonCounts,
+            ];
         }
 
         $json = wp_json_encode($payload);

--- a/lousy-outages/includes/Sources/ChatterRejectionReasons.php
+++ b/lousy-outages/includes/Sources/ChatterRejectionReasons.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages\Sources;
+
+class ChatterRejectionReasons {
+    public static function definitions(): array {
+        return [
+            'resolved_or_historical' => [
+                'code' => 'resolved_or_historical',
+                'short_label' => 'Historical or resolved',
+                'public_description' => 'Old incident, status-page history, postmortem, or discussion about past availability. Not current smoke.',
+                'priority' => 90,
+            ],
+            'quote_missing_provider_or_failure' => [
+                'code' => 'quote_missing_provider_or_failure',
+                'short_label' => 'Not actionable',
+                'public_description' => 'The quote does not contain both a tracked provider and a concrete failure symptom close together.',
+                'priority' => 80,
+            ],
+            'quote_missing_provider' => [
+                'code' => 'quote_missing_provider',
+                'short_label' => 'Missing provider',
+                'public_description' => 'The quote has failure language but no tracked provider.',
+                'priority' => 70,
+            ],
+            'quote_missing_failure' => [
+                'code' => 'quote_missing_failure',
+                'short_label' => 'Missing failure symptom',
+                'public_description' => 'The quote names a provider but does not describe a concrete service problem.',
+                'priority' => 70,
+            ],
+            'negated_issue' => [
+                'code' => 'negated_issue',
+                'short_label' => 'Negated report',
+                'public_description' => 'The quote says there is not an issue, e.g. “not down,” “no outage,” or “haven’t seen any outage.”',
+                'priority' => 95,
+            ],
+            'generic_noise' => [
+                'code' => 'generic_noise',
+                'short_label' => 'Generic noise',
+                'public_description' => 'Business, pricing, job, AI, or general tech chatter without current service impact.',
+                'priority' => 60,
+            ],
+        ];
+    }
+
+    public static function get(string $code): array {
+        $all = self::definitions();
+        return $all[$code] ?? [
+            'code' => $code,
+            'short_label' => ucwords(str_replace('_', ' ', $code)),
+            'public_description' => 'Filtered chatter that did not meet current-signal quality checks.',
+            'priority' => 10,
+        ];
+    }
+
+    public static function summarize_counts(array $counts): array {
+        $rows = [];
+        foreach ($counts as $code => $count) {
+            if (!is_string($code) || $code === '' || (int) $count <= 0) {
+                continue;
+            }
+            $meta = self::get($code);
+            $rows[] = [
+                'code' => $meta['code'],
+                'count' => (int) $count,
+                'label' => $meta['short_label'],
+                'description' => $meta['public_description'],
+                'priority' => (int) ($meta['priority'] ?? 0),
+            ];
+        }
+        usort($rows, static fn(array $a, array $b): int => ((int) $b['count'] <=> (int) $a['count']) ?: ((int) $b['priority'] <=> (int) $a['priority']));
+        return $rows;
+    }
+}

--- a/lousy-outages/includes/Sources/HackerNewsChatterSource.php
+++ b/lousy-outages/includes/Sources/HackerNewsChatterSource.php
@@ -191,7 +191,8 @@ class HackerNewsChatterSource implements SignalSourceInterface {
                         $diag['chatter_rows_skipped_quote_missing_failure']++;
                     }
                     $diag['chatter_rows_skipped']++; $diag['chatter_rows_skipped_weak_issue_language']=($diag['chatter_rows_skipped_weak_issue_language']??0)+1;
-                    $diag['chatter_candidates_preview_sample'][] = ['title'=>$title,'quote'=>$quote,'source'=>'hacker_news','reject_reason'=>'quote_missing_provider_or_failure','provider'=>(string)($provider['provider_name'] ?? ''),'category'=>(string)($provider['category'] ?? ''),'source_url'=>(string)('https://news.ycombinator.com/item?id='.(int)($hit['objectID']??0))];
+                    $rejectReason = $diag['chatter_rows_skipped_quote_missing_provider'] > $diag['chatter_rows_skipped_quote_missing_failure'] ? 'quote_missing_provider' : 'quote_missing_failure';
+                    $diag['chatter_candidates_preview_sample'][] = ['title'=>$title,'quote'=>$quote,'source'=>'hacker_news','reject_reason'=>'quote_missing_provider_or_failure','sub_reason'=>$rejectReason,'provider'=>(string)($provider['provider_name'] ?? ''),'category'=>(string)($provider['category'] ?? ''),'source_url'=>(string)('https://news.ycombinator.com/item?id='.(int)($hit['objectID']??0))];
                     continue;
                 }
                 $parsed = $this->parse_observed_at($hit);
@@ -212,6 +213,13 @@ class HackerNewsChatterSource implements SignalSourceInterface {
             }
         }
         $diag['chatter_candidates_preview_sample'] = array_slice($diag['chatter_candidates_preview_sample'], 0, 30);
+        $reasonCounts = [];
+        foreach ((array) $diag['chatter_candidates_preview_sample'] as $sample) {
+            $reason = (string) ($sample['reject_reason'] ?? '');
+            if ($reason === '' || $reason === 'accepted') { continue; }
+            $reasonCounts[$reason] = (int) ($reasonCounts[$reason] ?? 0) + 1;
+        }
+        $diag['chatter_rejected_by_reason'] = $reasonCounts;
         $out = $this->limit_output($out);
         update_option('lo_diag_'.$this->id(),$diag,false);
         return $out;

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -88,6 +88,7 @@ lousy_outages_require( 'includes/SignalSourceInterface.php' );
 lousy_outages_require( 'includes/ExternalSignals.php' );
 lousy_outages_require( 'includes/Sources/SourcePack.php' );
 lousy_outages_require( 'includes/Sources/SourceBudgetManager.php' );
+lousy_outages_require( 'includes/Sources/ChatterRejectionReasons.php' );
 lousy_outages_require( 'includes/Sources/StatuspageIntelSource.php' );
 lousy_outages_require( 'includes/Sources/ProviderFeedSource.php' );
 lousy_outages_require( 'includes/Sources/HackerNewsChatterSource.php' );

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -561,7 +561,17 @@ function render_shortcode(): string {
                 <p class="lo-history__meta">Unconfirmed posts from public dev/social channels. Useful smoke, not fire.</p>
             </div>
             <div class="lo-grid">
-            <?php if (!$public_chatter) : ?><p class="lo-history__meta">No fresh field reports intercepted. Official radar only.</p><?php endif; ?>
+            <?php if (!$public_chatter) : ?>
+                <p class="lo-history__meta">No fresh field reports intercepted. Official radar only.</p>
+                <?php $hnDiag = (array) get_option('lo_diag_hacker_news_chatter', []); $rejectSummary = \SuzyEaston\LousyOutages\Sources\ChatterRejectionReasons::summarize_counts((array)($hnDiag['chatter_rejected_by_reason'] ?? [])); ?>
+                <?php if (!empty($rejectSummary)) : ?><div class="lo-history__meta"><strong>Filtered chatter:</strong>
+                    <ul>
+                    <?php foreach (array_slice($rejectSummary, 0, 5) as $reasonRow) : ?>
+                        <li><?php echo esc_html((string)($reasonRow['count'] ?? 0) . ' ' . (string)($reasonRow['label'] ?? '')); ?> — <?php echo esc_html((string)($reasonRow['description'] ?? '')); ?></li>
+                    <?php endforeach; ?>
+                    </ul>
+                </div><?php endif; ?>
+            <?php endif; ?>
             <?php foreach (array_slice($public_chatter, 0, 6) as $sig) : $quote = trim((string)($sig['evidence_quote'] ?? '')); $sourceLabel = trim((string)($sig['evidence_source_label'] ?? '')); $sourceUrl = trim((string)($sig['evidence_url'] ?? '')); ?>
                 <article class="lo-card">
                     <div class="lo-head"><h4 class="lo-title"><?php echo esc_html((string)($sig['provider_name'] ?? $sig['provider_id'] ?? 'Provider')); ?></h4><span class="lo-pill">RUMOUR RADAR</span></div>

--- a/lousy-outages/scripts/preview-public-chatter.php
+++ b/lousy-outages/scripts/preview-public-chatter.php
@@ -57,7 +57,10 @@ foreach ($accepted as $p) {
 }
 echo "\nRejected candidates: " . count($rejected) . "\n";
 foreach ($rejected as $p) {
-    echo "[REJECT] reason=" . ($p['reject_reason'] ?? '') .
+    $reason = (string) ($p['reject_reason'] ?? '');
+    $reasonMeta = \SuzyEaston\LousyOutages\Sources\ChatterRejectionReasons::get($reason);
+    echo "[REJECT] reason=" . $reason .
+        " label=\"" . ($reasonMeta['short_label'] ?? '') . "\"" .
         " provider=" . ($p['provider'] ?? '') .
         " category=" . ($p['category'] ?? '') .
         " quote=\"" . substr((string)($p['quote'] ?? ''), 0, 160) . "\"" .


### PR DESCRIPTION
### Motivation
- Make public-chatter rejection reasons understandable to normal users while preserving machine-readable codes for debugging and automation.
- Surface summarized reject counts and human labels in preview, REST, and the public UI so visitors and operators can see why chatter was filtered.

### Description
- Add `ChatterRejectionReasons` helper at `lousy-outages/includes/Sources/ChatterRejectionReasons.php` with `code`, `short_label`, `public_description`, and `priority` for each reason (including the requested reasons).
- Load the helper in the top-level plugin bootstrap (`lousy-outages/lousy-outages.php`) without modifying `plugins/lousy-outages`.
- Update `HackerNewsChatterSource` to record a `sub_reason` for provider/failure splits and to compute `chatter_rejected_by_reason` counts saved in diagnostics.
- Update `scripts/preview-public-chatter.php` to print both the machine `reason` and the human `label` (e.g. `reason=resolved_or_historical label="Historical or resolved"`).
- Extend REST `/summary` (`Api::handle_summary`) to include `public_chatter_diagnostics` with `rejected_by_reason` (code/count/label/description/priority), `reason_definitions`, and `raw_rejected_codes` for debugging.
- Update public UI empty state in `public/shortcode.php` to show a compact filtered-chatter breakdown (count + label + short description) while leaving accepted chatter cards unchanged.
- Preserve preview safety: dry-run/no-email flags and transport disabling remain in place and no inserts or budget mutations occur during preview.

### Testing
- Ran `php -l` over the modified PHP files and there were no syntax errors reported.
- Ran `php lousy-outages/scripts/smoke-intel-source-pack.php` and it returned `ok`.
- Attempted `php lousy-outages/scripts/smoke-production-preflight.php` in this environment which printed usage because it requires a `WP` bootstrap path (`/path/to/wp-load.php`), which is expected in a non-WP test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a43c8318832ea0fda2fe666f9dc0)