### PR TITLE
Refine homepage arcade HUD

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -9,27 +9,32 @@ get_header();
         <div class="home-arcade-hero__cabinet" aria-label="Suzy Easton arcade start screen">
             <div class="home-arcade-hero__marquee pixel-font" aria-hidden="true">
                 <span><?php echo esc_html( '1UP: SUZY' ); ?></span>
-                <span><?php echo esc_html( 'HIGH SCORE 1984' ); ?></span>
+                <span><?php echo esc_html( 'LIVE SYSTEM' ); ?></span>
                 <span><?php echo esc_html( 'VANCOUVER' ); ?></span>
             </div>
 
             <div class="hero-grid home-arcade-hero__grid">
                 <div class="hero-main home-arcade-hero__intro">
-                    <p class="hero-eyebrow pixel-font"><?php echo esc_html( 'Vancouver · AI strategist · musician · creative technologist' ); ?></p>
+                    <p class="hero-eyebrow pixel-font"><?php echo esc_html( 'AI strategist · musician · creative technologist' ); ?></p>
                     <h1 id="home-hero-title" class="hero-core-headline home-arcade-title"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>
-                    <p class="home-arcade-subtitle pixel-font"><?php echo esc_html( 'AI STRATEGY / MUSIC / CREATIVE TECHNOLOGY' ); ?></p>
-                    <p class="hero-copy home-arcade-copy"><?php echo esc_html( 'Vancouver-based. Practical AI systems, music, weird tools, and useful little machines.' ); ?></p>
+                    <p class="home-arcade-subtitle pixel-font"><?php echo esc_html( 'AI STRATEGIST. MUSICIAN. CREATIVE TECHNOLOGIST.' ); ?></p>
+                    <p class="hero-copy home-arcade-copy"><?php echo esc_html( 'Practical AI systems, weird browser tools, outage radar, and music things from Vancouver.' ); ?></p>
                     <div class="home-cta-row hero-cta-group home-arcade-start-row">
                         <a href="#mission-select" class="pixel-button hero-primary-cta home-arcade-start" data-arcade-start><?php echo esc_html( 'Start Mission' ); ?></a>
-                        <a href="#lousy-outages-teaser" class="pixel-button pixel-button--secondary"><?php echo esc_html( 'View Alerts' ); ?></a>
+                        <a href="<?php echo esc_url( home_url( '/lousy-outages/' ) ); ?>" class="pixel-button pixel-button--secondary"><?php echo esc_html( 'View Lousy Outages' ); ?></a>
                     </div>
                 </div>
 
-                <aside class="hero-side home-arcade-hero__screen" aria-label="Pacific Static arcade panel">
+                <aside class="hero-side home-arcade-hero__screen" aria-label="Live alert monitor">
+                    <div class="home-hud-readout" aria-label="Homepage status readout">
+                        <p><span>SYSTEM</span><strong>personal command screen</strong></p>
+                        <p><span>CURRENT BUILD</span><strong>Lousy Outages</strong></p>
+                        <p><span>MODE</span><strong>strategy · tools · music</strong></p>
+                    </div>
                     <div class="hero-game-stage home-arcade-game" aria-label="Pacific Static mini arcade game. Press Start Mission, then use A and D or arrow keys to move and Space to fire." data-arcade-stage>
-                        <p class="hero-game-stage__header pixel-font"><?php echo esc_html( 'OUTAGE BLIPS // MINI ARCADE' ); ?></p>
+                        <p class="hero-game-stage__header pixel-font"><?php echo esc_html( 'OUTAGE BLIP SWEEP' ); ?></p>
                         <div class="hero-game-stage__screen" role="img" aria-label="A green CRT arcade screen with stars, a small player ship, and outage alert blips.">
-                            <p class="hero-game-stage__idle pixel-font"><?php echo wp_kses_post( 'ALERT BLIPS INCOMING<br>Desktop: A/D or arrows move // Space fires.<br>No keyboard focus stolen.' ); ?></p>
+                            <p class="hero-game-stage__idle pixel-font"><?php echo wp_kses_post( 'SIGNAL SWEEP ACTIVE<br>live alert radar below<br>no keyboard focus stolen' ); ?></p>
                             <div class="home-static-sprites" aria-hidden="true">
                                 <span class="home-static-sprites__ship"></span>
                                 <span class="home-static-sprites__enemy home-static-sprites__enemy--one"></span>
@@ -37,7 +42,7 @@ get_header();
                                 <span class="home-static-sprites__reticle"></span>
                             </div>
                         </div>
-                        <p class="hero-game-stage__mobile-note pixel-font"><?php echo esc_html( 'Mobile: static alert screen. Links stay tappable below.' ); ?></p>
+                        <p class="hero-game-stage__mobile-note pixel-font"><?php echo esc_html( 'Static monitor. Dashboard link stays tappable.' ); ?></p>
                     </div>
                 </aside>
             </div>
@@ -49,8 +54,8 @@ get_header();
     <section class="home-terminal-strip home-operator-strip crt-block" aria-label="Identity readout">
         <div class="home-terminal-readout" role="presentation">
             <p><span class="home-terminal-key"><?php echo esc_html( 'OPERATOR' ); ?></span><span class="home-terminal-dots" aria-hidden="true"></span><span class="home-terminal-val"><?php echo esc_html( 'Suzy Easton' ); ?></span></p>
-            <p><span class="home-terminal-key"><?php echo esc_html( 'DAY MODE' ); ?></span><span class="home-terminal-dots" aria-hidden="true"></span><span class="home-terminal-val"><?php echo esc_html( 'AI infrastructure · strategy · solutions engineering at Quercus IT' ); ?></span></p>
-            <p><span class="home-terminal-key"><?php echo esc_html( 'NIGHT MODE' ); ?></span><span class="home-terminal-dots" aria-hidden="true"></span><span class="home-terminal-val"><?php echo esc_html( 'Music · records · audio experiments · bands · touring' ); ?></span></p>
+            <p><span class="home-terminal-key"><?php echo esc_html( 'AI SYSTEMS' ); ?></span><span class="home-terminal-dots" aria-hidden="true"></span><span class="home-terminal-val"><?php echo esc_html( 'practical workflows · prototypes · adoption strategy' ); ?></span></p>
+            <p><span class="home-terminal-key"><?php echo esc_html( 'CREATIVE OUTPUT' ); ?></span><span class="home-terminal-dots" aria-hidden="true"></span><span class="home-terminal-val"><?php echo esc_html( 'music · records · browser experiments · weird utilities' ); ?></span></p>
         </div>
     </section>
 
@@ -61,13 +66,13 @@ get_header();
             <article class="home-project-card selected-work__card home-mission-card home-mission-card--boss">
                 <p class="home-mission-card__label pixel-font"><?php echo esc_html( 'BOSS ALERT' ); ?></p>
                 <h3 class="pixel-font"><?php echo esc_html( 'Lousy Outages' ); ?></h3>
-                <p><?php echo esc_html( 'Provider status alerts and outage signals, readable at a glance.' ); ?></p>
+                <p><?php echo esc_html( 'Live provider weirdness, outage signals, and status-page lies.' ); ?></p>
                 <a class="pixel-button" href="<?php echo esc_url( home_url( '/lousy-outages/' ) ); ?>"><?php echo esc_html( 'Scan' ); ?></a>
             </article>
-            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 02' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Gastown Simulator' ); ?></h3><p><?php echo esc_html( 'A civic-data browser toy for walking weird Vancouver routes.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/page-gastown-sim/' ) ); ?>"><?php echo esc_html( 'Explore' ); ?></a></article>
-            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 03' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Track Analyzer' ); ?></h3><p><?php echo esc_html( 'Upload a track. Get practical audio notes back.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/suzys-track-analyzer/' ) ); ?>"><?php echo esc_html( 'Try it' ); ?></a></article>
-            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 04' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'What Would Steve Do' ); ?></h3><p><?php echo esc_html( 'Blunt studio prompts for records that need fewer lies.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/albini-qa/' ) ); ?>"><?php echo esc_html( 'Ask' ); ?></a></article>
-            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 05' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'ASMR Lab' ); ?></h3><p><?php echo esc_html( 'Soft audio visuals, texture, and tiny browser rituals.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/asmr-lab/' ) ); ?>"><?php echo esc_html( 'Enter' ); ?></a></article>
+            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 02' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Gastown Simulator' ); ?></h3><p><?php echo esc_html( 'A Vancouver browser toy built from civic data, routes, buildings, and ghosts in the grid.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/page-gastown-sim/' ) ); ?>"><?php echo esc_html( 'Explore' ); ?></a></article>
+            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 03' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Track Analyzer' ); ?></h3><p><?php echo esc_html( 'Upload a rough mix and get practical audio notes back.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/suzys-track-analyzer/' ) ); ?>"><?php echo esc_html( 'Try it' ); ?></a></article>
+            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 04' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'What Would Steve Do' ); ?></h3><p><?php echo esc_html( 'Blunt recording prompts when the mix needs fewer lies.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/albini-qa/' ) ); ?>"><?php echo esc_html( 'Ask' ); ?></a></article>
+            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 05' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'ASMR Lab' ); ?></h3><p><?php echo esc_html( 'Tiny browser rituals for texture, sound, and soft chaos.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/asmr-lab/' ) ); ?>"><?php echo esc_html( 'Enter' ); ?></a></article>
         </div>
     </section>
 

--- a/parts/lousy-outages-teaser.php
+++ b/parts/lousy-outages-teaser.php
@@ -12,10 +12,11 @@ $teaser_data  = function_exists( 'get_lousy_outages_home_teaser_data' )
         'rows'     => [],
     ];
 $teaser_href = $teaser_data['href'] ?? home_url( '/lousy-outages/' );
-$rows = isset( $teaser_data['rows'] ) && is_array( $teaser_data['rows'] ) ? $teaser_data['rows'] : [];
+$rows = isset( $teaser_data['rows'] ) && is_array( $teaser_data['rows'] ) ? array_slice( $teaser_data['rows'], 0, 3 ) : [];
 ?>
 <section id="lousy-outages-teaser" class="lo-home-teaser">
     <div class="lo-home-teaser__titlebar">
+        <p class="lo-home-kicker">live boss radar</p>
         <h2 class="lo-home-heading">lousy outages</h2>
         <span class="lo-home-status-light<?php echo esc_attr( empty( $rows ) ? ' lo-home-status-light--clear' : ' lo-home-status-light--alert' ); ?>">
             <span class="screen-reader-text"><?php echo esc_html( empty( $rows ) ? 'No active alerts' : 'Active alerts' ); ?></span>
@@ -43,5 +44,5 @@ $rows = isset( $teaser_data['rows'] ) && is_array( $teaser_data['rows'] ) ? $tea
         <?php endif; ?>
     </div>
 
-    <a class="lo-home-dashboard-link" href="<?php echo esc_url( $teaser_href ); ?>">open dashboard <span aria-hidden="true">→</span></a>
+    <a class="lo-home-dashboard-link" href="<?php echo esc_url( $teaser_href ); ?>">open outage dashboard <span aria-hidden="true">→</span></a>
 </section>

--- a/style.css
+++ b/style.css
@@ -5433,3 +5433,281 @@ body {
     grid-column: auto;
   }
 }
+
+/* Homepage command-screen refinement: cleaner HUD, readable portfolio cards. */
+.home-arcade-layout {
+  overflow-x: clip;
+}
+
+.home-arcade-hero {
+  padding: clamp(1rem, 2.5vw, 2.5rem) clamp(0.9rem, 3vw, 2rem) clamp(0.5rem, 1vw, 1rem);
+}
+
+.home-arcade-hero__cabinet {
+  border: 1px solid rgba(57, 255, 20, 0.46);
+  border-radius: 16px;
+  background:
+    radial-gradient(circle at 18% 0, rgba(87, 243, 255, 0.12), transparent 34%),
+    radial-gradient(circle at 90% 12%, rgba(255, 72, 206, 0.08), transparent 28%),
+    linear-gradient(180deg, rgba(2, 16, 12, 0.97), rgba(0, 0, 0, 0.95));
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.45), inset 0 0 28px rgba(57, 255, 20, 0.06);
+}
+
+.home-arcade-hero__marquee {
+  border-bottom: 1px solid rgba(87, 243, 255, 0.2);
+  color: #ffff66;
+  padding-bottom: 0.7rem;
+  text-shadow: none;
+}
+
+.home-arcade-hero__grid {
+  grid-template-columns: minmax(0, 1.35fr) minmax(260px, 0.65fr);
+  align-items: stretch;
+}
+
+.home-arcade-title {
+  color: #dfffea;
+  letter-spacing: 0.02em;
+  text-shadow: 0 0 18px rgba(57, 255, 20, 0.38), 2px 2px 0 rgba(255, 72, 206, 0.28);
+}
+
+.home-arcade-subtitle {
+  max-width: 48rem;
+  color: #ffff66;
+  font-size: clamp(0.62rem, 1vw, 0.82rem);
+  line-height: 1.75;
+}
+
+.home-arcade-copy,
+.home-mission-card p:not(.home-mission-card__label),
+.music-world p,
+.home-terminal-val,
+.lo-home-alert__body,
+.lo-home-empty {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+}
+
+.home-arcade-copy {
+  color: rgba(223, 255, 234, 0.9);
+  font-size: clamp(1rem, 1.45vw, 1.16rem);
+  max-width: 42rem;
+}
+
+.home-hud-readout {
+  display: grid;
+  gap: 0.45rem;
+  margin-bottom: 0.75rem;
+  padding: 0.75rem;
+  border: 1px solid rgba(87, 243, 255, 0.34);
+  border-radius: 10px;
+  background: rgba(0, 12, 10, 0.72);
+}
+
+.home-hud-readout p {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin: 0;
+  color: rgba(223, 255, 234, 0.82);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: 0.78rem;
+  line-height: 1.35;
+}
+
+.home-hud-readout span {
+  color: #57f3ff;
+  font-family: var(--arcade-heading-font, monospace);
+  font-size: 0.55rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.home-hud-readout strong {
+  color: #dfffea;
+  font-weight: 600;
+  text-align: right;
+}
+
+.home-arcade-game {
+  border-color: rgba(87, 243, 255, 0.32);
+  box-shadow: 0 0 18px rgba(87, 243, 255, 0.08);
+}
+
+.home-arcade-game .hero-game-stage__screen {
+  min-height: clamp(150px, 18vw, 220px);
+}
+
+.home-static-sprites__ship {
+  width: 34px;
+  height: 22px;
+}
+
+.home-static-sprites__enemy {
+  width: 20px;
+  height: 16px;
+}
+
+.home-static-sprites__reticle {
+  width: 54px;
+  height: 54px;
+}
+
+#lousy-outages-teaser.lo-home-teaser {
+  display: flex;
+  width: min(1120px, calc(100% - 2rem));
+  margin-top: clamp(0.85rem, 2vw, 1.3rem);
+  border-color: rgba(255, 228, 138, 0.5);
+  border-radius: 14px;
+  background:
+    linear-gradient(90deg, rgba(255, 72, 206, 0.06), transparent 30%),
+    linear-gradient(180deg, rgba(4, 18, 14, 0.98), rgba(0, 0, 0, 0.96));
+}
+
+#lousy-outages-teaser .lo-home-teaser__titlebar {
+  justify-content: flex-start;
+}
+
+.lo-home-kicker {
+  margin: 0;
+  color: #ff4dce;
+  font-family: var(--arcade-heading-font, monospace);
+  font-size: clamp(0.54rem, 1vw, 0.68rem);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+#lousy-outages-teaser .lo-home-heading {
+  margin-right: auto;
+}
+
+#lousy-outages-teaser .lo-home-alert {
+  min-width: 0;
+  padding: 0.55rem 0;
+}
+
+#lousy-outages-teaser .lo-home-alert__body span {
+  overflow-wrap: anywhere;
+}
+
+#lousy-outages-teaser .lo-home-dashboard-link {
+  color: #ffff66;
+}
+
+.home-operator-strip,
+.home-mission-select,
+.home-unlocks {
+  width: min(1120px, calc(100% - 2rem));
+  border-width: 1px;
+  box-shadow: none;
+}
+
+.home-terminal-readout p {
+  font-size: clamp(0.78rem, 1.25vw, 0.95rem);
+}
+
+.home-mission-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: clamp(0.8rem, 1.5vw, 1.1rem);
+}
+
+.home-mission-card.selected-work__card {
+  border-radius: 12px;
+  padding: clamp(0.95rem, 1.7vw, 1.2rem);
+  background: linear-gradient(180deg, rgba(0, 22, 18, 0.78), rgba(0, 0, 0, 0.62));
+}
+
+.home-mission-card--boss {
+  grid-column: span 2;
+  border-color: rgba(255, 72, 206, 0.62);
+  background: linear-gradient(135deg, rgba(255, 72, 206, 0.13), rgba(0, 18, 10, 0.8));
+}
+
+.home-mission-card h3 {
+  color: #dfffea;
+}
+
+.home-mission-card p:not(.home-mission-card__label) {
+  color: rgba(223, 255, 234, 0.84);
+  font-size: 0.88rem;
+}
+
+.home-mission-card .pixel-button,
+.home-cta-row .pixel-button {
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+@media (max-width: 980px) {
+  .home-arcade-hero__grid,
+  .home-mission-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .home-arcade-hero__intro,
+  .home-arcade-hero__screen {
+    grid-column: 1 / -1;
+  }
+
+  .home-arcade-game {
+    max-width: none;
+  }
+}
+
+@media (max-width: 680px) {
+  .home-arcade-hero__grid,
+  .home-mission-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .home-mission-card--boss {
+    grid-column: auto;
+  }
+
+  .home-arcade-hero__intro {
+    text-align: left;
+  }
+
+  .home-arcade-subtitle,
+  .home-arcade-copy {
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  .home-arcade-start-row,
+  .home-cta-row {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .home-arcade-start-row .pixel-button,
+  .home-cta-row .pixel-button {
+    width: 100%;
+  }
+
+  .home-hud-readout p,
+  .home-terminal-readout p {
+    display: grid;
+    gap: 0.2rem;
+  }
+
+  .home-hud-readout strong {
+    text-align: left;
+  }
+
+  #lousy-outages-teaser.lo-home-teaser,
+  .home-operator-strip,
+  .home-mission-select,
+  .home-unlocks {
+    width: min(100% - 1rem, 1120px);
+  }
+
+  #lousy-outages-teaser .lo-home-teaser__titlebar {
+    flex-wrap: wrap;
+  }
+
+  #lousy-outages-teaser .lo-home-alert__label {
+    width: fit-content;
+  }
+}


### PR DESCRIPTION
### Motivation
- Make the homepage read as a confident personal command screen with a cleaner retro/HUD aesthetic and clearer information hierarchy. 
- Surface Lousy Outages as an integrated live status element (boss/radar) without reworking existing data plumbing. 
- Reduce visual noise from oversized pixel-font blocks and a dominant mini-arcade so the site reads as a portfolio-first experience. 

### Description
- Updated `page-home.php` to tighten hero copy and identity (H1, eyebrow, subtitle), change the secondary CTA to point to `/lousy-outages/`, and add a compact `home-hud-readout` beside the hero while shrinking the arcade visual. 
- Modified `parts/lousy-outages-teaser.php` to limit alerts to the latest three rows with `array_slice()`, add a small kicker (`live boss radar`), and change the dashboard link text to `open outage dashboard`. 
- Appended CSS in `style.css` with focused refinements including readable monospace body text for paragraphs, a `home-mission-grid` capped at three columns with the boss card spanning two, controlled HUD and arcade sizing, full-width/tappable CTAs on mobile, and removal of horizontal overflow. 
- Preserved the existing backend plumbing by continuing to use `get_lousy_outages_home_teaser_data()` and kept all links and accessibility hooks intact. 

### Testing
- Ran `php -l page-home.php` which returned no syntax errors. 
- Ran `php -l parts/lousy-outages-teaser.php` which returned no syntax errors. 
- Ran `git diff --check` to validate whitespace and diff hygiene which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b8d4509808331a63c97689b46cf48)