### PR TITLE
Improve public chatter corroboration diagnostics

### DIFF
--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -1993,3 +1993,101 @@
 .lo-chatter-scanner__empty p + p {
   margin-top: 4px;
 }
+
+.lo-chatter-scanner__strip,
+.lo-chatter-scanner__watch,
+.lo-chatter-scanner__corroboration,
+.lo-chatter-scanner__watchlist,
+.lo-chatter-scanner__table {
+  position: relative;
+  z-index: 1;
+}
+
+.lo-chatter-scanner__strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 12px 0;
+}
+
+.lo-chatter-scanner__source,
+.lo-chatter-scanner__watchlist span {
+  border: 1px solid rgba(154, 243, 255, 0.35);
+  border-radius: 999px;
+  color: #dffcff;
+  background: rgba(8, 20, 32, 0.82);
+  padding: 6px 10px;
+  font-size: 0.82rem;
+}
+
+.lo-chatter-scanner__source--blocked_by_safe_default,
+.lo-chatter-scanner__source--disabled,
+.lo-chatter-scanner__source--not_configured {
+  border-color: rgba(255, 199, 87, 0.42);
+  color: #ffe7aa;
+}
+
+.lo-chatter-scanner__watch,
+.lo-chatter-scanner__corroboration,
+.lo-chatter-scanner__watchlist {
+  border: 1px solid rgba(42, 255, 213, 0.18);
+  border-radius: 14px;
+  background: rgba(5, 5, 16, 0.72);
+  margin: 12px 0;
+  padding: 12px;
+}
+
+.lo-chatter-scanner__watch h4,
+.lo-chatter-scanner__corroboration h4,
+.lo-chatter-scanner__watchlist h4 {
+  margin: 0 0 8px;
+  color: #9af3ff;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.lo-chatter-scanner__watch p,
+.lo-chatter-scanner__corroboration p {
+  color: #d7f9ff;
+  margin: 0 0 8px;
+}
+
+.lo-chatter-scanner__watch ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: #f4feff;
+}
+
+.lo-chatter-scanner__table {
+  display: grid;
+  gap: 6px;
+}
+
+.lo-chatter-scanner__table [role="row"] {
+  display: grid;
+  grid-template-columns: 1.1fr 0.8fr 1fr 1fr 0.7fr;
+  gap: 8px;
+  align-items: center;
+  border-bottom: 1px solid rgba(154, 243, 255, 0.14);
+  color: #f4feff;
+  padding: 7px 0;
+}
+
+.lo-chatter-scanner__table-head {
+  color: #9af3ff !important;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.lo-chatter-scanner__watchlist div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+@media (max-width: 760px) {
+  .lo-chatter-scanner__table [role="row"] {
+    grid-template-columns: 1fr;
+  }
+}

--- a/lousy-outages/includes/Api.php
+++ b/lousy-outages/includes/Api.php
@@ -356,6 +356,19 @@ class Api {
             'source'        => 'live',
         ];
 
+        $publicDiag = (array) get_option('lo_diag_public_chatter', []);
+        $response['public_chatter_diagnostics'] = [
+            'source_statuses' => (array) ($publicDiag['source_statuses'] ?? []),
+            'enabled_sources' => (array) ($publicDiag['enabled_sources'] ?? []),
+            'skipped_sources' => (array) ($publicDiag['skipped_sources'] ?? []),
+            'direct_sources_enabled' => !empty($publicDiag['direct_sources_enabled']),
+            'direct_sources_disabled_by_safe_default' => !empty($publicDiag['direct_sources_disabled_by_safe_default']),
+            'watch_candidate_count' => (int) ($publicDiag['watch_candidate_count'] ?? 0),
+            'official_incident_corroboration' => array_slice((array) ($publicDiag['official_incident_corroboration'] ?? []), 0, 20),
+            'canadian_infrastructure_watchlist' => (array) ($publicDiag['canadian_infrastructure_watchlist'] ?? []),
+            'ran_at' => (string) ($publicDiag['ran_at'] ?? ''),
+        ];
+
         if (!empty($result['message']) && is_string($result['message'])) {
             $response['message'] = $result['message'];
         }
@@ -422,10 +435,26 @@ class Api {
                     $reasonCounts[$reason] = (int) ($reasonCounts[$reason] ?? 0) + 1;
                 }
             }
+            $publicDiag = (array) get_option('lo_diag_public_chatter', []);
             $payload['public_chatter_diagnostics'] = [
                 'rejected_by_reason' => ChatterRejectionReasons::summarize_counts($reasonCounts),
                 'reason_definitions' => array_values(ChatterRejectionReasons::definitions()),
                 'raw_rejected_codes' => $reasonCounts,
+                'source_statuses' => (array) ($publicDiag['source_statuses'] ?? []),
+                'enabled_sources' => (array) ($publicDiag['enabled_sources'] ?? []),
+                'skipped_sources' => (array) ($publicDiag['skipped_sources'] ?? []),
+                'direct_sources_enabled' => !empty($publicDiag['direct_sources_enabled']),
+                'direct_sources_disabled_by_safe_default' => !empty($publicDiag['direct_sources_disabled_by_safe_default']),
+                'providers_scanned_count' => (int) ($publicDiag['providers_scanned_count'] ?? 0),
+                'watch_candidate_count' => (int) ($publicDiag['watch_candidate_count'] ?? 0),
+                'watch_candidates' => array_slice((array) ($publicDiag['watch_candidates'] ?? []), 0, 20),
+                'official_incident_corroboration' => array_slice((array) ($publicDiag['official_incident_corroboration'] ?? []), 0, 20),
+                'canadian_infrastructure_watchlist' => (array) ($publicDiag['canadian_infrastructure_watchlist'] ?? []),
+                'mentions_seen_by_source' => (array) ($publicDiag['mentions_seen_by_source'] ?? []),
+                'mentions_seen_by_provider' => (array) ($publicDiag['mentions_seen_by_provider'] ?? []),
+                'thresholds' => (array) ($publicDiag['thresholds'] ?? []),
+                'scan_window_minutes' => (int) ($publicDiag['scan_window_minutes'] ?? 0),
+                'ran_at' => (string) ($publicDiag['ran_at'] ?? ''),
             ];
         }
 

--- a/lousy-outages/includes/Sources/CloudflareRadarSource.php
+++ b/lousy-outages/includes/Sources/CloudflareRadarSource.php
@@ -11,22 +11,59 @@ class CloudflareRadarSource implements SignalSourceInterface {
     public function label(): string { return 'Cloudflare Radar'; }
     public function is_configured(): bool { return '' !== trim($this->token()); }
     public function collect(array $options = []): array {
-        if (!$this->is_configured()) return [];
-        $endpoints = [
-            'internet_outage' => 'https://api.cloudflare.com/client/v4/radar/outages',
-            'traffic_anomaly' => 'https://api.cloudflare.com/client/v4/radar/anomalies'
+        $configured = $this->is_configured();
+        $diag = [
+            'configured' => $configured,
+            'attempted' => false,
+            'endpoint_attempted' => '',
+            'response_code' => 0,
+            'rows_seen' => 0,
+            'rows_stored' => 0,
+            'errors' => [],
+            'lane' => 'external_telemetry',
+            'ran_at' => gmdate('c'),
         ];
+        if (!$configured) { update_option('lo_diag_'.$this->id(), $diag, false); return []; }
+
+        // Current Cloudflare Radar API reference: GET /radar/annotations/outages retrieves latest Internet outages and anomalies.
+        $url = (string) apply_filters('lo_cloudflare_radar_outages_endpoint', 'https://api.cloudflare.com/client/v4/radar/annotations/outages');
+        $diag['attempted'] = true;
+        $diag['endpoint_attempted'] = $url;
+        $res = wp_remote_get($url,['timeout'=>8,'headers'=>['Authorization'=>'Bearer '.$this->token(),'User-Agent'=>'LousyOutages/'.(defined('LOUSY_OUTAGES_VERSION')?LOUSY_OUTAGES_VERSION:'0.1.0')]]);
+        if (is_wp_error($res)) { $diag['errors'][] = 'request_error'; update_option('lo_diag_'.$this->id(), $diag, false); return []; }
+        $code = (int)wp_remote_retrieve_response_code($res);
+        $diag['response_code'] = $code;
+        if ($code !== 200) { $diag['errors'][] = 'api_http_error'; update_option('lo_diag_'.$this->id(), $diag, false); return []; }
+
+        $body=json_decode((string)wp_remote_retrieve_body($res),true);
+        $annotations=(array)($body['result']['annotations'] ?? $body['result'] ?? []);
+        $diag['rows_seen'] = count($annotations);
         $out=[];
-        foreach($endpoints as $type=>$url){
-            $res = wp_remote_get($url,['timeout'=>8,'headers'=>['Authorization'=>'Bearer '.$this->token(),'User-Agent'=>'LousyOutages/'.(defined('LOUSY_OUTAGES_VERSION')?LOUSY_OUTAGES_VERSION:'0.1.0')]]);
-            if (is_wp_error($res)) continue;
-            if ((int)wp_remote_retrieve_response_code($res)!==200) continue;
-            $body=json_decode((string)wp_remote_retrieve_body($res),true);
-            $items=(array)($body['result'] ?? []);
-            foreach(array_slice($items,0,10) as $item){
-                $out[]=[ 'source'=>'cloudflare_radar','provider_id'=>sanitize_key((string)($item['asn'] ?? '')),'provider_name'=>sanitize_text_field((string)($item['name'] ?? $item['asn_name'] ?? 'Internet Health')),'category'=>'internet_health','region'=>sanitize_text_field((string)($item['location'] ?? $item['country'] ?? 'global')),'signal_type'=>$type,'severity'=>'degraded','confidence'=>70,'title'=>sanitize_text_field((string)($item['title'] ?? 'Internet-health anomaly detected')),'message'=>sanitize_text_field((string)($item['description'] ?? 'Unconfirmed external signal from internet-health telemetry.')),'url'=>esc_url_raw((string)($item['url'] ?? 'https://radar.cloudflare.com')),'observed_at'=>sanitize_text_field((string)($item['time'] ?? gmdate('Y-m-d H:i:s'))) ];
-            }
+        foreach(array_slice($annotations,0,10) as $item){
+            if (!is_array($item)) { continue; }
+            $asn = (string)($item['asn'] ?? $item['asNumber'] ?? '');
+            $name = (string)($item['name'] ?? $item['asnName'] ?? $item['as_name'] ?? $item['scopeName'] ?? 'Internet Health');
+            $kind = strtoupper((string)($item['eventType'] ?? $item['type'] ?? $item['annotationType'] ?? 'INTERNET_HEALTH'));
+            $signalType = str_contains($kind, 'ANOMAL') ? 'traffic_anomaly' : 'internet_outage';
+            $out[]=[
+                'source'=>'cloudflare_radar',
+                'source_type'=>'external_telemetry',
+                'signal_lane'=>'external_telemetry',
+                'provider_id'=>sanitize_key($asn !== '' ? 'asn_'.$asn : $name),
+                'provider_name'=>sanitize_text_field($name),
+                'category'=>'internet_health',
+                'region'=>sanitize_text_field((string)($item['locationName'] ?? $item['location'] ?? $item['country'] ?? 'global')),
+                'signal_type'=>$signalType,
+                'severity'=>'degraded',
+                'confidence'=>70,
+                'title'=>sanitize_text_field((string)($item['title'] ?? 'Internet-health telemetry anomaly detected')),
+                'message'=>sanitize_text_field((string)($item['description'] ?? 'External internet-health telemetry indicates a possible network disruption.')),
+                'url'=>esc_url_raw((string)($item['url'] ?? 'https://radar.cloudflare.com/outage-center')),
+                'observed_at'=>sanitize_text_field((string)($item['startTime'] ?? $item['startedAt'] ?? $item['time'] ?? gmdate('Y-m-d H:i:s'))),
+            ];
         }
+        $diag['rows_stored'] = count($out);
+        update_option('lo_diag_'.$this->id(), $diag, false);
         return $out;
     }
 }

--- a/lousy-outages/includes/Sources/PublicChatterSource.php
+++ b/lousy-outages/includes/Sources/PublicChatterSource.php
@@ -7,90 +7,410 @@ use SuzyEaston\LousyOutages\Providers;
 use SuzyEaston\LousyOutages\SignalSourceInterface;
 
 class PublicChatterSource implements SignalSourceInterface {
+    private array $requestDiagnostics = [];
+
     public function id(): string { return 'public_chatter'; }
     public function label(): string { return 'Public Chatter Radar'; }
     public function is_configured(): bool { return (bool) get_option('lousy_outages_public_chatter_enabled', false); }
 
     public function collect(array $options = []): array {
-        if (!$this->is_configured()) { update_option('lo_diag_'.$this->id(), ['configured'=>false,'attempted'=>false,'skipped_reasons'=>['not_configured']], false); return []; }
         $directEnabled = $this->direct_sources_enabled();
-        $window = max(10, min(180, (int) apply_filters('lo_public_chatter_window_minutes', 30)));
+        $sourceCheckboxes = $this->source_checkboxes();
+        $window = max(10, min(180, (int) apply_filters('lo_public_chatter_window_minutes', (int)($options['window_minutes'] ?? 30))));
         $thresholds = [
             'watch' => (int) apply_filters('lo_public_chatter_watch_threshold', 3),
             'trending' => (int) apply_filters('lo_public_chatter_trending_threshold', 6),
             'hot' => (int) apply_filters('lo_public_chatter_hot_threshold', 12),
+            'queries_per_provider_source' => (int) apply_filters('lo_public_chatter_queries_per_provider_source', 4),
+            'active_incident_queries_per_provider' => (int) apply_filters('lo_public_chatter_active_incident_queries_per_provider', 5),
         ];
         $providers = Providers::list();
-        $queries = (array) apply_filters('lo_public_chatter_queries', $this->default_queries($providers), $providers);
-        $signals = [];
-        $sources = [
-            'public_chatter_bluesky' => !empty(get_option('lousy_outages_public_chatter_bluesky_enabled', false)),
-            'public_chatter_mastodon' => !empty(get_option('lousy_outages_public_chatter_mastodon_enabled', false)),
-            'public_chatter_gdelt' => !empty(get_option('lousy_outages_public_chatter_gdelt_enabled', false)),
-        ];
-        if (!$directEnabled) {
-            $sources = ['public_chatter_bluesky'=>false,'public_chatter_mastodon'=>false,'public_chatter_gdelt'=>false];
+        $activeIncidents = $this->active_incident_seed_providers($providers);
+        $queryBuild = $this->build_query_sets($providers, $activeIncidents, $thresholds);
+        $queries = (array) apply_filters('lo_public_chatter_queries', $queryBuild['queries'], $providers, $activeIncidents);
+        $queries = $this->normalize_query_sets($queries, $queryBuild['providers']);
+
+        $diag = $this->base_diagnostics($sourceCheckboxes, $directEnabled, $window, $thresholds, $queryBuild, $activeIncidents);
+        $configured = $this->is_configured();
+        $diag['configured'] = $configured;
+        $diag['attempted'] = $configured;
+
+        if (!$configured) {
+            foreach (array_keys($sourceCheckboxes) as $sourceId) {
+                $diag['skipped_sources'][$sourceId][] = 'master_disabled';
+            }
+            $diag['source_statuses'] = $this->source_statuses($sourceCheckboxes, $directEnabled, $diag);
+            $diag['official_incident_corroboration'] = $this->official_incident_corroboration($activeIncidents, $diag, [], []);
+            $this->store_diagnostics($diag);
+            return [];
         }
-        foreach ($queries as $providerId => $providerQueries) {
-            $provider = (array)($providers[$providerId] ?? ['name' => ucfirst((string)$providerId), 'category'=>'general']);
-            foreach ($sources as $sourceId => $enabled) {
-                if (!$enabled) continue;
-                $mentions = $this->collect_mentions($sourceId, (array)$providerQueries, $window);
+
+        $enabledRuntimeSources = [];
+        foreach ($sourceCheckboxes as $sourceId => $checked) {
+            if (!$checked) {
+                $diag['skipped_sources'][$sourceId][] = 'source_checkbox_disabled';
+                continue;
+            }
+            if (!$directEnabled) {
+                $diag['skipped_sources'][$sourceId][] = 'direct_sources_gate_disabled';
+                continue;
+            }
+            $enabledRuntimeSources[$sourceId] = true;
+        }
+
+        $signals = [];
+        $perProviderSourceCounts = [];
+        foreach ($queries as $providerId => $row) {
+            $provider = (array)($row['provider'] ?? ['name' => ucfirst((string)$providerId), 'category'=>'general']);
+            $providerName = (string)($provider['name'] ?? $providerId);
+            $providerCategory = (string)($provider['category'] ?? 'general');
+            $providerQueries = array_values(array_filter(array_map('strval', (array)($row['queries'] ?? []))));
+            foreach ($enabledRuntimeSources as $sourceId => $_enabled) {
+                $mentions = $this->collect_mentions($sourceId, $providerQueries, $window, (int)$thresholds['queries_per_provider_source']);
+                $requestDiag = $this->requestDiagnostics[$sourceId] ?? [];
+                $diag['queries_attempted'] += (int)($requestDiag['queries_attempted'] ?? min(count($providerQueries), (int)$thresholds['queries_per_provider_source']));
+                $diag['source_request_details'][$sourceId]['queries_attempted'] = (int)($diag['source_request_details'][$sourceId]['queries_attempted'] ?? 0) + (int)($requestDiag['queries_attempted'] ?? 0);
+                if ($sourceId === 'public_chatter_mastodon') {
+                    $diag['source_request_details'][$sourceId]['instances_queried'] = array_values(array_unique(array_merge((array)($diag['source_request_details'][$sourceId]['instances_queried'] ?? []), (array)($requestDiag['instances_queried'] ?? []))));
+                }
+                foreach ((array)($requestDiag['errors'] ?? []) as $errorReason) {
+                    $diag['skipped_sources'][$sourceId][] = (string)$errorReason;
+                }
+
                 $count = count($mentions);
+                $diag['mentions_seen_by_source'][$sourceId] = (int)($diag['mentions_seen_by_source'][$sourceId] ?? 0) + $count;
+                $diag['mentions_seen_by_provider'][$providerId] = (int)($diag['mentions_seen_by_provider'][$providerId] ?? 0) + $count;
+                $perProviderSourceCounts[$providerId][$sourceId] = (int)($perProviderSourceCounts[$providerId][$sourceId] ?? 0) + $count;
+
+                if ($count <= 0) {
+                    $diag['skipped_sources'][$sourceId][] = 'no_results';
+                    continue;
+                }
+
                 $severity = $this->severity_for_count($count, $thresholds);
-                if ($severity === '') continue;
-                $signals[] = $this->build_signal($sourceId, (string)$providerId, (string)($provider['name'] ?? $providerId), (string)($provider['category'] ?? 'general'), $severity, $count, $window, $mentions);
+                if ($severity === '') {
+                    $diag['skipped_sources'][$sourceId][] = 'below_threshold';
+                    $diag['watch_candidates'][] = [
+                        'provider_id' => (string)$providerId,
+                        'provider_name' => $providerName,
+                        'source' => $sourceId,
+                        'source_label' => $this->source_label($sourceId),
+                        'count' => $count,
+                        'reason' => 'below_threshold',
+                    ];
+                    continue;
+                }
+
+                $signals[] = $this->build_signal($sourceId, (string)$providerId, $providerName, $providerCategory, $severity, $count, $window, $mentions);
+                $diag['signals_built_by_provider'][$providerId] = (int)($diag['signals_built_by_provider'][$providerId] ?? 0) + 1;
             }
         }
-        update_option('lo_diag_'.$this->id(), ['configured'=>true,'attempted'=>true,'queries_attempted'=>count($queries),'usable_results'=>count($signals),'rows_stored'=>count($signals),'direct_sources_enabled'=>$directEnabled,'direct_sources_disabled_by_safe_default'=>!$directEnabled], false);
+
+        $diag['usable_results'] = count($signals);
+        $diag['rows_stored'] = count($signals);
+        $diag['watch_candidate_count'] = count($diag['watch_candidates']);
+        $diag['source_statuses'] = $this->source_statuses($sourceCheckboxes, $directEnabled, $diag);
+        $diag['official_incident_corroboration'] = $this->official_incident_corroboration($activeIncidents, $diag, $perProviderSourceCounts, array_keys($enabledRuntimeSources));
+        $this->store_diagnostics($diag);
         return $signals;
     }
 
-    private function direct_sources_enabled(): bool {
+    public function direct_sources_enabled(): bool {
         $flag = defined('LOUSY_OUTAGES_ENABLE_DIRECT_PUBLIC_CHATTER') ? (bool) LOUSY_OUTAGES_ENABLE_DIRECT_PUBLIC_CHATTER : false;
         return (bool) apply_filters('lo_public_chatter_direct_sources_enabled', $flag);
+    }
+
+    public function source_checkboxes(): array {
+        return [
+            'public_chatter_bluesky' => !empty(get_option('lousy_outages_public_chatter_bluesky_enabled', '1')),
+            'public_chatter_mastodon' => !empty(get_option('lousy_outages_public_chatter_mastodon_enabled', '0')),
+            'public_chatter_gdelt' => !empty(get_option('lousy_outages_public_chatter_gdelt_enabled', '1')),
+        ];
+    }
+
+    public function canadian_infrastructure_watchlist(): array {
+        return [
+            'telecom' => ['rogers'=>'Rogers','shaw'=>'Shaw','bell'=>'Bell','telus'=>'TELUS','freedom_mobile'=>'Freedom Mobile','videotron'=>'Videotron','fizz'=>'Fizz','koodo'=>'Koodo','virgin_plus'=>'Virgin Plus','public_mobile'=>'Public Mobile'],
+            'payments' => ['interac'=>'Interac','etransfer'=>'e-Transfer','interac_debit'=>'Interac Debit','moneris'=>'Moneris','global_payments'=>'Global Payments','stripe_canada'=>'Stripe Canada'],
+            'banking' => ['rbc'=>'RBC / Royal Bank','td_canada_trust'=>'TD / TD Canada Trust','scotiabank'=>'Scotiabank','bmo'=>'BMO / Bank of Montreal','cibc'=>'CIBC','national_bank'=>'National Bank','tangerine'=>'Tangerine','simplii'=>'Simplii','eq_bank'=>'EQ Bank','vancity'=>'Vancity','coast_capital'=>'Coast Capital','desjardins'=>'Desjardins'],
+            'government_login' => ['bc_services_card'=>'BC Services Card','cra_my_account'=>'CRA My Account','service_canada'=>'Service Canada'],
+            'transit' => ['translink_compass'=>'TransLink Compass'],
+            'emergency_services' => ['911'=>'911','ecomm_911'=>'E-Comm 911'],
+        ];
+    }
+
+    private function base_diagnostics(array $sourceCheckboxes, bool $directEnabled, int $window, array $thresholds, array $queryBuild, array $activeIncidents): array {
+        return [
+            'configured' => false,
+            'attempted' => false,
+            'direct_sources_enabled' => $directEnabled,
+            'direct_sources_disabled_by_safe_default' => !$directEnabled,
+            'enabled_sources' => $sourceCheckboxes,
+            'skipped_sources' => ['public_chatter_bluesky'=>[],'public_chatter_mastodon'=>[],'public_chatter_gdelt'=>[]],
+            'source_statuses' => [],
+            'providers_scanned' => array_values(array_map(static fn($p) => ['provider_id'=>(string)$p['id'], 'provider_name'=>(string)$p['name'], 'category'=>(string)($p['category'] ?? 'general'), 'seed_types'=>(array)($p['seed_types'] ?? [])], (array)$queryBuild['providers'])),
+            'providers_scanned_count' => count((array)$queryBuild['providers']),
+            'active_incident_seed_providers' => array_values($activeIncidents),
+            'canadian_infrastructure_watchlist' => $this->watchlist_summary(),
+            'canadian_infrastructure_providers_scanned' => $this->flat_watchlist_providers(),
+            'queries_attempted' => 0,
+            'queries_planned' => (int)$queryBuild['query_count'],
+            'mentions_seen_by_source' => ['public_chatter_bluesky'=>0,'public_chatter_mastodon'=>0,'public_chatter_gdelt'=>0],
+            'mentions_seen_by_provider' => [],
+            'signals_built_by_provider' => [],
+            'thresholds' => $thresholds,
+            'scan_window_minutes' => $window,
+            'ran_at' => gmdate('c'),
+            'watch_candidates' => [],
+            'watch_candidate_count' => 0,
+            'official_incident_corroboration' => [],
+            'source_request_details' => [
+                'public_chatter_bluesky' => ['queries_attempted'=>0],
+                'public_chatter_mastodon' => ['queries_attempted'=>0,'instances_queried'=>[]],
+                'public_chatter_gdelt' => ['queries_attempted'=>0],
+            ],
+            'usable_results' => 0,
+            'rows_stored' => 0,
+        ];
+    }
+
+    private function store_diagnostics(array $diag): void {
+        foreach ($diag['skipped_sources'] as $sourceId => $reasons) {
+            $diag['skipped_sources'][$sourceId] = array_values(array_unique(array_filter(array_map('strval', (array)$reasons))));
+        }
+        update_option('lo_diag_'.$this->id(), $diag, false);
+    }
+
+    private function build_query_sets(array $providers, array $activeIncidents, array $thresholds): array {
+        $entries = [];
+        foreach ($this->default_queries($providers) as $providerId => $queries) {
+            $provider = (array)($providers[$providerId] ?? ['name'=>ucfirst((string)$providerId), 'category'=>'general']);
+            $entries[$providerId] = ['provider'=>['id'=>(string)$providerId,'name'=>(string)($provider['name'] ?? $providerId),'category'=>(string)($provider['category'] ?? 'general'),'seed_types'=>['default']], 'queries'=>$queries];
+        }
+        foreach ($activeIncidents as $incident) {
+            $providerId = (string)($incident['provider_id'] ?? '');
+            if ($providerId === '') { continue; }
+            $providerName = (string)($incident['provider_name'] ?? $providerId);
+            if (!isset($entries[$providerId])) {
+                $entries[$providerId] = ['provider'=>['id'=>$providerId,'name'=>$providerName,'category'=>(string)($incident['category'] ?? 'official_incident'),'seed_types'=>[]], 'queries'=>[]];
+            }
+            $entries[$providerId]['provider']['seed_types'][] = 'active_incident';
+            $entries[$providerId]['queries'] = array_merge((array)$entries[$providerId]['queries'], $this->active_incident_queries($providerName, (string)($incident['title'] ?? ''), (int)$thresholds['active_incident_queries_per_provider']));
+        }
+        foreach ($this->canadian_infrastructure_watchlist() as $category => $items) {
+            foreach ($items as $providerId => $name) {
+                if (!isset($entries[$providerId])) {
+                    $entries[$providerId] = ['provider'=>['id'=>(string)$providerId,'name'=>(string)$name,'category'=>(string)$category,'seed_types'=>[]], 'queries'=>[]];
+                }
+                $entries[$providerId]['provider']['seed_types'][] = 'canadian_infrastructure';
+                $entries[$providerId]['queries'] = array_merge((array)$entries[$providerId]['queries'], $this->provider_queries((string)$name));
+            }
+        }
+        return $this->normalize_query_sets($entries, []);
+    }
+
+    private function normalize_query_sets(array $queries, array $providers): array {
+        $normalized = [];
+        foreach ($queries as $providerId => $row) {
+            if (is_array($row) && array_key_exists('queries', $row)) {
+                $provider = (array)($row['provider'] ?? ($providers[$providerId] ?? []));
+                $providerQueries = (array)$row['queries'];
+            } else {
+                $provider = (array)($providers[$providerId] ?? []);
+                $providerQueries = (array)$row;
+            }
+            $id = sanitize_key((string)($provider['id'] ?? $providerId));
+            if ($id === '') { continue; }
+            $provider['id'] = $id;
+            $provider['name'] = (string)($provider['name'] ?? ucfirst($id));
+            $provider['seed_types'] = array_values(array_unique((array)($provider['seed_types'] ?? ['custom'])));
+            $normalized[$id] = ['provider'=>$provider, 'queries'=>array_values(array_unique(array_filter(array_map(static fn($q) => trim((string)$q), $providerQueries))))];
+            $normalized[$id]['queries'] = array_slice($normalized[$id]['queries'], 0, 8);
+        }
+        if ($providers === []) {
+            return ['queries'=>$normalized, 'providers'=>array_values(array_column($normalized, 'provider')), 'query_count'=>array_sum(array_map(static fn($r) => count((array)$r['queries']), $normalized))];
+        }
+        return $normalized;
     }
 
     private function default_queries(array $providers): array {
         $map = [
             'cloudflare' => ['cloudflare down','cloudflare outage','cloudflare warp down'],
-            'aws' => ['aws down','aws outage','aws us-east-1'],
+            'aws' => ['aws down','aws outage','aws us-east-1 errors'],
             'azure' => ['azure down','azure outage','microsoft 365 down'],
-            'google_cloud' => ['google cloud outage','gcp outage'],
-            'openai' => ['chatgpt down','openai outage'],
+            'google_cloud' => ['google cloud outage','gcp outage','google cloud errors'],
+            'google_workspace' => ['google workspace outage','gmail down','google drive down'],
+            'openai' => ['chatgpt down','openai outage','openai api errors'],
             'slack' => ['slack down','slack outage'],
+            'github' => ['github down','github actions failing','github outage'],
         ];
         return array_intersect_key($map, $providers);
     }
-    private function collect_mentions(string $sourceId, array $queries, int $window): array {
-        $out=[]; foreach(array_slice($queries,0,4) as $q){
-            if ($sourceId==='public_chatter_bluesky') $out=array_merge($out,$this->search_bluesky($q,$window));
-            elseif ($sourceId==='public_chatter_mastodon') $out=array_merge($out,$this->search_mastodon($q,$window));
-            elseif ($sourceId==='public_chatter_gdelt') $out=array_merge($out,$this->search_gdelt($q));
+
+    private function provider_queries(string $name): array {
+        $base = trim($name);
+        $plain = trim((string)preg_replace('/\s*\/.*$/', '', $base));
+        $queries = [$base.' outage', $base.' down', $base.' errors'];
+        if ($plain !== '' && strcasecmp($plain, $base) !== 0) {
+            $queries[] = $plain.' outage';
+            $queries[] = $plain.' down';
         }
+        return array_values(array_unique($queries));
+    }
+
+    private function active_incident_queries(string $providerName, string $title, int $limit): array {
+        $queries = [$providerName.' outage', $providerName.' down', $providerName.' errors'];
+        $short = $this->short_phrase($title);
+        if ($short !== '') { $queries[] = $short; }
+        $keyword = $this->incident_keyword($title);
+        if ($keyword !== '') { $queries[] = $providerName.' '.$keyword; }
+        return array_slice(array_values(array_unique(array_filter($queries))), 0, max(1, $limit));
+    }
+
+    private function short_phrase(string $text): string {
+        $text = trim((string)preg_replace('/[^\pL\pN\s\-]/u', ' ', $text));
+        $parts = preg_split('/\s+/', $text) ?: [];
+        return trim(implode(' ', array_slice($parts, 0, 6)));
+    }
+
+    private function incident_keyword(string $title): string {
+        $words = ['login','api','errors','latency','degraded','outage','payments','email','network','dns','dashboard','e-transfer','debit'];
+        $lower = strtolower($title);
+        foreach ($words as $word) { if (str_contains($lower, $word)) { return $word; } }
+        return '';
+    }
+
+    private function active_incident_seed_providers(array $providers): array {
+        $snapshot = function_exists('lousy_outages_get_snapshot') ? \lousy_outages_get_snapshot(false) : get_option('lousy_outages_snapshot', []);
+        if (!is_array($snapshot) || empty($snapshot['providers']) || !is_array($snapshot['providers'])) {
+            $snapshot = get_option('lousy_outages_snapshot', []);
+        }
+        $out = [];
+        foreach ((array)($snapshot['providers'] ?? []) as $tile) {
+            if (!is_array($tile)) { continue; }
+            $providerId = sanitize_key((string)($tile['provider'] ?? $tile['id'] ?? ''));
+            if ($providerId === '') { continue; }
+            $status = strtolower((string)($tile['status'] ?? $tile['stateCode'] ?? ''));
+            $incidents = (array)($tile['incidents'] ?? []);
+            $active = !in_array($status, ['', 'operational', 'ok', 'unknown'], true) || !empty($incidents);
+            if (!$active) { continue; }
+            $title = (string)($tile['summary'] ?? $tile['status_label'] ?? $tile['state'] ?? 'Active incident');
+            if (!empty($incidents[0]) && is_array($incidents[0])) {
+                $title = (string)($incidents[0]['name'] ?? $incidents[0]['title'] ?? $title);
+                $status = strtolower((string)($incidents[0]['status'] ?? $status));
+            }
+            $out[$providerId] = [
+                'provider_id' => $providerId,
+                'provider_name' => (string)($tile['name'] ?? $tile['provider_name'] ?? ($providers[$providerId]['name'] ?? $providerId)),
+                'official_status' => $status ?: 'active',
+                'title' => $title,
+                'category' => (string)($providers[$providerId]['category'] ?? 'official_incident'),
+            ];
+        }
+        return array_values($out);
+    }
+
+    private function collect_mentions(string $sourceId, array $queries, int $window, int $limit): array {
+        $out=[]; $diag=['queries_attempted'=>0,'errors'=>[],'instances_queried'=>[]];
+        foreach(array_slice($queries,0,max(1,$limit)) as $q){
+            $diag['queries_attempted']++;
+            if ($sourceId==='public_chatter_bluesky') { $result=$this->search_bluesky($q,$window); }
+            elseif ($sourceId==='public_chatter_mastodon') { $result=$this->search_mastodon($q,$window); }
+            elseif ($sourceId==='public_chatter_gdelt') { $result=$this->search_gdelt($q); }
+            else { $result=['mentions'=>[],'errors'=>['request_error']]; }
+            $out=array_merge($out,(array)($result['mentions'] ?? []));
+            $diag['errors']=array_merge($diag['errors'], (array)($result['errors'] ?? []));
+            $diag['instances_queried']=array_merge($diag['instances_queried'], (array)($result['instances_queried'] ?? []));
+        }
+        $this->requestDiagnostics[$sourceId] = $diag;
         return array_values(array_unique($out));
     }
+
     private function search_bluesky(string $q,int $window): array {
         $url = add_query_arg(['q'=>$q,'limit'=>25,'sort'=>'latest'],'https://public.api.bsky.app/xrpc/app.bsky.feed.searchPosts');
-        $res = wp_remote_get($url,['timeout'=>8]); if(is_wp_error($res) || (int)wp_remote_retrieve_response_code($res)>=400) return [];
+        $res = wp_remote_get($url,['timeout'=>8]);
+        if(is_wp_error($res)) { return ['mentions'=>[],'errors'=>['request_error']]; }
+        if((int)wp_remote_retrieve_response_code($res)>=400) { return ['mentions'=>[],'errors'=>['api_http_error']]; }
         $body = json_decode((string)wp_remote_retrieve_body($res), true); $posts=(array)($body['posts']??[]); $min=time()-$window*60; $hashes=[];
         foreach($posts as $p){ $created = strtotime((string)($p['record']['createdAt'] ?? $p['indexedAt'] ?? '')); if($created && $created < $min) continue; $hashes[] = hash('sha256', (string)($p['uri'] ?? '').'|'.substr((string)($p['record']['text'] ?? ''),0,60)); }
-        return $hashes;
+        return ['mentions'=>$hashes,'errors'=>[]];
     }
+
     private function search_mastodon(string $q,int $window): array {
-        $instances=(array)apply_filters('lo_public_chatter_mastodon_instances',['https://mastodon.social']); $hashes=[]; $min=time()-$window*60;
-        foreach(array_slice($instances,0,2) as $instance){ $url = trailingslashit((string)$instance).'api/v2/search?q='.rawurlencode($q).'&type=statuses&limit=20'; $res=wp_remote_get($url,['timeout'=>8]); if(is_wp_error($res)||(int)wp_remote_retrieve_response_code($res)>=400) continue; $body=json_decode((string)wp_remote_retrieve_body($res),true); foreach((array)($body['statuses']??[]) as $s){ $created=strtotime((string)($s['created_at']??'')); if($created && $created<$min) continue; $hashes[] = hash('sha256',(string)($s['url']??'').'|'.substr(wp_strip_all_tags((string)($s['content']??'')),0,60)); }}
-        return $hashes;
+        $instances=(array)apply_filters('lo_public_chatter_mastodon_instances',['https://mastodon.social']); $hashes=[]; $min=time()-$window*60; $errors=[]; $queried=[];
+        foreach(array_slice($instances,0,2) as $instance){ $instance=rtrim((string)$instance,'/'); $queried[]=$instance; $url = $instance.'/api/v2/search?q='.rawurlencode($q).'&type=statuses&limit=20'; $res=wp_remote_get($url,['timeout'=>8]); if(is_wp_error($res)){ $errors[]='request_error'; continue; } if((int)wp_remote_retrieve_response_code($res)>=400){ $errors[]='api_http_error'; continue; } $body=json_decode((string)wp_remote_retrieve_body($res),true); foreach((array)($body['statuses']??[]) as $s){ $created=strtotime((string)($s['created_at']??'')); if($created && $created<$min) continue; $hashes[] = hash('sha256',(string)($s['url']??'').'|'.substr(wp_strip_all_tags((string)($s['content']??'')),0,60)); }}
+        return ['mentions'=>$hashes,'errors'=>array_values(array_unique($errors)),'instances_queried'=>array_values(array_unique($queried))];
     }
+
     private function search_gdelt(string $q): array {
         $url=add_query_arg(['query'=>$q,'mode'=>'ArtList','format'=>'json','timespan'=>'60m','sort'=>'datedesc'],'https://api.gdeltproject.org/api/v2/doc/doc');
-        $res=wp_remote_get($url,['timeout'=>8]); if(is_wp_error($res)||(int)wp_remote_retrieve_response_code($res)>=400) return [];
-        $body=json_decode((string)wp_remote_retrieve_body($res),true); $arts=(array)($body['articles']??[]); $hashes=[]; foreach(array_slice($arts,0,20) as $a){ $hashes[] = hash('sha256',(string)($a['url']??'').'|'.(string)($a['title']??'')); } return $hashes;
+        $res=wp_remote_get($url,['timeout'=>8]); if(is_wp_error($res)) return ['mentions'=>[],'errors'=>['request_error']]; if((int)wp_remote_retrieve_response_code($res)>=400) return ['mentions'=>[],'errors'=>['api_http_error']];
+        $body=json_decode((string)wp_remote_retrieve_body($res),true); $arts=(array)($body['articles']??[]); $hashes=[]; foreach(array_slice($arts,0,20) as $a){ $hashes[] = hash('sha256',(string)($a['url']??'').'|'.(string)($a['title']??'')); } return ['mentions'=>$hashes,'errors'=>[]];
     }
+
+    private function source_statuses(array $checkboxes, bool $directEnabled, array $diag): array {
+        $out = ['hacker_news_chatter'=>['label'=>'HN chatter','status'=>!empty(get_option('lo_hn_chatter_enabled', '1')) ? 'enabled' : 'disabled']];
+        foreach ($checkboxes as $sourceId => $checked) {
+            $status = !$checked ? 'disabled' : ($directEnabled ? 'enabled' : 'blocked_by_safe_default');
+            $out[$sourceId] = ['label'=>$this->source_label($sourceId),'status'=>$status,'reasons'=>(array)($diag['skipped_sources'][$sourceId] ?? [])];
+        }
+        $cfDiag = (array)get_option('lo_diag_cloudflare_radar', []);
+        $out['cloudflare_radar'] = ['label'=>'Cloudflare Radar (external telemetry)','status'=>!empty($cfDiag['configured']) ? 'configured' : 'not_configured'];
+        return $out;
+    }
+
+    private function official_incident_corroboration(array $activeIncidents, array $diag, array $perProviderSourceCounts, array $enabledRuntimeSourceIds): array {
+        $rows = [];
+        foreach ($activeIncidents as $incident) {
+            $providerId = (string)($incident['provider_id'] ?? '');
+            $promoted = (int)($diag['signals_built_by_provider'][$providerId] ?? 0) > 0;
+            $watch = 0;
+            foreach ((array)$diag['watch_candidates'] as $candidate) {
+                if (($candidate['provider_id'] ?? '') === $providerId) { $watch += (int)($candidate['count'] ?? 0); }
+            }
+            if (!$enabledRuntimeSourceIds) { $label = 'No chatter sources enabled'; }
+            elseif ($promoted) { $label = 'Public corroboration'; }
+            elseif ($watch > 0 || !empty($perProviderSourceCounts[$providerId])) { $label = 'Public watch'; }
+            else { $label = 'Official only'; }
+            $rows[] = [
+                'provider_id'=>$providerId,
+                'provider_name'=>(string)($incident['provider_name'] ?? $providerId),
+                'official_status'=>(string)($incident['official_status'] ?? 'active'),
+                'public_chatter_promoted'=>$promoted,
+                'watch_candidates'=>$watch,
+                'sources_checked'=>array_map(fn($s) => $this->source_label((string)$s), $enabledRuntimeSourceIds),
+                'result_label'=>$label,
+            ];
+        }
+        return $rows;
+    }
+
+    private function watchlist_summary(): array {
+        $summary = [];
+        foreach ($this->canadian_infrastructure_watchlist() as $category => $items) {
+            $summary[] = ['category'=>$category, 'label'=>$this->watchlist_category_label($category), 'count'=>count($items), 'providers'=>array_values($items)];
+        }
+        return $summary;
+    }
+
+    private function flat_watchlist_providers(): array {
+        $out=[]; foreach($this->canadian_infrastructure_watchlist() as $category=>$items){ foreach($items as $id=>$name){ $out[]=['provider_id'=>(string)$id,'provider_name'=>(string)$name,'category'=>(string)$category]; }} return $out;
+    }
+
+    private function watchlist_category_label(string $category): string {
+        $labels=['telecom'=>'Telecom','payments'=>'Payments','banking'=>'Banking','government_login'=>'Government login','transit'=>'Transit','emergency_services'=>'Emergency services'];
+        return $labels[$category] ?? ucwords(str_replace('_',' ',$category));
+    }
+
+    private function source_label(string $sourceId): string {
+        $labels=['public_chatter_bluesky'=>'Bluesky','public_chatter_mastodon'=>'Mastodon','public_chatter_gdelt'=>'GDELT open web','hacker_news_chatter'=>'HN chatter'];
+        return $labels[$sourceId] ?? $sourceId;
+    }
+
     private function severity_for_count(int $count, array $t): string { if($count >= $t['hot']) return 'hot'; if($count >= $t['trending']) return 'trending'; if($count >= $t['watch']) return 'watch'; return ''; }
     private function build_signal(string $source,string $providerId,string $providerName,string $category,string $severity,int $count,int $window,array $mentions): array {
         $confMap=['watch'=>25,'trending'=>45,'hot'=>65]; if($source==='public_chatter_gdelt') $confMap=['watch'=>35,'trending'=>55,'hot'=>70];
-        $msg = $source==='public_chatter_gdelt' ? "Recent public web/news mentions suggest a possible {$providerName} issue. Official status may still be unconfirmed." : "Public posts mentioning possible {$providerName} issues increased recently. This is unconfirmed.";
+        $msg = $source==='public_chatter_gdelt' ? "Recent open-web/news mentions suggest a possible {$providerName} issue. Official status may still be unconfirmed." : "Public posts mentioning possible {$providerName} issues increased recently. This is unconfirmed.";
         return ['source'=>$source,'provider_id'=>$providerId,'provider_name'=>$providerName,'category'=>$source==='public_chatter_gdelt'?'open_web':$category,'region'=>'global','signal_type'=>'public_chatter','severity'=>$severity,'confidence'=>min(85,max(0,(int)$confMap[$severity])),'title'=>$source==='public_chatter_gdelt'?"Open web mentions increasing for {$providerName}":"Public chatter mentions increasing for {$providerName}",'message'=>$msg,'url'=>$this->safe_url_for_source($source,$providerName),'observed_at'=>gmdate('Y-m-d H:i:s'),'expires_at'=>gmdate('Y-m-d H:i:s',time()+$window*60),'raw_hash'=>hash('sha256',$source.'|'.$providerId.'|'.$severity.'|'.count($mentions).'|'.implode('|',$mentions))];
     }
     private function safe_url_for_source(string $source, string $provider): string { if($source==='public_chatter_bluesky') return 'https://bsky.app/search?q='.rawurlencode($provider.' outage'); if($source==='public_chatter_mastodon') return 'https://mastodon.social'; if($source==='public_chatter_gdelt') return 'https://api.gdeltproject.org/api/v2/doc/doc'; return ''; }

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -1069,12 +1069,26 @@ function lousy_outages_settings_page() {
                     </td>
                 </tr>
                 
+                <?php
+                $lo_public_chatter_source = new \SuzyEaston\LousyOutages\Sources\PublicChatterSource();
+                $lo_public_chatter_master_enabled = ! empty( get_option( 'lousy_outages_public_chatter_enabled', '0' ) );
+                $lo_public_chatter_direct_enabled = $lo_public_chatter_source->direct_sources_enabled();
+                $lo_public_chatter_source_statuses = [
+                    'Bluesky' => ! empty( get_option( 'lousy_outages_public_chatter_bluesky_enabled', '1' ) ),
+                    'Mastodon' => ! empty( get_option( 'lousy_outages_public_chatter_mastodon_enabled', '0' ) ),
+                    'GDELT' => ! empty( get_option( 'lousy_outages_public_chatter_gdelt_enabled', '1' ) ),
+                ];
+                ?>
                 <tr><th scope="row">Rumour Radar</th><td>
-                    <input type="hidden" name="lousy_outages_public_chatter_enabled" value="0"><label><input type="checkbox" name="lousy_outages_public_chatter_enabled" value="1" <?php checked( ! empty( get_option( 'lousy_outages_public_chatter_enabled', '0' ) ) ); ?>> Enable Public Chatter Radar</label><br>
-                    <input type="hidden" name="lousy_outages_public_chatter_bluesky_enabled" value="0"><label><input type="checkbox" name="lousy_outages_public_chatter_bluesky_enabled" value="1" <?php checked( ! empty( get_option( 'lousy_outages_public_chatter_bluesky_enabled', '1' ) ) ); ?>> Enable Bluesky source</label><br>
-                    <input type="hidden" name="lousy_outages_public_chatter_mastodon_enabled" value="0"><label><input type="checkbox" name="lousy_outages_public_chatter_mastodon_enabled" value="1" <?php checked( ! empty( get_option( 'lousy_outages_public_chatter_mastodon_enabled', '0' ) ) ); ?>> Enable Mastodon source</label><br>
-                    <input type="hidden" name="lousy_outages_public_chatter_gdelt_enabled" value="0"><label><input type="checkbox" name="lousy_outages_public_chatter_gdelt_enabled" value="1" <?php checked( ! empty( get_option( 'lousy_outages_public_chatter_gdelt_enabled', '1' ) ) ); ?>> Enable GDELT source</label>
-                    <p class="description">Public chatter signals are unconfirmed and should be treated as early warning only.</p>
+                    <p><strong>Master Public Chatter Radar:</strong> <?php echo esc_html( $lo_public_chatter_master_enabled ? 'Enabled' : 'Disabled' ); ?> | <strong>Direct public source gate:</strong> <?php echo esc_html( $lo_public_chatter_direct_enabled ? 'Enabled' : 'Disabled by safe default' ); ?></p>
+                    <?php if ( ! $lo_public_chatter_direct_enabled ) : ?>
+                        <div class="notice notice-warning inline"><p><?php echo esc_html__( 'Direct public chatter sources are disabled by safe default. Source checkboxes are saved, but they will not collect until the direct source gate is enabled.', 'lousy-outages' ); ?></p></div>
+                    <?php endif; ?>
+                    <input type="hidden" name="lousy_outages_public_chatter_enabled" value="0"><label><input type="checkbox" name="lousy_outages_public_chatter_enabled" value="1" <?php checked( $lo_public_chatter_master_enabled ); ?>> Enable Public Chatter Radar</label><br>
+                    <input type="hidden" name="lousy_outages_public_chatter_bluesky_enabled" value="0"><label><input type="checkbox" name="lousy_outages_public_chatter_bluesky_enabled" value="1" <?php checked( $lo_public_chatter_source_statuses['Bluesky'] ); ?>> Enable Bluesky source</label> <em><?php echo esc_html( $lo_public_chatter_source_statuses['Bluesky'] ? ( $lo_public_chatter_direct_enabled ? 'enabled' : 'saved, blocked by safe default' ) : 'disabled' ); ?></em><br>
+                    <input type="hidden" name="lousy_outages_public_chatter_mastodon_enabled" value="0"><label><input type="checkbox" name="lousy_outages_public_chatter_mastodon_enabled" value="1" <?php checked( $lo_public_chatter_source_statuses['Mastodon'] ); ?>> Enable Mastodon source</label> <em><?php echo esc_html( $lo_public_chatter_source_statuses['Mastodon'] ? ( $lo_public_chatter_direct_enabled ? 'enabled' : 'saved, blocked by safe default' ) : 'disabled' ); ?></em><br>
+                    <input type="hidden" name="lousy_outages_public_chatter_gdelt_enabled" value="0"><label><input type="checkbox" name="lousy_outages_public_chatter_gdelt_enabled" value="1" <?php checked( $lo_public_chatter_source_statuses['GDELT'] ); ?>> Enable GDELT source</label> <em><?php echo esc_html( $lo_public_chatter_source_statuses['GDELT'] ? ( $lo_public_chatter_direct_enabled ? 'enabled' : 'saved, blocked by safe default' ) : 'disabled' ); ?></em>
+                    <p class="description">Public chatter signals are unconfirmed and thresholded. GDELT is open-web/news corroboration; Cloudflare Radar remains external telemetry, not rumour radar.</p>
                 </td></tr>
 
 <tr>

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -643,6 +643,33 @@ function render_shortcode(): string {
         if ($checkedTotal <= 0) {
             $checkedTotal = $promotedTotal + $rejectedTotal;
         }
+        $publicDiag = (array) get_option('lo_diag_public_chatter', []);
+        $cfDiag = (array) get_option('lo_diag_cloudflare_radar', []);
+        $watchCandidates = isset($publicDiag['watch_candidates']) && is_array($publicDiag['watch_candidates']) ? $publicDiag['watch_candidates'] : [];
+        $watchCandidateCount = (int) ($publicDiag['watch_candidate_count'] ?? count($watchCandidates));
+        $sourceStatuses = isset($publicDiag['source_statuses']) && is_array($publicDiag['source_statuses']) ? $publicDiag['source_statuses'] : [];
+        $sourceStatusRows = [
+            'hacker_news_chatter' => $sourceStatuses['hacker_news_chatter'] ?? ['label' => 'HN chatter', 'status' => !empty(get_option('lo_hn_chatter_enabled', '1')) ? 'enabled' : 'disabled'],
+            'public_chatter_bluesky' => $sourceStatuses['public_chatter_bluesky'] ?? ['label' => 'Bluesky', 'status' => !empty(get_option('lousy_outages_public_chatter_bluesky_enabled', '1')) ? (!empty($publicDiag['direct_sources_enabled']) ? 'enabled' : 'blocked_by_safe_default') : 'disabled'],
+            'public_chatter_mastodon' => $sourceStatuses['public_chatter_mastodon'] ?? ['label' => 'Mastodon', 'status' => !empty(get_option('lousy_outages_public_chatter_mastodon_enabled', '0')) ? (!empty($publicDiag['direct_sources_enabled']) ? 'enabled' : 'blocked_by_safe_default') : 'disabled'],
+            'public_chatter_gdelt' => $sourceStatuses['public_chatter_gdelt'] ?? ['label' => 'GDELT', 'status' => !empty(get_option('lousy_outages_public_chatter_gdelt_enabled', '1')) ? (!empty($publicDiag['direct_sources_enabled']) ? 'enabled' : 'blocked_by_safe_default') : 'disabled'],
+            'cloudflare_radar' => $sourceStatuses['cloudflare_radar'] ?? ['label' => 'Cloudflare Radar (external telemetry)', 'status' => !empty($cfDiag['configured']) ? 'configured' : 'not_configured'],
+        ];
+        $sourcesEnabledCount = 0;
+        $sourcesBlockedCount = 0;
+        foreach ($sourceStatusRows as $sourceStatusRow) {
+            $statusValue = (string) ($sourceStatusRow['status'] ?? 'disabled');
+            if (in_array($statusValue, ['enabled', 'configured'], true)) { $sourcesEnabledCount++; }
+            if (in_array($statusValue, ['disabled', 'blocked_by_safe_default', 'not_configured'], true)) { $sourcesBlockedCount++; }
+        }
+        $officialCorroborationRows = isset($publicDiag['official_incident_corroboration']) && is_array($publicDiag['official_incident_corroboration']) ? $publicDiag['official_incident_corroboration'] : [];
+        $canadianWatchRows = isset($publicDiag['canadian_infrastructure_watchlist']) && is_array($publicDiag['canadian_infrastructure_watchlist']) ? $publicDiag['canadian_infrastructure_watchlist'] : [];
+        $statusLabel = static function($status): string {
+            $status = (string) $status;
+            if ($status === 'blocked_by_safe_default') { return 'blocked by safe default'; }
+            if ($status === 'not_configured') { return 'not configured'; }
+            return str_replace('_', ' ', $status);
+        };
         ?>
         <div class="lo-incidents" data-lo-incidents>
             <section class="lo-section lo-section--incidents" data-lo-section="incidents">
@@ -676,46 +703,78 @@ function render_shortcode(): string {
                 <span class="lo-chatter-scanner__stat"><strong><?php echo esc_html((string) $checkedTotal); ?></strong> Checked</span>
                 <span class="lo-chatter-scanner__stat"><strong><?php echo esc_html((string) $promotedTotal); ?></strong> Promoted</span>
                 <span class="lo-chatter-scanner__stat"><strong><?php echo esc_html((string) $rejectedTotal); ?></strong> Rejected</span>
-                <?php foreach (array_slice($rejectSummary, 0, 2) as $reasonRow) : ?>
-                    <span class="lo-chatter-scanner__stat"><strong><?php echo esc_html((string) ($reasonRow['count'] ?? 0)); ?></strong> <?php echo esc_html((string) ($reasonRow['label'] ?? 'Filtered')); ?></span>
+                <span class="lo-chatter-scanner__stat"><strong><?php echo esc_html((string) $watchCandidateCount); ?></strong> Watch candidates</span>
+                <span class="lo-chatter-scanner__stat"><strong><?php echo esc_html((string) $sourcesEnabledCount); ?></strong> Sources enabled</span>
+                <span class="lo-chatter-scanner__stat"><strong><?php echo esc_html((string) $sourcesBlockedCount); ?></strong> Sources blocked/disabled</span>
+            </div>
+            <div class="lo-chatter-scanner__strip" aria-label="Public chatter source status">
+                <?php foreach ($sourceStatusRows as $sourceStatusRow) : $sourceStatus = (string) ($sourceStatusRow['status'] ?? 'disabled'); ?>
+                    <span class="lo-chatter-scanner__source lo-chatter-scanner__source--<?php echo esc_attr(sanitize_html_class($sourceStatus)); ?>">
+                        <?php echo esc_html((string) ($sourceStatusRow['label'] ?? 'Source')); ?>: <?php echo esc_html($statusLabel($sourceStatus)); ?>
+                    </span>
                 <?php endforeach; ?>
             </div>
+            <?php if (!empty($watchCandidates)) : ?>
+                <div class="lo-chatter-scanner__watch">
+                    <h4>Watch candidates</h4>
+                    <p>Watch candidates are unconfirmed volume/context hints. They are not outage reports.</p>
+                    <ul>
+                        <?php foreach (array_slice($watchCandidates, 0, 8) as $candidate) : ?>
+                            <li><?php echo esc_html((string) ($candidate['provider_name'] ?? $candidate['provider_id'] ?? 'Provider')); ?>: <?php echo esc_html((string) ($candidate['count'] ?? 0)); ?> <?php echo esc_html((string) ($candidate['source_label'] ?? $candidate['source'] ?? 'source')); ?> mentions, below threshold</li>
+                        <?php endforeach; ?>
+                    </ul>
+                </div>
+            <?php endif; ?>
+            <div class="lo-chatter-scanner__corroboration">
+                <h4>Official incident corroboration</h4>
+                <?php if (!empty($officialCorroborationRows)) : ?>
+                    <div class="lo-chatter-scanner__table" role="table" aria-label="Official incident public corroboration">
+                        <div role="row" class="lo-chatter-scanner__table-head"><span>Provider</span><span>Official status</span><span>Sources checked</span><span>Public result</span><span>Watch candidates</span></div>
+                        <?php foreach (array_slice($officialCorroborationRows, 0, 8) as $row) : ?>
+                            <div role="row"><span><?php echo esc_html((string) ($row['provider_name'] ?? $row['provider_id'] ?? 'Provider')); ?></span><span><?php echo esc_html((string) ($row['official_status'] ?? 'active')); ?></span><span><?php echo esc_html(implode(', ', array_map('strval', (array) ($row['sources_checked'] ?? []))) ?: 'None'); ?></span><span><?php echo esc_html((string) ($row['result_label'] ?? 'Official only')); ?></span><span><?php echo esc_html((string) ($row['watch_candidates'] ?? 0)); ?></span></div>
+                        <?php endforeach; ?>
+                    </div>
+                <?php else : ?>
+                    <p>No active official incidents were available to seed public corroboration in the last scan.</p>
+                <?php endif; ?>
+            </div>
+            <?php if (!empty($canadianWatchRows)) : ?>
+                <div class="lo-chatter-scanner__watchlist">
+                    <h4>Canadian infrastructure watch</h4>
+                    <div>
+                        <?php foreach ($canadianWatchRows as $watchRow) : ?>
+                            <span><?php echo esc_html((string) ($watchRow['label'] ?? $watchRow['category'] ?? 'Watchlist')); ?> armed (<?php echo esc_html((string) ($watchRow['count'] ?? 0)); ?>)</span>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+            <?php endif; ?>
             <?php if ($public_chatter) : ?>
                 <div class="lo-chatter-scanner__cards">
-                    <?php foreach (array_slice($public_chatter, 0, 6) as $sig) : $quote = trim((string)($sig['evidence_quote'] ?? '')); $sourceLabel = trim((string)($sig['evidence_source_label'] ?? '')); $sourceUrl = trim((string)($sig['evidence_url'] ?? '')); ?>
+                    <?php foreach (array_slice($public_chatter, 0, 6) as $sig) : $sourceLabel = trim((string)($sig['evidence_source_label'] ?? $sig['source'] ?? '')); $sourceUrl = trim((string)($sig['evidence_url'] ?? $sig['url'] ?? '')); ?>
                         <article class="lo-card">
                             <div class="lo-head"><h4 class="lo-title"><?php echo esc_html((string)($sig['provider_name'] ?? $sig['provider_id'] ?? 'Provider')); ?></h4><span class="lo-pill">RUMOUR RADAR</span></div>
                             <p class="lo-summary">Unconfirmed public report. Needs corroboration.</p>
-                            <?php if ($quote !== '') : ?><blockquote class="lo-evidence-quote">“<?php echo esc_html($quote); ?>”</blockquote><?php endif; ?>
                             <p class="lo-message"><?php echo esc_html((string)($sig['message'] ?? 'Needs corroboration from official/synthetic signals.')); ?></p>
                             <p class="lo-card-meta">Source: <?php echo esc_html($sourceLabel ?: 'Public chatter'); ?><?php if ($sourceUrl !== '') : ?> · <a class="lo-link" href="<?php echo esc_url($sourceUrl); ?>" target="_blank" rel="noopener">View source</a><?php endif; ?> · Observed: <?php echo esc_html($format_datetime($sig['observed_at'] ?? null)); ?></p>
                         </article>
                     <?php endforeach; ?>
                 </div>
-            <?php elseif ($checkedTotal > 0 || !empty($rejectSummary) || !empty($previewSample)) : ?>
-                <?php
-                // Public chatter can be empty because weak, noisy, historical, or non-provider posts were rejected; that is expected and diagnostics make the quiet result visible.
-                ?>
-                <div class="lo-chatter-scanner__empty">
-                    <h4>Public chatter scan complete</h4>
-                    <p>No credible field reports promoted. Official radar only.</p>
-                </div>
-                <?php if (!empty($rejectSummary)) : ?>
-                    <div class="lo-chatter-scanner__reasons" aria-label="Rejected public chatter categories">
-                        <?php foreach (array_slice($rejectSummary, 0, 5) as $reasonRow) : ?>
-                            <div class="lo-chatter-scanner__reason">
-                                <span><?php echo esc_html((string) ($reasonRow['label'] ?? 'Filtered chatter')); ?></span>
-                                <strong><?php echo esc_html((string) ($reasonRow['count'] ?? 0)); ?></strong>
-                                <small><?php echo esc_html((string) ($reasonRow['description'] ?? 'Filtered chatter that did not meet current-signal quality checks.')); ?></small>
-                            </div>
-                        <?php endforeach; ?>
-                    </div>
-                <?php endif; ?>
             <?php else : ?>
-                <div class="lo-chatter-scanner__empty lo-chatter-scanner__empty--fallback">
-                    <h4>Public chatter scanner online</h4>
-                    <p>No rumour radar hits or diagnostics available yet.</p>
-                    <p>Official radar only for now.</p>
+                <div class="lo-chatter-scanner__empty<?php echo ($checkedTotal <= 0 && empty($rejectSummary) && empty($previewSample)) ? ' lo-chatter-scanner__empty--fallback' : ''; ?>">
+                    <h4><?php echo ($checkedTotal > 0 || !empty($rejectSummary) || !empty($previewSample)) ? esc_html('Public chatter scan complete') : esc_html('Public chatter scanner online'); ?></h4>
+                    <p><?php echo ($checkedTotal > 0 || !empty($rejectSummary) || !empty($previewSample)) ? esc_html('No credible field reports promoted. Official radar only.') : esc_html('No rumour radar hits or diagnostics available yet.'); ?></p>
+                    <p>Missing results can mean sources are disabled, the direct-source safe gate is closed, thresholds were not met, or there was no credible recent chatter.</p>
+                </div>
+            <?php endif; ?>
+            <?php if (!empty($rejectSummary)) : ?>
+                <div class="lo-chatter-scanner__reasons" aria-label="Rejected public chatter categories">
+                    <?php foreach (array_slice($rejectSummary, 0, 6) as $reasonRow) : ?>
+                        <div class="lo-chatter-scanner__reason">
+                            <span><?php echo esc_html((string) ($reasonRow['label'] ?? 'Filtered chatter')); ?></span>
+                            <strong><?php echo esc_html((string) ($reasonRow['count'] ?? 0)); ?></strong>
+                            <small><?php echo esc_html((string) ($reasonRow['description'] ?? 'Filtered chatter that did not meet current-signal quality checks.')); ?></small>
+                        </div>
+                    <?php endforeach; ?>
                 </div>
             <?php endif; ?>
         </section>

--- a/lousy-outages/scripts/preview-public-chatter.php
+++ b/lousy-outages/scripts/preview-public-chatter.php
@@ -12,24 +12,10 @@ $_SERVER['REQUEST_METHOD'] = 'GET';
 
 register_shutdown_function(static function (): void {
     $error = error_get_last();
-    if (!is_array($error)) {
-        return;
-    }
-
+    if (!is_array($error)) { return; }
     $fatalTypes = [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR];
-    if (!in_array((int) ($error['type'] ?? 0), $fatalTypes, true)) {
-        return;
-    }
-
-    fwrite(
-        STDERR,
-        sprintf(
-            "Fatal error: %s in %s:%d\n",
-            (string) ($error['message'] ?? 'unknown error'),
-            (string) ($error['file'] ?? 'unknown file'),
-            (int) ($error['line'] ?? 0)
-        )
-    );
+    if (!in_array((int) ($error['type'] ?? 0), $fatalTypes, true)) { return; }
+    fwrite(STDERR, sprintf("Fatal error: %s in %s:%d\n", (string) ($error['message'] ?? 'unknown error'), (string) ($error['file'] ?? 'unknown file'), (int) ($error['line'] ?? 0)));
 });
 
 define('LOUSY_OUTAGES_NO_EMAIL', true);
@@ -39,31 +25,60 @@ if (class_exists(\SuzyEaston\LousyOutages\MailTransport::class)
     && method_exists(\SuzyEaston\LousyOutages\MailTransport::class, 'set_enabled')) {
     \SuzyEaston\LousyOutages\MailTransport::set_enabled(false);
 }
-$src = new \SuzyEaston\LousyOutages\Sources\HackerNewsChatterSource();
-$rows = $src->collect(['dry_run'=>true,'diagnostic_mode'=>true,'window_minutes'=>$window,'suppress_notifications'=>true,'no_email'=>true]);
-$diag = get_option('lo_diag_hacker_news_chatter', []);
-$preview = array_slice((array)($diag['chatter_candidates_preview_sample'] ?? []), 0, $limit);
 
-$accepted = array_values(array_filter($preview, static fn($p) => ($p['reject_reason'] ?? '') === 'accepted'));
-$rejected = array_values(array_filter($preview, static fn($p) => ($p['reject_reason'] ?? '') !== 'accepted'));
+$publicSource = new \SuzyEaston\LousyOutages\Sources\PublicChatterSource();
+$signals = $publicSource->collect(['dry_run'=>true,'diagnostic_mode'=>true,'window_minutes'=>$window,'suppress_notifications'=>true,'no_email'=>true]);
+$publicDiag = (array) get_option('lo_diag_public_chatter', []);
 
-echo "Accepted candidates: " . count($accepted) . "\n";
-foreach ($accepted as $p) {
-    echo "[ACCEPT] provider=" . ($p['provider'] ?? '') .
-        " category=" . ($p['category'] ?? '') .
-        " quote=\"" . substr((string)($p['quote'] ?? ''), 0, 160) . "\"" .
-        " source_url=" . ($p['source_url'] ?? '') .
-        " observed_at=" . ($p['observed_at'] ?? '') . "\n";
+$hnSource = new \SuzyEaston\LousyOutages\Sources\HackerNewsChatterSource();
+$hnRows = $hnSource->collect(['dry_run'=>true,'diagnostic_mode'=>true,'window_minutes'=>$window,'suppress_notifications'=>true,'no_email'=>true]);
+$hnDiag = (array) get_option('lo_diag_hacker_news_chatter', []);
+$reasonCounts = (array)($hnDiag['chatter_rejected_by_reason'] ?? []);
+
+$printList = static function (string $label, array $values, int $limit = 30): void {
+    echo $label . ': ';
+    $values = array_slice(array_values(array_filter(array_map('strval', $values))), 0, $limit);
+    echo $values ? implode(', ', $values) : 'none';
+    echo "\n";
+};
+
+echo "Public Chatter Corroboration Preview (diagnostics-only; no email, no inserts requested)\n";
+echo "Master enabled: " . (!empty($publicDiag['configured']) ? 'yes' : 'no') . "\n";
+echo "Direct source gate: " . (!empty($publicDiag['direct_sources_enabled']) ? 'enabled' : 'disabled') . "\n";
+
+echo "Enabled source checkboxes:\n";
+foreach ((array)($publicDiag['enabled_sources'] ?? []) as $source => $enabled) {
+    echo "- {$source}: " . ($enabled ? 'checked' : 'unchecked') . "\n";
 }
-echo "\nRejected candidates: " . count($rejected) . "\n";
-foreach ($rejected as $p) {
-    $reason = (string) ($p['reject_reason'] ?? '');
-    $reasonMeta = \SuzyEaston\LousyOutages\Sources\ChatterRejectionReasons::get($reason);
-    echo "[REJECT] reason=" . $reason .
-        " label=\"" . ($reasonMeta['short_label'] ?? '') . "\"" .
-        " provider=" . ($p['provider'] ?? '') .
-        " category=" . ($p['category'] ?? '') .
-        " quote=\"" . substr((string)($p['quote'] ?? ''), 0, 160) . "\"" .
-        " source_url=" . ($p['source_url'] ?? '') .
-        " observed_at=" . ($p['observed_at'] ?? '') . "\n";
+
+echo "Disabled/blocked sources:\n";
+foreach ((array)($publicDiag['skipped_sources'] ?? []) as $source => $reasons) {
+    $reasons = array_values(array_unique(array_filter(array_map('strval', (array)$reasons))));
+    if (!$reasons) { continue; }
+    echo "- {$source}: " . implode(', ', $reasons) . "\n";
+}
+
+$printList('Providers scanned', array_map(static fn($p) => (string)($p['provider_name'] ?? $p['provider_id'] ?? ''), (array)($publicDiag['providers_scanned'] ?? [])), $limit);
+$printList('Active incident seed providers', array_map(static fn($p) => (string)($p['provider_name'] ?? $p['provider_id'] ?? ''), (array)($publicDiag['active_incident_seed_providers'] ?? [])), $limit);
+$printList('Canadian infra providers scanned', array_map(static fn($p) => (string)($p['provider_name'] ?? $p['provider_id'] ?? ''), (array)($publicDiag['canadian_infrastructure_providers_scanned'] ?? [])), $limit);
+
+echo "Mentions seen by source:\n";
+foreach ((array)($publicDiag['mentions_seen_by_source'] ?? []) as $source => $count) { echo "- {$source}: " . (int)$count . "\n"; }
+echo "Mentions seen by provider:\n";
+foreach (array_slice((array)($publicDiag['mentions_seen_by_provider'] ?? []), 0, $limit, true) as $provider => $count) { echo "- {$provider}: " . (int)$count . "\n"; }
+
+echo "Watch candidates: " . (int)($publicDiag['watch_candidate_count'] ?? 0) . "\n";
+foreach (array_slice((array)($publicDiag['watch_candidates'] ?? []), 0, $limit) as $candidate) {
+    echo "[WATCH] provider=" . ($candidate['provider_name'] ?? $candidate['provider_id'] ?? '') . " source=" . ($candidate['source_label'] ?? $candidate['source'] ?? '') . " count=" . (int)($candidate['count'] ?? 0) . " reason=" . ($candidate['reason'] ?? '') . "\n";
+}
+
+echo "Promoted signals: " . count($signals) . " direct public, " . count($hnRows) . " HN\n";
+foreach (array_slice($signals, 0, $limit) as $signal) {
+    echo "[PROMOTED] provider=" . ($signal['provider_name'] ?? $signal['provider_id'] ?? '') . " source=" . ($signal['source'] ?? '') . " severity=" . ($signal['severity'] ?? '') . "\n";
+}
+
+echo "Rejected reasons:\n";
+foreach ($reasonCounts as $reason => $count) {
+    $reasonMeta = \SuzyEaston\LousyOutages\Sources\ChatterRejectionReasons::get((string)$reason);
+    echo "- {$reason}: " . (int)$count . " (" . (string)($reasonMeta['short_label'] ?? '') . ")\n";
 }

--- a/lousy-outages/scripts/smoke-production-preflight.php
+++ b/lousy-outages/scripts/smoke-production-preflight.php
@@ -43,6 +43,21 @@ if(!empty($statusDiag)){
 }
 $chatterDiag=(array)get_option('lo_diag_public_chatter',[]);
 if(!empty($chatterDiag) && !empty($chatterDiag['direct_sources_enabled'])){ $errors[]='Public chatter direct sources enabled (expected safe-default disabled)'; }
+if(!empty($chatterDiag)){
+    foreach(['configured','attempted','direct_sources_enabled','direct_sources_disabled_by_safe_default','enabled_sources','skipped_sources','providers_scanned','queries_attempted','mentions_seen_by_source','mentions_seen_by_provider','signals_built_by_provider','thresholds','scan_window_minutes','ran_at','watch_candidates','official_incident_corroboration','canadian_infrastructure_watchlist'] as $key){
+        if(!array_key_exists($key,$chatterDiag)){ $errors[]='Public chatter diagnostics missing '.$key; }
+    }
+    if(empty($chatterDiag['direct_sources_enabled']) && empty($chatterDiag['direct_sources_disabled_by_safe_default'])){ $errors[]='Public chatter safe-default gate not visible in diagnostics'; }
+    if(!array_key_exists('public_chatter_bluesky',(array)($chatterDiag['enabled_sources']??[])) || !array_key_exists('public_chatter_mastodon',(array)($chatterDiag['enabled_sources']??[])) || !array_key_exists('public_chatter_gdelt',(array)($chatterDiag['enabled_sources']??[]))){ $errors[]='Public chatter source checkbox diagnostics incomplete'; }
+    foreach((array)($chatterDiag['watch_candidates']??[]) as $candidate){
+        $pid=(string)($candidate['provider_id']??'');
+        if($pid!=='' && !empty($chatterDiag['signals_built_by_provider'][$pid])){ $errors[]='Watch candidate also promoted for provider '.$pid; break; }
+    }
+    $seeded=false; foreach((array)($chatterDiag['providers_scanned']??[]) as $provider){ if(in_array('active_incident',(array)($provider['seed_types']??[]),true)){ $seeded=true; break; } }
+    if(!empty($chatterDiag['active_incident_seed_providers']) && !$seeded){ $errors[]='Active incident seed providers missing from generated query providers'; }
+    $hasCanada=false; foreach((array)($chatterDiag['providers_scanned']??[]) as $provider){ if(in_array('canadian_infrastructure',(array)($provider['seed_types']??[]),true)){ $hasCanada=true; break; } }
+    if(!$hasCanada){ $errors[]='Canadian infrastructure watchlist queries not generated'; }
+}
 $hnDiag=(array)get_option('lo_diag_hacker_news_chatter',[]);
 if(!empty($hnDiag) && !array_key_exists('queries_attempted',$hnDiag)){ $errors[]='HN diagnostics missing queries_attempted'; }
 if($errors){ fwrite(STDERR, "Preflight FAILED:\n- ".implode("\n- ",$errors)."\n"); exit(1);} echo "Preflight passed with ".count($sources)." sources.\n";

--- a/lousy-outages/scripts/smoke-signal-sources.php
+++ b/lousy-outages/scripts/smoke-signal-sources.php
@@ -40,6 +40,24 @@ foreach ($sources as $index => $source) {
     if (!is_bool($configured)) {
         $errors[] = sprintf('%s::is_configured() did not return bool.', get_class($source));
     }
+
+    if ($source instanceof \SuzyEaston\LousyOutages\Sources\PublicChatterSource) {
+        $checkboxes = $source->source_checkboxes();
+        foreach (['public_chatter_bluesky', 'public_chatter_mastodon', 'public_chatter_gdelt'] as $expected) {
+            if (!array_key_exists($expected, $checkboxes)) {
+                $errors[] = 'PublicChatterSource missing source checkbox diagnostic key: ' . $expected;
+            }
+        }
+        $watchlist = $source->canadian_infrastructure_watchlist();
+        foreach (['telecom', 'payments', 'banking', 'government_login', 'transit', 'emergency_services'] as $category) {
+            if (empty($watchlist[$category])) {
+                $errors[] = 'PublicChatterSource missing Canadian watchlist category: ' . $category;
+            }
+        }
+        if (!is_bool($source->direct_sources_enabled())) {
+            $errors[] = 'PublicChatterSource direct source gate did not return bool.';
+        }
+    }
 }
 
 if ($errors !== []) {


### PR DESCRIPTION
### Motivation
- Make the Public Chatter / Field Reports scanner more useful by exposing why results are (or are not) appearing and by correlating chatter with active official incidents. 
- Surface the direct-source safe-default gate so admins do not think checked source boxes imply live collection. 
- Expand passive coverage for Canadian infrastructure providers and add a conservative “watch candidates” tier so near-misses are visible without promoting rumours. 
- Treat Cloudflare Radar as external telemetry with proper diagnostics rather than a rumour source.

### Description
- Expanded diagnostics in `PublicChatterSource` (stored in `lo_diag_public_chatter`) to include `configured`, `attempted`, `direct_sources_enabled`, `direct_sources_disabled_by_safe_default`, `enabled_sources`, `skipped_sources` (with reasons), `providers_scanned`, `queries_attempted`, `mentions_seen_by_source`, `mentions_seen_by_provider`, `signals_built_by_provider`, `thresholds`, `scan_window_minutes`, `ran_at`, `watch_candidates` and request-level details; diagnostics are normalized and saved with `update_option`. 
- Added active-incident seeded queries and per-provider query set building in `PublicChatterSource::build_query_sets` and `active_incident_seed_providers`, limited queries per provider and per source to avoid over-querying. 
- Added a Canadian infrastructure watchlist and used it to add provider queries (watchlist is available via `canadian_infrastructure_watchlist`). 
- Introduced a watch-tier: mentions below promotion thresholds are recorded as `watch_candidates` (counts only, no raw post text), and watch candidates are prevented from being promoted unless thresholds are met. 
- Improved runtime source handling and diagnostics: `source_checkboxes()`, `direct_sources_enabled()` (exposed to admin UI), `source_statuses()` and `official_incident_corroboration()` that correlate active official incidents with chatter results. 
- Reworked `collect_mentions()` and source-specific search helpers to return structured diagnostics (`mentions`, `errors`, `instances_queried`) so per-source errors are reflected in diagnostics and UI. 
- Updated `CloudflareRadarSource` to use the Radar annotations outages endpoint and to record telemetry diagnostics (`endpoint_attempted`, `response_code`, `rows_seen`, `rows_stored`, `errors`) while treating Radar as `external_telemetry`. 
- Clarified settings UI in `lousy-outages.php` to show master Rumour Radar status, the direct public-source gate state and an inline admin warning when direct collection is blocked, and augmented source checkboxes with described statuses (saved vs blocked). 
- Updated public rendering in `public/shortcode.php` to show new scanner blocks: scan stats (Checked/Promoted/Rejected/Watch candidates/Sources enabled/Sources blocked), a source-status strip, a compact list of watch candidates, an “Official incident corroboration” table, and a Canadian infrastructure watch summary while avoiding exposing raw social post text. 
- Added CSS rules in `assets/lousy-outages.css` for the new UI blocks and strip. 
- Added public diagnostics to REST responses in `includes/Api.php` (`public_chatter_diagnostics`) for both refresh and summary endpoints in a backwards-compatible shape. 
- Updated preview/dry-run and smoke scripts: `scripts/preview-public-chatter.php`, `scripts/smoke-production-preflight.php`, and `scripts/smoke-signal-sources.php` to print and assert the new diagnostic fields; preview is diagnostics-only and respects `LOUSY_OUTAGES_NO_EMAIL`. 
- Preserved conservative, thresholded promotion logic and ensured no raw post text is exposed publicly, no scraping added, and no email behavior changed.

### Testing
- Ran PHP lint on modified files: `php -l lousy-outages/public/shortcode.php`, `php -l lousy-outages/includes/Sources/PublicChatterSource.php`, `php -l lousy-outages/includes/Sources/CloudflareRadarSource.php`, `php -l lousy-outages/includes/SignalEngine.php`, `php -l lousy-outages/includes/Api.php`, and `php -l lousy-outages/lousy-outages.php` — all passed. 
- Checked frontend JS syntax with `node --check lousy-outages/assets/lousy-outages.js` — passed. 
- Ran smoke/preflight scripts: `php lousy-outages/scripts/preview-public-chatter.php` (diagnostics-only), `php lousy-outages/scripts/smoke-signal-sources.php`, and `php lousy-outages/scripts/smoke-production-preflight.php` to validate diagnostics shape and safe-default gating — all checks passed. 
- Executed a repository whitespace/sanity check with `git diff --check` — no issues found. 

If you want, I can split this into smaller PRs (diagnostics, UI, Cloudflare changes, scripts) or add unit-style tests to assert diagnostics shapes programmatically.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbc6083984832eb15c4802e64f2044)