### PR TITLE
Refine homepage ASCII / ANSI arcade art

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -19,13 +19,21 @@ get_header();
                     <h1 id="home-hero-title" class="hero-core-headline home-arcade-title"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>
                     <p class="home-arcade-subtitle"><?php echo esc_html( 'Musician, creative technologist, and technical systems operator.' ); ?></p>
                     <p class="hero-copy home-arcade-copy"><?php echo esc_html( 'I build practical AI workflows, outage and ops dashboards, music tools, and Vancouver-flavoured web experiments: playable, readable, and useful after the glow wears off.' ); ?></p>
-                    <div class="home-ascii-panel" aria-label="Arcade identity readout">
-                        <pre aria-hidden="true">╔═ SIGNAL BOARD ═╗
-║ MUSIC  ▸ BASS  ║
-║ OPS    ▸ PROOF ║
-║ AI     ▸ TOOLS ║
-╚═ PRESS START ═╝</pre>
-                        <p>Terminal texture, Galaga motion, real-world troubleshooting underneath.</p>
+                    <div class="home-ascii-panel" aria-label="Decorative Vancouver coast terminal art">
+                        <pre class="home-ascii-panel__scene home-ascii-panel__scene--wide" aria-hidden="true">      ·        ✦        .          ·
+  .        /\        /\_      ✧        .
+     /\__/  \__/\__/   \__        ·
+  __/  \  NORTH SHORE  /  \___
+ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
+     .  |  | .  |▵|  . |  |  .
+  . . . |__| .  | |  . |__| . .
+       signal ⇢ noise ⇢ song</pre>
+                        <pre class="home-ascii-panel__scene home-ascii-panel__scene--compact" aria-hidden="true">    ·  ✦   /\_/\
+ /\_/  \_/ coast
+ ~ ~ ~ ~ ~ ~ ~
+  . |▵| . | | .
+ signal ⇢ song</pre>
+                        <p>Vancouver night coast rendered as terminal glow: mountains, water, city lights, and a signal path back to the work.</p>
                     </div>
                     <div class="home-cta-row hero-cta-group home-arcade-start-row">
                         <a href="#mission-select" class="pixel-button hero-primary-cta home-arcade-start" data-arcade-start><?php echo esc_html( 'Enter the lab' ); ?></a>

--- a/style.css
+++ b/style.css
@@ -5783,47 +5783,79 @@ body {
 
 /* QA polish: make the homepage arcade language more intentional without hiding the work. */
 .home-ascii-panel {
-  max-width: 32rem;
+  position: relative;
+  max-width: 42rem;
   margin: clamp(1rem, 2.5vw, 1.6rem) auto 0;
-  padding: 0.85rem;
-  border: 1px solid rgba(126, 246, 209, 0.45);
-  border-radius: 12px;
+  padding: clamp(0.8rem, 1.8vw, 1.1rem);
+  overflow: hidden;
+  border: 1px solid rgba(126, 246, 209, 0.38);
+  border-radius: 14px;
   background:
-    linear-gradient(135deg, rgba(87, 243, 255, 0.08), transparent 42%),
-    rgba(0, 10, 8, 0.78);
-  box-shadow: inset 0 0 24px rgba(57, 255, 20, 0.07), 0 0 22px rgba(87, 243, 255, 0.08);
+    radial-gradient(circle at 18% 12%, rgba(255, 255, 102, 0.15) 0 1px, transparent 2px),
+    radial-gradient(circle at 72% 18%, rgba(87, 243, 255, 0.18) 0 1px, transparent 2px),
+    linear-gradient(180deg, rgba(2, 20, 21, 0.9), rgba(0, 7, 12, 0.82));
+  box-shadow: inset 0 0 28px rgba(57, 255, 20, 0.06), 0 0 24px rgba(87, 243, 255, 0.08);
+}
+
+.home-ascii-panel::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    radial-gradient(circle, rgba(223, 255, 234, 0.55) 0 1px, transparent 1.5px),
+    radial-gradient(circle, rgba(255, 255, 102, 0.42) 0 1px, transparent 1.5px);
+  background-position: 8% 18%, 82% 34%;
+  background-size: 5.5rem 4rem, 7rem 5rem;
+  opacity: 0.22;
+  pointer-events: none;
 }
 
 .home-ascii-panel pre,
 .home-ascii-panel p {
+  position: relative;
+  z-index: 1;
   margin: 0;
   color: rgba(223, 255, 234, 0.9);
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
-  line-height: 1.35;
+  line-height: 1.25;
   text-transform: none;
 }
 
-.home-ascii-panel pre {
-  color: #ffff66;
-  font-size: clamp(0.78rem, 1.45vw, 1rem);
-  letter-spacing: 0.03em;
-  text-shadow: 0 0 10px rgba(255, 255, 102, 0.2);
+.home-ascii-panel__scene {
+  display: block;
+  color: #dfffea;
+  font-size: clamp(0.54rem, 1.12vw, 0.78rem);
+  letter-spacing: 0.02em;
+  overflow: hidden;
+  text-align: left;
+  text-shadow: 0 0 8px rgba(126, 246, 209, 0.32), 0 0 18px rgba(87, 243, 255, 0.16);
+  white-space: pre;
+}
+
+.home-ascii-panel__scene--compact {
+  display: none;
 }
 
 .home-ascii-panel p {
-  margin-top: 0.65rem;
-  font-size: clamp(0.82rem, 1.2vw, 0.95rem);
+  max-width: 36rem;
+  margin-top: 0.7rem;
+  color: rgba(203, 255, 231, 0.82);
+  font-size: clamp(0.78rem, 1.1vw, 0.92rem);
+  line-height: 1.45;
+  text-align: left;
 }
 
 .home-static-sprites::before {
-  content: "✦   ·   ✧   ·   ✦";
+  content: "✦      ·        ✧   ·      ✦\A   .        .       ·       .";
   position: absolute;
-  inset: 10% 8% auto;
-  color: rgba(255, 255, 102, 0.72);
+  inset: 9% 7% auto;
+  color: rgba(255, 255, 102, 0.68);
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
-  font-size: clamp(0.75rem, 1.6vw, 1.2rem);
-  letter-spacing: 0.7em;
-  text-shadow: 0 0 12px rgba(255, 255, 102, 0.35);
+  font-size: clamp(0.62rem, 1.25vw, 0.95rem);
+  letter-spacing: 0.45em;
+  line-height: 2;
+  text-shadow: 0 0 12px rgba(255, 255, 102, 0.28);
+  white-space: pre;
   pointer-events: none;
 }
 
@@ -5833,7 +5865,12 @@ body {
     margin-right: 0;
   }
 
-  .home-ascii-panel pre {
-    white-space: pre-wrap;
+  .home-ascii-panel__scene--wide {
+    display: none;
+  }
+
+  .home-ascii-panel__scene--compact {
+    display: block;
+    font-size: clamp(0.62rem, 3.4vw, 0.82rem);
   }
 }


### PR DESCRIPTION
### Motivation
- Make the homepage feel more atmospheric and artful in a terminal/ANSI / Galaga‑style way while keeping the hero copy and CTAs clear and hireable. 
- Replace the literal “SIGNAL BOARD” menu panel with decorative text‑art that evokes Vancouver’s coast, mountains, city lights, and a signal ⇢ noise motif. 
- Keep the art decorative and accessible (nonessential copy hidden from screen readers) and ensure it scales down on small screens.

### Description
- Replaced the boxed list panel in `page-home.php` with two preserved `<pre>` scenes (wide and compact) representing the Vancouver night coast and a short signal phrase, with `aria-hidden="true"` for the decorative content. 
- Kept all hero copy and CTAs unchanged, including the line: “Musician, creative technologist, and technical systems operator.” in `page-home.php`. 
- Updated `style.css` to style the new ASCII panel (`.home-ascii-panel` and `.home-ascii-panel__scene`), add a subtle terminal glow texture (`.home-ascii-panel::before`), and provide responsive show/hide behavior for wide/compact scenes. 
- Tuned the mini starfield/sprites texture (`.home-static-sprites::before`) so the moving stars feel intentional and less like random static.

### Testing
- Ran `php -l page-home.php` and it reported no syntax errors. 
- Ran `php -l page-projects.php`, `php -l page-bio.php`, and `php -l page-asmr-lab.php` and each reported no syntax errors. 
- Ran `git diff --check` and it returned no whitespace or diff issues. 
- Attempted `npm.cmd run test:e2e` and `npm run test:e2e`, but the environment lacks the Windows `npm.cmd` binary and Playwright (`playwright: not found`), so end‑to‑end tests could not be executed here; visual screenshots were not captured for the same reason.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c7374513c83319fe07f2414c42bfa)