### PR TITLE
Refine homepage arcade layout and restore Lousy Outages widget

### DIFF
--- a/js/hero-galaga.js
+++ b/js/hero-galaga.js
@@ -58,8 +58,8 @@
     const ui = document.createElement('div');
     ui.className = 'hero-galaga-ui';
     ui.innerHTML = '' +
-      '<p class="hero-galaga-status" data-galaga-status>PACIFIC STATIC</p>' +
-      '<p class="hero-galaga-vessel">Vessel: LIONS GATE</p>' +
+      '<p class="hero-galaga-status" data-galaga-status>OUTAGE BLIPS</p>' +
+      '<p class="hero-galaga-vessel">Signal: provider alerts</p>' +
       '<p class="hero-galaga-scoreline">Score: <span data-galaga-score>000000</span> // Lives: <span data-galaga-lives>3</span> // Wave: <span data-galaga-wave>1</span></p>' +
       '<p class="hero-galaga-help">WASD move // Space fire // Esc quit</p>' +
       '<p class="hero-galaga-wavecall" data-galaga-wavecall hidden></p>';
@@ -69,7 +69,7 @@
     overlay.innerHTML = '' +
       '<div class="hero-galaga-panel hero-galaga-panel--idle hero-galaga-overlay--idle" data-galaga-idle-panel>' +
         '<p class="hero-galaga-hint-text" data-galaga-hint-text></p>' +
-        '<button type="button" class="hero-galaga-reboot" data-galaga-start>Start Signal</button>' +
+        '<button type="button" class="hero-galaga-reboot" data-galaga-start>Start Blip Sweep</button>' +
       '</div>' +
       '<div class="hero-galaga-panel hero-galaga-panel--gameover hero-galaga-overlay--gameover hero-galaga-gameover" data-galaga-gameover-panel hidden>' +
         '<p class="hero-galaga-gameover__title">SIGNAL LOST</p>' +
@@ -146,11 +146,11 @@
     };
 
     const waveCalls = [
-      'WAVE 1 // VANCOUVER SIGNAL',
-      'WAVE 2 // GASTOWN GHOSTS',
-      'WAVE 3 // STEAM CLOCK SWARM',
-      'WAVE 4 // SEABUS DRONES',
-      'WAVE 5 // PACIFIC STATIC',
+      'WAVE 1 // PROVIDER ALERTS',
+      'WAVE 2 // STATUSPAGE BLIPS',
+      'WAVE 3 // CLOUD FLAREUPS',
+      'WAVE 4 // INCIDENT NOISE',
+      'WAVE 5 // OUTAGE STATIC',
     ];
 
     function setGameMode(mode) {
@@ -282,7 +282,7 @@
       idlePanelEl.hidden = !isIdle;
       gameOverPanelEl.hidden = !isGameOver;
 
-      hintTextEl.innerHTML = 'PACIFIC STATIC<br>Vessel: LIONS GATE<br>Defend the Vancouver signal.<br>Press G to play.<br>WASD move // Space fire // Esc quit';
+      hintTextEl.innerHTML = 'OUTAGE BLIPS<br>Provider alerts as arcade static.<br>Click to play, or ignore it.<br>WASD move // Space fire // Esc quit';
       if (startButton) {
         startButton.hidden = !isIdle;
       }
@@ -494,7 +494,6 @@
         waveCallEl.hidden = true;
         waveCallEl.textContent = '';
       }
-      gameStage.focus({ preventScroll: true });
       debugLog('game start');
       startLoop();
     }

--- a/page-home.php
+++ b/page-home.php
@@ -15,20 +15,21 @@ get_header();
 
             <div class="hero-grid home-arcade-hero__grid">
                 <div class="hero-main home-arcade-hero__intro">
-                    <p class="hero-eyebrow pixel-font"><?php echo esc_html( 'Vancouver · AI Strategist · Creative Technologist · Bass' ); ?></p>
+                    <p class="hero-eyebrow pixel-font"><?php echo esc_html( 'Vancouver · AI strategist · musician · creative technologist' ); ?></p>
                     <h1 id="home-hero-title" class="hero-core-headline home-arcade-title"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>
-                    <p class="home-arcade-subtitle pixel-font"><?php echo esc_html( 'Day: AI infrastructure / strategy. Night: bass, records, weird tools.' ); ?></p>
-                    <p class="hero-copy home-arcade-copy"><?php echo esc_html( 'A playable personal operating system for AI builds, Vancouver experiments, loud bass, and useful glitches.' ); ?></p>
+                    <p class="home-arcade-subtitle pixel-font"><?php echo esc_html( 'AI STRATEGY / MUSIC / CREATIVE TECHNOLOGY' ); ?></p>
+                    <p class="hero-copy home-arcade-copy"><?php echo esc_html( 'Vancouver-based. Practical AI systems, music, weird tools, and useful little machines.' ); ?></p>
                     <div class="home-cta-row hero-cta-group home-arcade-start-row">
                         <a href="#mission-select" class="pixel-button hero-primary-cta home-arcade-start" data-arcade-start><?php echo esc_html( 'Start Mission' ); ?></a>
+                        <a href="#lousy-outages-teaser" class="pixel-button pixel-button--secondary"><?php echo esc_html( 'View Alerts' ); ?></a>
                     </div>
                 </div>
 
                 <aside class="hero-side home-arcade-hero__screen" aria-label="Pacific Static arcade panel">
                     <div class="hero-game-stage home-arcade-game" aria-label="Pacific Static mini arcade game. Press Start Mission, then use A and D or arrow keys to move and Space to fire." data-arcade-stage>
-                        <p class="hero-game-stage__header pixel-font"><?php echo esc_html( 'PACIFIC STATIC // ORIGINAL MINI ARCADE' ); ?></p>
-                        <div class="hero-game-stage__screen" role="img" aria-label="A green CRT arcade screen with stars, a small player ship, and incoming signal objects.">
-                            <p class="hero-game-stage__idle pixel-font"><?php echo wp_kses_post( 'TAP START MISSION<br>Desktop unlocks playable mode.<br>A/D or arrows move // Space fires.' ); ?></p>
+                        <p class="hero-game-stage__header pixel-font"><?php echo esc_html( 'OUTAGE BLIPS // MINI ARCADE' ); ?></p>
+                        <div class="hero-game-stage__screen" role="img" aria-label="A green CRT arcade screen with stars, a small player ship, and outage alert blips.">
+                            <p class="hero-game-stage__idle pixel-font"><?php echo wp_kses_post( 'ALERT BLIPS INCOMING<br>Desktop: A/D or arrows move // Space fires.<br>No keyboard focus stolen.' ); ?></p>
                             <div class="home-static-sprites" aria-hidden="true">
                                 <span class="home-static-sprites__ship"></span>
                                 <span class="home-static-sprites__enemy home-static-sprites__enemy--one"></span>
@@ -36,42 +37,44 @@ get_header();
                                 <span class="home-static-sprites__reticle"></span>
                             </div>
                         </div>
-                        <p class="hero-game-stage__mobile-note pixel-font"><?php echo esc_html( 'Mobile: attract mode only. Mission cards are fully tappable below.' ); ?></p>
+                        <p class="hero-game-stage__mobile-note pixel-font"><?php echo esc_html( 'Mobile: static alert screen. Links stay tappable below.' ); ?></p>
                     </div>
                 </aside>
             </div>
         </div>
     </section>
 
+    <?php get_template_part( 'parts/lousy-outages-teaser' ); ?>
+
     <section class="home-terminal-strip home-operator-strip crt-block" aria-label="Identity readout">
         <div class="home-terminal-readout" role="presentation">
             <p><span class="home-terminal-key"><?php echo esc_html( 'OPERATOR' ); ?></span><span class="home-terminal-dots" aria-hidden="true"></span><span class="home-terminal-val"><?php echo esc_html( 'Suzy Easton' ); ?></span></p>
             <p><span class="home-terminal-key"><?php echo esc_html( 'DAY MODE' ); ?></span><span class="home-terminal-dots" aria-hidden="true"></span><span class="home-terminal-val"><?php echo esc_html( 'AI infrastructure · strategy · solutions engineering at Quercus IT' ); ?></span></p>
-            <p><span class="home-terminal-key"><?php echo esc_html( 'NIGHT MODE' ); ?></span><span class="home-terminal-dots" aria-hidden="true"></span><span class="home-terminal-val"><?php echo esc_html( 'Bass · records · strange instruments · tools that should not work but do' ); ?></span></p>
+            <p><span class="home-terminal-key"><?php echo esc_html( 'NIGHT MODE' ); ?></span><span class="home-terminal-dots" aria-hidden="true"></span><span class="home-terminal-val"><?php echo esc_html( 'Music · records · audio experiments · bands · touring' ); ?></span></p>
         </div>
     </section>
 
     <section id="mission-select" class="home-project-grid home-mission-select crt-block" aria-labelledby="selected-projects-title">
         <p class="home-section-kicker pixel-font"><?php echo esc_html( '// MISSION SELECT //' ); ?></p>
-        <h2 id="selected-projects-title" class="pixel-font"><?php echo esc_html( 'Choose your level' ); ?></h2>
+        <h2 id="selected-projects-title" class="pixel-font"><?php echo esc_html( 'Projects' ); ?></h2>
         <div class="selected-work__grid home-mission-grid">
             <article class="home-project-card selected-work__card home-mission-card home-mission-card--boss">
                 <p class="home-mission-card__label pixel-font"><?php echo esc_html( 'BOSS ALERT' ); ?></p>
                 <h3 class="pixel-font"><?php echo esc_html( 'Lousy Outages' ); ?></h3>
-                <p><?php echo esc_html( 'Official status pages lie. This one watches provider weirdness like a cranky radar screen.' ); ?></p>
+                <p><?php echo esc_html( 'Provider status alerts and outage signals, readable at a glance.' ); ?></p>
                 <a class="pixel-button" href="<?php echo esc_url( home_url( '/lousy-outages/' ) ); ?>"><?php echo esc_html( 'Scan' ); ?></a>
             </article>
-            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 02' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Gastown Simulator' ); ?></h3><p><?php echo esc_html( 'Vancouver in a browser: civic data, routes, buildings, and ghosts in the grid.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/page-gastown-sim/' ) ); ?>"><?php echo esc_html( 'Explore' ); ?></a></article>
-            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 03' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Track Analyzer' ); ?></h3><p><?php echo esc_html( 'Rough mix goes in. Practical notes come out. No fake studio mysticism.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/suzys-track-analyzer/' ) ); ?>"><?php echo esc_html( 'Try it' ); ?></a></article>
-            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 04' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'What Would Steve Do' ); ?></h3><p><?php echo esc_html( 'Albini-ish prompts for when your mix needs fewer lies and better drums.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/albini-qa/' ) ); ?>"><?php echo esc_html( 'Ask' ); ?></a></article>
-            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 05' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'ASMR Lab' ); ?></h3><p><?php echo esc_html( 'Audio/visual experiments, soft chaos, and tiny browser rituals.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/asmr-lab/' ) ); ?>"><?php echo esc_html( 'Enter' ); ?></a></article>
+            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 02' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Gastown Simulator' ); ?></h3><p><?php echo esc_html( 'A civic-data browser toy for walking weird Vancouver routes.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/page-gastown-sim/' ) ); ?>"><?php echo esc_html( 'Explore' ); ?></a></article>
+            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 03' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Track Analyzer' ); ?></h3><p><?php echo esc_html( 'Upload a track. Get practical audio notes back.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/suzys-track-analyzer/' ) ); ?>"><?php echo esc_html( 'Try it' ); ?></a></article>
+            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 04' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'What Would Steve Do' ); ?></h3><p><?php echo esc_html( 'Blunt studio prompts for records that need fewer lies.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/albini-qa/' ) ); ?>"><?php echo esc_html( 'Ask' ); ?></a></article>
+            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 05' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'ASMR Lab' ); ?></h3><p><?php echo esc_html( 'Soft audio visuals, texture, and tiny browser rituals.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/asmr-lab/' ) ); ?>"><?php echo esc_html( 'Enter' ); ?></a></article>
         </div>
     </section>
 
     <section id="music" class="music-world home-unlocks crt-block" aria-labelledby="music-world-title">
         <p class="home-section-kicker pixel-font"><?php echo esc_html( '// UNLOCKS //' ); ?></p>
         <h2 id="music-world-title" class="pixel-font"><?php echo esc_html( 'Music, bio, contact' ); ?></h2>
-        <p><?php echo esc_html( 'National touring bassist. Minto and The Smokes. Canada-wide, MuchMusic, recorded with Steve Albini in Chicago. Still releasing — somewhere between Sade, Grimes, and Metric.' ); ?></p>
+        <p><?php echo esc_html( 'Music, records, bands, touring, and audio experiments — from Minto and The Smokes to new solo releases and strange browser instruments.' ); ?></p>
         <div class="home-cta-row">
             <a class="pixel-button" href="https://suzyeaston.bandcamp.com" target="_blank" rel="noopener noreferrer"><?php echo esc_html( 'Bandcamp' ); ?></a>
             <a class="pixel-button" href="<?php echo esc_url( home_url( '/music-releases/' ) ); ?>"><?php echo esc_html( 'Records' ); ?></a>

--- a/style.css
+++ b/style.css
@@ -5254,3 +5254,182 @@ body {
 @media (max-width: 980px) { .home-arcade-hero__grid { grid-template-columns:1fr; } .home-mission-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
 @media (max-width: 620px) { .home-arcade-hero__marquee { flex-direction:column; align-items:center; text-align:center; } .home-mission-grid { grid-template-columns:1fr; } .home-arcade-game .hero-game-stage__screen { min-height:230px; } }
 @media (prefers-reduced-motion: reduce) { .home-arcade-start { animation:none; } }
+
+/* Focused homepage polish: portfolio first, arcade second. */
+.page-template-page-home-php .pixel-button--secondary,
+.home .pixel-button--secondary,
+.front-page .pixel-button--secondary {
+  border-color: rgba(87, 243, 255, 0.72);
+  color: #baf7ff;
+  box-shadow: none;
+}
+
+.home-arcade-hero {
+  padding-top: clamp(1rem, 2.4vw, 2.25rem);
+}
+
+.home-arcade-hero__cabinet {
+  max-width: 1140px;
+  padding: clamp(0.9rem, 2vw, 1.25rem);
+}
+
+.home-arcade-hero__marquee {
+  margin-bottom: clamp(0.75rem, 1.5vw, 1.1rem);
+}
+
+.home-arcade-hero__grid {
+  grid-template-columns: minmax(0, 1.24fr) minmax(280px, 0.76fr);
+  gap: clamp(1rem, 3vw, 2rem);
+}
+
+.home-arcade-hero__intro {
+  text-align: left;
+}
+
+.home-arcade-title {
+  font-size: clamp(2.7rem, 8vw, 5.8rem);
+  line-height: 0.95;
+  margin-top: 0.35rem;
+}
+
+.home-arcade-subtitle,
+.home-arcade-copy {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.home-arcade-subtitle {
+  max-width: 760px;
+  color: #ffff66;
+}
+
+.home-arcade-copy {
+  max-width: 700px;
+  font-size: clamp(0.86rem, 1.5vw, 1.08rem);
+  line-height: 1.75;
+}
+
+.home-arcade-start-row {
+  justify-content: flex-start;
+  gap: 0.75rem;
+}
+
+.home-arcade-game {
+  max-width: 420px;
+}
+
+.home-arcade-game .hero-game-stage__screen {
+  min-height: clamp(210px, 24vw, 300px);
+}
+
+.home-arcade-game .hero-game-stage__header,
+.home-arcade-game .hero-game-stage__mobile-note {
+  font-size: 0.55rem;
+  line-height: 1.45;
+}
+
+#lousy-outages-teaser.lo-home-teaser {
+  max-width: 1120px;
+  margin: clamp(1rem, 2vw, 1.5rem) auto;
+  overflow: hidden;
+  border: 1px solid rgba(112, 255, 168, 0.62);
+  border-radius: 10px;
+  background: linear-gradient(180deg, rgba(0, 18, 10, 0.94), rgba(0, 0, 0, 0.96));
+  box-shadow: inset 0 0 0 1px rgba(255, 184, 28, 0.12), 0 0 24px rgba(57, 255, 20, 0.1);
+}
+
+#lousy-outages-teaser .lo-home-heading {
+  color: #a7ffbe;
+  font-size: clamp(0.75rem, 1.4vw, 1rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+#lousy-outages-teaser .lo-home-teaser__screen {
+  padding: clamp(0.75rem, 2vw, 1rem);
+}
+
+#lousy-outages-teaser .lo-home-alert {
+  grid-template-columns: minmax(5.5rem, auto) minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.5rem 0.75rem;
+  font-size: clamp(0.68rem, 1.2vw, 0.82rem);
+}
+
+#lousy-outages-teaser .lo-home-alert__time {
+  grid-column: auto;
+  white-space: nowrap;
+}
+
+#lousy-outages-teaser .lo-home-empty {
+  font-size: clamp(0.78rem, 1.5vw, 0.95rem);
+}
+
+.home-operator-strip,
+.home-mission-select,
+.home-unlocks {
+  margin-top: clamp(1rem, 2vw, 1.5rem);
+}
+
+.home-mission-grid {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  align-items: stretch;
+}
+
+.home-mission-card.selected-work__card {
+  min-height: 0;
+  padding: 1rem;
+  gap: 0.55rem;
+  justify-content: space-between;
+}
+
+.home-mission-card h3 {
+  font-size: clamp(0.82rem, 1.25vw, 1rem);
+  line-height: 1.35;
+}
+
+.home-mission-card p:not(.home-mission-card__label) {
+  font-size: 0.76rem;
+  line-height: 1.6;
+}
+
+.home-mission-card .pixel-button {
+  align-self: flex-start;
+  padding: 0.55rem 0.7rem;
+  font-size: 0.62rem;
+}
+
+@media (max-width: 980px) {
+  .home-arcade-hero__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .home-arcade-game {
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 680px) {
+  .home-arcade-hero__intro {
+    text-align: center;
+  }
+
+  .home-arcade-subtitle,
+  .home-arcade-copy {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .home-arcade-start-row {
+    justify-content: center;
+  }
+
+  #lousy-outages-teaser .lo-home-alert {
+    grid-template-columns: 1fr;
+    align-items: start;
+  }
+
+  #lousy-outages-teaser .lo-home-alert__time {
+    grid-column: auto;
+  }
+}


### PR DESCRIPTION
### Motivation
- Make the front page feel like a polished retro-arcade–inspired portfolio where the arcade element supports the content instead of taking over. 
- Re-center the identity as “AI strategist / musician / creative technologist” and keep hero copy short, readable, and confident. 
- Bring back a visible, usable Lousy Outages teaser and visually integrate outage alerts into the arcade panel without hiding real status information. 

### Description
- Adjusted homepage template `page-home.php` to tighten hero copy, add a clear primary CTA (`Start Mission`) and a secondary CTA (`View Alerts`), reframe the arcade panel language toward outages, insert the Lousy Outages teaser via `get_template_part( 'parts/lousy-outages-teaser' )`, and shorten/clarify project card copy while preserving existing links. 
- Updated `js/hero-galaga.js` to re-label UI text and wave labels to reference provider/status/outage blips, change the start button wording, and remove the automatic `focus()` call so the mini-arcade does not steal keyboard focus. 
- Added targeted CSS rules in `style.css` to rebalance the hero grid, reduce the mini-arcade footprint, restyle the Lousy Outages teaser as a readable arcade-style alert console, compact mission/project cards, and improve responsive behavior and spacing. 
- Kept changes scoped to the homepage, styling, and the small arcade JS; existing WordPress links and structure were preserved and no new dependencies were introduced. 

### Testing
- Ran `php -l page-home.php` and it returned no syntax errors. (passed)
- Ran `node -c js/hero-galaga.js` and it returned no syntax errors. (passed)
- Ran `git diff --check` to ensure no whitespace/check issues. (passed)
- Ran the repository JS test suite via `npm test`; the run produced unrelated failures in Gastown simulator/generator and some Lousy Outages tests (these failures pre-existed and are not caused by the homepage edits). (test suite run: partial failure)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b8a1a0f148331aa46515570c7f094)