### PR TITLE
Polish Corroboration Radar layout, enable safe defaults, and add per-source budgets + GDELT protections

### DIFF
--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -2091,3 +2091,230 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* Corroboration Radar: polished public chatter/NOC module. */
+.lo-corroboration-radar {
+  margin: 2rem 0 2.5rem;
+  padding: clamp(1rem, 2vw, 1.5rem);
+  border: 1px solid rgba(77, 255, 196, 0.36);
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(5, 16, 28, 0.96), rgba(10, 31, 44, 0.92));
+  box-shadow: 0 0 0 1px rgba(77, 255, 196, 0.08), 0 18px 38px rgba(0, 0, 0, 0.28);
+  color: #e9fff8;
+}
+
+.lo-corroboration-radar__head,
+.lo-corroboration-radar__section-title {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.lo-corroboration-radar__muted,
+.lo-corroboration-radar__section-title span,
+.lo-corroboration-radar small {
+  color: rgba(233, 255, 248, 0.78);
+}
+
+.lo-corroboration-radar__badge {
+  flex: 0 0 auto;
+  padding: 0.45rem 0.75rem;
+  border: 1px solid rgba(255, 214, 102, 0.55);
+  border-radius: 999px;
+  background: rgba(255, 214, 102, 0.12);
+  color: #ffe08a;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.lo-corroboration-radar__summary,
+.lo-corroboration-radar__sources,
+.lo-corroboration-radar__incident-grid,
+.lo-corroboration-radar__watch-grid,
+.lo-corroboration-radar__diagnostic-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.lo-corroboration-radar__summary {
+  grid-template-columns: repeat(auto-fit, minmax(135px, 1fr));
+  margin-bottom: 1rem;
+}
+
+.lo-corroboration-radar__metric,
+.lo-corroboration-radar__source,
+.lo-corroboration-radar__incident,
+.lo-corroboration-radar__watch-grid article,
+.lo-corroboration-radar__reason,
+.lo-corroboration-radar__empty,
+.lo-corroboration-radar__watch-candidates {
+  border: 1px solid rgba(77, 255, 196, 0.18);
+  border-radius: 14px;
+  background: rgba(0, 10, 18, 0.42);
+  padding: 0.85rem;
+}
+
+.lo-corroboration-radar__metric strong {
+  display: block;
+  color: #78ffd6;
+  font-size: clamp(1.35rem, 3vw, 2rem);
+  line-height: 1;
+}
+
+.lo-corroboration-radar__metric span,
+.lo-corroboration-radar__source span,
+.lo-corroboration-radar__incident span,
+.lo-corroboration-radar__watch-grid span {
+  display: block;
+  margin-top: 0.25rem;
+  color: rgba(233, 255, 248, 0.82);
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.lo-corroboration-radar__sources {
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  margin-bottom: 1.1rem;
+}
+
+.lo-corroboration-radar__source div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.lo-corroboration-radar__source div span {
+  margin: 0;
+  padding: 0.2rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(233, 255, 248, 0.1);
+  white-space: nowrap;
+}
+
+.lo-corroboration-radar__source p,
+.lo-corroboration-radar__incident p,
+.lo-corroboration-radar__watch-candidates p {
+  margin: 0.45rem 0 0;
+}
+
+.lo-corroboration-radar__source--enabled div span,
+.lo-corroboration-radar__source--configured div span { color: #78ffd6; }
+.lo-corroboration-radar__source--cooldown div span,
+.lo-corroboration-radar__source--rate_limited div span,
+.lo-corroboration-radar__source--budget_skipped div span { color: #ffe08a; }
+.lo-corroboration-radar__source--disabled div span,
+.lo-corroboration-radar__source--blocked_by_safe_default div span,
+.lo-corroboration-radar__source--not_configured div span { color: #ffb4b4; }
+
+.lo-corroboration-radar__incidents,
+.lo-corroboration-radar__canada-watch,
+.lo-corroboration-radar__diagnostics {
+  margin-top: 1rem;
+}
+
+.lo-corroboration-radar__incident-grid {
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+}
+
+.lo-corroboration-radar__incident h5,
+.lo-corroboration-radar__section-title h4,
+.lo-corroboration-radar__watch-candidates h4,
+.lo-corroboration-radar__diagnostics h4 {
+  margin: 0;
+  color: #ffffff;
+}
+
+.lo-corroboration-radar__incident p {
+  display: grid;
+  grid-template-columns: minmax(95px, auto) 1fr;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+
+.lo-corroboration-radar__incident p strong {
+  color: #e9fff8;
+  overflow-wrap: anywhere;
+}
+
+.lo-corroboration-radar__watch-grid {
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.lo-corroboration-radar__watch-grid article strong,
+.lo-corroboration-radar__watch-grid article small {
+  display: block;
+}
+
+.lo-corroboration-radar__watch-candidates div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.65rem;
+}
+
+.lo-corroboration-radar__watch-candidates div span {
+  padding: 0.35rem 0.55rem;
+  border: 1px solid rgba(255, 214, 102, 0.28);
+  border-radius: 999px;
+  background: rgba(255, 214, 102, 0.08);
+  color: #ffe08a;
+}
+
+.lo-corroboration-radar__diagnostics {
+  opacity: 0.92;
+}
+
+.lo-corroboration-radar__diagnostic-grid {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  margin-top: 0.65rem;
+}
+
+.lo-corroboration-radar__reason span,
+.lo-corroboration-radar__reason strong,
+.lo-corroboration-radar__reason small {
+  display: block;
+}
+
+.lo-corroboration-radar__reason strong {
+  color: #ffe08a;
+  font-size: 1.35rem;
+}
+
+.lo-corroboration-radar details {
+  margin-top: 0.75rem;
+}
+
+.lo-corroboration-radar summary {
+  cursor: pointer;
+  color: #78ffd6;
+  font-weight: 700;
+}
+
+@media (max-width: 640px) {
+  .lo-corroboration-radar__head,
+  .lo-corroboration-radar__section-title {
+    flex-direction: column;
+  }
+
+  .lo-corroboration-radar__badge {
+    align-self: flex-start;
+    white-space: normal;
+  }
+
+  .lo-corroboration-radar__source div,
+  .lo-corroboration-radar__incident p {
+    display: block;
+  }
+
+  .lo-corroboration-radar__source div span {
+    display: inline-block;
+    margin-top: 0.35rem;
+  }
+}

--- a/lousy-outages/includes/Sources/PublicChatterSource.php
+++ b/lousy-outages/includes/Sources/PublicChatterSource.php
@@ -11,7 +11,7 @@ class PublicChatterSource implements SignalSourceInterface {
 
     public function id(): string { return 'public_chatter'; }
     public function label(): string { return 'Public Chatter Radar'; }
-    public function is_configured(): bool { return (bool) get_option('lousy_outages_public_chatter_enabled', false); }
+    public function is_configured(): bool { return !empty(get_option('lousy_outages_public_chatter_enabled', '1')); }
 
     public function collect(array $options = []): array {
         $directEnabled = $this->direct_sources_enabled();
@@ -23,6 +23,7 @@ class PublicChatterSource implements SignalSourceInterface {
             'hot' => (int) apply_filters('lo_public_chatter_hot_threshold', 12),
             'queries_per_provider_source' => (int) apply_filters('lo_public_chatter_queries_per_provider_source', 4),
             'active_incident_queries_per_provider' => (int) apply_filters('lo_public_chatter_active_incident_queries_per_provider', 5),
+            'source_budgets' => $this->source_budgets(),
         ];
         $providers = Providers::list();
         $activeIncidents = $this->active_incident_seed_providers($providers);
@@ -60,18 +61,38 @@ class PublicChatterSource implements SignalSourceInterface {
 
         $signals = [];
         $perProviderSourceCounts = [];
+        $sourceBudgetUsed = array_fill_keys(array_keys($enabledRuntimeSources), 0);
         foreach ($queries as $providerId => $row) {
             $provider = (array)($row['provider'] ?? ['name' => ucfirst((string)$providerId), 'category'=>'general']);
             $providerName = (string)($provider['name'] ?? $providerId);
             $providerCategory = (string)($provider['category'] ?? 'general');
             $providerQueries = array_values(array_filter(array_map('strval', (array)($row['queries'] ?? []))));
             foreach ($enabledRuntimeSources as $sourceId => $_enabled) {
-                $mentions = $this->collect_mentions($sourceId, $providerQueries, $window, (int)$thresholds['queries_per_provider_source']);
+                $sourceBudget = (int)($thresholds['source_budgets'][$sourceId] ?? $thresholds['queries_per_provider_source']);
+                $sourceBudgetRemaining = max(0, $sourceBudget - (int)($sourceBudgetUsed[$sourceId] ?? 0));
+                if ($sourceBudgetRemaining <= 0) {
+                    $diag['skipped_sources'][$sourceId][] = 'skipped_due_to_budget';
+                    $diag['source_request_details'][$sourceId]['queries_skipped_due_to_budget'] = (int)($diag['source_request_details'][$sourceId]['queries_skipped_due_to_budget'] ?? 0) + count($providerQueries);
+                    if ($sourceId === 'public_chatter_gdelt') {
+                        $diag['gdelt_queries_skipped_due_to_budget'] = (int)$diag['gdelt_queries_skipped_due_to_budget'] + count($providerQueries);
+                    }
+                    continue;
+                }
+                $mentions = $this->collect_mentions($sourceId, $providerQueries, $window, min((int)$thresholds['queries_per_provider_source'], $sourceBudgetRemaining));
                 $requestDiag = $this->requestDiagnostics[$sourceId] ?? [];
-                $diag['queries_attempted'] += (int)($requestDiag['queries_attempted'] ?? min(count($providerQueries), (int)$thresholds['queries_per_provider_source']));
-                $diag['source_request_details'][$sourceId]['queries_attempted'] = (int)($diag['source_request_details'][$sourceId]['queries_attempted'] ?? 0) + (int)($requestDiag['queries_attempted'] ?? 0);
+                $queriesAttemptedThisSource = (int)($requestDiag['queries_attempted'] ?? 0);
+                $sourceBudgetUsed[$sourceId] = (int)($sourceBudgetUsed[$sourceId] ?? 0) + $queriesAttemptedThisSource;
+                $diag['queries_attempted'] += $queriesAttemptedThisSource;
+                $diag['source_request_details'][$sourceId]['queries_attempted'] = (int)($diag['source_request_details'][$sourceId]['queries_attempted'] ?? 0) + $queriesAttemptedThisSource;
                 if ($sourceId === 'public_chatter_mastodon') {
                     $diag['source_request_details'][$sourceId]['instances_queried'] = array_values(array_unique(array_merge((array)($diag['source_request_details'][$sourceId]['instances_queried'] ?? []), (array)($requestDiag['instances_queried'] ?? []))));
+                }
+                if ($sourceId === 'public_chatter_gdelt') {
+                    foreach (['gdelt_attempted','gdelt_rate_limited','gdelt_last_response_code','gdelt_cooldown_until','gdelt_rows_seen','gdelt_watch_candidates'] as $gdeltKey) {
+                        if (array_key_exists($gdeltKey, $requestDiag)) {
+                            $diag[$gdeltKey] = in_array($gdeltKey, ['gdelt_rows_seen','gdelt_watch_candidates'], true) ? (int)$diag[$gdeltKey] + (int)$requestDiag[$gdeltKey] : $requestDiag[$gdeltKey];
+                        }
+                    }
                 }
                 foreach ((array)($requestDiag['errors'] ?? []) as $errorReason) {
                     $diag['skipped_sources'][$sourceId][] = (string)$errorReason;
@@ -116,14 +137,14 @@ class PublicChatterSource implements SignalSourceInterface {
     }
 
     public function direct_sources_enabled(): bool {
-        $flag = defined('LOUSY_OUTAGES_ENABLE_DIRECT_PUBLIC_CHATTER') ? (bool) LOUSY_OUTAGES_ENABLE_DIRECT_PUBLIC_CHATTER : false;
+        $flag = defined('LOUSY_OUTAGES_ENABLE_DIRECT_PUBLIC_CHATTER') ? (bool) LOUSY_OUTAGES_ENABLE_DIRECT_PUBLIC_CHATTER : true;
         return (bool) apply_filters('lo_public_chatter_direct_sources_enabled', $flag);
     }
 
     public function source_checkboxes(): array {
         return [
             'public_chatter_bluesky' => !empty(get_option('lousy_outages_public_chatter_bluesky_enabled', '1')),
-            'public_chatter_mastodon' => !empty(get_option('lousy_outages_public_chatter_mastodon_enabled', '0')),
+            'public_chatter_mastodon' => !empty(get_option('lousy_outages_public_chatter_mastodon_enabled', '1')),
             'public_chatter_gdelt' => !empty(get_option('lousy_outages_public_chatter_gdelt_enabled', '1')),
         ];
     }
@@ -164,11 +185,20 @@ class PublicChatterSource implements SignalSourceInterface {
             'watch_candidates' => [],
             'watch_candidate_count' => 0,
             'official_incident_corroboration' => [],
+            'source_budgets' => $thresholds['source_budgets'],
             'source_request_details' => [
-                'public_chatter_bluesky' => ['queries_attempted'=>0],
-                'public_chatter_mastodon' => ['queries_attempted'=>0,'instances_queried'=>[]],
-                'public_chatter_gdelt' => ['queries_attempted'=>0],
+                'public_chatter_bluesky' => ['queries_attempted'=>0,'queries_skipped_due_to_budget'=>0],
+                'public_chatter_mastodon' => ['queries_attempted'=>0,'queries_skipped_due_to_budget'=>0,'instances_queried'=>[]],
+                'public_chatter_gdelt' => ['queries_attempted'=>0,'queries_skipped_due_to_budget'=>0],
             ],
+            'gdelt_enabled' => !empty($sourceCheckboxes['public_chatter_gdelt']),
+            'gdelt_attempted' => false,
+            'gdelt_rate_limited' => false,
+            'gdelt_cooldown_until' => $this->gdelt_cooldown_until(),
+            'gdelt_last_response_code' => (int)get_option('lo_public_chatter_gdelt_last_response_code', 0),
+            'gdelt_queries_skipped_due_to_budget' => 0,
+            'gdelt_rows_seen' => 0,
+            'gdelt_watch_candidates' => 0,
             'usable_results' => 0,
             'rows_stored' => 0,
         ];
@@ -178,6 +208,7 @@ class PublicChatterSource implements SignalSourceInterface {
         foreach ($diag['skipped_sources'] as $sourceId => $reasons) {
             $diag['skipped_sources'][$sourceId] = array_values(array_unique(array_filter(array_map('strval', (array)$reasons))));
         }
+        $diag['gdelt_watch_candidates'] = count(array_filter((array)($diag['watch_candidates'] ?? []), static fn($c): bool => (($c['source'] ?? '') === 'public_chatter_gdelt')));
         update_option('lo_diag_'.$this->id(), $diag, false);
     }
 
@@ -312,15 +343,30 @@ class PublicChatterSource implements SignalSourceInterface {
 
     private function collect_mentions(string $sourceId, array $queries, int $window, int $limit): array {
         $out=[]; $diag=['queries_attempted'=>0,'errors'=>[],'instances_queried'=>[]];
+        if ($sourceId === 'public_chatter_gdelt') {
+            $diag += ['gdelt_attempted'=>false,'gdelt_rate_limited'=>false,'gdelt_cooldown_until'=>$this->gdelt_cooldown_until(),'gdelt_last_response_code'=>(int)get_option('lo_public_chatter_gdelt_last_response_code', 0),'gdelt_rows_seen'=>0,'gdelt_watch_candidates'=>0];
+            if ($diag['gdelt_cooldown_until'] !== '') {
+                $diag['errors'][] = 'cooldown';
+                $this->requestDiagnostics[$sourceId] = $diag;
+                return [];
+            }
+        }
         foreach(array_slice($queries,0,max(1,$limit)) as $q){
             $diag['queries_attempted']++;
             if ($sourceId==='public_chatter_bluesky') { $result=$this->search_bluesky($q,$window); }
             elseif ($sourceId==='public_chatter_mastodon') { $result=$this->search_mastodon($q,$window); }
-            elseif ($sourceId==='public_chatter_gdelt') { $result=$this->search_gdelt($q); }
+            elseif ($sourceId==='public_chatter_gdelt') { $diag['gdelt_attempted']=true; $result=$this->search_gdelt($q); }
             else { $result=['mentions'=>[],'errors'=>['request_error']]; }
             $out=array_merge($out,(array)($result['mentions'] ?? []));
             $diag['errors']=array_merge($diag['errors'], (array)($result['errors'] ?? []));
             $diag['instances_queried']=array_merge($diag['instances_queried'], (array)($result['instances_queried'] ?? []));
+            if ($sourceId === 'public_chatter_gdelt') {
+                $diag['gdelt_rows_seen'] += (int)($result['rows_seen'] ?? 0);
+                if (isset($result['response_code'])) { $diag['gdelt_last_response_code'] = (int)$result['response_code']; }
+                if (!empty($result['rate_limited'])) { $diag['gdelt_rate_limited'] = true; }
+                $cooldownUntil = $this->gdelt_cooldown_until();
+                if ($cooldownUntil !== '') { $diag['gdelt_cooldown_until'] = $cooldownUntil; break; }
+            }
         }
         $this->requestDiagnostics[$sourceId] = $diag;
         return array_values(array_unique($out));
@@ -343,16 +389,56 @@ class PublicChatterSource implements SignalSourceInterface {
     }
 
     private function search_gdelt(string $q): array {
+        $cacheKey = 'lo_public_chatter_gdelt_cache_' . md5($q);
+        $cached = get_transient($cacheKey);
+        if (is_array($cached)) {
+            return ['mentions'=>(array)($cached['mentions'] ?? []),'errors'=>[],'rows_seen'=>(int)($cached['rows_seen'] ?? 0),'response_code'=>(int)get_option('lo_public_chatter_gdelt_last_response_code', 0),'cached'=>true];
+        }
         $url=add_query_arg(['query'=>$q,'mode'=>'ArtList','format'=>'json','timespan'=>'60m','sort'=>'datedesc'],'https://api.gdeltproject.org/api/v2/doc/doc');
-        $res=wp_remote_get($url,['timeout'=>8]); if(is_wp_error($res)) return ['mentions'=>[],'errors'=>['request_error']]; if((int)wp_remote_retrieve_response_code($res)>=400) return ['mentions'=>[],'errors'=>['api_http_error']];
-        $body=json_decode((string)wp_remote_retrieve_body($res),true); $arts=(array)($body['articles']??[]); $hashes=[]; foreach(array_slice($arts,0,20) as $a){ $hashes[] = hash('sha256',(string)($a['url']??'').'|'.(string)($a['title']??'')); } return ['mentions'=>$hashes,'errors'=>[]];
+        $res=wp_remote_get($url,['timeout'=>8]);
+        if(is_wp_error($res)) { $this->gdelt_register_failure(0, 'timeout'); return ['mentions'=>[],'errors'=>['request_error','cooldown'],'response_code'=>0,'rate_limited'=>true]; }
+        $code=(int)wp_remote_retrieve_response_code($res); update_option('lo_public_chatter_gdelt_last_response_code', $code, false);
+        if($code===429 || $code===403 || $code>=500) { $this->gdelt_register_failure($code, 'rate_limit'); return ['mentions'=>[],'errors'=>[$code===429?'rate_limited':'api_http_error','cooldown'],'response_code'=>$code,'rate_limited'=>true]; }
+        if($code>=400) return ['mentions'=>[],'errors'=>['api_http_error'],'response_code'=>$code];
+        delete_option('lo_public_chatter_gdelt_failure_count');
+        $body=json_decode((string)wp_remote_retrieve_body($res),true); $arts=(array)($body['articles']??[]); $hashes=[]; foreach(array_slice($arts,0,12) as $a){ $hashes[] = hash('sha256',(string)($a['url']??'').'|'.(string)($a['title']??'')); }
+        $summary = ['mentions'=>array_values(array_unique($hashes)), 'rows_seen'=>count($arts)];
+        set_transient($cacheKey, $summary, (int)apply_filters('lo_public_chatter_gdelt_cache_ttl', 20 * MINUTE_IN_SECONDS));
+        return ['mentions'=>$summary['mentions'],'errors'=>[],'rows_seen'=>$summary['rows_seen'],'response_code'=>$code];
+    }
+
+    private function source_budgets(): array {
+        return (array) apply_filters('lo_public_chatter_source_budgets', [
+            'public_chatter_bluesky' => 10,
+            'public_chatter_mastodon' => 6,
+            'public_chatter_gdelt' => 3,
+        ]);
+    }
+
+    private function gdelt_cooldown_until(): string {
+        $until = (int)get_transient('lo_public_chatter_gdelt_cooldown_until');
+        return $until > time() ? gmdate('c', $until) : '';
+    }
+
+    private function gdelt_register_failure(int $code, string $reason): void {
+        $count = max(1, (int)get_option('lo_public_chatter_gdelt_failure_count', 0) + 1);
+        update_option('lo_public_chatter_gdelt_failure_count', $count, false);
+        $seconds = min(6 * HOUR_IN_SECONDS, (15 * MINUTE_IN_SECONDS) * (2 ** min(4, $count - 1)));
+        if ($code === 429 || $code === 403) { $seconds = max($seconds, HOUR_IN_SECONDS); }
+        $until = time() + $seconds;
+        set_transient('lo_public_chatter_gdelt_cooldown_until', $until, $seconds);
+        update_option('lo_public_chatter_gdelt_last_response_code', $code, false);
     }
 
     private function source_statuses(array $checkboxes, bool $directEnabled, array $diag): array {
         $out = ['hacker_news_chatter'=>['label'=>'HN chatter','status'=>!empty(get_option('lo_hn_chatter_enabled', '1')) ? 'enabled' : 'disabled']];
         foreach ($checkboxes as $sourceId => $checked) {
+            $reasons = (array)($diag['skipped_sources'][$sourceId] ?? []);
             $status = !$checked ? 'disabled' : ($directEnabled ? 'enabled' : 'blocked_by_safe_default');
-            $out[$sourceId] = ['label'=>$this->source_label($sourceId),'status'=>$status,'reasons'=>(array)($diag['skipped_sources'][$sourceId] ?? [])];
+            if ($checked && $directEnabled && in_array('cooldown', $reasons, true)) { $status = 'cooldown'; }
+            if ($checked && $directEnabled && (!empty($diag['gdelt_rate_limited'])) && $sourceId === 'public_chatter_gdelt') { $status = 'rate_limited'; }
+            if ($checked && $directEnabled && in_array('skipped_due_to_budget', $reasons, true)) { $status = 'budget_skipped'; }
+            $out[$sourceId] = ['label'=>$this->source_label($sourceId),'status'=>$status,'reasons'=>$reasons,'last_response_code'=>$sourceId==='public_chatter_gdelt' ? (int)($diag['gdelt_last_response_code'] ?? 0) : 0,'cooldown_until'=>$sourceId==='public_chatter_gdelt' ? (string)($diag['gdelt_cooldown_until'] ?? '') : ''];
         }
         $cfDiag = (array)get_option('lo_diag_cloudflare_radar', []);
         $out['cloudflare_radar'] = ['label'=>'Cloudflare Radar (external telemetry)','status'=>!empty($cfDiag['configured']) ? 'configured' : 'not_configured'];

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -918,9 +918,9 @@ add_action( 'admin_init', function () {
         ]
     );
 
-    register_setting( 'lousy_outages', 'lousy_outages_public_chatter_enabled', ['sanitize_callback'=>'lousy_outages_sanitize_checkbox','default'=>'0'] );
+    register_setting( 'lousy_outages', 'lousy_outages_public_chatter_enabled', ['sanitize_callback'=>'lousy_outages_sanitize_checkbox','default'=>'1'] );
     register_setting( 'lousy_outages', 'lousy_outages_public_chatter_bluesky_enabled', ['sanitize_callback'=>'lousy_outages_sanitize_checkbox','default'=>'1'] );
-    register_setting( 'lousy_outages', 'lousy_outages_public_chatter_mastodon_enabled', ['sanitize_callback'=>'lousy_outages_sanitize_checkbox','default'=>'0'] );
+    register_setting( 'lousy_outages', 'lousy_outages_public_chatter_mastodon_enabled', ['sanitize_callback'=>'lousy_outages_sanitize_checkbox','default'=>'1'] );
     register_setting( 'lousy_outages', 'lousy_outages_public_chatter_gdelt_enabled', ['sanitize_callback'=>'lousy_outages_sanitize_checkbox','default'=>'1'] );
 
     register_setting(
@@ -932,6 +932,23 @@ add_action( 'admin_init', function () {
         ]
     );
 } );
+
+
+function lousy_outages_initialize_public_chatter_defaults(): void {
+    $defaults = [
+        'lousy_outages_public_chatter_enabled' => '1',
+        'lousy_outages_public_chatter_bluesky_enabled' => '1',
+        'lousy_outages_public_chatter_mastodon_enabled' => '1',
+        'lousy_outages_public_chatter_gdelt_enabled' => '1',
+    ];
+    foreach ( $defaults as $option => $value ) {
+        if ( null === get_option( $option, null ) ) {
+            update_option( $option, $value, false );
+        }
+    }
+}
+add_action( 'init', 'lousy_outages_initialize_public_chatter_defaults', 1 );
+add_action( 'admin_init', 'lousy_outages_initialize_public_chatter_defaults', 1 );
 
 function lousy_outages_settings_page() {
     $providers       = Providers::list();
@@ -1071,24 +1088,34 @@ function lousy_outages_settings_page() {
                 
                 <?php
                 $lo_public_chatter_source = new \SuzyEaston\LousyOutages\Sources\PublicChatterSource();
-                $lo_public_chatter_master_enabled = ! empty( get_option( 'lousy_outages_public_chatter_enabled', '0' ) );
+                $lo_public_chatter_master_enabled = ! empty( get_option( 'lousy_outages_public_chatter_enabled', '1' ) );
                 $lo_public_chatter_direct_enabled = $lo_public_chatter_source->direct_sources_enabled();
                 $lo_public_chatter_source_statuses = [
                     'Bluesky' => ! empty( get_option( 'lousy_outages_public_chatter_bluesky_enabled', '1' ) ),
-                    'Mastodon' => ! empty( get_option( 'lousy_outages_public_chatter_mastodon_enabled', '0' ) ),
+                    'Mastodon' => ! empty( get_option( 'lousy_outages_public_chatter_mastodon_enabled', '1' ) ),
                     'GDELT' => ! empty( get_option( 'lousy_outages_public_chatter_gdelt_enabled', '1' ) ),
                 ];
                 ?>
+                <?php
+                $lo_public_chatter_diag = (array) get_option( 'lo_diag_public_chatter', [] );
+                $lo_gdelt_cooldown = (string) ( $lo_public_chatter_diag['gdelt_cooldown_until'] ?? '' );
+                $lo_gdelt_limited = ! empty( $lo_public_chatter_diag['gdelt_rate_limited'] ) || $lo_gdelt_cooldown !== '';
+                ?>
                 <tr><th scope="row">Rumour Radar</th><td>
-                    <p><strong>Master Public Chatter Radar:</strong> <?php echo esc_html( $lo_public_chatter_master_enabled ? 'Enabled' : 'Disabled' ); ?> | <strong>Direct public source gate:</strong> <?php echo esc_html( $lo_public_chatter_direct_enabled ? 'Enabled' : 'Disabled by safe default' ); ?></p>
+                    <p><strong>Recommended defaults:</strong> enabled, conservative, budgeted.</p>
+                    <p class="description">Public chatter sources are enabled by default but budgeted. They create dashboard/watch diagnostics only. They do not send email alerts unless future alert thresholds explicitly promote corroborated signals.</p>
+                    <p><strong>Master Public Chatter Radar:</strong> <?php echo esc_html( $lo_public_chatter_master_enabled ? 'Enabled' : 'Disabled' ); ?> | <strong>Direct public source gate:</strong> <?php echo esc_html( $lo_public_chatter_direct_enabled ? 'Enabled' : 'Disabled' ); ?></p>
                     <?php if ( ! $lo_public_chatter_direct_enabled ) : ?>
-                        <div class="notice notice-warning inline"><p><?php echo esc_html__( 'Direct public chatter sources are disabled by safe default. Source checkboxes are saved, but they will not collect until the direct source gate is enabled.', 'lousy-outages' ); ?></p></div>
+                        <div class="notice notice-warning inline"><p><?php echo esc_html__( 'Direct public chatter source gate is disabled. Saved source checkboxes will be visible but collection is blocked until the gate is enabled.', 'lousy-outages' ); ?></p></div>
+                    <?php endif; ?>
+                    <?php if ( $lo_gdelt_limited ) : ?>
+                        <div class="notice notice-warning inline"><p><?php echo esc_html( $lo_gdelt_cooldown !== '' ? 'GDELT is temporarily in cooldown after a rate-limit/error response. It will resume automatically; do not disable it permanently.' : 'GDELT recently reported rate limiting. It remains enabled and budgeted.' ); ?></p></div>
                     <?php endif; ?>
                     <input type="hidden" name="lousy_outages_public_chatter_enabled" value="0"><label><input type="checkbox" name="lousy_outages_public_chatter_enabled" value="1" <?php checked( $lo_public_chatter_master_enabled ); ?>> Enable Public Chatter Radar</label><br>
-                    <input type="hidden" name="lousy_outages_public_chatter_bluesky_enabled" value="0"><label><input type="checkbox" name="lousy_outages_public_chatter_bluesky_enabled" value="1" <?php checked( $lo_public_chatter_source_statuses['Bluesky'] ); ?>> Enable Bluesky source</label> <em><?php echo esc_html( $lo_public_chatter_source_statuses['Bluesky'] ? ( $lo_public_chatter_direct_enabled ? 'enabled' : 'saved, blocked by safe default' ) : 'disabled' ); ?></em><br>
-                    <input type="hidden" name="lousy_outages_public_chatter_mastodon_enabled" value="0"><label><input type="checkbox" name="lousy_outages_public_chatter_mastodon_enabled" value="1" <?php checked( $lo_public_chatter_source_statuses['Mastodon'] ); ?>> Enable Mastodon source</label> <em><?php echo esc_html( $lo_public_chatter_source_statuses['Mastodon'] ? ( $lo_public_chatter_direct_enabled ? 'enabled' : 'saved, blocked by safe default' ) : 'disabled' ); ?></em><br>
-                    <input type="hidden" name="lousy_outages_public_chatter_gdelt_enabled" value="0"><label><input type="checkbox" name="lousy_outages_public_chatter_gdelt_enabled" value="1" <?php checked( $lo_public_chatter_source_statuses['GDELT'] ); ?>> Enable GDELT source</label> <em><?php echo esc_html( $lo_public_chatter_source_statuses['GDELT'] ? ( $lo_public_chatter_direct_enabled ? 'enabled' : 'saved, blocked by safe default' ) : 'disabled' ); ?></em>
-                    <p class="description">Public chatter signals are unconfirmed and thresholded. GDELT is open-web/news corroboration; Cloudflare Radar remains external telemetry, not rumour radar.</p>
+                    <input type="hidden" name="lousy_outages_public_chatter_bluesky_enabled" value="0"><label><input type="checkbox" name="lousy_outages_public_chatter_bluesky_enabled" value="1" <?php checked( $lo_public_chatter_source_statuses['Bluesky'] ); ?>> Enable Bluesky source</label> <em>Bluesky: <?php echo esc_html( $lo_public_chatter_source_statuses['Bluesky'] ? ( $lo_public_chatter_direct_enabled ? 'enabled' : 'enabled, gate disabled' ) : 'disabled' ); ?></em><br>
+                    <input type="hidden" name="lousy_outages_public_chatter_mastodon_enabled" value="0"><label><input type="checkbox" name="lousy_outages_public_chatter_mastodon_enabled" value="1" <?php checked( $lo_public_chatter_source_statuses['Mastodon'] ); ?>> Enable Mastodon source</label> <em>Mastodon: <?php echo esc_html( $lo_public_chatter_source_statuses['Mastodon'] ? ( $lo_public_chatter_direct_enabled ? 'enabled' : 'enabled, gate disabled' ) : 'disabled' ); ?></em><br>
+                    <input type="hidden" name="lousy_outages_public_chatter_gdelt_enabled" value="0"><label><input type="checkbox" name="lousy_outages_public_chatter_gdelt_enabled" value="1" <?php checked( $lo_public_chatter_source_statuses['GDELT'] ); ?>> Enable GDELT source</label> <em>GDELT: <?php echo esc_html( $lo_public_chatter_source_statuses['GDELT'] ? ( $lo_gdelt_limited ? 'enabled, rate-limited/cooldown' : ( $lo_public_chatter_direct_enabled ? 'enabled' : 'enabled, gate disabled' ) ) : 'disabled' ); ?></em>
+                    <p class="description">GDELT is open-web/news corroboration with a very small per-run budget, success cache, and automatic cooldown/backoff. Cloudflare Radar remains external telemetry, not rumour radar.</p>
                 </td></tr>
 
 <tr>

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -651,7 +651,7 @@ function render_shortcode(): string {
         $sourceStatusRows = [
             'hacker_news_chatter' => $sourceStatuses['hacker_news_chatter'] ?? ['label' => 'HN chatter', 'status' => !empty(get_option('lo_hn_chatter_enabled', '1')) ? 'enabled' : 'disabled'],
             'public_chatter_bluesky' => $sourceStatuses['public_chatter_bluesky'] ?? ['label' => 'Bluesky', 'status' => !empty(get_option('lousy_outages_public_chatter_bluesky_enabled', '1')) ? (!empty($publicDiag['direct_sources_enabled']) ? 'enabled' : 'blocked_by_safe_default') : 'disabled'],
-            'public_chatter_mastodon' => $sourceStatuses['public_chatter_mastodon'] ?? ['label' => 'Mastodon', 'status' => !empty(get_option('lousy_outages_public_chatter_mastodon_enabled', '0')) ? (!empty($publicDiag['direct_sources_enabled']) ? 'enabled' : 'blocked_by_safe_default') : 'disabled'],
+            'public_chatter_mastodon' => $sourceStatuses['public_chatter_mastodon'] ?? ['label' => 'Mastodon', 'status' => !empty(get_option('lousy_outages_public_chatter_mastodon_enabled', '1')) ? (!empty($publicDiag['direct_sources_enabled']) ? 'enabled' : 'blocked_by_safe_default') : 'disabled'],
             'public_chatter_gdelt' => $sourceStatuses['public_chatter_gdelt'] ?? ['label' => 'GDELT', 'status' => !empty(get_option('lousy_outages_public_chatter_gdelt_enabled', '1')) ? (!empty($publicDiag['direct_sources_enabled']) ? 'enabled' : 'blocked_by_safe_default') : 'disabled'],
             'cloudflare_radar' => $sourceStatuses['cloudflare_radar'] ?? ['label' => 'Cloudflare Radar (external telemetry)', 'status' => !empty($cfDiag['configured']) ? 'configured' : 'not_configured'],
         ];
@@ -660,16 +660,35 @@ function render_shortcode(): string {
         foreach ($sourceStatusRows as $sourceStatusRow) {
             $statusValue = (string) ($sourceStatusRow['status'] ?? 'disabled');
             if (in_array($statusValue, ['enabled', 'configured'], true)) { $sourcesEnabledCount++; }
-            if (in_array($statusValue, ['disabled', 'blocked_by_safe_default', 'not_configured'], true)) { $sourcesBlockedCount++; }
+            if (in_array($statusValue, ['disabled', 'blocked_by_safe_default', 'not_configured', 'cooldown', 'rate_limited', 'budget_skipped'], true)) { $sourcesBlockedCount++; }
         }
         $officialCorroborationRows = isset($publicDiag['official_incident_corroboration']) && is_array($publicDiag['official_incident_corroboration']) ? $publicDiag['official_incident_corroboration'] : [];
         $canadianWatchRows = isset($publicDiag['canadian_infrastructure_watchlist']) && is_array($publicDiag['canadian_infrastructure_watchlist']) ? $publicDiag['canadian_infrastructure_watchlist'] : [];
         $statusLabel = static function($status): string {
             $status = (string) $status;
-            if ($status === 'blocked_by_safe_default') { return 'blocked by safe default'; }
+            if ($status === 'blocked_by_safe_default') { return 'blocked'; }
+            if ($status === 'budget_skipped') { return 'budget skipped'; }
             if ($status === 'not_configured') { return 'not configured'; }
+            if ($status === 'rate_limited') { return 'rate limited'; }
             return str_replace('_', ' ', $status);
         };
+        $sourceReason = static function(array $row): string {
+            $status = (string) ($row['status'] ?? 'disabled');
+            $reasons = array_values(array_unique(array_filter(array_map('strval', (array) ($row['reasons'] ?? [])))));
+            if ($status === 'enabled' || $status === 'configured') { return 'Budgeted and available.'; }
+            if ($status === 'cooldown') { return 'Temporarily paused.'; }
+            if ($status === 'rate_limited') { return 'Provider asked us to slow down.'; }
+            if ($status === 'budget_skipped') { return 'Per-run budget spent.'; }
+            if ($status === 'blocked_by_safe_default') { return 'Direct source gate disabled.'; }
+            if ($status === 'not_configured') { return 'API/config missing.'; }
+            if ($status === 'disabled') { return 'Disabled by admin.'; }
+            if ($reasons) { return ucfirst(str_replace('_', ' ', (string) $reasons[0])) . '.'; }
+            return 'No extra diagnostics.';
+        };
+        $statusBadge = 'Official radar only';
+        if ($promotedTotal > 0) { $statusBadge = 'Public corroboration'; }
+        elseif ($watchCandidateCount > 0) { $statusBadge = 'Public watch'; }
+        elseif ($sourcesBlockedCount > 0) { $statusBadge = 'Sources limited'; }
         ?>
         <div class="lo-incidents" data-lo-incidents>
             <section class="lo-section lo-section--incidents" data-lo-section="incidents">
@@ -691,63 +710,79 @@ function render_shortcode(): string {
                 <div class="lo-grid lo-grid--section" data-lo-section-grid="unverified" hidden></div>
             </section>
         </div>
-        <section class="lo-chatter-scanner" data-lo-chatter-scanner>
-            <div class="lo-chatter-scanner__head">
+        <section class="lo-corroboration-radar lo-chatter-scanner" data-lo-chatter-scanner>
+            <div class="lo-corroboration-radar__head">
                 <div>
                     <h3 class="lo-block-title">PUBLIC CHATTER / FIELD REPORTS</h3>
-                    <p class="lo-history__meta">Unconfirmed public/dev chatter. Useful smoke, not fire.</p>
+                    <p class="lo-corroboration-radar__muted">Unconfirmed public/dev chatter. Useful smoke, not fire.</p>
                 </div>
-                <span class="lo-chatter-scanner__status"><?php echo $public_chatter ? esc_html('Needs corroboration') : esc_html('Official radar only'); ?></span>
+                <span class="lo-corroboration-radar__badge"><?php echo esc_html($statusBadge); ?></span>
             </div>
-            <div class="lo-chatter-scanner__stats" aria-label="Public chatter scan summary">
-                <span class="lo-chatter-scanner__stat"><strong><?php echo esc_html((string) $checkedTotal); ?></strong> Checked</span>
-                <span class="lo-chatter-scanner__stat"><strong><?php echo esc_html((string) $promotedTotal); ?></strong> Promoted</span>
-                <span class="lo-chatter-scanner__stat"><strong><?php echo esc_html((string) $rejectedTotal); ?></strong> Rejected</span>
-                <span class="lo-chatter-scanner__stat"><strong><?php echo esc_html((string) $watchCandidateCount); ?></strong> Watch candidates</span>
-                <span class="lo-chatter-scanner__stat"><strong><?php echo esc_html((string) $sourcesEnabledCount); ?></strong> Sources enabled</span>
-                <span class="lo-chatter-scanner__stat"><strong><?php echo esc_html((string) $sourcesBlockedCount); ?></strong> Sources blocked/disabled</span>
-            </div>
-            <div class="lo-chatter-scanner__strip" aria-label="Public chatter source status">
-                <?php foreach ($sourceStatusRows as $sourceStatusRow) : $sourceStatus = (string) ($sourceStatusRow['status'] ?? 'disabled'); ?>
-                    <span class="lo-chatter-scanner__source lo-chatter-scanner__source--<?php echo esc_attr(sanitize_html_class($sourceStatus)); ?>">
-                        <?php echo esc_html((string) ($sourceStatusRow['label'] ?? 'Source')); ?>: <?php echo esc_html($statusLabel($sourceStatus)); ?>
-                    </span>
+
+            <div class="lo-corroboration-radar__summary" aria-label="Public chatter scan summary">
+                <?php foreach ([['Checked',$checkedTotal],['Promoted',$promotedTotal],['Rejected',$rejectedTotal],['Watch candidates',$watchCandidateCount],['Sources active',$sourcesEnabledCount],['Sources blocked/limited',$sourcesBlockedCount]] as $metric) : ?>
+                    <div class="lo-corroboration-radar__metric"><strong><?php echo esc_html((string) $metric[1]); ?></strong><span><?php echo esc_html((string) $metric[0]); ?></span></div>
                 <?php endforeach; ?>
             </div>
-            <?php if (!empty($watchCandidates)) : ?>
-                <div class="lo-chatter-scanner__watch">
-                    <h4>Watch candidates</h4>
-                    <p>Watch candidates are unconfirmed volume/context hints. They are not outage reports.</p>
-                    <ul>
-                        <?php foreach (array_slice($watchCandidates, 0, 8) as $candidate) : ?>
-                            <li><?php echo esc_html((string) ($candidate['provider_name'] ?? $candidate['provider_id'] ?? 'Provider')); ?>: <?php echo esc_html((string) ($candidate['count'] ?? 0)); ?> <?php echo esc_html((string) ($candidate['source_label'] ?? $candidate['source'] ?? 'source')); ?> mentions, below threshold</li>
-                        <?php endforeach; ?>
-                    </ul>
-                </div>
-            <?php endif; ?>
-            <div class="lo-chatter-scanner__corroboration">
-                <h4>Official incident corroboration</h4>
+
+            <div class="lo-corroboration-radar__sources" aria-label="Public chatter source status">
+                <?php foreach ($sourceStatusRows as $sourceStatusRow) : $sourceStatus = (string) ($sourceStatusRow['status'] ?? 'disabled'); $lastCode = (int) ($sourceStatusRow['last_response_code'] ?? 0); $cooldownUntil = (string) ($sourceStatusRow['cooldown_until'] ?? ''); ?>
+                    <article class="lo-corroboration-radar__source lo-corroboration-radar__source--<?php echo esc_attr(sanitize_html_class($sourceStatus)); ?>">
+                        <div><strong><?php echo esc_html((string) ($sourceStatusRow['label'] ?? 'Source')); ?></strong><span><?php echo esc_html($statusLabel($sourceStatus)); ?></span></div>
+                        <p><?php echo esc_html($sourceReason((array) $sourceStatusRow)); ?></p>
+                        <?php if ($lastCode > 0 || $cooldownUntil !== '') : ?>
+                            <small><?php echo $lastCode > 0 ? esc_html('HTTP ' . $lastCode) : ''; ?><?php echo ($lastCode > 0 && $cooldownUntil !== '') ? esc_html(' · ') : ''; ?><?php echo $cooldownUntil !== '' ? esc_html('Cooldown until ' . $format_datetime($cooldownUntil)) : ''; ?></small>
+                        <?php endif; ?>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+
+            <div class="lo-corroboration-radar__incidents" aria-label="Official incident public corroboration">
+                <div class="lo-corroboration-radar__section-title"><h4>Official Incident Corroboration</h4><span>Official incidents seeded into public-source queries</span></div>
                 <?php if (!empty($officialCorroborationRows)) : ?>
-                    <div class="lo-chatter-scanner__table" role="table" aria-label="Official incident public corroboration">
-                        <div role="row" class="lo-chatter-scanner__table-head"><span>Provider</span><span>Official status</span><span>Sources checked</span><span>Public result</span><span>Watch candidates</span></div>
-                        <?php foreach (array_slice($officialCorroborationRows, 0, 8) as $row) : ?>
-                            <div role="row"><span><?php echo esc_html((string) ($row['provider_name'] ?? $row['provider_id'] ?? 'Provider')); ?></span><span><?php echo esc_html((string) ($row['official_status'] ?? 'active')); ?></span><span><?php echo esc_html(implode(', ', array_map('strval', (array) ($row['sources_checked'] ?? []))) ?: 'None'); ?></span><span><?php echo esc_html((string) ($row['result_label'] ?? 'Official only')); ?></span><span><?php echo esc_html((string) ($row['watch_candidates'] ?? 0)); ?></span></div>
+                    <div class="lo-corroboration-radar__incident-grid">
+                        <?php foreach (array_slice($officialCorroborationRows, 0, 8) as $row) : $sourcesChecked = implode(', ', array_map('strval', (array) ($row['sources_checked'] ?? []))) ?: 'None'; ?>
+                            <article class="lo-corroboration-radar__incident">
+                                <h5><?php echo esc_html((string) ($row['provider_name'] ?? $row['provider_id'] ?? 'Provider')); ?></h5>
+                                <p><span>Official</span><strong><?php echo esc_html((string) ($row['official_status'] ?? 'active')); ?></strong></p>
+                                <p><span>Public result</span><strong><?php echo esc_html((string) ($row['result_label'] ?? 'Official only')); ?></strong></p>
+                                <p><span>Watch candidates</span><strong><?php echo esc_html((string) ($row['watch_candidates'] ?? 0)); ?></strong></p>
+                                <small>Sources checked: <?php echo esc_html($sourcesChecked); ?></small>
+                            </article>
                         <?php endforeach; ?>
                     </div>
                 <?php else : ?>
-                    <p>No active official incidents were available to seed public corroboration in the last scan.</p>
+                    <p class="lo-corroboration-radar__muted">No active official incidents were available to seed public corroboration in the last scan.</p>
                 <?php endif; ?>
             </div>
+
             <?php if (!empty($canadianWatchRows)) : ?>
-                <div class="lo-chatter-scanner__watchlist">
-                    <h4>Canadian infrastructure watch</h4>
-                    <div>
-                        <?php foreach ($canadianWatchRows as $watchRow) : ?>
-                            <span><?php echo esc_html((string) ($watchRow['label'] ?? $watchRow['category'] ?? 'Watchlist')); ?> armed (<?php echo esc_html((string) ($watchRow['count'] ?? 0)); ?>)</span>
+                <div class="lo-corroboration-radar__canada-watch">
+                    <div class="lo-corroboration-radar__section-title"><h4>Canadian Infrastructure Watch</h4><span>Watchlist armed</span></div>
+                    <div class="lo-corroboration-radar__watch-grid">
+                        <?php foreach ($canadianWatchRows as $watchRow) : $providersShown = array_values(array_map('strval', (array) ($watchRow['providers'] ?? []))); $more = max(0, (int) ($watchRow['count'] ?? count($providersShown)) - 3); ?>
+                            <article>
+                                <strong><?php echo esc_html((string) ($watchRow['label'] ?? $watchRow['category'] ?? 'Watchlist')); ?></strong>
+                                <span><?php echo esc_html((string) ($watchRow['count'] ?? 0)); ?> watched</span>
+                                <small><?php echo esc_html(implode(', ', array_slice($providersShown, 0, 3)) . ($more > 0 ? ' +' . $more . ' more' : '')); ?></small>
+                            </article>
                         <?php endforeach; ?>
                     </div>
                 </div>
             <?php endif; ?>
+
+            <?php if (!empty($watchCandidates)) : ?>
+                <div class="lo-corroboration-radar__watch-candidates">
+                    <h4>Watch candidates</h4>
+                    <p class="lo-corroboration-radar__muted">Unconfirmed volume/context hints below promotion thresholds.</p>
+                    <div>
+                        <?php foreach (array_slice($watchCandidates, 0, 6) as $candidate) : ?>
+                            <span><?php echo esc_html((string) ($candidate['provider_name'] ?? $candidate['provider_id'] ?? 'Provider')); ?> · <?php echo esc_html((string) ($candidate['count'] ?? 0)); ?> <?php echo esc_html((string) ($candidate['source_label'] ?? $candidate['source'] ?? 'source')); ?></span>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+            <?php endif; ?>
+
             <?php if ($public_chatter) : ?>
                 <div class="lo-chatter-scanner__cards">
                     <?php foreach (array_slice($public_chatter, 0, 6) as $sig) : $sourceLabel = trim((string)($sig['evidence_source_label'] ?? $sig['source'] ?? '')); $sourceUrl = trim((string)($sig['evidence_url'] ?? $sig['url'] ?? '')); ?>
@@ -760,21 +795,29 @@ function render_shortcode(): string {
                     <?php endforeach; ?>
                 </div>
             <?php else : ?>
-                <div class="lo-chatter-scanner__empty<?php echo ($checkedTotal <= 0 && empty($rejectSummary) && empty($previewSample)) ? ' lo-chatter-scanner__empty--fallback' : ''; ?>">
+                <div class="lo-corroboration-radar__empty">
                     <h4><?php echo ($checkedTotal > 0 || !empty($rejectSummary) || !empty($previewSample)) ? esc_html('Public chatter scan complete') : esc_html('Public chatter scanner online'); ?></h4>
                     <p><?php echo ($checkedTotal > 0 || !empty($rejectSummary) || !empty($previewSample)) ? esc_html('No credible field reports promoted. Official radar only.') : esc_html('No rumour radar hits or diagnostics available yet.'); ?></p>
-                    <p>Missing results can mean sources are disabled, the direct-source safe gate is closed, thresholds were not met, or there was no credible recent chatter.</p>
                 </div>
             <?php endif; ?>
+
             <?php if (!empty($rejectSummary)) : ?>
-                <div class="lo-chatter-scanner__reasons" aria-label="Rejected public chatter categories">
-                    <?php foreach (array_slice($rejectSummary, 0, 6) as $reasonRow) : ?>
-                        <div class="lo-chatter-scanner__reason">
-                            <span><?php echo esc_html((string) ($reasonRow['label'] ?? 'Filtered chatter')); ?></span>
-                            <strong><?php echo esc_html((string) ($reasonRow['count'] ?? 0)); ?></strong>
-                            <small><?php echo esc_html((string) ($reasonRow['description'] ?? 'Filtered chatter that did not meet current-signal quality checks.')); ?></small>
-                        </div>
-                    <?php endforeach; ?>
+                <div class="lo-corroboration-radar__diagnostics" aria-label="Rejected public chatter categories">
+                    <h4>Filtered chatter</h4>
+                    <div class="lo-corroboration-radar__diagnostic-grid">
+                        <?php foreach (array_slice($rejectSummary, 0, 2) as $reasonRow) : ?>
+                            <div class="lo-corroboration-radar__reason"><span><?php echo esc_html((string) ($reasonRow['label'] ?? 'Filtered chatter')); ?></span><strong><?php echo esc_html((string) ($reasonRow['count'] ?? 0)); ?></strong><small><?php echo esc_html((string) ($reasonRow['description'] ?? 'Filtered chatter that did not meet current-signal quality checks.')); ?></small></div>
+                        <?php endforeach; ?>
+                    </div>
+                    <?php if (count($rejectSummary) > 2) : ?>
+                        <details><summary>Show diagnostics</summary>
+                            <div class="lo-corroboration-radar__diagnostic-grid">
+                                <?php foreach (array_slice($rejectSummary, 2) as $reasonRow) : ?>
+                                    <div class="lo-corroboration-radar__reason"><span><?php echo esc_html((string) ($reasonRow['label'] ?? 'Filtered chatter')); ?></span><strong><?php echo esc_html((string) ($reasonRow['count'] ?? 0)); ?></strong><small><?php echo esc_html((string) ($reasonRow['description'] ?? 'Filtered chatter that did not meet current-signal quality checks.')); ?></small></div>
+                                <?php endforeach; ?>
+                            </div>
+                        </details>
+                    <?php endif; ?>
                 </div>
             <?php endif; ?>
         </section>

--- a/lousy-outages/scripts/preview-public-chatter.php
+++ b/lousy-outages/scripts/preview-public-chatter.php
@@ -2,11 +2,12 @@
 declare(strict_types=1);
 if (PHP_SAPI !== 'cli') { fwrite(STDERR, "CLI only\n"); exit(1); }
 $wpLoad = $argv[1] ?? '';
-if ($wpLoad === '' || !is_file($wpLoad)) { fwrite(STDERR, "Usage: php preview-public-chatter.php /path/to/wp-load.php [--window-minutes=1440] [--limit=30]\n"); exit(1); }
-$window=1440; $limit=30;
+if ($wpLoad === '' || !is_file($wpLoad)) { fwrite(STDERR, "Usage: php preview-public-chatter.php /path/to/wp-load.php [--window-minutes=1440] [--limit=30] [--json]\n"); exit(1); }
+$window=1440; $limit=30; $json=false;
 foreach (array_slice($argv,2) as $arg) {
     if (str_starts_with($arg,'--window-minutes=')) { $window=max(5,(int)substr($arg,17)); }
     if (str_starts_with($arg,'--limit=')) { $limit=max(1,(int)substr($arg,8)); }
+    if ($arg === '--json') { $json=true; }
 }
 $_SERVER['REQUEST_METHOD'] = 'GET';
 
@@ -35,50 +36,70 @@ $hnRows = $hnSource->collect(['dry_run'=>true,'diagnostic_mode'=>true,'window_mi
 $hnDiag = (array) get_option('lo_diag_hacker_news_chatter', []);
 $reasonCounts = (array)($hnDiag['chatter_rejected_by_reason'] ?? []);
 
+$sourceStatuses = (array)($publicDiag['source_statuses'] ?? []);
+$enabledSources = [];
+$cooldownSources = [];
+$budgetSkipped = [];
+foreach ((array)($publicDiag['enabled_sources'] ?? []) as $source => $enabled) {
+    if ($enabled) { $enabledSources[] = (string)$source; }
+}
+foreach ($sourceStatuses as $source => $row) {
+    $status = (string)(((array)$row)['status'] ?? 'disabled');
+    if (in_array($status, ['cooldown','rate_limited'], true)) { $cooldownSources[] = (string)$source . ' (' . $status . ')'; }
+}
+foreach ((array)($publicDiag['source_request_details'] ?? []) as $source => $details) {
+    if ((int)(((array)$details)['queries_skipped_due_to_budget'] ?? 0) > 0) {
+        $budgetSkipped[] = (string)$source . ' (' . (int)(((array)$details)['queries_skipped_due_to_budget'] ?? 0) . ')';
+    }
+}
+
+$summary = [
+    'master_enabled' => !empty($publicDiag['configured']),
+    'direct_gate_enabled' => !empty($publicDiag['direct_sources_enabled']),
+    'enabled_sources' => $enabledSources,
+    'rate_limited_or_cooldown_sources' => $cooldownSources,
+    'sources_skipped_by_budget' => $budgetSkipped,
+    'active_official_providers_scanned' => array_values(array_map(static fn($p) => (string)($p['provider_name'] ?? $p['provider_id'] ?? ''), (array)($publicDiag['active_incident_seed_providers'] ?? []))),
+    'canadian_infrastructure_categories_armed' => array_values(array_map(static fn($p) => (string)($p['label'] ?? $p['category'] ?? ''), (array)($publicDiag['canadian_infrastructure_watchlist'] ?? []))),
+    'watch_candidates' => (int)($publicDiag['watch_candidate_count'] ?? 0),
+    'promoted_signals' => ['direct_public' => count($signals), 'hn' => count($hnRows)],
+    'rejected_reason_summary' => $reasonCounts,
+    'gdelt' => [
+        'enabled' => !empty($publicDiag['gdelt_enabled']),
+        'attempted' => !empty($publicDiag['gdelt_attempted']),
+        'rate_limited' => !empty($publicDiag['gdelt_rate_limited']),
+        'cooldown_until' => (string)($publicDiag['gdelt_cooldown_until'] ?? ''),
+        'last_response_code' => (int)($publicDiag['gdelt_last_response_code'] ?? 0),
+        'queries_skipped_due_to_budget' => (int)($publicDiag['gdelt_queries_skipped_due_to_budget'] ?? 0),
+        'rows_seen' => (int)($publicDiag['gdelt_rows_seen'] ?? 0),
+        'watch_candidates' => (int)($publicDiag['gdelt_watch_candidates'] ?? 0),
+    ],
+];
+
+if ($json) {
+    echo wp_json_encode(['summary'=>$summary, 'diagnostics'=>$publicDiag], JSON_PRETTY_PRINT) . "\n";
+    exit(0);
+}
+
 $printList = static function (string $label, array $values, int $limit = 30): void {
-    echo $label . ': ';
     $values = array_slice(array_values(array_filter(array_map('strval', $values))), 0, $limit);
-    echo $values ? implode(', ', $values) : 'none';
-    echo "\n";
+    echo $label . ': ' . ($values ? implode(', ', $values) : 'none') . "\n";
 };
 
-echo "Public Chatter Corroboration Preview (diagnostics-only; no email, no inserts requested)\n";
-echo "Master enabled: " . (!empty($publicDiag['configured']) ? 'yes' : 'no') . "\n";
-echo "Direct source gate: " . (!empty($publicDiag['direct_sources_enabled']) ? 'enabled' : 'disabled') . "\n";
-
-echo "Enabled source checkboxes:\n";
-foreach ((array)($publicDiag['enabled_sources'] ?? []) as $source => $enabled) {
-    echo "- {$source}: " . ($enabled ? 'checked' : 'unchecked') . "\n";
-}
-
-echo "Disabled/blocked sources:\n";
-foreach ((array)($publicDiag['skipped_sources'] ?? []) as $source => $reasons) {
-    $reasons = array_values(array_unique(array_filter(array_map('strval', (array)$reasons))));
-    if (!$reasons) { continue; }
-    echo "- {$source}: " . implode(', ', $reasons) . "\n";
-}
-
-$printList('Providers scanned', array_map(static fn($p) => (string)($p['provider_name'] ?? $p['provider_id'] ?? ''), (array)($publicDiag['providers_scanned'] ?? [])), $limit);
-$printList('Active incident seed providers', array_map(static fn($p) => (string)($p['provider_name'] ?? $p['provider_id'] ?? ''), (array)($publicDiag['active_incident_seed_providers'] ?? [])), $limit);
-$printList('Canadian infra providers scanned', array_map(static fn($p) => (string)($p['provider_name'] ?? $p['provider_id'] ?? ''), (array)($publicDiag['canadian_infrastructure_providers_scanned'] ?? [])), $limit);
-
-echo "Mentions seen by source:\n";
-foreach ((array)($publicDiag['mentions_seen_by_source'] ?? []) as $source => $count) { echo "- {$source}: " . (int)$count . "\n"; }
-echo "Mentions seen by provider:\n";
-foreach (array_slice((array)($publicDiag['mentions_seen_by_provider'] ?? []), 0, $limit, true) as $provider => $count) { echo "- {$provider}: " . (int)$count . "\n"; }
-
-echo "Watch candidates: " . (int)($publicDiag['watch_candidate_count'] ?? 0) . "\n";
-foreach (array_slice((array)($publicDiag['watch_candidates'] ?? []), 0, $limit) as $candidate) {
-    echo "[WATCH] provider=" . ($candidate['provider_name'] ?? $candidate['provider_id'] ?? '') . " source=" . ($candidate['source_label'] ?? $candidate['source'] ?? '') . " count=" . (int)($candidate['count'] ?? 0) . " reason=" . ($candidate['reason'] ?? '') . "\n";
-}
-
-echo "Promoted signals: " . count($signals) . " direct public, " . count($hnRows) . " HN\n";
-foreach (array_slice($signals, 0, $limit) as $signal) {
-    echo "[PROMOTED] provider=" . ($signal['provider_name'] ?? $signal['provider_id'] ?? '') . " source=" . ($signal['source'] ?? '') . " severity=" . ($signal['severity'] ?? '') . "\n";
-}
-
-echo "Rejected reasons:\n";
+echo "Public Chatter Corroboration Preview (diagnostics-only; no email)\n";
+echo "Master enabled: " . ($summary['master_enabled'] ? 'yes' : 'no') . "\n";
+echo "Direct gate enabled: " . ($summary['direct_gate_enabled'] ? 'yes' : 'no') . "\n";
+$printList('Enabled sources', $summary['enabled_sources'], $limit);
+$printList('Rate-limited/cooldown sources', $summary['rate_limited_or_cooldown_sources'], $limit);
+$printList('Sources skipped by budget', $summary['sources_skipped_by_budget'], $limit);
+$printList('Active official providers scanned', $summary['active_official_providers_scanned'], $limit);
+$printList('Canadian infrastructure categories armed', $summary['canadian_infrastructure_categories_armed'], $limit);
+echo "Watch candidates: " . $summary['watch_candidates'] . "\n";
+echo "Promoted signals: " . $summary['promoted_signals']['direct_public'] . " direct public, " . $summary['promoted_signals']['hn'] . " HN\n";
+echo "GDELT: " . ($summary['gdelt']['enabled'] ? 'enabled' : 'disabled') . ', ' . ($summary['gdelt']['attempted'] ? 'attempted' : 'not attempted') . ', HTTP ' . $summary['gdelt']['last_response_code'] . ($summary['gdelt']['cooldown_until'] !== '' ? ', cooldown until ' . $summary['gdelt']['cooldown_until'] : '') . "\n";
+echo "Rejected reason summary:\n";
+if (!$reasonCounts) { echo "- none\n"; }
 foreach ($reasonCounts as $reason => $count) {
     $reasonMeta = \SuzyEaston\LousyOutages\Sources\ChatterRejectionReasons::get((string)$reason);
-    echo "- {$reason}: " . (int)$count . " (" . (string)($reasonMeta['short_label'] ?? '') . ")\n";
+    echo "- " . (string)($reasonMeta['short_label'] ?? $reason) . ': ' . (int)$count . "\n";
 }

--- a/lousy-outages/scripts/smoke-production-preflight.php
+++ b/lousy-outages/scripts/smoke-production-preflight.php
@@ -42,12 +42,11 @@ if(!empty($statusDiag)){
     if($attempted<=0 && !$cooldown){ $errors[]='Statuspage diagnostics: endpoints_attempted=0 without cooldown'; }
 }
 $chatterDiag=(array)get_option('lo_diag_public_chatter',[]);
-if(!empty($chatterDiag) && !empty($chatterDiag['direct_sources_enabled'])){ $errors[]='Public chatter direct sources enabled (expected safe-default disabled)'; }
 if(!empty($chatterDiag)){
-    foreach(['configured','attempted','direct_sources_enabled','direct_sources_disabled_by_safe_default','enabled_sources','skipped_sources','providers_scanned','queries_attempted','mentions_seen_by_source','mentions_seen_by_provider','signals_built_by_provider','thresholds','scan_window_minutes','ran_at','watch_candidates','official_incident_corroboration','canadian_infrastructure_watchlist'] as $key){
+    foreach(['configured','attempted','direct_sources_enabled','direct_sources_disabled_by_safe_default','enabled_sources','skipped_sources','providers_scanned','queries_attempted','mentions_seen_by_source','mentions_seen_by_provider','signals_built_by_provider','thresholds','scan_window_minutes','ran_at','watch_candidates','official_incident_corroboration','canadian_infrastructure_watchlist','source_budgets','gdelt_enabled','gdelt_attempted','gdelt_rate_limited','gdelt_cooldown_until','gdelt_last_response_code','gdelt_queries_skipped_due_to_budget','gdelt_rows_seen','gdelt_watch_candidates'] as $key){
         if(!array_key_exists($key,$chatterDiag)){ $errors[]='Public chatter diagnostics missing '.$key; }
     }
-    if(empty($chatterDiag['direct_sources_enabled']) && empty($chatterDiag['direct_sources_disabled_by_safe_default'])){ $errors[]='Public chatter safe-default gate not visible in diagnostics'; }
+    if(!array_key_exists('direct_sources_enabled',$chatterDiag) || !array_key_exists('direct_sources_disabled_by_safe_default',$chatterDiag)){ $errors[]='Public chatter direct source gate not visible in diagnostics'; }
     if(!array_key_exists('public_chatter_bluesky',(array)($chatterDiag['enabled_sources']??[])) || !array_key_exists('public_chatter_mastodon',(array)($chatterDiag['enabled_sources']??[])) || !array_key_exists('public_chatter_gdelt',(array)($chatterDiag['enabled_sources']??[]))){ $errors[]='Public chatter source checkbox diagnostics incomplete'; }
     foreach((array)($chatterDiag['watch_candidates']??[]) as $candidate){
         $pid=(string)($candidate['provider_id']??'');


### PR DESCRIPTION
### Motivation
- Make the Public Chatter / Corroboration Radar readable and NOC-like instead of a cramped diagnostic dump so the public page is scannable at a glance.
- Preserve conservative signal policy while surfacing clear diagnostics (source status, budgets, GDELT cooldown) and avoid noisy retries or exposing raw public post text.
- Ensure sane defaults for new installs while not overriding explicit admin choices.

### Description
- Replace the table/pill-heavy public radar markup with a polished module in `public/shortcode.php` that renders a header/badge, compact summary metrics, a source-status card grid, official-incident cards, a Canadian-infrastructure watch strip, watch-candidate chips, and a collapsible filtered-chatter diagnostics area using the `lo-corroboration-radar*` classes.
- Add a responsive retro/NOC style block to `assets/lousy-outages.css` to control summary cards, source cards, incident cards, watchlist cards, and small-screen stacking for the new radar UI.
- Make public-chatter options default ON for missing/new installs by changing `register_setting` defaults and adding `lousy_outages_initialize_public_chatter_defaults()` in `lousy-outages.php` so absent option keys are initialized but existing admin-disabled values are honored.
- Change the `PublicChatterSource` behavior in `includes/Sources/PublicChatterSource.php`: enable the direct-source gate by default (but still filterable via the existing constant/filter), add conservative per-source `source_budgets()` and track budget usage, expose budget-skipped diagnostics, and treat enabled-but-skipped sources distinctly in `source_statuses` (e.g. `budget_skipped`, `cooldown`, `rate_limited`).
- Add robust GDELT protections: small per-run caps, caching of recent result summaries, detection of 429/403/5xx/timeouts to register failure, increasing cooldown/backoff via `gdelt_register_failure()`, `gdelt_cooldown_until()` transient, and new diagnostic fields (`gdelt_attempted`, `gdelt_rate_limited`, `gdelt_cooldown_until`, `gdelt_last_response_code`, `gdelt_queries_skipped_due_to_budget`, `gdelt_rows_seen`, `gdelt_watch_candidates`).
- Surface concise, human-friendly source reasons and last-response/cooldown info in the public UI instead of raw API output; preserve old REST/diag keys and add new fields rather than removing existing ones.
- Improve admin settings copy in `lousy-outages.php` to explain recommended defaults, gate semantics, and a non-alarming GDELT warning when rate-limited/cooldown is active.
- Update the preview tool `scripts/preview-public-chatter.php` to print a compact human-readable summary and add `--json` for raw diagnostics output.
- Update `scripts/smoke-production-preflight.php` to validate the new diagnostics fields (budgets, GDELT diagnostics) and to stop assuming the direct-source gate must be disabled in diagnostics.

### Testing
- Ran PHP lint on changed files: `php -l lousy-outages/public/shortcode.php`, `php -l lousy-outages/lousy-outages.php`, `php -l lousy-outages/includes/Sources/PublicChatterSource.php`, `php -l lousy-outages/includes/Sources/CloudflareRadarSource.php`, `php -l lousy-outages/includes/SignalEngine.php`, `php -l lousy-outages/includes/Api.php`, `php -l lousy-outages/scripts/preview-public-chatter.php`, `php -l lousy-outages/scripts/smoke-signal-sources.php`, and `php -l lousy-outages/scripts/smoke-production-preflight.php`; all checks reported no syntax errors.
- Ran `node --check lousy-outages/assets/lousy-outages.js`; the JS check passed.
- Ran `git diff --check`; there were no whitespace/overlap problems.
- All automated checks executed during the change succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf218c76c832e821a144b214acbc8)