### PR TITLE
Add Lousy Outages homepage command window

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -513,6 +513,7 @@ function get_lousy_outages_home_teaser_data(): array {
         'status'   => 'clear',
         'footnote' => '',
         'feed_url' => $feed_url,
+        'rows'     => [],
     ];
 
     $summary = get_lousy_outages_home_teaser_from_summary( $default );
@@ -559,6 +560,7 @@ function get_lousy_outages_home_teaser_from_summary( array $default ): ?array {
     $unverified_count = (int) ( $meta['unverified_count'] ?? 0 );
     $generated_at_raw = $meta['generated_at'] ?? $payload['generated_at'] ?? $payload['fetched_at'] ?? '';
     $generated_at = lousy_outages_home_format_generated_at( $generated_at_raw );
+    $rows = lousy_outages_home_build_alert_rows( $payload['providers'] ?? [], $default['href'] );
 
     $dashboard_url = $default['href'];
     $footnote_link = sprintf( '<a href="%s">%s</a>', esc_url( $dashboard_url ), esc_html__( 'View the dashboard', 'suzyeastonca' ) );
@@ -592,6 +594,7 @@ function get_lousy_outages_home_teaser_from_summary( array $default ): ?array {
             'status'   => 'outage',
             'footnote' => $footnote_text,
             'feed_url' => $default['feed_url'],
+            'rows'     => $rows,
         ];
     }
 
@@ -625,7 +628,69 @@ function get_lousy_outages_home_teaser_from_summary( array $default ): ?array {
         'status'   => 'clear',
         'footnote' => $footnote_text,
         'feed_url' => $default['feed_url'],
+        'rows'     => $rows,
     ];
+}
+
+/**
+ * Reduce the public summary payload to a small, safe homepage alert window.
+ */
+function lousy_outages_home_build_alert_rows( array $providers, string $dashboard_url ): array {
+    $rows = [];
+
+    foreach ( $providers as $provider ) {
+        if ( ! is_array( $provider ) ) {
+            continue;
+        }
+
+        $status = strtolower( trim( (string) ( $provider['stateCode'] ?? $provider['status'] ?? '' ) ) );
+        $kind = strtolower( trim( (string) ( $provider['tile_kind'] ?? $provider['tileKind'] ?? '' ) ) );
+        $incidents = isset( $provider['incidents'] ) && is_array( $provider['incidents'] ) ? $provider['incidents'] : [];
+        $is_outage = 'outage' === $kind || ! empty( $incidents ) || in_array( $status, [ 'outage', 'major', 'critical', 'major_outage' ], true );
+        $is_signal = 'signal' === $kind || in_array( $status, [ 'degraded', 'minor', 'partial_outage' ], true );
+        $is_unverified = in_array( $kind, [ 'unknown', 'manual' ], true ) || 'unknown' === $status;
+
+        if ( ! $is_outage && ! $is_signal && ! $is_unverified ) {
+            continue;
+        }
+
+        $name = trim( (string) ( $provider['name'] ?? $provider['provider'] ?? $provider['id'] ?? '' ) );
+        if ( '' === $name ) {
+            $name = 'Unknown provider';
+        }
+
+        $incident = ! empty( $incidents[0] ) && is_array( $incidents[0] ) ? $incidents[0] : [];
+        $message = trim( (string) ( $incident['title'] ?? $incident['summary'] ?? $provider['summary'] ?? $provider['state'] ?? '' ) );
+        if ( '' === $message ) {
+            $message = $is_outage ? 'Incident posted' : ( $is_signal ? 'Signals detected' : 'Status unverified' );
+        }
+
+        $label = trim( (string) ( $provider['state'] ?? '' ) );
+        if ( '' === $label ) {
+            $label = $is_outage ? 'Outage' : ( $is_signal ? 'Degraded' : 'Unverified' );
+        }
+
+        $updated = $incident['updatedAt'] ?? $incident['updated_at'] ?? $provider['updatedAt'] ?? $provider['updated_at'] ?? '';
+        $rows[] = [
+            'provider' => $name,
+            'message'  => $message,
+            'label'    => $label,
+            'time'     => lousy_outages_home_format_generated_at( $updated ),
+            'href'     => $dashboard_url,
+            'tone'     => $is_outage ? 'outage' : ( $is_signal ? 'signal' : 'unknown' ),
+            'priority' => $is_outage ? 0 : ( $is_signal ? 1 : 2 ),
+            'sort_key' => is_numeric( $provider['sort_key'] ?? null ) ? (int) $provider['sort_key'] : 999,
+        ];
+    }
+
+    usort(
+        $rows,
+        static function ( array $a, array $b ): int {
+            return [ $a['priority'], $a['sort_key'] ] <=> [ $b['priority'], $b['sort_key'] ];
+        }
+    );
+
+    return array_slice( $rows, 0, 3 );
 }
 
 function lousy_outages_home_find_top_provider( array $providers ): array {
@@ -773,6 +838,16 @@ function get_lousy_outages_home_teaser_from_feed( array $default ): array {
             'status'   => 'outage',
             'footnote' => '',
             'feed_url' => $feed_url,
+            'rows'     => [
+                [
+                    'provider' => $recent_outage['provider'],
+                    'message'  => $recent_outage['incident'],
+                    'label'    => 'Outage',
+                    'time'     => lousy_outages_home_format_generated_at( $recent_outage['timestamp'] ),
+                    'href'     => $default['href'],
+                    'tone'     => 'outage',
+                ],
+            ],
         ];
     }
 

--- a/page-home.php
+++ b/page-home.php
@@ -24,6 +24,7 @@ get_header();
                     </a>
                 </div>
                 <p class="hero-photo-caption pixel-font"><a class="hero-photo-link" href="<?php echo esc_url( home_url( '/bio/' ) ); ?>"><?php echo esc_html( 'Vancouver, BC / Read bio →' ); ?></a></p>
+                <?php get_template_part( 'parts/lousy-outages-teaser' ); ?>
             </aside>
         </div>
     </section>

--- a/parts/lousy-outages-teaser.php
+++ b/parts/lousy-outages-teaser.php
@@ -1,19 +1,5 @@
 <?php
-use LousyOutages\I18n;
-
-$teaser_strings = [
-    'teaserCaption' => 'Check if your favourite services are up. Insert coin to refresh.',
-    'viewDashboard' => 'View full dashboard',
-    'subscribeRss'  => 'Subscribe (RSS)',
-];
-
 $feed_url = home_url( '/?feed=lousy_outages_status' ); // Pretty /feed/lousy_outages_status/ works after a permalink flush, but the query form is more reliable.
-
-if ( class_exists( '\\LousyOutages\\I18n' ) ) {
-    $locale         = I18n::determine_locale();
-    $localized      = I18n::strings( $locale );
-    $teaser_strings = array_merge( $teaser_strings, array_intersect_key( $localized, $teaser_strings ) );
-}
 
 $teaser_data  = function_exists( 'get_lousy_outages_home_teaser_data' )
     ? get_lousy_outages_home_teaser_data()
@@ -23,39 +9,39 @@ $teaser_data  = function_exists( 'get_lousy_outages_home_teaser_data' )
         'status'   => 'clear',
         'footnote' => '',
         'feed_url' => $feed_url,
+        'rows'     => [],
     ];
-$teaser_href  = $teaser_data['href'] ?? home_url( '/lousy-outages/' );
-$feed_url     = $teaser_data['feed_url'] ?? $feed_url;
-$status       = $teaser_data['status'] ?? 'clear';
-$status_class = 'clear' === $status ? ' lo-home-pacman-alert--clear' : ' lo-home-pacman-alert--outage';
-$footnote     = $teaser_data['footnote'] ?? '';
+$teaser_href = $teaser_data['href'] ?? home_url( '/lousy-outages/' );
+$rows = isset( $teaser_data['rows'] ) && is_array( $teaser_data['rows'] ) ? $teaser_data['rows'] : [];
 ?>
-<section id="lousy-outages-teaser" class="lo-home-teaser" aria-live="polite">
-    <h2 class="lo-home-heading">Lousy Outages</h2>
-
-    <p class="lo-home-pacman-alert<?php echo esc_attr( $status_class ); ?>">
-        <span class="lo-pacman" aria-hidden="true"></span>
-        <span class="lo-pacman-dots" aria-hidden="true"></span>
-        <span class="lo-alert-text">
-            <?php echo esc_html( $teaser_data['headline'] ?? '' ); ?>
+<section id="lousy-outages-teaser" class="lo-home-teaser">
+    <div class="lo-home-teaser__titlebar">
+        <h2 class="lo-home-heading">lousy outages</h2>
+        <span class="lo-home-status-light<?php echo esc_attr( empty( $rows ) ? ' lo-home-status-light--clear' : ' lo-home-status-light--alert' ); ?>">
+            <span class="screen-reader-text"><?php echo esc_html( empty( $rows ) ? 'No active alerts' : 'Active alerts' ); ?></span>
         </span>
-    </p>
-
-    <?php if ( ! empty( $footnote ) ) : ?>
-        <p class="lo-home-footnote"><?php echo wp_kses_post( $footnote ); ?></p>
-    <?php endif; ?>
-
-    <p class="caption"><?php echo esc_html( $teaser_strings['teaserCaption'] ); ?></p>
-
-    <div class="lo-actions lo-actions--rss">
-        <a class="lo-link" href="<?php echo esc_url( $teaser_href ); ?>">
-            <?php echo esc_html( $teaser_strings['viewDashboard'] ); ?>
-        </a>
-        <a class="lo-link" href="<?php echo esc_url( $feed_url ); ?>" target="_blank" rel="noopener">
-            <svg class="lo-icon" viewBox="0 0 24 24" aria-hidden="true">
-                <path fill="currentColor" d="M6 17a2 2 0 11.001 3.999A2 2 0 016 17zm-2-7v3a8 8 0 018 8h3c0-6.075-4.925-11-11-11zm0-5v3c9.389 0 17 7.611 17 17h3C24 13.85 10.15 0 4 0z"/>
-            </svg>
-            <?php echo esc_html( $teaser_strings['subscribeRss'] ); ?>
-        </a>
     </div>
+
+    <div class="lo-home-teaser__screen">
+        <?php if ( empty( $rows ) ) : ?>
+            <p class="lo-home-empty">all quiet. suspicious, but fine.</p>
+        <?php else : ?>
+            <ul class="lo-home-alert-list">
+                <?php foreach ( $rows as $row ) : ?>
+                    <li class="lo-home-alert lo-home-alert--<?php echo esc_attr( $row['tone'] ?? 'unknown' ); ?>">
+                        <span class="lo-home-alert__label"><?php echo esc_html( $row['label'] ?? 'Status' ); ?></span>
+                        <a class="lo-home-alert__body" href="<?php echo esc_url( $row['href'] ?? $teaser_href ); ?>">
+                            <strong><?php echo esc_html( $row['provider'] ?? 'Unknown provider' ); ?></strong>
+                            <span><?php echo esc_html( $row['message'] ?? '' ); ?></span>
+                        </a>
+                        <?php if ( ! empty( $row['time'] ) ) : ?>
+                            <time class="lo-home-alert__time"><?php echo esc_html( $row['time'] ); ?></time>
+                        <?php endif; ?>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php endif; ?>
+    </div>
+
+    <a class="lo-home-dashboard-link" href="<?php echo esc_url( $teaser_href ); ?>">open dashboard <span aria-hidden="true">→</span></a>
 </section>

--- a/style.css
+++ b/style.css
@@ -1663,6 +1663,149 @@ footer,
   to   { transform: translateX(-1.5rem); }
 }
 
+/* Homepage Lousy Outages command window. */
+.hero-side .lo-home-teaser {
+  width: 100%;
+  max-width: none;
+  margin: 1rem 0 0;
+  padding: 0;
+  gap: 0;
+  overflow: hidden;
+  border: 1px solid rgba(112, 255, 168, 0.62);
+  border-radius: 4px;
+  background: #050a08;
+  box-shadow: inset 0 0 0 1px rgba(255, 184, 28, 0.12), 0 0 18px rgba(57, 255, 20, 0.12);
+}
+
+.lo-home-teaser__titlebar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.5rem 0.65rem;
+  border-bottom: 1px solid rgba(112, 255, 168, 0.35);
+  background: linear-gradient(90deg, rgba(57, 255, 20, 0.12), rgba(255, 184, 28, 0.08));
+}
+
+.hero-side .lo-home-heading {
+  margin: 0;
+  color: #a7ffbe;
+  font-size: 0.72rem;
+  letter-spacing: 0.09em;
+}
+
+.lo-home-status-light {
+  width: 0.58rem;
+  height: 0.58rem;
+  flex: 0 0 auto;
+  border: 1px solid #ffdb7b;
+  border-radius: 50%;
+  background: #ffb81c;
+  box-shadow: 0 0 7px #ffb81c;
+}
+
+.lo-home-status-light--clear {
+  border-color: #8effb0;
+  background: #39ff14;
+  box-shadow: 0 0 7px #39ff14;
+}
+
+.lo-home-status-light--alert {
+  border-color: #ff9b83;
+  background: #ff4d4d;
+  box-shadow: 0 0 7px #ff4d4d;
+}
+
+.lo-home-teaser__screen {
+  padding: 0.45rem 0.6rem;
+  background: repeating-linear-gradient(0deg, rgba(255, 255, 255, 0.025) 0 1px, transparent 1px 3px);
+}
+
+.lo-home-alert-list {
+  display: grid;
+  gap: 0.35rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.lo-home-alert {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.15rem 0.45rem;
+  padding: 0.35rem 0;
+  border-bottom: 1px dashed rgba(155, 255, 198, 0.2);
+  font-size: 0.72rem;
+  line-height: 1.35;
+}
+
+.lo-home-alert:last-child { border-bottom: 0; }
+
+.lo-home-alert__label {
+  align-self: start;
+  padding: 0.1rem 0.25rem;
+  border: 1px solid currentColor;
+  color: #ffe48a;
+  font-family: var(--arcade-heading-font, monospace);
+  font-size: 0.52rem;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.lo-home-alert--outage .lo-home-alert__label { color: #ff8a8a; }
+.lo-home-alert--signal .lo-home-alert__label { color: #ffe48a; }
+.lo-home-alert--unknown .lo-home-alert__label { color: #a8d9ff; }
+
+.lo-home-alert__body {
+  min-width: 0;
+  color: #d9ffe5;
+  text-decoration: none;
+}
+
+.lo-home-alert__body strong,
+.lo-home-alert__body span {
+  display: block;
+}
+
+.lo-home-alert__body span { color: rgba(217, 255, 229, 0.72); }
+
+.lo-home-alert__time {
+  grid-column: 2;
+  color: rgba(255, 228, 138, 0.72);
+  font-size: 0.64rem;
+}
+
+.lo-home-empty {
+  margin: 0;
+  padding: 0.25rem 0;
+  color: #a7ffbe;
+  font-size: 0.78rem;
+}
+
+.lo-home-dashboard-link {
+  display: block;
+  padding: 0.5rem 0.65rem;
+  border-top: 1px solid rgba(112, 255, 168, 0.35);
+  color: #a7ffbe;
+  font-family: var(--arcade-heading-font, monospace);
+  font-size: 0.62rem;
+  letter-spacing: 0.06em;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.lo-home-alert__body:focus-visible,
+.lo-home-dashboard-link:focus-visible {
+  outline: 2px solid #ffe48a;
+  outline-offset: 2px;
+  text-decoration: underline;
+}
+
+@media (max-width: 720px) {
+  .hero-side .lo-home-teaser { margin-top: 0.75rem; }
+  .lo-home-alert { font-size: 0.7rem; }
+}
+
 
 body {
   padding-top: var(--se-header-height);


### PR DESCRIPTION
## Summary

Adds a compact Lousy Outages command-window widget to the homepage hero/right-side area.

The widget reuses the existing server-side Lousy Outages summary/feed fallback path and shows up to 3 outage/status rows, with an empty state of:

> all quiet. suspicious, but fine.

## Changed

- Adds homepage alert rows from the existing summary payload
- Updates the Lousy Outages teaser partial into a compact terminal/HUD widget
- Places the widget in the homepage hero side column
- Adds responsive CRT/neon styling

## QA

- `git diff --check` passed
- Confirmed only these files changed:
  - `functions.php`
  - `page-home.php`
  - `parts/lousy-outages-teaser.php`
  - `style.css`
- Did not touch `plugins/lousy-outages/`
- Did not commit `AGENTS.md`

## Manual QA after deploy

- Visit homepage on desktop and mobile
- Visit `/wp-json/lousy-outages/v1/summary`
- Visit `/lousy-outages/`
- Confirm widget links open the dashboard
- Confirm empty state appears when there are no alert rows