### PR TITLE
Add local Docker Compose WordPress environment and Playwright E2E smoke tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ secrets.php
 *.key
 .DS_Store
 screenshots/
+playwright-report/
+test-results/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,62 @@
+services:
+  db:
+    image: mariadb:11.4
+    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
+    environment:
+      MARIADB_DATABASE: ${LOCAL_WP_DB_NAME:-wordpress}
+      MARIADB_USER: ${LOCAL_WP_DB_USER:-wordpress}
+      MARIADB_PASSWORD: ${LOCAL_WP_DB_PASSWORD:-wordpress}
+      MARIADB_ROOT_PASSWORD: ${LOCAL_WP_DB_ROOT_PASSWORD:-wordpress}
+    volumes:
+      - wp_db_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  wordpress:
+    image: wordpress:6.5-php8.2-apache
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "${LOCAL_WP_PORT:-8080}:80"
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_NAME: ${LOCAL_WP_DB_NAME:-wordpress}
+      WORDPRESS_DB_USER: ${LOCAL_WP_DB_USER:-wordpress}
+      WORDPRESS_DB_PASSWORD: ${LOCAL_WP_DB_PASSWORD:-wordpress}
+      WORDPRESS_DEBUG: ${LOCAL_WP_DEBUG:-1}
+      WORDPRESS_CONFIG_EXTRA: |
+        define( 'WP_DEBUG_DISPLAY', true );
+        define( 'SCRIPT_DEBUG', true );
+        define( 'DISALLOW_FILE_EDIT', true );
+        define( 'FS_METHOD', 'direct' );
+    volumes:
+      - wp_core:/var/www/html
+      - ./:/var/www/html/wp-content/themes/suzyeastonca
+      - ./plugins/lousy-outages:/var/www/html/wp-content/plugins/lousy-outages
+
+  wpcli:
+    image: wordpress:cli-php8.2
+    depends_on:
+      wordpress:
+        condition: service_started
+      db:
+        condition: service_healthy
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_NAME: ${LOCAL_WP_DB_NAME:-wordpress}
+      WORDPRESS_DB_USER: ${LOCAL_WP_DB_USER:-wordpress}
+      WORDPRESS_DB_PASSWORD: ${LOCAL_WP_DB_PASSWORD:-wordpress}
+    volumes:
+      - wp_core:/var/www/html
+      - ./:/var/www/html/wp-content/themes/suzyeastonca
+      - ./plugins/lousy-outages:/var/www/html/wp-content/plugins/lousy-outages
+    working_dir: /var/www/html
+    entrypoint: ["wp"]
+
+volumes:
+  wp_core:
+  wp_db_data:

--- a/docs/local-wordpress.md
+++ b/docs/local-wordpress.md
@@ -1,0 +1,89 @@
+# Local WordPress + Front-End QA Environment
+
+This repo can run as a local WordPress site through Docker Compose. The setup mounts the current repository as the active theme and mounts the standalone Lousy Outages plugin copy for plugin-flow testing.
+
+## Requirements
+
+- Docker with Docker Compose support
+- Node.js 20+ recommended
+- npm
+
+Docker Desktop is free for personal use under Docker's current licensing. If you are using this inside a larger commercial organization, check Docker's current subscription terms.
+
+## First-time setup
+
+```bash
+npm install
+npm run local:start
+npm run local:setup
+```
+
+The setup script installs WordPress if needed, activates the theme, activates the Lousy Outages plugin when available, creates the key QA pages, assigns templates, sets the homepage, and flushes permalinks.
+
+## Local URLs
+
+- Site: <http://localhost:8080>
+- Admin: <http://localhost:8080/wp-admin/>
+- Username: `admin`
+- Password: `password`
+
+You can override the defaults with environment variables:
+
+```bash
+LOCAL_WP_PORT=8090 \
+LOCAL_WP_ADMIN_USER=suzy \
+LOCAL_WP_ADMIN_PASSWORD='change-me' \
+npm run local:start
+
+LOCAL_WP_PORT=8090 \
+LOCAL_WP_ADMIN_USER=suzy \
+LOCAL_WP_ADMIN_PASSWORD='change-me' \
+npm run local:setup
+```
+
+## Daily use
+
+```bash
+npm run local:start
+npm run local:setup
+```
+
+Stop containers without deleting the database:
+
+```bash
+npm run local:stop
+```
+
+Reset WordPress and the database completely:
+
+```bash
+npm run local:reset
+```
+
+## Front-end smoke tests
+
+Install Playwright browsers once:
+
+```bash
+npx playwright install chromium
+```
+
+Run the smoke checks:
+
+```bash
+npm run test:e2e
+```
+
+Run visibly in a browser:
+
+```bash
+npm run test:e2e:headed
+```
+
+The Playwright smoke suite checks critical pages, browser console/page errors, the contact modal, Lousy Outages dashboard rendering, and Track Analyzer form controls.
+
+## Notes
+
+- External AI/API-dependent features still need keys in your real environment; the local setup is intended to validate front-end behavior, WordPress routing/templates, REST surfaces, and graceful UI states.
+- The WordPress container mounts this repository at `wp-content/themes/suzyeastonca`.
+- The Lousy Outages plugin is mounted from `plugins/lousy-outages` at `wp-content/plugins/lousy-outages`.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,15 @@
   "scripts": {
     "test": "node --test \"./__tests__/**/*.test.js\"",
     "build:gastown-world": "npm run sync:cov && node scripts/build-gastown-world.js",
-    "sync:cov": "node scripts/sync-cov-open-data.js"
+    "sync:cov": "node scripts/sync-cov-open-data.js",
+    "local:start": "docker compose up -d",
+    "local:setup": "./scripts/setup-local-wp.sh",
+    "local:stop": "docker compose down",
+    "local:reset": "docker compose down -v",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.56.0"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,35 @@
+// @ts-check
+const { defineConfig, devices } = require('@playwright/test');
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL || `http://localhost:${process.env.LOCAL_WP_PORT || '8080'}`;
+
+module.exports = defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium-desktop',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'mobile-chrome',
+      use: { ...devices['Pixel 5'] },
+    },
+  ],
+  webServer: process.env.PLAYWRIGHT_SKIP_WEB_SERVER
+    ? undefined
+    : {
+        command: 'docker compose up -d wordpress',
+        url: baseURL,
+        reuseExistingServer: true,
+        timeout: 120_000,
+      },
+});

--- a/scripts/setup-local-wp.sh
+++ b/scripts/setup-local-wp.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DC="${DC:-docker compose}"
+LOCAL_WP_URL="${LOCAL_WP_URL:-http://localhost:${LOCAL_WP_PORT:-8080}}"
+LOCAL_WP_TITLE="${LOCAL_WP_TITLE:-Suzy Easton Local QA}"
+LOCAL_WP_ADMIN_USER="${LOCAL_WP_ADMIN_USER:-admin}"
+LOCAL_WP_ADMIN_PASSWORD="${LOCAL_WP_ADMIN_PASSWORD:-password}"
+LOCAL_WP_ADMIN_EMAIL="${LOCAL_WP_ADMIN_EMAIL:-suzy.local@example.test}"
+THEME_SLUG="${LOCAL_WP_THEME_SLUG:-suzyeastonca}"
+PLUGIN_SLUG="${LOCAL_WP_LOUSY_PLUGIN:-lousy-outages}"
+
+wp_cli() {
+  ${DC} run --rm wpcli "$@"
+}
+
+wait_for_wordpress() {
+  local attempts=60
+  echo "Waiting for WordPress at ${LOCAL_WP_URL}..."
+  until curl -fsS "${LOCAL_WP_URL}/wp-admin/install.php" >/dev/null 2>&1 || curl -fsS "${LOCAL_WP_URL}" >/dev/null 2>&1; do
+    attempts=$((attempts - 1))
+    if [[ ${attempts} -le 0 ]]; then
+      echo "WordPress did not become reachable at ${LOCAL_WP_URL}." >&2
+      exit 1
+    fi
+    sleep 2
+  done
+}
+
+create_or_update_page() {
+  local title="$1"
+  local slug="$2"
+  local template="$3"
+  local content="${4:-}"
+  local id
+
+  id="$(wp_cli post list --post_type=page --name="${slug}" --field=ID --allow-root 2>/dev/null || true)"
+  if [[ -z "${id}" ]]; then
+    id="$(wp_cli post create \
+      --post_type=page \
+      --post_status=publish \
+      --post_title="${title}" \
+      --post_name="${slug}" \
+      --post_content="${content}" \
+      --porcelain \
+      --allow-root)"
+  else
+    wp_cli post update "${id}" \
+      --post_status=publish \
+      --post_title="${title}" \
+      --post_content="${content}" \
+      --allow-root >/dev/null
+  fi
+
+  if [[ -n "${template}" ]]; then
+    wp_cli post meta update "${id}" _wp_page_template "${template}" --allow-root >/dev/null
+  fi
+
+  echo "${id}"
+}
+
+wait_for_wordpress
+
+if ! wp_cli core is-installed --allow-root >/dev/null 2>&1; then
+  wp_cli core install \
+    --url="${LOCAL_WP_URL}" \
+    --title="${LOCAL_WP_TITLE}" \
+    --admin_user="${LOCAL_WP_ADMIN_USER}" \
+    --admin_password="${LOCAL_WP_ADMIN_PASSWORD}" \
+    --admin_email="${LOCAL_WP_ADMIN_EMAIL}" \
+    --skip-email \
+    --allow-root
+fi
+
+wp_cli theme activate "${THEME_SLUG}" --allow-root
+
+if wp_cli plugin is-installed "${PLUGIN_SLUG}" --allow-root >/dev/null 2>&1; then
+  wp_cli plugin activate "${PLUGIN_SLUG}" --allow-root || true
+fi
+
+home_id="$(create_or_update_page "Home" "home" "page-home.php")"
+create_or_update_page "Lousy Outages" "lousy-outages" "page-lousy-outages.php" >/dev/null
+create_or_update_page "Work With Suzy" "work-with-suzy" "page-work-with-suzy.php" >/dev/null
+create_or_update_page "Projects" "projects" "page-projects.php" >/dev/null
+create_or_update_page "Suzy's Track Analyzer" "suzys-track-analyzer" "page-track-analyzer.php" >/dev/null
+create_or_update_page "Gastown Simulator" "gastown-sim" "page-gastown-sim.php" >/dev/null
+create_or_update_page "ASMR Lab" "asmr-lab" "page-asmr-lab.php" >/dev/null
+create_or_update_page "Albini Q&A" "albini-qa" "page-albini-qa.php" >/dev/null
+create_or_update_page "Music Releases" "music-releases" "page-music-releases.php" >/dev/null
+create_or_update_page "Riff Generator" "riff-generator" "page-riff-generator.php" >/dev/null
+create_or_update_page "Bio" "bio" "page-bio.php" >/dev/null
+create_or_update_page "VanOps Radar" "vanops-radar" "page-vanops-radar.php" >/dev/null
+
+wp_cli option update show_on_front page --allow-root >/dev/null
+wp_cli option update page_on_front "${home_id}" --allow-root >/dev/null
+wp_cli rewrite structure '/%postname%/' --allow-root >/dev/null
+wp_cli rewrite flush --hard --allow-root >/dev/null
+
+cat <<SUMMARY
+
+Local WordPress QA environment is ready.
+URL:      ${LOCAL_WP_URL}
+Admin:    ${LOCAL_WP_URL}/wp-admin/
+Username: ${LOCAL_WP_ADMIN_USER}
+Password: ${LOCAL_WP_ADMIN_PASSWORD}
+
+Run FE checks with:
+  npm run test:e2e
+
+SUMMARY

--- a/tests/e2e/site-smoke.spec.js
+++ b/tests/e2e/site-smoke.spec.js
@@ -1,0 +1,60 @@
+const { test, expect } = require('@playwright/test');
+
+const criticalPages = [
+  ['home', '/'],
+  ['lousy outages', '/lousy-outages/'],
+  ['work with suzy', '/work-with-suzy/'],
+  ['projects', '/projects/'],
+  ['track analyzer', '/suzys-track-analyzer/'],
+  ['gastown simulator', '/gastown-sim/'],
+  ['asmr lab', '/asmr-lab/'],
+  ['albini qa', '/albini-qa/'],
+];
+
+test.describe('critical page smoke checks', () => {
+  for (const [name, path] of criticalPages) {
+    test(`${name} page loads without client-side errors`, async ({ page }) => {
+      const errors = [];
+      page.on('pageerror', (error) => errors.push(error.message));
+      page.on('console', (message) => {
+        if (message.type() === 'error') {
+          errors.push(message.text());
+        }
+      });
+
+      const response = await page.goto(path, { waitUntil: 'domcontentloaded' });
+      expect(response, `${path} should return a response`).not.toBeNull();
+      expect(response.status(), `${path} should not 404/500`).toBeLessThan(400);
+      await expect(page.locator('body')).toBeVisible();
+      expect(errors, `${path} console/page errors`).toEqual([]);
+    });
+  }
+});
+
+test('contact modal opens from every visible contact trigger', async ({ page }) => {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  const triggers = page.locator('[data-contact-trigger]:visible');
+  await expect(triggers.first()).toBeVisible();
+  const triggerCount = await triggers.count();
+  expect(triggerCount).toBeGreaterThan(0);
+
+  for (let index = 0; index < triggerCount; index += 1) {
+    await triggers.nth(index).click();
+    await expect(page.locator('#contact-suzy-modal')).toBeVisible();
+    await expect(page.locator('#se-contact-name')).toBeFocused();
+    await page.keyboard.press('Escape');
+    await expect(page.locator('#contact-suzy-modal')).toBeHidden();
+  }
+});
+
+test('lousy outages dashboard exposes status surface and report form area', async ({ page }) => {
+  await page.goto('/lousy-outages/', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByRole('heading', { name: /lousy outages/i })).toBeVisible();
+  await expect(page.locator('.lousy-outages, [data-lo-endpoint]').first()).toBeVisible();
+});
+
+test('track analyzer upload form exposes expected controls', async ({ page }) => {
+  await page.goto('/suzys-track-analyzer/', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByLabel(/upload mp3 file/i)).toBeVisible();
+  await expect(page.getByRole('button', { name: /analyze track/i })).toBeVisible();
+});


### PR DESCRIPTION
### Motivation

- Provide a reproducible local WordPress + theme + plugin development environment for front-end QA and smoke testing.

### Description

- Add a `docker-compose.yml` that brings up `mariadb`, `wordpress`, and a `wpcli` service and mounts the repo as the active theme and a local plugin copy.
- Add `scripts/setup-local-wp.sh` to initialize WordPress, activate the theme/plugin, create QA pages, set the front page, and flush permalinks using `wp` in the `wpcli` container.
- Add Playwright configuration in `playwright.config.js`, Playwright tests in `tests/e2e/site-smoke.spec.js`, and developer dependency `@playwright/test` in `package.json` plus `npm` scripts `local:start`, `local:setup`, `local:stop`, `local:reset`, `test:e2e`, and `test:e2e:headed`.
- Add user-facing documentation `docs/local-wordpress.md` describing setup and usage, and update `.gitignore` to exclude `playwright-report/` and `test-results/`.

### Testing

- Ran the existing unit test runner with `npm test`, and it completed successfully.
- Executed the Playwright smoke suite locally using `npx playwright test` against the Docker Compose WordPress services, and the smoke checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c5351de408331981329964ff34491)