### PR TITLE
Fix contact modal trigger binding

### DIFF
--- a/assets/js/header-contact-modal.js
+++ b/assets/js/header-contact-modal.js
@@ -1,7 +1,7 @@
 (function () {
-  var trigger = document.querySelector('[data-contact-trigger]');
+  var triggers = document.querySelectorAll('[data-contact-trigger]');
   var modal = document.querySelector('[data-contact-modal]');
-  if (!trigger || !modal) return;
+  if (!triggers.length || !modal) return;
 
   var dialog = modal.querySelector('.se-contact-modal__dialog');
   var closeEls = modal.querySelectorAll('[data-contact-close]');
@@ -52,8 +52,13 @@
     window.speechSynthesis.speak(utterance);
   }
 
-  function openModal() {
-    lastFocused = document.activeElement;
+  function openModal(event) {
+    if (event) {
+      event.preventDefault();
+      lastFocused = event.currentTarget;
+    } else {
+      lastFocused = document.activeElement;
+    }
     modal.hidden = false;
     document.body.classList.add('se-modal-open');
 
@@ -76,8 +81,6 @@
     document.removeEventListener('keydown', onKeydown);
     if (lastFocused && typeof lastFocused.focus === 'function') {
       lastFocused.focus();
-    } else {
-      trigger.focus();
     }
   }
 
@@ -133,7 +136,9 @@
     }
   }
 
-  trigger.addEventListener('click', openModal);
+  triggers.forEach(function (trigger) {
+    trigger.addEventListener('click', openModal);
+  });
   closeEls.forEach(function (el) {
     el.addEventListener('click', closeModal);
   });


### PR DESCRIPTION
### Motivation
- Fix the bug where only the first `[data-contact-trigger]` received a click handler so that every visible contact trigger opens `#contact-suzy-modal` and focus/close behavior works per trigger.

### Description
- Replace `document.querySelector('[data-contact-trigger]')` with `document.querySelectorAll('[data-contact-trigger]')`, attach the click handler to each trigger, change `openModal` to accept the event and set `lastFocused` to `event.currentTarget`, call `event.preventDefault()` only when opening, and restore focus to the trigger that opened the modal while preserving all existing modal, form, and accessibility behavior in `assets/js/header-contact-modal.js`.

### Testing
- `node --check assets/js/header-contact-modal.js` succeeded and `git diff --check` returned no issues; `npm run test:e2e` could not be executed because the Playwright CLI is not installed in this environment and `npm install` failed with a `403 Forbidden` for `@playwright/test` when attempting to fetch dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c6946c5b483318b10e355e955b49a)