### PR TITLE
Restore homepage arcade system

### DIFF
--- a/assets/css/lousy-outages-teaser.css
+++ b/assets/css/lousy-outages-teaser.css
@@ -132,3 +132,81 @@
   color: #7ef6d1;
   font-weight: 800;
 }
+
+/* Surgical homepage repair: keep incident rows readable at full width. */
+#lousy-outages-teaser.lo-home-teaser,
+#lousy-outages-teaser.lo-home-teaser * {
+  box-sizing: border-box;
+  writing-mode: horizontal-tb;
+  word-break: normal;
+}
+
+#lousy-outages-teaser.lo-home-teaser {
+  width: min(1180px, calc(100% - 2rem));
+  min-width: 0;
+  min-height: 0;
+  margin: clamp(1rem, 3vw, 2rem) auto;
+  border-color: rgba(0, 255, 0, 0.38);
+  background:
+    radial-gradient(circle at 8% 0%, rgba(0, 255, 128, 0.13), transparent 24rem),
+    linear-gradient(180deg, rgba(0, 20, 12, 0.94), rgba(0, 0, 0, 0.9));
+  box-shadow: 0 0 28px rgba(0, 255, 80, 0.14), inset 0 0 24px rgba(0, 255, 80, 0.06);
+}
+
+#lousy-outages-teaser .lo-home-teaser__titlebar,
+#lousy-outages-teaser .lo-home-teaser__screen,
+#lousy-outages-teaser .lo-home-alert-list,
+#lousy-outages-teaser .lo-home-alert,
+#lousy-outages-teaser .lo-home-alert__meta,
+#lousy-outages-teaser .lo-home-alert__body,
+#lousy-outages-teaser .lo-home-alert__time {
+  min-width: 0;
+}
+
+#lousy-outages-teaser .lo-home-teaser__titlebar {
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+
+#lousy-outages-teaser .lo-home-teaser__screen {
+  min-height: 0;
+}
+
+#lousy-outages-teaser .lo-home-alert {
+  grid-template-columns: minmax(9rem, 0.75fr) minmax(0, 2fr) minmax(7rem, auto);
+  align-items: center;
+  column-gap: 1rem;
+  row-gap: 0.45rem;
+}
+
+#lousy-outages-teaser .lo-home-alert__meta {
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+#lousy-outages-teaser .lo-home-alert__meta strong,
+#lousy-outages-teaser .lo-home-alert__meta span,
+#lousy-outages-teaser .lo-home-alert__body,
+#lousy-outages-teaser .lo-home-alert__time {
+  overflow-wrap: normal;
+  hyphens: none;
+}
+
+#lousy-outages-teaser .lo-home-alert__body[href*='http'] {
+  overflow-wrap: anywhere;
+}
+
+#lousy-outages-teaser .lo-home-alert__time {
+  text-align: right;
+  white-space: normal;
+}
+
+@media (max-width: 720px) {
+  #lousy-outages-teaser .lo-home-alert {
+    grid-template-columns: 1fr;
+  }
+
+  #lousy-outages-teaser .lo-home-alert__time {
+    text-align: left;
+  }
+}

--- a/functions.php
+++ b/functions.php
@@ -69,6 +69,21 @@ function retro_game_music_theme_scripts() {
     }
 
     if ( is_front_page() || is_page_template( 'page-home.php' ) ) {
+        wp_enqueue_script(
+            'hero-ship-drag',
+            get_template_directory_uri() . '/js/hero-ship-drag.js',
+            array(),
+            filemtime( get_template_directory() . '/js/hero-ship-drag.js' ),
+            true
+        );
+        wp_enqueue_script(
+            'hero-galaga',
+            get_template_directory_uri() . '/js/hero-galaga.js',
+            array( 'hero-ship-drag' ),
+            filemtime( get_template_directory() . '/js/hero-galaga.js' ),
+            true
+        );
+
         $teaser_css = get_template_directory() . '/assets/css/lousy-outages-teaser.css';
         if ( file_exists( $teaser_css ) ) {
             wp_enqueue_style(

--- a/page-home.php
+++ b/page-home.php
@@ -3,54 +3,64 @@
 get_header();
 ?>
 
-<main id="homepage-content" class="home-layout home-creative-system">
+<main id="homepage-content" class="home-layout home-arcade-layout">
 
-    <section class="home-title-screen" aria-labelledby="home-hero-title">
-        <div class="home-title-screen__marquee pixel-font" aria-label="Site themes">
-            <span><?php echo esc_html( 'MUSIC // MACHINES // VANCOUVER' ); ?></span>
-            <span><?php echo esc_html( 'OUTAGES // RECORDS // GASTOWN' ); ?></span>
-            <span><?php echo esc_html( 'PUBLIC INTERNET // PRIVATE STATIC' ); ?></span>
-            <span><?php echo esc_html( 'AI // AUDIO // CIVIC GHOSTS' ); ?></span>
-        </div>
-
-        <div class="home-title-screen__grid">
-            <div class="home-title-screen__intro">
-                <p class="hero-eyebrow pixel-font"><?php echo esc_html( 'music // machines // vancouver' ); ?></p>
-                <h1 id="home-hero-title" class="hero-core-headline home-title-screen__title"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>
-                <p class="home-title-screen__identity"><?php echo esc_html( 'AI strategist. Musician. Creative technologist.' ); ?></p>
-                <p class="home-title-screen__copy"><?php echo esc_html( 'Building small public systems for outages, songs, civic data, ghosts in the browser, and whatever starts talking back.' ); ?></p>
-                <div class="home-cta-row hero-cta-group home-title-screen__actions">
-                    <a href="#public-systems" class="pixel-button hero-primary-cta"><?php echo esc_html( 'Enter Site' ); ?></a>
-                    <a href="<?php echo esc_url( home_url( '/lousy-outages/' ) ); ?>" class="pixel-button pixel-button--secondary"><?php echo esc_html( 'Check Lousy Outages' ); ?></a>
-                </div>
+    <section class="home-hero home-arcade-hero hero hero-section crt-block" aria-labelledby="home-hero-title">
+        <div class="home-arcade-hero__cabinet" aria-label="Suzy Easton Pacific Static arcade screen">
+            <div class="home-arcade-hero__marquee pixel-font" aria-hidden="true">
+                <span><?php echo esc_html( 'PACIFIC STATIC' ); ?></span>
+                <span><?php echo esc_html( '1UP: SUZY' ); ?></span>
+                <span><?php echo esc_html( 'VANCOUVER' ); ?></span>
             </div>
 
-            <?php get_template_part( 'parts/lousy-outages-teaser' ); ?>
+            <div class="hero-grid home-arcade-hero__grid">
+                <div class="hero-main home-arcade-hero__intro">
+                    <p class="hero-eyebrow pixel-font"><?php echo esc_html( 'music // machines // vancouver' ); ?></p>
+                    <h1 id="home-hero-title" class="hero-core-headline home-arcade-title"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>
+                    <p class="home-arcade-subtitle"><?php echo esc_html( 'AI strategist. Musician. Creative technologist.' ); ?></p>
+                    <p class="hero-copy home-arcade-copy"><?php echo esc_html( 'Songs, systems, outage static, civic ghosts, AI experiments, and little internet machines that start living on their own.' ); ?></p>
+                    <div class="home-cta-row hero-cta-group home-arcade-start-row">
+                        <a href="#mission-select" class="pixel-button hero-primary-cta home-arcade-start" data-arcade-start><?php echo esc_html( 'Start Mission' ); ?></a>
+                        <a href="<?php echo esc_url( home_url( '/lousy-outages/' ) ); ?>" class="pixel-button pixel-button--secondary"><?php echo esc_html( 'Check Lousy Outages' ); ?></a>
+                    </div>
+                </div>
+
+                <aside class="hero-side home-arcade-hero__screen" aria-label="Pacific Static arcade monitor">
+                    <div class="hero-game-stage home-arcade-game" aria-label="Pacific Static mini arcade game. Press Start Mission, then use WASD or arrow keys to move, Space to fire, and Escape to quit." data-arcade-stage>
+                        <p class="hero-game-stage__header pixel-font"><?php echo esc_html( 'PACIFIC STATIC' ); ?></p>
+                        <div class="hero-game-stage__screen" role="img" aria-label="A green CRT arcade screen with stars, a small player ship, and outage alert blips.">
+                            <p class="hero-game-stage__idle pixel-font"><?php echo wp_kses_post( 'OUTAGE BLIP SWEEP<br>WASD move // Space fire // Esc quit<br>No sleep till deploy' ); ?></p>
+                            <div class="home-static-sprites" aria-hidden="true">
+                                <span class="home-static-sprites__ship"></span>
+                                <span class="home-static-sprites__enemy home-static-sprites__enemy--one"></span>
+                                <span class="home-static-sprites__enemy home-static-sprites__enemy--two"></span>
+                                <span class="home-static-sprites__reticle"></span>
+                            </div>
+                        </div>
+                        <p class="hero-game-stage__mobile-note pixel-font"><?php echo esc_html( 'Tap Start Mission on a keyboard screen to play.' ); ?></p>
+                    </div>
+                </aside>
+            </div>
         </div>
     </section>
 
-    <section class="home-status-strip" aria-label="Site status">
-        <p><span><?php echo esc_html( 'FROM:' ); ?></span> <?php echo esc_html( 'Vancouver' ); ?></p>
-        <p><span><?php echo esc_html( 'MODE:' ); ?></span> <?php echo esc_html( 'music / machines / civic ghosts' ); ?></p>
-        <p><span><?php echo esc_html( 'CURRENT SYSTEM:' ); ?></span> <?php echo esc_html( 'Lousy Outages' ); ?></p>
-        <p><span><?php echo esc_html( 'SIDE QUEST:' ); ?></span> <?php echo esc_html( 'Canucks emotional support' ); ?></p>
-    </section>
+    <?php get_template_part( 'parts/lousy-outages-teaser' ); ?>
 
-    <section id="public-systems" class="home-project-grid home-public-systems" aria-labelledby="selected-projects-title">
-        <p class="home-section-kicker pixel-font"><?php echo esc_html( 'public systems' ); ?></p>
-        <h2 id="selected-projects-title" class="pixel-font"><?php echo esc_html( 'things that escaped the lab' ); ?></h2>
+    <section id="mission-select" class="home-project-grid home-mission-select crt-block" aria-labelledby="selected-projects-title">
+        <p class="home-section-kicker pixel-font"><?php echo esc_html( 'SELECT SYSTEM' ); ?></p>
+        <h2 id="selected-projects-title" class="pixel-font"><?php echo esc_html( 'SELECT SYSTEM' ); ?></h2>
         <div class="selected-work__grid home-mission-grid">
             <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'status weather' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Lousy Outages' ); ?></h3><p><?php echo esc_html( 'Provider pages, outage signals, and internet weather without the corporate shrug.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/lousy-outages/' ) ); ?>"><?php echo esc_html( 'Check status' ); ?></a></article>
             <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'civic ghost world' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Gastown Simulator' ); ?></h3><p><?php echo esc_html( 'A browser-built Gastown made from civic data, routes, buildings, and memory.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/page-gastown-sim/' ) ); ?>"><?php echo esc_html( 'Enter Gastown' ); ?></a></article>
             <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'audio notes' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Track Analyzer' ); ?></h3><p><?php echo esc_html( 'Upload a rough mix and get direct, useful notes back.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/suzys-track-analyzer/' ) ); ?>"><?php echo esc_html( 'Analyze track' ); ?></a></article>
             <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'recording oracle' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'What Would Steve Do' ); ?></h3><p><?php echo esc_html( 'A blunt little recording prompt machine for mixes with too much nonsense.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/albini-qa/' ) ); ?>"><?php echo esc_html( 'Ask Steve' ); ?></a></article>
             <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'soft machine' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'ASMR Lab' ); ?></h3><p><?php echo esc_html( 'Tiny browser rituals for texture, sound, and controlled weirdness.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/asmr-lab/' ) ); ?>"><?php echo esc_html( 'Enter lab' ); ?></a></article>
-            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'discography' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Music / Records' ); ?></h3><p><?php echo esc_html( 'Bands, records, touring, bass, songs, and the long tail of making noise.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/music-releases/' ) ); ?>"><?php echo esc_html( 'Listen' ); ?></a></article>
+            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'discography' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Music / Records' ); ?></h3><p><?php echo esc_html( 'Songs, bands, records, touring, bass, and the handmade internet paths around them.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/music-releases/' ) ); ?>"><?php echo esc_html( 'Listen' ); ?></a></article>
         </div>
     </section>
 
-    <section id="music" class="music-world home-unlocks" aria-labelledby="music-world-title">
-        <p class="home-section-kicker pixel-font"><?php echo esc_html( 'records / contact / next noise' ); ?></p>
+    <section id="music" class="music-world home-unlocks crt-block" aria-labelledby="music-world-title">
+        <p class="home-section-kicker pixel-font"><?php echo esc_html( 'music / contact' ); ?></p>
         <h2 id="music-world-title" class="pixel-font"><?php echo esc_html( 'Music, bio, contact' ); ?></h2>
         <p><?php echo esc_html( 'Songs, records, bands, touring, bass, audio experiments, and the handmade internet paths around them.' ); ?></p>
         <div class="home-cta-row">

--- a/style.css
+++ b/style.css
@@ -5712,167 +5712,71 @@ body {
   }
 }
 
-/* Homepage 2026: creative public systems, not a terminal dashboard. */
-.home-creative-system {
-  --home-bg: #100f1d;
-  --home-card: rgba(255, 247, 223, 0.08);
-  --home-cream: #fff7df;
-  --home-mint: #7ef6d1;
-  --home-pink: #ff6aa8;
-  --home-gold: #ffcf66;
-  color: var(--home-cream);
+/* Surgical homepage arcade restoration after the creative-system experiment. */
+.home-arcade-layout {
   background:
-    radial-gradient(circle at 12% 8%, rgba(255, 106, 168, 0.2), transparent 28rem),
-    radial-gradient(circle at 82% 14%, rgba(126, 246, 209, 0.16), transparent 24rem),
-    linear-gradient(180deg, #100f1d 0%, #171426 62%, #0d101a 100%);
+    radial-gradient(circle at 14% 4%, rgba(0, 255, 128, 0.16), transparent 26rem),
+    radial-gradient(circle at 86% 12%, rgba(230, 0, 115, 0.14), transparent 24rem),
+    linear-gradient(180deg, #020805 0%, #05000c 58%, #010301 100%);
 }
 
-.home-creative-system .home-title-screen,
-.home-creative-system .home-status-strip,
-.home-creative-system .home-public-systems,
-.home-creative-system .home-unlocks,
-.home-creative-system .home-territory {
+.home-arcade-layout .home-mission-select,
+.home-arcade-layout .home-unlocks,
+.home-arcade-layout .home-territory {
   width: min(1180px, calc(100% - 2rem));
-  margin: 0 auto clamp(1.5rem, 4vw, 3rem);
+  margin: 0 auto clamp(1.25rem, 4vw, 3rem);
 }
 
-.home-title-screen {
-  padding-top: clamp(1rem, 3vw, 2rem);
-}
-
-.home-title-screen__marquee {
-  display: flex;
-  gap: 1rem;
-  overflow: hidden;
-  margin-bottom: clamp(1.5rem, 4vw, 2.5rem);
-  padding: 0.7rem 0;
-  border-block: 1px solid rgba(255, 247, 223, 0.2);
-  color: var(--home-gold);
-  font-size: clamp(0.58rem, 1.1vw, 0.75rem);
-  white-space: nowrap;
-}
-
-.home-title-screen__marquee span { flex: 0 0 auto; }
-
-.home-title-screen__grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
-  gap: clamp(1rem, 3vw, 2rem);
-  align-items: stretch;
-}
-
-.home-title-screen__intro {
-  display: grid;
-  align-content: center;
-  min-height: clamp(28rem, 58vh, 39rem);
-  padding: clamp(1.35rem, 4vw, 3rem);
-  border-radius: 30px;
-  background:
-    linear-gradient(135deg, rgba(255, 247, 223, 0.1), rgba(255, 247, 223, 0.025)),
-    linear-gradient(180deg, rgba(16, 15, 29, 0.86), rgba(16, 15, 29, 0.96));
-  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.35);
-}
-
-.home-title-screen__title {
-  margin: 0.35rem 0 0.8rem;
-  color: var(--home-cream);
-  text-shadow: 0.08em 0.08em 0 rgba(255, 106, 168, 0.45);
-}
-
-.home-title-screen__identity {
-  max-width: 48rem;
-  margin: 0 0 1rem;
-  color: var(--home-mint);
-  font-size: clamp(1.05rem, 2vw, 1.45rem);
-  font-weight: 800;
-}
-
-.home-title-screen__copy {
-  max-width: 45rem;
-  margin: 0 0 1.5rem;
-  color: rgba(255, 247, 223, 0.88);
-  font-size: clamp(1.05rem, 2vw, 1.35rem);
-  line-height: 1.55;
-}
-
-.home-status-strip {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.65rem;
-  align-items: center;
-  justify-content: center;
-  padding: 0.8rem;
-  border-radius: 18px;
-  background: rgba(0, 0, 0, 0.26);
-}
-
-.home-status-strip p {
-  margin: 0;
-  color: rgba(255, 247, 223, 0.86);
-  font-size: 0.9rem;
-}
-
-.home-status-strip span {
-  color: var(--home-gold);
-  font-weight: 900;
-}
-
-.home-public-systems,
-.home-unlocks,
-.home-territory {
+.home-arcade-layout .home-mission-select,
+.home-arcade-layout .home-unlocks {
   padding: clamp(1rem, 3vw, 2rem);
-  border-radius: 26px;
-  background: rgba(255, 247, 223, 0.055);
 }
 
-.home-public-systems .home-mission-grid {
+.home-arcade-layout .home-section-kicker {
+  color: #ffff66;
+}
+
+.home-arcade-layout .home-mission-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 1rem;
 }
 
-.home-public-systems .home-mission-card {
-  display: flex;
-  flex-direction: column;
-  gap: 0.8rem;
-  min-height: 17rem;
-  border-radius: 18px;
-  border: 1px solid rgba(255, 247, 223, 0.16);
-  background: linear-gradient(180deg, rgba(255, 247, 223, 0.09), rgba(255, 247, 223, 0.035));
+.home-arcade-layout .home-mission-card {
+  min-width: 0;
 }
 
-.home-public-systems .home-mission-card__label {
-  color: var(--home-mint);
-  font-size: 0.62rem;
+.home-arcade-layout .home-mission-card__label {
+  color: #7ef6d1;
 }
 
-.home-public-systems .home-mission-card .pixel-button { margin-top: auto; }
-
-.home-territory {
-  background: rgba(0, 0, 0, 0.22);
+.home-arcade-layout .home-territory {
+  padding: 0 0 clamp(1.5rem, 4vw, 3rem);
+  border: 0;
+  background: transparent;
+  box-shadow: none;
 }
 
-.home-territory p {
-  max-width: 78rem;
-  margin: 0;
-  color: rgba(255, 247, 223, 0.9);
-  font-size: 0.95rem;
+.home-arcade-layout .home-territory p {
+  max-width: 76rem;
+  margin: 0 auto;
+  color: rgba(218, 255, 232, 0.78);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: clamp(0.78rem, 1.2vw, 0.95rem);
   line-height: 1.65;
+  text-align: center;
+  text-transform: none;
+  letter-spacing: 0;
 }
 
-@media (max-width: 900px) {
-  .home-title-screen__grid,
-  .home-public-systems .home-mission-grid {
+@media (max-width: 980px) {
+  .home-arcade-layout .home-mission-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .home-arcade-layout .home-mission-grid {
     grid-template-columns: 1fr;
-  }
-
-  .home-title-screen__intro {
-    min-height: auto;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .home-title-screen__marquee {
-    scroll-behavior: auto;
   }
 }


### PR DESCRIPTION
### Motivation
- A recent homepage redesign removed the Galaga/Pacific Static game markup and stopped enqueueing the arcade scripts, which broke the hero layout and the arcade feeling.  
- The goal is a surgical repair to restore the mini-arcade experience while keeping the Lousy Outages data/state improvements and cache-busting behavior.  
- Also fix the vertical-stacked incident text and ensure the Lousy Outages teaser remains readable and separate from the game.

### Description
- Restored arcade homepage markup in `page-home.php` including `home-arcade-layout`, `home-arcade-hero`/`__cabinet`, `hero-grid`, `hero-main`, `hero-side`, `hero-game-stage`, `hero-game-stage__screen`, `home-static-sprites`, `hero-game-stage__idle`, `hero-game-stage__mobile-note`, and the `data-arcade-start` Start Mission CTA.  
- Re-enqueued `js/hero-ship-drag.js` and `js/hero-galaga.js` in `functions.php` inside `if ( is_front_page() || is_page_template( 'page-home.php' ) ) { ... }` using `filemtime()` versions, and kept the `lousy-outages-teaser` stylesheet enqueue intact.  
- Fixed the Lousy Outages teaser CSS in `assets/css/lousy-outages-teaser.css` to force horizontal writing, add `min-width: 0` on flex/grid children, set a simple `provider | summary | time` grid for alerts with clean mobile stacking, and only use `overflow-wrap: anywhere` for long URLs.  
- Removed/overrode the broken `home-creative-system` homepage rules and added scoped arcade restoration styles in `style.css`; preserved backend data/state fixes such as `get_lousy_outages_home_teaser_from_summary` and all incident loading/empty/error handling.  
- Changed files: `page-home.php`, `functions.php`, `style.css`, `assets/css/lousy-outages-teaser.css`.

### Testing
- Ran `php -l page-home.php`, `php -l parts/lousy-outages-teaser.php`, `php -l functions.php`, and `php -l lousy-outages/public/shortcode.php` and all reported no syntax errors.  
- Ran `node --check` on `js/hero-galaga.js`, `js/hero-ship-drag.js`, `assets/js/lousy-outages-teaser.js`, and `lousy-outages/assets/lousy-outages.js` and all passed.  
- Ran repository grep/style checks for arcade hooks and forbidden copy phrases and confirmed expected strings present/absent as intended.  
- Automated checks completed successfully (no syntax or static-check failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c2bb50dc48331961d440849c441dc)