### PR TITLE
Polish public chatter scanner

### DIFF
--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -1700,3 +1700,210 @@
 .lo-signals-panel .lo-pill{flex-shrink:0;white-space:nowrap;font-size:10px;padding:3px 7px}
 .lo-signals-panel .lo-message,.lo-signals-panel .lo-summary,.lo-signals-panel .lo-card-meta{font-size:12px;line-height:1.4}
 .lo-evidence-quote{font-size:12px;line-height:1.45;border-left:2px solid currentColor;padding-left:8px;margin:8px 0}
+
+/* Public chatter scanner: intentional quiet-state diagnostics for conservative field-report filtering. */
+.lo-chatter-scanner {
+  margin: 16px 0 18px;
+  padding: 14px;
+  border: 1px solid rgba(138, 247, 228, 0.55);
+  border-radius: 14px;
+  background:
+    linear-gradient(180deg, rgba(10, 16, 32, 0.92), rgba(5, 9, 19, 0.88)),
+    repeating-linear-gradient(0deg, rgba(138, 247, 228, 0.04) 0, rgba(138, 247, 228, 0.04) 1px, transparent 1px, transparent 8px);
+  box-shadow:
+    0 14px 30px rgba(0, 0, 0, 0.34),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.04),
+    inset 0 0 24px rgba(138, 247, 228, 0.05);
+  position: relative;
+  overflow: hidden;
+}
+
+.lo-chatter-scanner::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(90deg, transparent, rgba(138, 247, 228, 0.12), transparent);
+  transform: translateX(-100%);
+  animation: lo-chatter-sweep 7s linear infinite;
+}
+
+@keyframes lo-chatter-sweep {
+  0% { transform: translateX(-100%); opacity: 0; }
+  20% { opacity: 0.35; }
+  55% { opacity: 0.12; }
+  100% { transform: translateX(100%); opacity: 0; }
+}
+
+.lo-chatter-scanner__head,
+.lo-chatter-scanner__stats,
+.lo-chatter-scanner__empty,
+.lo-chatter-scanner__reasons,
+.lo-chatter-scanner__cards {
+  position: relative;
+  z-index: 1;
+}
+
+.lo-chatter-scanner__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.lo-chatter-scanner__status {
+  flex-shrink: 0;
+  border: 1px dashed rgba(255, 184, 28, 0.75);
+  border-radius: 999px;
+  padding: 5px 9px;
+  color: #ffecc7;
+  background: rgba(255, 184, 28, 0.08);
+  font-size: 0.68rem;
+  line-height: 1.1;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.lo-chatter-scanner__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(128px, 1fr));
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.lo-chatter-scanner__stat {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  min-height: 38px;
+  padding: 8px 10px;
+  border: 1px solid rgba(138, 247, 228, 0.28);
+  border-radius: 10px;
+  background: rgba(18, 28, 51, 0.72);
+  color: var(--lo-muted);
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.lo-chatter-scanner__stat strong {
+  color: var(--lo-accent);
+  font-size: 1rem;
+  text-shadow: 0 0 8px rgba(138, 247, 228, 0.35);
+}
+
+.lo-chatter-scanner__empty {
+  padding: 12px;
+  border: 1px solid rgba(244, 154, 229, 0.32);
+  border-radius: 12px;
+  background: rgba(244, 154, 229, 0.08);
+}
+
+.lo-chatter-scanner__empty h4 {
+  margin: 0 0 6px;
+  color: var(--lo-accent);
+  font-size: 0.95rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.lo-chatter-scanner__empty p {
+  margin: 0;
+  color: var(--lo-muted);
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+.lo-chatter-scanner__reasons {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.lo-chatter-scanner__reason {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 4px 10px;
+  padding: 9px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.22);
+}
+
+.lo-chatter-scanner__reason span {
+  color: var(--lo-text);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.lo-chatter-scanner__reason strong {
+  color: #ffecc7;
+  font-size: 0.86rem;
+}
+
+.lo-chatter-scanner__reason small {
+  grid-column: 1 / -1;
+  color: var(--lo-muted);
+  font-size: 0.76rem;
+  line-height: 1.35;
+}
+
+.lo-chatter-scanner__cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
+}
+
+.lo-chatter-scanner__cards .lo-card {
+  padding: 12px;
+  overflow: hidden;
+}
+
+.lo-chatter-scanner__cards .lo-head {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.lo-chatter-scanner__cards .lo-title {
+  max-width: 70%;
+  font-size: 15px;
+  line-height: 1.25;
+  white-space: normal;
+  word-break: break-word;
+}
+
+.lo-chatter-scanner__cards .lo-pill {
+  flex-shrink: 0;
+  white-space: nowrap;
+  font-size: 10px;
+  padding: 3px 7px;
+}
+
+.lo-chatter-scanner__cards .lo-message,
+.lo-chatter-scanner__cards .lo-summary,
+.lo-chatter-scanner__cards .lo-card-meta {
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+@media (max-width: 640px) {
+  .lo-chatter-scanner {
+    padding: 12px;
+  }
+
+  .lo-chatter-scanner__head {
+    display: grid;
+  }
+
+  .lo-chatter-scanner__status {
+    justify-self: start;
+  }
+
+  .lo-chatter-scanner__stats,
+  .lo-chatter-scanner__cards {
+    grid-template-columns: 1fr;
+  }
+}

--- a/lousy-outages/includes/Sources/ChatterRejectionReasons.php
+++ b/lousy-outages/includes/Sources/ChatterRejectionReasons.php
@@ -46,8 +46,20 @@ class ChatterRejectionReasons {
     }
 
     public static function get(string $code): array {
+        $aliases = [
+            'business_or_regulatory_chatter' => 'generic_noise',
+            'no_provider_match' => 'quote_missing_provider',
+            'no_issue_language' => 'quote_missing_failure',
+            'weak_issue_language' => 'quote_missing_provider_or_failure',
+        ];
+        $lookupCode = $aliases[$code] ?? $code;
         $all = self::definitions();
-        return $all[$code] ?? [
+        if (isset($all[$lookupCode])) {
+            $definition = $all[$lookupCode];
+            $definition['code'] = $code;
+            return $definition;
+        }
+        return [
             'code' => $code,
             'short_label' => ucwords(str_replace('_', ' ', $code)),
             'public_description' => 'Filtered chatter that did not meet current-signal quality checks.',

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -537,52 +537,87 @@ function render_shortcode(): string {
             <button type="button" class="lo-mode-toggle__button is-active" data-lo-mode="incidents" aria-pressed="true">Incidents (0)</button>
             <button type="button" class="lo-mode-toggle__button" data-lo-mode="all" aria-pressed="false">All providers</button>
         </div>
-        <?php $fused_public = SignalEngine::summarize_fused_signals(120); $fused_public = is_array($fused_public) ? array_values(array_filter($fused_public, static function($r){ $c = strtolower((string)($r['classification'] ?? 'quiet')); return in_array($c,['watch','trending','hot'], true); })) : []; $official_signals=array_values(array_filter($fused_public, static fn($s)=>!empty($s['official_confirmed']) || (($s['signal_lane'] ?? '') === 'official'))); // Public chatter must stay quote-backed human/public reports only.
-        // Feed/synthetic/watch telemetry lanes should render in dedicated sections later.
-        $public_chatter=array_values(array_filter($fused_public, static fn($s)=>(($s['signal_lane'] ?? '') === 'chatter'))); ?>
-        <section class="lo-signals-panel" data-lo-signals-panel<?php echo $fused_public ? '' : ' hidden'; ?>>
-            <div class="lo-section__head">
-                <h3 class="lo-block-title">OFFICIAL STATUS SIGNALS</h3>
-                <p class="lo-history__meta">Provider-confirmed status, active maintenance, or degraded components.</p>
+        <?php
+        $fused_public = SignalEngine::summarize_fused_signals(120);
+        $fused_public = is_array($fused_public) ? array_values(array_filter($fused_public, static function($r){ $c = strtolower((string)($r['classification'] ?? 'quiet')); return in_array($c,['watch','trending','hot'], true); })) : [];
+        // Official fused signals are intentionally not rendered here; Active incidents is the public, non-duplicative official incident surface.
+        // Public chatter must stay quote-backed human/public reports only. Feed/synthetic/watch telemetry lanes render in dedicated sections later.
+        $public_chatter = array_values(array_filter($fused_public, static fn($s) => (($s['signal_lane'] ?? '') === 'chatter')));
+        $hnDiag = (array) get_option('lo_diag_hacker_news_chatter', []);
+        $previewSample = isset($hnDiag['chatter_candidates_preview_sample']) && is_array($hnDiag['chatter_candidates_preview_sample']) ? $hnDiag['chatter_candidates_preview_sample'] : [];
+        $rejectedCounts = (array) ($hnDiag['chatter_rejected_by_reason'] ?? []);
+        if ($rejectedCounts === [] && $previewSample) {
+            foreach ($previewSample as $sample) {
+                $reasonCode = (string) ($sample['reject_reason'] ?? '');
+                if ($reasonCode === '' || $reasonCode === 'accepted') {
+                    continue;
+                }
+                $rejectedCounts[$reasonCode] = (int) ($rejectedCounts[$reasonCode] ?? 0) + 1;
+            }
+        }
+        $rejectSummary = \SuzyEaston\LousyOutages\Sources\ChatterRejectionReasons::summarize_counts($rejectedCounts);
+        $rejectedTotal = array_sum(array_map(static fn($row): int => (int) ($row['count'] ?? 0), $rejectSummary));
+        $promotedTotal = count($public_chatter);
+        $checkedTotal = (int) ($hnDiag['chatter_rows_attempted'] ?? 0);
+        if ($checkedTotal <= 0 && $previewSample) {
+            $checkedTotal = count($previewSample);
+        }
+        if ($checkedTotal <= 0) {
+            $checkedTotal = $promotedTotal + $rejectedTotal;
+        }
+        $showChatterScanner = ($promotedTotal > 0) || !empty($rejectSummary);
+        ?>
+        <?php if ($showChatterScanner) : ?>
+        <section class="lo-chatter-scanner" data-lo-chatter-scanner>
+            <div class="lo-chatter-scanner__head">
+                <div>
+                    <h3 class="lo-block-title">PUBLIC CHATTER / FIELD REPORTS</h3>
+                    <p class="lo-history__meta">Unconfirmed public/dev chatter. Useful smoke, not fire.</p>
+                </div>
+                <span class="lo-chatter-scanner__status"><?php echo $public_chatter ? esc_html('Needs corroboration') : esc_html('Official radar only'); ?></span>
             </div>
-            <div class="lo-grid">
-            <?php foreach (array_slice($official_signals, 0, 6) as $sig) : $quote = trim((string)($sig['evidence_quote'] ?? '')); $sourceLabel = trim((string)($sig['evidence_source_label'] ?? '')); $sourceUrl = trim((string)($sig['evidence_url'] ?? ''));  ?>
-                <article class="lo-card">
-                    <div class="lo-head"><h4 class="lo-title"><?php echo esc_html((string)($sig['provider_name'] ?? $sig['provider_id'] ?? 'Provider')); ?></h4><span class="lo-pill">OFFICIAL</span></div>
-                    <p class="lo-summary">Official status evidence</p>
-                    <?php if ($quote !== '') : ?><blockquote class="lo-evidence-quote">“<?php echo esc_html($quote); ?>”</blockquote><?php endif; ?>
-                    <p class="lo-message"><?php echo esc_html((string)($sig['message'] ?? 'Early warning signal detected.')); ?></p>
-                    <p class="lo-card-meta">Source: <?php echo esc_html($sourceLabel ?: 'Signal feed'); ?><?php if ($sourceUrl !== '') : ?> · <a class="lo-link" href="<?php echo esc_url($sourceUrl); ?>" target="_blank" rel="noopener">View source</a><?php endif; ?> · Observed: <?php echo esc_html($format_datetime($sig['observed_at'] ?? $sig['last_seen_at'] ?? null)); ?></p>
-                </article>
-            <?php endforeach; ?>
+            <div class="lo-chatter-scanner__stats" aria-label="Public chatter scan summary">
+                <span class="lo-chatter-scanner__stat"><strong><?php echo esc_html((string) $checkedTotal); ?></strong> Checked</span>
+                <span class="lo-chatter-scanner__stat"><strong><?php echo esc_html((string) $promotedTotal); ?></strong> Promoted</span>
+                <span class="lo-chatter-scanner__stat"><strong><?php echo esc_html((string) $rejectedTotal); ?></strong> Rejected</span>
+                <?php foreach (array_slice($rejectSummary, 0, 2) as $reasonRow) : ?>
+                    <span class="lo-chatter-scanner__stat"><strong><?php echo esc_html((string) ($reasonRow['count'] ?? 0)); ?></strong> <?php echo esc_html((string) ($reasonRow['label'] ?? 'Filtered')); ?></span>
+                <?php endforeach; ?>
             </div>
-            <div class="lo-section__head">
-                <h3 class="lo-block-title">PUBLIC CHATTER / FIELD REPORTS</h3>
-                <p class="lo-history__meta">Unconfirmed posts from public dev/social channels. Useful smoke, not fire.</p>
-            </div>
-            <div class="lo-grid">
             <?php if (!$public_chatter) : ?>
-                <p class="lo-history__meta">No fresh field reports intercepted. Official radar only.</p>
-                <?php $hnDiag = (array) get_option('lo_diag_hacker_news_chatter', []); $rejectSummary = \SuzyEaston\LousyOutages\Sources\ChatterRejectionReasons::summarize_counts((array)($hnDiag['chatter_rejected_by_reason'] ?? [])); ?>
-                <?php if (!empty($rejectSummary)) : ?><div class="lo-history__meta"><strong>Filtered chatter:</strong>
-                    <ul>
-                    <?php foreach (array_slice($rejectSummary, 0, 5) as $reasonRow) : ?>
-                        <li><?php echo esc_html((string)($reasonRow['count'] ?? 0) . ' ' . (string)($reasonRow['label'] ?? '')); ?> — <?php echo esc_html((string)($reasonRow['description'] ?? '')); ?></li>
+                <?php
+                // Public chatter can be empty because weak, noisy, historical, or non-provider posts were rejected; that is expected and diagnostics make the quiet result visible.
+                ?>
+                <div class="lo-chatter-scanner__empty">
+                    <h4>Public chatter scan complete</h4>
+                    <p>No credible field reports promoted. Official radar only.</p>
+                </div>
+                <?php if (!empty($rejectSummary)) : ?>
+                    <div class="lo-chatter-scanner__reasons" aria-label="Rejected public chatter categories">
+                        <?php foreach (array_slice($rejectSummary, 0, 5) as $reasonRow) : ?>
+                            <div class="lo-chatter-scanner__reason">
+                                <span><?php echo esc_html((string) ($reasonRow['label'] ?? 'Filtered chatter')); ?></span>
+                                <strong><?php echo esc_html((string) ($reasonRow['count'] ?? 0)); ?></strong>
+                                <small><?php echo esc_html((string) ($reasonRow['description'] ?? 'Filtered chatter that did not meet current-signal quality checks.')); ?></small>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+                <?php endif; ?>
+            <?php else : ?>
+                <div class="lo-chatter-scanner__cards">
+                    <?php foreach (array_slice($public_chatter, 0, 6) as $sig) : $quote = trim((string)($sig['evidence_quote'] ?? '')); $sourceLabel = trim((string)($sig['evidence_source_label'] ?? '')); $sourceUrl = trim((string)($sig['evidence_url'] ?? '')); ?>
+                        <article class="lo-card">
+                            <div class="lo-head"><h4 class="lo-title"><?php echo esc_html((string)($sig['provider_name'] ?? $sig['provider_id'] ?? 'Provider')); ?></h4><span class="lo-pill">RUMOUR RADAR</span></div>
+                            <p class="lo-summary">Unconfirmed public report. Needs corroboration.</p>
+                            <?php if ($quote !== '') : ?><blockquote class="lo-evidence-quote">“<?php echo esc_html($quote); ?>”</blockquote><?php endif; ?>
+                            <p class="lo-message"><?php echo esc_html((string)($sig['message'] ?? 'Needs corroboration from official/synthetic signals.')); ?></p>
+                            <p class="lo-card-meta">Source: <?php echo esc_html($sourceLabel ?: 'Public chatter'); ?><?php if ($sourceUrl !== '') : ?> · <a class="lo-link" href="<?php echo esc_url($sourceUrl); ?>" target="_blank" rel="noopener">View source</a><?php endif; ?> · Observed: <?php echo esc_html($format_datetime($sig['observed_at'] ?? null)); ?></p>
+                        </article>
                     <?php endforeach; ?>
-                    </ul>
-                </div><?php endif; ?>
+                </div>
             <?php endif; ?>
-            <?php foreach (array_slice($public_chatter, 0, 6) as $sig) : $quote = trim((string)($sig['evidence_quote'] ?? '')); $sourceLabel = trim((string)($sig['evidence_source_label'] ?? '')); $sourceUrl = trim((string)($sig['evidence_url'] ?? '')); ?>
-                <article class="lo-card">
-                    <div class="lo-head"><h4 class="lo-title"><?php echo esc_html((string)($sig['provider_name'] ?? $sig['provider_id'] ?? 'Provider')); ?></h4><span class="lo-pill">RUMOUR RADAR</span></div>
-                    <p class="lo-summary">Public chatter reports possible user impact.</p>
-                    <?php if ($quote !== '') : ?><blockquote class="lo-evidence-quote">“<?php echo esc_html($quote); ?>”</blockquote><?php endif; ?>
-                    <p class="lo-message"><?php echo esc_html((string)($sig['message'] ?? 'Needs corroboration from official/synthetic signals.')); ?></p>
-                    <p class="lo-card-meta">Source: <?php echo esc_html($sourceLabel ?: 'Public chatter'); ?><?php if ($sourceUrl !== '') : ?> · <a class="lo-link" href="<?php echo esc_url($sourceUrl); ?>" target="_blank" rel="noopener">View source</a><?php endif; ?> · Observed: <?php echo esc_html($format_datetime($sig['observed_at'] ?? null)); ?></p>
-                </article>
-            <?php endforeach; ?>
-            </div>
         </section>
+        <?php endif; ?>
         <div class="lo-incidents" data-lo-incidents>
             <section class="lo-section lo-section--incidents" data-lo-section="incidents">
                 <div class="lo-section__head">


### PR DESCRIPTION
### Motivation
- Remove the duplicated top “OFFICIAL STATUS SIGNALS” evidence panel to keep `Active incidents` as the canonical public official surface. 
- Make the public chatter area a standalone, intentional scanner so diagnostic visibility remains even when no chatter is promoted. 
- Present a conservative, explanatory empty/diagnostic state so the dashboard does not look like a dead black box when public chatter is filtered.

### Description
- Stop rendering the top official fused-signal card grid in the public shortcode while keeping `SignalEngine::summarize_fused_signals(120)` and official signal collection logic intact. 
- Replace the combined signals panel with a dedicated chatter scanner section that renders when there are accepted public chatter signals or rejection diagnostics from `get_option('lo_diag_hacker_news_chatter', [])`. 
- Compute and render derived counts (`Checked`, `Promoted`, `Rejected`) using `chatter_rows_attempted`, `chatter_candidates_preview_sample`, `chatter_rows_output`, and `ChatterRejectionReasons::summarize_counts()` and show top rejection categories with public labels/descriptions (no raw quotes). 
- Preserve accepted chatter rendering as cautious “RUMOUR RADAR” cards with `evidence_quote`, source label/URL, and observed time. 
- Add aliases in `ChatterRejectionReasons::get()` to map internal rejection codes (e.g. `business_or_regulatory_chatter`, `no_provider_match`) to public-friendly labels. 
- Add retro scanner UI styles and responsive layout to `lousy-outages/assets/lousy-outages.css` using the classes `lo-chatter-scanner`, `lo-chatter-scanner__head`, `lo-chatter-scanner__stats`, `lo-chatter-scanner__stat`, `lo-chatter-scanner__reasons`, `lo-chatter-scanner__reason`, and `lo-chatter-scanner__empty`.

### Testing
- Ran `git diff --check` and it reported no whitespace/format issues. 
- Ran `find lousy-outages -name '*.php' -print0 | xargs -0 -n1 php -l` and PHP syntax checks passed for the modified files and the plugin codebase. 
- Attempted the optional preview script but `wp-load.php` was not found under `/workspace`, so `php lousy-outages/scripts/preview-public-chatter.php` was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb922d2750832ea4da5300f4622c16)