### PR TITLE
Redesign homepage as creative public systems

### DIFF
--- a/assets/css/lousy-outages-teaser.css
+++ b/assets/css/lousy-outages-teaser.css
@@ -1,87 +1,134 @@
-#lousy-outages-teaser {
-  margin: 2rem auto;
-}
-
-.lo-teaser {
-  max-width: 820px;
-  margin: 0 auto;
-  text-align: center;
-  padding: 8px 16px;
-  font-family: 'Press Start 2P', monospace;
+#lousy-outages-teaser.lo-home-teaser {
   display: flex;
   flex-direction: column;
+  gap: 1rem;
+  min-height: 100%;
+  padding: clamp(1rem, 2vw, 1.35rem);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 24px;
+  background:
+    linear-gradient(135deg, rgba(15, 18, 28, 0.92), rgba(37, 15, 55, 0.82)),
+    radial-gradient(circle at 20% 0%, rgba(255, 204, 102, 0.18), transparent 35%);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.28);
+  color: #fff7df;
+}
+
+#lousy-outages-teaser .lo-home-teaser__titlebar,
+#lousy-outages-teaser .lo-home-alert__meta {
+  display: flex;
   align-items: center;
-  gap: 12px;
+  justify-content: space-between;
+  gap: 0.75rem;
 }
 
-.lo-teaser h2 {
-  margin: 0 0 12px;
+#lousy-outages-teaser .lo-home-kicker,
+#lousy-outages-teaser .lo-home-heading,
+#lousy-outages-teaser .lo-home-alert__meta span {
+  margin: 0;
+  font-family: 'Press Start 2P', monospace;
+  text-transform: lowercase;
 }
 
-.lo-teaser p {
-  margin: 6px 0 12px;
-  color: #a7ff9a;
+#lousy-outages-teaser .lo-home-kicker {
+  color: #7ef6d1;
+  font-size: clamp(0.62rem, 1vw, 0.72rem);
+  letter-spacing: 0.06em;
 }
 
-.lo-status-line {
-  font-size: 0.95rem;
-  margin-bottom: 4px;
-  font-weight: 700;
+#lousy-outages-teaser .lo-home-heading {
+  color: #fff7df;
+  font-size: clamp(0.82rem, 1.45vw, 1.05rem);
 }
 
-.lo-status-line--alert {
-  color: #ff8299;
+#lousy-outages-teaser .lo-home-status-light {
+  width: 0.8rem;
+  height: 0.8rem;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: #ffcf66;
+  box-shadow: 0 0 18px rgba(255, 207, 102, 0.7);
 }
 
-.lo-status-line--ok {
-  color: #a7ff9a;
+#lousy-outages-teaser .lo-home-status-light--clear {
+  background: #7ef6d1;
+  box-shadow: 0 0 18px rgba(126, 246, 209, 0.65);
 }
 
-.lo-status-line .lo-status-link {
-  color: inherit;
+#lousy-outages-teaser .lo-home-status-light--alert {
+  background: #ff6aa8;
+  box-shadow: 0 0 18px rgba(255, 106, 168, 0.7);
+}
+
+#lousy-outages-teaser .lo-home-teaser__screen {
+  flex: 1;
+  min-height: 12rem;
+  padding: 0.85rem;
+  border-radius: 18px;
+  background: rgba(3, 8, 15, 0.72);
+}
+
+#lousy-outages-teaser .lo-home-empty {
+  display: grid;
+  min-height: 9rem;
+  align-content: center;
+  gap: 0.5rem;
+  color: #cdeee4;
+}
+
+#lousy-outages-teaser .lo-home-empty p,
+#lousy-outages-teaser .lo-home-alert-list {
+  margin: 0;
+}
+
+#lousy-outages-teaser .lo-home-alert-list {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0;
+  list-style: none;
+}
+
+#lousy-outages-teaser .lo-home-alert {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.75rem;
+  border-left: 4px solid #ffcf66;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.07);
+}
+
+#lousy-outages-teaser .lo-home-alert--outage { border-left-color: #ff6aa8; }
+#lousy-outages-teaser .lo-home-alert--signal { border-left-color: #ffcf66; }
+#lousy-outages-teaser .lo-home-alert--unknown { border-left-color: #9ea7ff; }
+
+#lousy-outages-teaser .lo-home-alert__meta strong {
+  font-size: 0.96rem;
+}
+
+#lousy-outages-teaser .lo-home-alert__meta span {
+  color: #ffcf66;
+  font-size: 0.58rem;
+}
+
+#lousy-outages-teaser .lo-home-alert__body {
+  color: #fff7df;
+  line-height: 1.45;
   text-decoration: none;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
 }
 
-.lo-status-line .lo-status-link:hover {
+#lousy-outages-teaser .lo-home-alert__body:hover,
+#lousy-outages-teaser .lo-home-alert__body:focus-visible,
+#lousy-outages-teaser .lo-home-dashboard-link:hover,
+#lousy-outages-teaser .lo-home-dashboard-link:focus-visible {
   text-decoration: underline;
 }
 
-.lo-teaser .lo-teaser-meta,
-.lo-teaser .providers,
-.lo-teaser .card,
-.lo-teaser .dot,
-.lo-teaser .status-up,
-.lo-teaser .status-warn,
-.lo-teaser .status-down {
-  display: none;
+#lousy-outages-teaser .lo-home-alert__time {
+  color: #b7c8d8;
+  font-size: 0.82rem;
 }
 
-.lo-teaser .caption {
-  font-size: 0.75rem;
+#lousy-outages-teaser .lo-home-dashboard-link {
+  align-self: flex-start;
+  color: #7ef6d1;
+  font-weight: 800;
 }
-
-.lo-teaser .lo-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  justify-content: center;
-}
-
-.lo-teaser .lo-link {
-  font-weight: 700;
-}
-
-.lo-teaser .view-all {
-  display: inline-flex;
-  justify-content: center;
-  margin-top: 0;
-}
-
-.lo-teaser { max-width: 820px; margin: 0 auto; text-align: center; padding: 8px 16px; }
-.lo-actions { display:flex; gap:10px; align-items:center; justify-content:center; flex-wrap:wrap; margin:10px 0 16px; }
-.lo-link { display:inline-flex; align-items:center; gap:8px; border:2px solid #2af200; color:#2af200; background:transparent; padding:6px 12px; border-radius:10px; text-decoration:none; font-weight:700; }
-.lo-link:hover { text-decoration:underline; }
-.lo-icon { width:16px; height:16px; display:inline-block; }

--- a/functions.php
+++ b/functions.php
@@ -69,20 +69,15 @@ function retro_game_music_theme_scripts() {
     }
 
     if ( is_front_page() || is_page_template( 'page-home.php' ) ) {
-        wp_enqueue_script(
-            'hero-ship-drag',
-            get_template_directory_uri() . '/js/hero-ship-drag.js',
-            array(),
-            filemtime( get_template_directory() . '/js/hero-ship-drag.js' ),
-            true
-        );
-        wp_enqueue_script(
-            'hero-galaga',
-            get_template_directory_uri() . '/js/hero-galaga.js',
-            array( 'hero-ship-drag' ),
-            filemtime( get_template_directory() . '/js/hero-galaga.js' ),
-            true
-        );
+        $teaser_css = get_template_directory() . '/assets/css/lousy-outages-teaser.css';
+        if ( file_exists( $teaser_css ) ) {
+            wp_enqueue_style(
+                'lousy-outages-teaser',
+                get_template_directory_uri() . '/assets/css/lousy-outages-teaser.css',
+                array( 'main-styles' ),
+                filemtime( $teaser_css )
+            );
+        }
     }
 
 }
@@ -508,12 +503,13 @@ if ( ! defined( 'LOUSY_OUTAGES_HOME_COMMUNITY_WINDOW_HOURS' ) ) {
 function get_lousy_outages_home_teaser_data(): array {
     $feed_url = home_url( '/?feed=lousy_outages_status' );
     $default = [
-        'headline' => 'All clear — no active outages right now.',
+        'headline' => 'all quiet for now',
         'href'     => home_url( '/lousy-outages/' ),
         'status'   => 'clear',
         'footnote' => '',
         'feed_url' => $feed_url,
         'rows'     => [],
+        'last_checked' => '',
     ];
 
     $summary = get_lousy_outages_home_teaser_from_summary( $default );
@@ -555,12 +551,13 @@ function get_lousy_outages_home_teaser_from_summary( array $default ): ?array {
         $meta = [];
     }
 
-    $outage_count = (int) ( $meta['outage_count'] ?? $meta['active_outage_count'] ?? 0 );
+    $outage_count = (int) ( $meta['official_incident_count'] ?? $meta['outage_count'] ?? $meta['active_outage_count'] ?? 0 );
     $signal_count = (int) ( $meta['signal_count'] ?? 0 );
     $unverified_count = (int) ( $meta['unverified_count'] ?? 0 );
     $generated_at_raw = $meta['generated_at'] ?? $payload['generated_at'] ?? $payload['fetched_at'] ?? '';
     $generated_at = lousy_outages_home_format_generated_at( $generated_at_raw );
     $rows = lousy_outages_home_build_alert_rows( $payload['providers'] ?? [], $default['href'] );
+    $outage_count = max( $outage_count, lousy_outages_home_count_official_incident_providers( $payload['providers'] ?? [] ) );
 
     $dashboard_url = $default['href'];
     $footnote_link = sprintf( '<a href="%s">%s</a>', esc_url( $dashboard_url ), esc_html__( 'View the dashboard', 'suzyeastonca' ) );
@@ -595,6 +592,7 @@ function get_lousy_outages_home_teaser_from_summary( array $default ): ?array {
             'footnote' => $footnote_text,
             'feed_url' => $default['feed_url'],
             'rows'     => $rows,
+            'last_checked' => $generated_at,
         ];
     }
 
@@ -623,13 +621,32 @@ function get_lousy_outages_home_teaser_from_summary( array $default ): ?array {
     }
 
     return [
-        'headline' => 'All clear — no active outages right now.',
+        'headline' => 'all quiet for now',
         'href'     => $dashboard_url,
         'status'   => 'clear',
         'footnote' => $footnote_text,
         'feed_url' => $default['feed_url'],
         'rows'     => $rows,
+        'last_checked' => $generated_at,
     ];
+}
+
+
+function lousy_outages_home_count_official_incident_providers( array $providers ): int {
+    $count = 0;
+
+    foreach ( $providers as $provider ) {
+        if ( ! is_array( $provider ) ) {
+            continue;
+        }
+
+        $incidents = isset( $provider['incidents'] ) && is_array( $provider['incidents'] ) ? $provider['incidents'] : [];
+        if ( ! empty( $incidents ) ) {
+            $count++;
+        }
+    }
+
+    return $count;
 }
 
 /**

--- a/lousy-outages/assets/lousy-outages.js
+++ b/lousy-outages/assets/lousy-outages.js
@@ -1024,7 +1024,9 @@
       generated_at: ''
     };
     if (meta && typeof meta === 'object') {
-      if (typeof meta.active_outage_count === 'number' && Number.isFinite(meta.active_outage_count)) {
+      if (typeof meta.official_incident_count === 'number' && Number.isFinite(meta.official_incident_count)) {
+        counts.active_outage_count = meta.official_incident_count;
+      } else if (typeof meta.active_outage_count === 'number' && Number.isFinite(meta.active_outage_count)) {
         counts.active_outage_count = meta.active_outage_count;
       }
       if (typeof meta.signal_count === 'number' && Number.isFinite(meta.signal_count)) {
@@ -1038,16 +1040,28 @@
       }
     }
 
-    var needsFallback = counts.active_outage_count === 0 && counts.signal_count === 0 && counts.unverified_count === 0;
+    var officialIncidentProviders = 0;
+    if (Array.isArray(providers)) {
+      providers.forEach(function (provider) {
+        if (!provider) {
+          return;
+        }
+        var incidents = Array.isArray(provider.incidents) ? provider.incidents : [];
+        if (incidents.length) {
+          officialIncidentProviders += 1;
+        }
+      });
+    }
+    counts.active_outage_count = Math.max(counts.active_outage_count, officialIncidentProviders);
+
+    var needsFallback = counts.signal_count === 0 && counts.unverified_count === 0;
     if (needsFallback && Array.isArray(providers)) {
       providers.forEach(function (provider) {
         if (!provider) {
           return;
         }
         var kind = resolveTileKind(provider);
-        if (kind === 'outage') {
-          counts.active_outage_count += 1;
-        } else if (kind === 'signal') {
+        if (kind === 'signal') {
           counts.signal_count += 1;
         } else if (kind === 'unknown' || kind === 'manual') {
           counts.unverified_count += 1;
@@ -2822,6 +2836,7 @@
       state.historyEmpty.setAttribute('hidden', 'hidden');
     }
     if (state.historyError) {
+      state.historyError.textContent = '';
       state.historyError.setAttribute('hidden', 'hidden');
     }
     if (state.historyCharts) {
@@ -2841,7 +2856,12 @@
     }
     state.historyToggleButton = null;
     if (state.historyError) {
+      state.historyError.textContent = '';
       state.historyError.setAttribute('hidden', 'hidden');
+    }
+    if (state.historyEmpty) {
+      state.historyEmpty.textContent = '';
+      state.historyEmpty.setAttribute('hidden', 'hidden');
     }
 
     renderHistoryCharts(providers, meta || {});
@@ -3000,7 +3020,12 @@
       state.historyList.innerHTML = '';
     }
     if (state.historyEmpty) {
+      state.historyEmpty.textContent = '';
       state.historyEmpty.setAttribute('hidden', 'hidden');
+    }
+    if (state.historyCharts) {
+      state.historyCharts.innerHTML = '';
+      state.historyCharts.setAttribute('hidden', 'hidden');
     }
     if (state.historyError) {
       state.historyError.textContent = message || 'Unable to load incidents right now.';

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -857,9 +857,9 @@ function render_shortcode(): string {
         <div class="lo-hero" data-lo-hero hidden>
             <article class="lo-card lo-card--hero">
                 <div class="lo-head">
-                    <h3 class="lo-title">No active incidents</h3>
+                    <h3 class="lo-title">No official active incidents</h3>
                 </div>
-                <p class="lo-summary">Signals and verification issues are hidden by default.</p>
+                <p class="lo-summary">Public signals are being watched.</p>
                 <p class="lo-card-meta">Last checked: <span data-lo-hero-time>—</span></p>
             </article>
         </div>

--- a/page-home.php
+++ b/page-home.php
@@ -3,89 +3,65 @@
 get_header();
 ?>
 
-<main id="homepage-content" class="home-layout home-arcade-layout">
+<main id="homepage-content" class="home-layout home-creative-system">
 
-    <section class="home-hero home-arcade-hero hero hero-section crt-block" aria-labelledby="home-hero-title">
-        <div class="home-arcade-hero__cabinet" aria-label="Suzy Easton arcade start screen">
-            <div class="home-arcade-hero__marquee pixel-font" aria-hidden="true">
-                <span><?php echo esc_html( '1UP: SUZY' ); ?></span>
-                <span><?php echo esc_html( 'LIVE SYSTEM' ); ?></span>
-                <span><?php echo esc_html( 'VANCOUVER' ); ?></span>
-            </div>
+    <section class="home-title-screen" aria-labelledby="home-hero-title">
+        <div class="home-title-screen__marquee pixel-font" aria-label="Site themes">
+            <span><?php echo esc_html( 'MUSIC // MACHINES // VANCOUVER' ); ?></span>
+            <span><?php echo esc_html( 'OUTAGES // RECORDS // GASTOWN' ); ?></span>
+            <span><?php echo esc_html( 'PUBLIC INTERNET // PRIVATE STATIC' ); ?></span>
+            <span><?php echo esc_html( 'AI // AUDIO // CIVIC GHOSTS' ); ?></span>
+        </div>
 
-            <div class="hero-grid home-arcade-hero__grid">
-                <div class="hero-main home-arcade-hero__intro">
-                    <p class="hero-eyebrow pixel-font"><?php echo esc_html( 'AI strategist · musician · creative technologist' ); ?></p>
-                    <h1 id="home-hero-title" class="hero-core-headline home-arcade-title"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>
-                    <p class="home-arcade-subtitle pixel-font"><?php echo esc_html( 'AI STRATEGIST. MUSICIAN. CREATIVE TECHNOLOGIST.' ); ?></p>
-                    <p class="hero-copy home-arcade-copy"><?php echo esc_html( 'Practical AI systems, weird browser tools, outage radar, and music things from Vancouver.' ); ?></p>
-                    <div class="home-cta-row hero-cta-group home-arcade-start-row">
-                        <a href="#mission-select" class="pixel-button hero-primary-cta home-arcade-start" data-arcade-start><?php echo esc_html( 'Start Mission' ); ?></a>
-                        <a href="<?php echo esc_url( home_url( '/lousy-outages/' ) ); ?>" class="pixel-button pixel-button--secondary"><?php echo esc_html( 'View Lousy Outages' ); ?></a>
-                    </div>
+        <div class="home-title-screen__grid">
+            <div class="home-title-screen__intro">
+                <p class="hero-eyebrow pixel-font"><?php echo esc_html( 'music // machines // vancouver' ); ?></p>
+                <h1 id="home-hero-title" class="hero-core-headline home-title-screen__title"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>
+                <p class="home-title-screen__identity"><?php echo esc_html( 'AI strategist. Musician. Creative technologist.' ); ?></p>
+                <p class="home-title-screen__copy"><?php echo esc_html( 'Building small public systems for outages, songs, civic data, ghosts in the browser, and whatever starts talking back.' ); ?></p>
+                <div class="home-cta-row hero-cta-group home-title-screen__actions">
+                    <a href="#public-systems" class="pixel-button hero-primary-cta"><?php echo esc_html( 'Enter Site' ); ?></a>
+                    <a href="<?php echo esc_url( home_url( '/lousy-outages/' ) ); ?>" class="pixel-button pixel-button--secondary"><?php echo esc_html( 'Check Lousy Outages' ); ?></a>
                 </div>
-
-                <aside class="hero-side home-arcade-hero__screen" aria-label="Live alert monitor">
-                    <div class="home-hud-readout" aria-label="Homepage status readout">
-                        <p><span>SYSTEM</span><strong>personal command screen</strong></p>
-                        <p><span>CURRENT BUILD</span><strong>Lousy Outages</strong></p>
-                        <p><span>MODE</span><strong>strategy · tools · music</strong></p>
-                    </div>
-                    <div class="hero-game-stage home-arcade-game" aria-label="Pacific Static mini arcade game. Press Start Mission, then use A and D or arrow keys to move and Space to fire." data-arcade-stage>
-                        <p class="hero-game-stage__header pixel-font"><?php echo esc_html( 'OUTAGE BLIP SWEEP' ); ?></p>
-                        <div class="hero-game-stage__screen" role="img" aria-label="A green CRT arcade screen with stars, a small player ship, and outage alert blips.">
-                            <p class="hero-game-stage__idle pixel-font"><?php echo wp_kses_post( 'SIGNAL SWEEP ACTIVE<br>live alert radar below<br>no keyboard focus stolen' ); ?></p>
-                            <div class="home-static-sprites" aria-hidden="true">
-                                <span class="home-static-sprites__ship"></span>
-                                <span class="home-static-sprites__enemy home-static-sprites__enemy--one"></span>
-                                <span class="home-static-sprites__enemy home-static-sprites__enemy--two"></span>
-                                <span class="home-static-sprites__reticle"></span>
-                            </div>
-                        </div>
-                        <p class="hero-game-stage__mobile-note pixel-font"><?php echo esc_html( 'Static monitor. Dashboard link stays tappable.' ); ?></p>
-                    </div>
-                </aside>
             </div>
+
+            <?php get_template_part( 'parts/lousy-outages-teaser' ); ?>
         </div>
     </section>
 
-    <?php get_template_part( 'parts/lousy-outages-teaser' ); ?>
-
-    <section class="home-terminal-strip home-operator-strip crt-block" aria-label="Identity readout">
-        <div class="home-terminal-readout" role="presentation">
-            <p><span class="home-terminal-key"><?php echo esc_html( 'OPERATOR' ); ?></span><span class="home-terminal-dots" aria-hidden="true"></span><span class="home-terminal-val"><?php echo esc_html( 'Suzy Easton' ); ?></span></p>
-            <p><span class="home-terminal-key"><?php echo esc_html( 'AI SYSTEMS' ); ?></span><span class="home-terminal-dots" aria-hidden="true"></span><span class="home-terminal-val"><?php echo esc_html( 'practical workflows · prototypes · adoption strategy' ); ?></span></p>
-            <p><span class="home-terminal-key"><?php echo esc_html( 'CREATIVE OUTPUT' ); ?></span><span class="home-terminal-dots" aria-hidden="true"></span><span class="home-terminal-val"><?php echo esc_html( 'music · records · browser experiments · weird utilities' ); ?></span></p>
-        </div>
+    <section class="home-status-strip" aria-label="Site status">
+        <p><span><?php echo esc_html( 'FROM:' ); ?></span> <?php echo esc_html( 'Vancouver' ); ?></p>
+        <p><span><?php echo esc_html( 'MODE:' ); ?></span> <?php echo esc_html( 'music / machines / civic ghosts' ); ?></p>
+        <p><span><?php echo esc_html( 'CURRENT SYSTEM:' ); ?></span> <?php echo esc_html( 'Lousy Outages' ); ?></p>
+        <p><span><?php echo esc_html( 'SIDE QUEST:' ); ?></span> <?php echo esc_html( 'Canucks emotional support' ); ?></p>
     </section>
 
-    <section id="mission-select" class="home-project-grid home-mission-select crt-block" aria-labelledby="selected-projects-title">
-        <p class="home-section-kicker pixel-font"><?php echo esc_html( '// MISSION SELECT //' ); ?></p>
-        <h2 id="selected-projects-title" class="pixel-font"><?php echo esc_html( 'Projects' ); ?></h2>
+    <section id="public-systems" class="home-project-grid home-public-systems" aria-labelledby="selected-projects-title">
+        <p class="home-section-kicker pixel-font"><?php echo esc_html( 'public systems' ); ?></p>
+        <h2 id="selected-projects-title" class="pixel-font"><?php echo esc_html( 'things that escaped the lab' ); ?></h2>
         <div class="selected-work__grid home-mission-grid">
-            <article class="home-project-card selected-work__card home-mission-card home-mission-card--boss">
-                <p class="home-mission-card__label pixel-font"><?php echo esc_html( 'BOSS ALERT' ); ?></p>
-                <h3 class="pixel-font"><?php echo esc_html( 'Lousy Outages' ); ?></h3>
-                <p><?php echo esc_html( 'Live provider weirdness, outage signals, and status-page lies.' ); ?></p>
-                <a class="pixel-button" href="<?php echo esc_url( home_url( '/lousy-outages/' ) ); ?>"><?php echo esc_html( 'Scan' ); ?></a>
-            </article>
-            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 02' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Gastown Simulator' ); ?></h3><p><?php echo esc_html( 'A Vancouver browser toy built from civic data, routes, buildings, and ghosts in the grid.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/page-gastown-sim/' ) ); ?>"><?php echo esc_html( 'Explore' ); ?></a></article>
-            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 03' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Track Analyzer' ); ?></h3><p><?php echo esc_html( 'Upload a rough mix and get practical audio notes back.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/suzys-track-analyzer/' ) ); ?>"><?php echo esc_html( 'Try it' ); ?></a></article>
-            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 04' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'What Would Steve Do' ); ?></h3><p><?php echo esc_html( 'Blunt recording prompts when the mix needs fewer lies.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/albini-qa/' ) ); ?>"><?php echo esc_html( 'Ask' ); ?></a></article>
-            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'LEVEL 05' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'ASMR Lab' ); ?></h3><p><?php echo esc_html( 'Tiny browser rituals for texture, sound, and soft chaos.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/asmr-lab/' ) ); ?>"><?php echo esc_html( 'Enter' ); ?></a></article>
+            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'status weather' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Lousy Outages' ); ?></h3><p><?php echo esc_html( 'Provider pages, outage signals, and internet weather without the corporate shrug.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/lousy-outages/' ) ); ?>"><?php echo esc_html( 'Check status' ); ?></a></article>
+            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'civic ghost world' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Gastown Simulator' ); ?></h3><p><?php echo esc_html( 'A browser-built Gastown made from civic data, routes, buildings, and memory.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/page-gastown-sim/' ) ); ?>"><?php echo esc_html( 'Enter Gastown' ); ?></a></article>
+            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'audio notes' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Track Analyzer' ); ?></h3><p><?php echo esc_html( 'Upload a rough mix and get direct, useful notes back.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/suzys-track-analyzer/' ) ); ?>"><?php echo esc_html( 'Analyze track' ); ?></a></article>
+            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'recording oracle' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'What Would Steve Do' ); ?></h3><p><?php echo esc_html( 'A blunt little recording prompt machine for mixes with too much nonsense.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/albini-qa/' ) ); ?>"><?php echo esc_html( 'Ask Steve' ); ?></a></article>
+            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'soft machine' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'ASMR Lab' ); ?></h3><p><?php echo esc_html( 'Tiny browser rituals for texture, sound, and controlled weirdness.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/asmr-lab/' ) ); ?>"><?php echo esc_html( 'Enter lab' ); ?></a></article>
+            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'discography' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Music / Records' ); ?></h3><p><?php echo esc_html( 'Bands, records, touring, bass, songs, and the long tail of making noise.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/music-releases/' ) ); ?>"><?php echo esc_html( 'Listen' ); ?></a></article>
         </div>
     </section>
 
-    <section id="music" class="music-world home-unlocks crt-block" aria-labelledby="music-world-title">
-        <p class="home-section-kicker pixel-font"><?php echo esc_html( '// UNLOCKS //' ); ?></p>
+    <section id="music" class="music-world home-unlocks" aria-labelledby="music-world-title">
+        <p class="home-section-kicker pixel-font"><?php echo esc_html( 'records / contact / next noise' ); ?></p>
         <h2 id="music-world-title" class="pixel-font"><?php echo esc_html( 'Music, bio, contact' ); ?></h2>
-        <p><?php echo esc_html( 'Music, records, bands, touring, and audio experiments — from Minto and The Smokes to new solo releases and strange browser instruments.' ); ?></p>
+        <p><?php echo esc_html( 'Songs, records, bands, touring, bass, audio experiments, and the handmade internet paths around them.' ); ?></p>
         <div class="home-cta-row">
             <a class="pixel-button" href="https://suzyeaston.bandcamp.com" target="_blank" rel="noopener noreferrer"><?php echo esc_html( 'Bandcamp' ); ?></a>
-            <a class="pixel-button" href="<?php echo esc_url( home_url( '/music-releases/' ) ); ?>"><?php echo esc_html( 'Records' ); ?></a>
             <a class="pixel-button" href="<?php echo esc_url( home_url( '/bio/' ) ); ?>"><?php echo esc_html( 'Bio' ); ?></a>
             <button class="pixel-button" type="button" data-contact-trigger aria-haspopup="dialog" aria-controls="contact-suzy-modal"><?php echo esc_html( 'Contact' ); ?></button>
         </div>
+    </section>
+
+    <section class="home-territory" aria-label="Territory acknowledgement">
+        <p><?php echo esc_html( 'This site is made in Vancouver, on the shared, unceded, ancestral territories of the xʷməθkʷəy̓əm (Musqueam), Sḵwx̱wú7mesh Úxwumixw (Squamish Nation), and səlilwətaɬ (Tsleil-Waututh) Nations.' ); ?></p>
     </section>
 
 </main>

--- a/parts/lousy-outages-teaser.php
+++ b/parts/lousy-outages-teaser.php
@@ -1,39 +1,46 @@
 <?php
-$feed_url = home_url( '/?feed=lousy_outages_status' ); // Pretty /feed/lousy_outages_status/ works after a permalink flush, but the query form is more reliable.
+$feed_url = home_url( '/?feed=lousy_outages_status' );
 
 $teaser_data  = function_exists( 'get_lousy_outages_home_teaser_data' )
     ? get_lousy_outages_home_teaser_data()
     : [
-        'headline' => 'All clear — no active outages right now.',
+        'headline' => 'all quiet for now',
         'href'     => home_url( '/lousy-outages/' ),
         'status'   => 'clear',
         'footnote' => '',
         'feed_url' => $feed_url,
         'rows'     => [],
+        'last_checked' => '',
     ];
 $teaser_href = $teaser_data['href'] ?? home_url( '/lousy-outages/' );
-$rows = isset( $teaser_data['rows'] ) && is_array( $teaser_data['rows'] ) ? array_slice( $teaser_data['rows'], 0, 3 ) : [];
+$rows = isset( $teaser_data['rows'] ) && is_array( $teaser_data['rows'] ) ? array_slice( $teaser_data['rows'], 0, 4 ) : [];
+$last_checked = $teaser_data['last_checked'] ?? '';
 ?>
-<section id="lousy-outages-teaser" class="lo-home-teaser">
+<section id="lousy-outages-teaser" class="lo-home-teaser" aria-labelledby="lo-home-heading">
     <div class="lo-home-teaser__titlebar">
-        <p class="lo-home-kicker">live boss radar</p>
-        <h2 class="lo-home-heading">lousy outages</h2>
+        <p class="lo-home-kicker">outage static</p>
+        <h2 id="lo-home-heading" class="lo-home-heading">lousy outages live</h2>
         <span class="lo-home-status-light<?php echo esc_attr( empty( $rows ) ? ' lo-home-status-light--clear' : ' lo-home-status-light--alert' ); ?>">
-            <span class="screen-reader-text"><?php echo esc_html( empty( $rows ) ? 'No active alerts' : 'Active alerts' ); ?></span>
+            <span class="screen-reader-text"><?php echo esc_html( empty( $rows ) ? 'No active provider incidents' : 'Active provider incidents or degraded signals' ); ?></span>
         </span>
     </div>
 
     <div class="lo-home-teaser__screen">
         <?php if ( empty( $rows ) ) : ?>
-            <p class="lo-home-empty">all quiet. suspicious, but fine.</p>
+            <div class="lo-home-empty">
+                <p><?php echo esc_html( 'all quiet for now' ); ?></p>
+                <p><?php echo esc_html( $last_checked ? 'last checked: ' . $last_checked : 'last checked: recently' ); ?></p>
+            </div>
         <?php else : ?>
             <ul class="lo-home-alert-list">
                 <?php foreach ( $rows as $row ) : ?>
                     <li class="lo-home-alert lo-home-alert--<?php echo esc_attr( $row['tone'] ?? 'unknown' ); ?>">
-                        <span class="lo-home-alert__label"><?php echo esc_html( $row['label'] ?? 'Status' ); ?></span>
-                        <a class="lo-home-alert__body" href="<?php echo esc_url( $row['href'] ?? $teaser_href ); ?>">
+                        <div class="lo-home-alert__meta">
                             <strong><?php echo esc_html( $row['provider'] ?? 'Unknown provider' ); ?></strong>
-                            <span><?php echo esc_html( $row['message'] ?? '' ); ?></span>
+                            <span><?php echo esc_html( $row['label'] ?? 'Status' ); ?></span>
+                        </div>
+                        <a class="lo-home-alert__body" href="<?php echo esc_url( $row['href'] ?? $teaser_href ); ?>">
+                            <?php echo esc_html( $row['message'] ?? 'Status update' ); ?>
                         </a>
                         <?php if ( ! empty( $row['time'] ) ) : ?>
                             <time class="lo-home-alert__time"><?php echo esc_html( $row['time'] ); ?></time>
@@ -44,5 +51,5 @@ $rows = isset( $teaser_data['rows'] ) && is_array( $teaser_data['rows'] ) ? arra
         <?php endif; ?>
     </div>
 
-    <a class="lo-home-dashboard-link" href="<?php echo esc_url( $teaser_href ); ?>">open outage dashboard <span aria-hidden="true">→</span></a>
+    <a class="lo-home-dashboard-link" href="<?php echo esc_url( $teaser_href ); ?>">open lousy outages <span aria-hidden="true">→</span></a>
 </section>

--- a/style.css
+++ b/style.css
@@ -5711,3 +5711,168 @@ body {
     width: fit-content;
   }
 }
+
+/* Homepage 2026: creative public systems, not a terminal dashboard. */
+.home-creative-system {
+  --home-bg: #100f1d;
+  --home-card: rgba(255, 247, 223, 0.08);
+  --home-cream: #fff7df;
+  --home-mint: #7ef6d1;
+  --home-pink: #ff6aa8;
+  --home-gold: #ffcf66;
+  color: var(--home-cream);
+  background:
+    radial-gradient(circle at 12% 8%, rgba(255, 106, 168, 0.2), transparent 28rem),
+    radial-gradient(circle at 82% 14%, rgba(126, 246, 209, 0.16), transparent 24rem),
+    linear-gradient(180deg, #100f1d 0%, #171426 62%, #0d101a 100%);
+}
+
+.home-creative-system .home-title-screen,
+.home-creative-system .home-status-strip,
+.home-creative-system .home-public-systems,
+.home-creative-system .home-unlocks,
+.home-creative-system .home-territory {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto clamp(1.5rem, 4vw, 3rem);
+}
+
+.home-title-screen {
+  padding-top: clamp(1rem, 3vw, 2rem);
+}
+
+.home-title-screen__marquee {
+  display: flex;
+  gap: 1rem;
+  overflow: hidden;
+  margin-bottom: clamp(1.5rem, 4vw, 2.5rem);
+  padding: 0.7rem 0;
+  border-block: 1px solid rgba(255, 247, 223, 0.2);
+  color: var(--home-gold);
+  font-size: clamp(0.58rem, 1.1vw, 0.75rem);
+  white-space: nowrap;
+}
+
+.home-title-screen__marquee span { flex: 0 0 auto; }
+
+.home-title-screen__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
+  gap: clamp(1rem, 3vw, 2rem);
+  align-items: stretch;
+}
+
+.home-title-screen__intro {
+  display: grid;
+  align-content: center;
+  min-height: clamp(28rem, 58vh, 39rem);
+  padding: clamp(1.35rem, 4vw, 3rem);
+  border-radius: 30px;
+  background:
+    linear-gradient(135deg, rgba(255, 247, 223, 0.1), rgba(255, 247, 223, 0.025)),
+    linear-gradient(180deg, rgba(16, 15, 29, 0.86), rgba(16, 15, 29, 0.96));
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.35);
+}
+
+.home-title-screen__title {
+  margin: 0.35rem 0 0.8rem;
+  color: var(--home-cream);
+  text-shadow: 0.08em 0.08em 0 rgba(255, 106, 168, 0.45);
+}
+
+.home-title-screen__identity {
+  max-width: 48rem;
+  margin: 0 0 1rem;
+  color: var(--home-mint);
+  font-size: clamp(1.05rem, 2vw, 1.45rem);
+  font-weight: 800;
+}
+
+.home-title-screen__copy {
+  max-width: 45rem;
+  margin: 0 0 1.5rem;
+  color: rgba(255, 247, 223, 0.88);
+  font-size: clamp(1.05rem, 2vw, 1.35rem);
+  line-height: 1.55;
+}
+
+.home-status-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  align-items: center;
+  justify-content: center;
+  padding: 0.8rem;
+  border-radius: 18px;
+  background: rgba(0, 0, 0, 0.26);
+}
+
+.home-status-strip p {
+  margin: 0;
+  color: rgba(255, 247, 223, 0.86);
+  font-size: 0.9rem;
+}
+
+.home-status-strip span {
+  color: var(--home-gold);
+  font-weight: 900;
+}
+
+.home-public-systems,
+.home-unlocks,
+.home-territory {
+  padding: clamp(1rem, 3vw, 2rem);
+  border-radius: 26px;
+  background: rgba(255, 247, 223, 0.055);
+}
+
+.home-public-systems .home-mission-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.home-public-systems .home-mission-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  min-height: 17rem;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 247, 223, 0.16);
+  background: linear-gradient(180deg, rgba(255, 247, 223, 0.09), rgba(255, 247, 223, 0.035));
+}
+
+.home-public-systems .home-mission-card__label {
+  color: var(--home-mint);
+  font-size: 0.62rem;
+}
+
+.home-public-systems .home-mission-card .pixel-button { margin-top: auto; }
+
+.home-territory {
+  background: rgba(0, 0, 0, 0.22);
+}
+
+.home-territory p {
+  max-width: 78rem;
+  margin: 0;
+  color: rgba(255, 247, 223, 0.9);
+  font-size: 0.95rem;
+  line-height: 1.65;
+}
+
+@media (max-width: 900px) {
+  .home-title-screen__grid,
+  .home-public-systems .home-mission-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .home-title-screen__intro {
+    min-height: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-title-screen__marquee {
+    scroll-behavior: auto;
+  }
+}


### PR DESCRIPTION
### Motivation
- Replace the old faux-terminal / boss-radar homepage with a readable, playful title-screen that foregrounds Suzy’s music + creative-technology identity and treats projects as small public systems rather than corporate tooling.  
- Surface Lousy Outages data immediately and truthfully on the homepage so the teaser matches the dashboard and doesn't show stale or decorative states.  
- Reduce visual clutter and nested boxes, improve mobile stacking, accessibility, asset cache-busting, and respect reduced-motion preferences.  
- Clarify data-state semantics for official incidents vs. public signals so the UI never shows contradictory counts/messages.

### Description
- Rebuilt the homepage hero into a title-screen in `page-home.php` with new marquee, H1/identity/copy, CTAs (`Enter Site`, `Check Lousy Outages`) and immediate placement of the teaser panel.  
- Reworked the homepage teaser into a useful “outage static” panel in `parts/lousy-outages-teaser.php` to show provider, label/severity, message, timestamp, `last_checked`, and a dashboard link instead of decorative boss/arcade copy.  
- Updated data flow in `functions.php` so the homepage prefers the summary REST endpoint (`/wp-json/lousy-outages/v1/summary`), carries `last_checked`, and counts official incidents derived from provider `incidents` (added `lousy_outages_home_count_official_incident_providers`).  
- Restyled and added assets: replaced/rewrote `assets/css/lousy-outages-teaser.css`, appended homepage system styles to `style.css`, and enqueued the teaser CSS via `filemtime` to avoid stale cache.  
- JS/data fixes in `lousy-outages/assets/lousy-outages.js` to prefer `official_incident_count` when present, infer official provider incident counts from provider rows, and to clear stale loading/empty/error/chart nodes so only one history state is shown at a time.  
- Clarified dashboard wording in `lousy-outages/public/shortcode.php` to distinguish “No official active incidents” from public signals being watched.  
- Small copy updates across project cards and music section to match the new tone and remove terminal/boss language.

### Testing
- PHP syntax checks: ran `php -l page-home.php`, `php -l parts/lousy-outages-teaser.php`, `php -l functions.php`, and `php -l lousy-outages/public/shortcode.php`, all reported no syntax errors.  
- JavaScript syntax checks: ran `node --check lousy-outages/assets/lousy-outages.js` and `node --check assets/js/lousy-outages-teaser.js`, both passed.  
- Quick grep to confirm removal/replacement of stale/undesired copy with `rg` and to validate new labels; checks completed with expected matches.  
- Manual test guidance included for local QA: verify homepage hero content and CTAs, the “outage static” teaser rows and empty state, dashboard incident counts (official vs signals), history loading/empty/error transitions, mobile stacking under 900px, reduced-motion behavior, and territory acknowledgement rendering with special characters.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c24c9c01c8331a855e03f959ef817)