### PR TITLE
Redesign homepage as retro arcade start screen

### DIFF
--- a/js/hero-galaga.js
+++ b/js/hero-galaga.js
@@ -99,6 +99,7 @@
     const idlePanelEl = overlay.querySelector('[data-galaga-idle-panel]');
     const gameOverPanelEl = overlay.querySelector('[data-galaga-gameover-panel]');
     const startButton = overlay.querySelector('[data-galaga-start]');
+    const externalStartButtons = document.querySelectorAll('[data-arcade-start]');
     const rebootButtons = overlay.querySelectorAll('[data-galaga-reboot]');
     const hintTextEl = overlay.querySelector('[data-galaga-hint-text]');
     const finalScoreEl = overlay.querySelector('[data-galaga-final-score]');
@@ -1112,6 +1113,14 @@
         restartGame();
       });
     }
+
+    externalStartButtons.forEach(function (button) {
+      button.addEventListener('click', function () {
+        if (desktopQuery.matches && !reducedMotionQuery.matches) {
+          restartGame();
+        }
+      });
+    });
 
     rebootButtons.forEach(function (button) {
       button.addEventListener('click', function (event) {

--- a/page-home.php
+++ b/page-home.php
@@ -3,119 +3,80 @@
 get_header();
 ?>
 
-<main id="homepage-content" class="home-layout">
+<main id="homepage-content" class="home-layout home-arcade-layout">
 
-    <section class="home-hero hero hero-section crt-block" aria-labelledby="home-hero-title">
-        <div class="hero-grid">
-            <div class="hero-main">
-                <p class="hero-eyebrow pixel-font"><?php echo esc_html( 'Vancouver · AI Strategist · Creative Technologist · Bass' ); ?></p>
-                <h1 id="home-hero-title" class="hero-core-headline"><?php echo esc_html( 'Day: AI infrastructure.' ); ?><br><?php echo esc_html( 'Night: bass and weird tools.' ); ?></h1>
-                <p class="hero-copy"><?php echo esc_html( 'AI strategy and solutions engineering at Quercus IT. Formerly a touring bassist — national tours, MuchMusic, recorded with Steve Albini in Chicago. Still releasing music. Still building weird tools.' ); ?></p>
-                <div class="home-cta-row hero-cta-group">
-                    <a href="<?php echo esc_url( home_url( '/projects/' ) ); ?>" class="pixel-button hero-primary-cta"><?php echo esc_html( 'Explore Projects' ); ?></a>
-                    <a href="#music" class="pixel-button hero-secondary-cta"><?php echo esc_html( 'Hear the Music' ); ?></a>
-                    <button class="pixel-button hero-secondary-cta" type="button" data-contact-trigger aria-haspopup="dialog" aria-controls="contact-suzy-modal"><?php echo esc_html( 'Contact' ); ?></button>
-                </div>
+    <section class="home-hero home-arcade-hero hero hero-section crt-block" aria-labelledby="home-hero-title">
+        <div class="home-arcade-hero__cabinet" aria-label="Suzy Easton arcade start screen">
+            <div class="home-arcade-hero__marquee pixel-font" aria-hidden="true">
+                <span><?php echo esc_html( '1UP: SUZY' ); ?></span>
+                <span><?php echo esc_html( 'HIGH SCORE 1984' ); ?></span>
+                <span><?php echo esc_html( 'VANCOUVER' ); ?></span>
             </div>
-            <aside class="hero-side hero-photo-card" aria-label="Hero portrait">
-                <div class="hero-photo-frame">
-                    <a class="hero-photo-link hero-photo-link-block" href="<?php echo esc_url( home_url( '/bio/' ) ); ?>">
-                        <img class="hero-photo" src="<?php echo esc_url( home_url( '/wp-content/uploads/2026/01/IMG_9003.jpg' ) ); ?>" alt="<?php echo esc_attr( 'Suzy Easton' ); ?>" loading="lazy" decoding="async">
-                    </a>
-                </div>
-                <p class="hero-photo-caption pixel-font"><a class="hero-photo-link" href="<?php echo esc_url( home_url( '/bio/' ) ); ?>"><?php echo esc_html( 'Vancouver, BC / Read bio →' ); ?></a></p>
-                <?php get_template_part( 'parts/lousy-outages-teaser' ); ?>
-            </aside>
-        </div>
-    </section>
 
-    <section id="music" class="music-world crt-block" aria-labelledby="music-world-title">
-        <p class="home-section-kicker pixel-font"><?php echo esc_html( '// NIGHT SHIFT //' ); ?></p>
-        <h2 id="music-world-title" class="pixel-font"><?php echo esc_html( 'Bass. Records. That one time in Chicago.' ); ?></h2>
-        <p><?php echo esc_html( 'National touring bassist. Minto and The Smokes. Canada-wide, MuchMusic, recorded with Steve Albini in Chicago. Still releasing — somewhere between Sade, Grimes, and Metric.' ); ?></p>
-        <div class="home-music-player">
-            <?php
-            // Drop in your Bandcamp embed iframe here — replace ALBUM_ID with the numeric ID from your Bandcamp album URL.
-            // Example: <iframe style="border:0;width:100%;height:120px;" src="https://bandcamp.com/EmbeddedPlayer/album=ALBUM_ID/size=large/bgcol=000000/linkcol=39ff14/tracklist=false/artwork=small/transparent=true/" seamless></iframe>
-            ?>
-            <div class="home-cta-row">
-                <a class="pixel-button" href="https://suzyeaston.bandcamp.com" target="_blank" rel="noopener noreferrer"><?php echo esc_html( 'Listen on Bandcamp' ); ?></a>
-                <a class="pixel-button" href="<?php echo esc_url( home_url( '/music-releases/' ) ); ?>"><?php echo esc_html( 'Music Releases' ); ?></a>
+            <div class="hero-grid home-arcade-hero__grid">
+                <div class="hero-main home-arcade-hero__intro">
+                    <p class="hero-eyebrow pixel-font"><?php echo esc_html( 'Vancouver · AI Strategist · Creative Technologist · Bass' ); ?></p>
+                    <h1 id="home-hero-title" class="hero-core-headline home-arcade-title"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>
+                    <p class="home-arcade-subtitle pixel-font"><?php echo esc_html( 'Day: AI infrastructure / strategy. Night: bass, records, weird tools.' ); ?></p>
+                    <p class="hero-copy home-arcade-copy"><?php echo esc_html( 'A playable personal operating system for AI builds, Vancouver experiments, loud bass, and useful glitches.' ); ?></p>
+                    <div class="home-cta-row hero-cta-group home-arcade-start-row">
+                        <a href="#mission-select" class="pixel-button hero-primary-cta home-arcade-start" data-arcade-start><?php echo esc_html( 'Start Mission' ); ?></a>
+                    </div>
+                </div>
+
+                <aside class="hero-side home-arcade-hero__screen" aria-label="Pacific Static arcade panel">
+                    <div class="hero-game-stage home-arcade-game" aria-label="Pacific Static mini arcade game. Press Start Mission, then use A and D or arrow keys to move and Space to fire." data-arcade-stage>
+                        <p class="hero-game-stage__header pixel-font"><?php echo esc_html( 'PACIFIC STATIC // ORIGINAL MINI ARCADE' ); ?></p>
+                        <div class="hero-game-stage__screen" role="img" aria-label="A green CRT arcade screen with stars, a small player ship, and incoming signal objects.">
+                            <p class="hero-game-stage__idle pixel-font"><?php echo wp_kses_post( 'TAP START MISSION<br>Desktop unlocks playable mode.<br>A/D or arrows move // Space fires.' ); ?></p>
+                            <div class="home-static-sprites" aria-hidden="true">
+                                <span class="home-static-sprites__ship"></span>
+                                <span class="home-static-sprites__enemy home-static-sprites__enemy--one"></span>
+                                <span class="home-static-sprites__enemy home-static-sprites__enemy--two"></span>
+                                <span class="home-static-sprites__reticle"></span>
+                            </div>
+                        </div>
+                        <p class="hero-game-stage__mobile-note pixel-font"><?php echo esc_html( 'Mobile: attract mode only. Mission cards are fully tappable below.' ); ?></p>
+                    </div>
+                </aside>
             </div>
         </div>
     </section>
 
-    <section class="home-terminal-strip crt-block" aria-label="Identity readout">
+    <section class="home-terminal-strip home-operator-strip crt-block" aria-label="Identity readout">
         <div class="home-terminal-readout" role="presentation">
-            <p>
-                <span class="home-terminal-key"><?php echo esc_html( 'OPERATOR' ); ?></span>
-                <span class="home-terminal-dots" aria-hidden="true"></span>
-                <span class="home-terminal-val"><?php echo esc_html( 'Suzy Easton' ); ?></span>
-            </p>
-            <p>
-                <span class="home-terminal-key"><?php echo esc_html( 'LOCATION' ); ?></span>
-                <span class="home-terminal-dots" aria-hidden="true"></span>
-                <span class="home-terminal-val"><?php echo esc_html( 'Vancouver, BC' ); ?></span>
-            </p>
-            <p>
-                <span class="home-terminal-key"><?php echo esc_html( 'DAY JOB' ); ?></span>
-                <span class="home-terminal-dots" aria-hidden="true"></span>
-                <span class="home-terminal-val"><?php echo esc_html( 'AI Strategist & Solutions Eng. · Quercus IT' ); ?></span>
-            </p>
-            <p>
-                <span class="home-terminal-key"><?php echo esc_html( 'NIGHT JOB' ); ?></span>
-                <span class="home-terminal-dots" aria-hidden="true"></span>
-                <span class="home-terminal-val"><?php echo esc_html( 'Bass. Bandcamp. Tools that shouldn\'t work but do.' ); ?></span>
-            </p>
-            <p>
-                <span class="home-terminal-key"><?php echo esc_html( 'TOURING' ); ?></span>
-                <span class="home-terminal-dots" aria-hidden="true"></span>
-                <span class="home-terminal-val"><?php echo esc_html( 'Canada-wide · MuchMusic · Steve Albini in Chicago' ); ?></span>
-            </p>
-            <p class="home-terminal-status">
-                <span class="home-status-tag"><?php echo esc_html( 'EMPLOYED' ); ?></span>
-                <span class="home-status-tag"><?php echo esc_html( 'BUILDING' ); ?></span>
-                <span class="home-status-tag"><?php echo esc_html( 'RELEASING' ); ?></span>
-            </p>
-        </div>
-        <div class="home-cta-row">
-            <button class="pixel-button" type="button" data-contact-trigger aria-haspopup="dialog" aria-controls="contact-suzy-modal"><?php echo esc_html( 'Contact' ); ?></button>
-            <a class="pixel-button" href="<?php echo esc_url( home_url( '/bio/' ) ); ?>"><?php echo esc_html( 'Full bio' ); ?></a>
+            <p><span class="home-terminal-key"><?php echo esc_html( 'OPERATOR' ); ?></span><span class="home-terminal-dots" aria-hidden="true"></span><span class="home-terminal-val"><?php echo esc_html( 'Suzy Easton' ); ?></span></p>
+            <p><span class="home-terminal-key"><?php echo esc_html( 'DAY MODE' ); ?></span><span class="home-terminal-dots" aria-hidden="true"></span><span class="home-terminal-val"><?php echo esc_html( 'AI infrastructure · strategy · solutions engineering at Quercus IT' ); ?></span></p>
+            <p><span class="home-terminal-key"><?php echo esc_html( 'NIGHT MODE' ); ?></span><span class="home-terminal-dots" aria-hidden="true"></span><span class="home-terminal-val"><?php echo esc_html( 'Bass · records · strange instruments · tools that should not work but do' ); ?></span></p>
         </div>
     </section>
 
-    <section class="home-project-grid crt-block" aria-labelledby="selected-projects-title">
-        <p class="home-section-kicker pixel-font"><?php echo esc_html( '// SELECT YOUR BUILD //' ); ?></p>
-        <h2 id="selected-projects-title" class="pixel-font"><?php echo esc_html( 'Projects' ); ?></h2>
-        <div class="selected-work__grid">
-            <article class="home-project-card selected-work__card">
+    <section id="mission-select" class="home-project-grid home-mission-select crt-block" aria-labelledby="selected-projects-title">
+        <p class="home-section-kicker pixel-font"><?php echo esc_html( '// MISSION SELECT //' ); ?></p>
+        <h2 id="selected-projects-title" class="pixel-font"><?php echo esc_html( 'Choose your level' ); ?></h2>
+        <div class="selected-work__grid home-mission-grid">
+            <article class="home-project-card selected-work__card home-mission-card home-mission-card--boss">
+                <p class="home-mission-card__label pixel-font"><?php echo esc_html( 'BOSS ALERT' ); ?></p>
                 <h3 class="pixel-font"><?php echo esc_html( 'Lousy Outages' ); ?></h3>
-                <p><?php echo esc_html( 'Official status pages lie. This one doesn\'t.' ); ?></p>
-                <a class="pixel-button" href="<?php echo esc_url( home_url( '/lousy-outages/' ) ); ?>"><?php echo esc_html( 'Open' ); ?></a>
+                <p><?php echo esc_html( 'Official status pages lie. This one watches provider weirdness like a cranky radar screen.' ); ?></p>
+                <a class="pixel-button" href="<?php echo esc_url( home_url( '/lousy-outages/' ) ); ?>"><?php echo esc_html( 'Scan' ); ?></a>
             </article>
-            <article class="home-project-card selected-work__card">
-                <h3 class="pixel-font"><?php echo esc_html( 'Gastown Simulator' ); ?></h3>
-                <p><?php echo esc_html( 'Vancouver in a browser. Maps, routes, civic data.' ); ?></p>
-                <a class="pixel-button" href="<?php echo esc_url( home_url( '/page-gastown-sim/' ) ); ?>"><?php echo esc_html( 'Explore' ); ?></a>
-            </article>
-            <article class="home-project-card selected-work__card">
-                <h3 class="pixel-font"><?php echo esc_html( 'Track Analyzer' ); ?></h3>
-                <p><?php echo esc_html( 'Rough mix goes in. Notes come out.' ); ?></p>
-                <a class="pixel-button" href="<?php echo esc_url( home_url( '/suzys-track-analyzer/' ) ); ?>"><?php echo esc_html( 'Try it' ); ?></a>
-            </article>
-            <article class="home-project-card selected-work__card">
-                <h3 class="pixel-font"><?php echo esc_html( 'What Would Steve Do' ); ?></h3>
-                <p><?php echo esc_html( 'AI Albini-isms for when your mix sounds wrong.' ); ?></p>
-                <a class="pixel-button" href="<?php echo esc_url( home_url( '/albini-qa/' ) ); ?>"><?php echo esc_html( 'Ask Steve' ); ?></a>
-            </article>
-            <article class="home-project-card selected-work__card">
-                <h3 class="pixel-font"><?php echo esc_html( 'ASMR Lab' ); ?></h3>
-                <p><?php echo esc_html( 'Audio/visual experiments. Probably fine.' ); ?></p>
-                <a class="pixel-button" href="<?php echo esc_url( home_url( '/asmr-lab/' ) ); ?>"><?php echo esc_html( 'Enter' ); ?></a>
-            </article>
+            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 02' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Gastown Simulator' ); ?></h3><p><?php echo esc_html( 'Vancouver in a browser: civic data, routes, buildings, and ghosts in the grid.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/page-gastown-sim/' ) ); ?>"><?php echo esc_html( 'Explore' ); ?></a></article>
+            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 03' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Track Analyzer' ); ?></h3><p><?php echo esc_html( 'Rough mix goes in. Practical notes come out. No fake studio mysticism.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/suzys-track-analyzer/' ) ); ?>"><?php echo esc_html( 'Try it' ); ?></a></article>
+            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 04' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'What Would Steve Do' ); ?></h3><p><?php echo esc_html( 'Albini-ish prompts for when your mix needs fewer lies and better drums.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/albini-qa/' ) ); ?>"><?php echo esc_html( 'Ask' ); ?></a></article>
+            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 05' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'ASMR Lab' ); ?></h3><p><?php echo esc_html( 'Audio/visual experiments, soft chaos, and tiny browser rituals.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/asmr-lab/' ) ); ?>"><?php echo esc_html( 'Enter' ); ?></a></article>
         </div>
-        <div class="home-cta-row home-project-grid__all">
-            <a class="pixel-button" href="<?php echo esc_url( home_url( '/projects/' ) ); ?>"><?php echo esc_html( 'All projects →' ); ?></a>
+    </section>
+
+    <section id="music" class="music-world home-unlocks crt-block" aria-labelledby="music-world-title">
+        <p class="home-section-kicker pixel-font"><?php echo esc_html( '// UNLOCKS //' ); ?></p>
+        <h2 id="music-world-title" class="pixel-font"><?php echo esc_html( 'Music, bio, contact' ); ?></h2>
+        <p><?php echo esc_html( 'National touring bassist. Minto and The Smokes. Canada-wide, MuchMusic, recorded with Steve Albini in Chicago. Still releasing — somewhere between Sade, Grimes, and Metric.' ); ?></p>
+        <div class="home-cta-row">
+            <a class="pixel-button" href="https://suzyeaston.bandcamp.com" target="_blank" rel="noopener noreferrer"><?php echo esc_html( 'Bandcamp' ); ?></a>
+            <a class="pixel-button" href="<?php echo esc_url( home_url( '/music-releases/' ) ); ?>"><?php echo esc_html( 'Records' ); ?></a>
+            <a class="pixel-button" href="<?php echo esc_url( home_url( '/bio/' ) ); ?>"><?php echo esc_html( 'Bio' ); ?></a>
+            <button class="pixel-button" type="button" data-contact-trigger aria-haspopup="dialog" aria-controls="contact-suzy-modal"><?php echo esc_html( 'Contact' ); ?></button>
         </div>
     </section>
 

--- a/style.css
+++ b/style.css
@@ -5222,3 +5222,35 @@ body {
     white-space: normal;
   }
 }
+
+/* Homepage arcade redesign */
+.home-arcade-layout { padding-bottom: clamp(2rem, 6vw, 5rem); }
+.home-arcade-hero { padding: clamp(1.5rem, 4vw, 3.5rem) clamp(1rem, 3vw, 2rem); }
+.home-arcade-hero__cabinet { max-width: 1180px; margin: 0 auto; border: 2px solid rgba(0,255,0,.58); border-radius: 18px; background: radial-gradient(circle at 50% 0, rgba(0,255,128,.16), transparent 42%), linear-gradient(180deg, rgba(0,20,12,.96), rgba(0,0,0,.94)); box-shadow: 0 0 0 4px rgba(0,0,0,.85), 0 0 36px rgba(0,255,80,.22), inset 0 0 36px rgba(0,255,80,.08); padding: clamp(.85rem, 2vw, 1.4rem); }
+.home-arcade-hero__marquee { display:flex; justify-content:space-between; gap:1rem; margin-bottom: clamp(1rem,2vw,1.6rem); color:#ffff66; font-size:clamp(.52rem,1.1vw,.72rem); letter-spacing:.08em; }
+.home-arcade-hero__grid { grid-template-columns: minmax(0,.9fr) minmax(320px,1.1fr); align-items:center; margin-bottom:0; }
+.home-arcade-title { font-size: clamp(2.4rem, 7vw, 6.8rem); letter-spacing:.04em; text-shadow: 0 0 10px rgba(0,255,0,.65), 4px 4px 0 rgba(230,0,115,.45); }
+.home-arcade-subtitle { max-width: 720px; margin: 1rem auto 0; color:#cbffe7; font-size:clamp(.7rem,1.4vw,.95rem); line-height:1.7; }
+.home-arcade-copy { max-width: 660px; margin: 1rem auto 0; color:rgba(218,255,232,.86); }
+.home-arcade-start-row { margin-top:1.5rem; }
+.home-arcade-start { animation: homeStartPulse 1.6s steps(2,end) infinite; }
+.home-arcade-game { margin-bottom:0; min-height: 100%; }
+.home-arcade-game .hero-game-stage__screen { min-height: clamp(300px, 36vw, 440px); background: radial-gradient(circle at 20% 18%, rgba(87,243,255,.14) 0 2px, transparent 3px), radial-gradient(circle at 78% 28%, rgba(255,255,102,.22) 0 1px, transparent 2px), radial-gradient(circle at 50% 110%, rgba(0,255,0,.16), transparent 44%), repeating-linear-gradient(180deg, rgba(255,255,255,.035) 0 2px, transparent 2px 5px), #010806; }
+.home-static-sprites { position:absolute; inset:0; pointer-events:none; }
+.home-static-sprites__ship { position:absolute; left:50%; bottom:14%; width:46px; height:30px; transform:translateX(-50%); background: linear-gradient(to bottom, transparent 0 20%, #39ff14 20% 42%, transparent 42%), linear-gradient(to right, transparent 0 16%, #39ff14 16% 36%, #cbffe7 36% 64%, #39ff14 64% 84%, transparent 84%); filter: drop-shadow(0 0 10px rgba(57,255,20,.7)); }
+.home-static-sprites__enemy { position:absolute; width:28px; height:22px; border:2px solid #ff4dce; box-shadow:0 0 12px rgba(255,77,206,.7); }
+.home-static-sprites__enemy--one { left:28%; top:30%; clip-path: polygon(50% 0,100% 45%,70% 100%,50% 70%,30% 100%,0 45%); }
+.home-static-sprites__enemy--two { right:25%; top:22%; border-color:#57f3ff; clip-path: polygon(50% 0,100% 100%,65% 72%,50% 100%,35% 72%,0 100%); }
+.home-static-sprites__reticle { position:absolute; left:50%; top:42%; width:74px; height:74px; border:1px solid rgba(255,255,102,.72); border-radius:50%; transform:translate(-50%,-50%); box-shadow: inset 0 0 16px rgba(255,255,102,.12), 0 0 14px rgba(255,255,102,.22); }
+.home-operator-strip, .home-mission-select, .home-unlocks { max-width: 1120px; margin-inline:auto; }
+.home-mission-select { scroll-margin-top: calc(var(--se-header-height) + 1rem); }
+.home-mission-grid { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.home-mission-card { position:relative; overflow:hidden; border-color:rgba(87,243,255,.45); }
+.home-mission-card::before { content:""; position:absolute; inset:0; background:linear-gradient(135deg, rgba(87,243,255,.08), transparent 40%); pointer-events:none; }
+.home-mission-card--boss { border-color:rgba(255,72,206,.72); box-shadow:0 0 24px rgba(255,72,206,.18); }
+.home-mission-card__label { margin:0 0 .6rem; color:#ffff66; font-size:.58rem; }
+.home-unlocks { display:grid; gap:1rem; }
+@keyframes homeStartPulse { 50% { color:#ffff66; border-color:#ffff66; box-shadow:0 0 18px rgba(255,255,102,.45); } }
+@media (max-width: 980px) { .home-arcade-hero__grid { grid-template-columns:1fr; } .home-mission-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 620px) { .home-arcade-hero__marquee { flex-direction:column; align-items:center; text-align:center; } .home-mission-grid { grid-template-columns:1fr; } .home-arcade-game .hero-game-stage__screen { min-height:230px; } }
+@media (prefers-reduced-motion: reduce) { .home-arcade-start { animation:none; } }


### PR DESCRIPTION
### Motivation
- Simplify the first fold into a single, confident visual concept (arcade attract / start screen) so the homepage reads as a playful personal OS rather than a crowded portfolio dashboard.
- Surface one primary action (`Start Mission`) and make a small, decorative/playable Galaga‑style panel that is accessible, performant, and respectful of reduced‑motion preferences.
- Preserve existing WordPress structure and links while reshaping content hierarchy into Day/Night operator readouts, mission select, and unlockable music/bio/contact actions.

### Description
- Replaced the old hero with an arcade cabinet / marquee layout and a single primary CTA by editing `page-home.php` to a new `home-arcade-layout` structure and mission‑select flow.
- Added focused stylesheet rules to `style.css` for cabinet / marquee / CRT / sprites / mission cards, responsive breakpoints, and `prefers-reduced-motion` safe behavior.
- Wired the existing lightweight Galaga-like engine by updating `js/hero-galaga.js` to accept external start triggers (`[data-arcade-start]`) so the hero CTA can start the desktop game without adding heavy dependencies.
- Kept implementation vanilla (PHP/HTML/CSS/vanilla JS), accessible (aria labels, fallback idle text), and non-blocking on mobile (attract mode + tappable mission cards).

### Testing
- Ran PHP syntax checks: `php -l page-home.php` and `php -l functions.php` (both passed).
- Checked JS syntax: `node -c js/hero-galaga.js` (passed).
- Ran full JS test suite: `npm test` — the repo test run completed but reported pre-existing failing tests (18 failures) in Gastown / Lousy Outages / Open Data areas unrelated to the homepage edits; homepage-related syntax and file checks passed.

Files changed: `page-home.php`, `style.css`, `js/hero-galaga.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b8679af6083319900d15d577f8f54)