### PR TITLE
Refine homepage hero with animated ASCII coastal orca art

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -13,28 +13,36 @@ get_header();
                 <span><?php echo esc_html( 'VANCOUVER' ); ?></span>
             </div>
 
+            <div class="home-hero-ascii-scene" aria-hidden="true">
+                <pre class="home-hero-ascii-scene__stars">  ·          *        .          +          ·        .
+       .          ·        /\        .          *
+   *        .        /__\      ·        .          +
+        ·       .     /  \          *        .
+ .          +        ^    ^       .          ·</pre>
+                <pre class="home-hero-ascii-scene__coast">        .        ·             *                 .
+   ^        .          ·              .        ^
+      /\          /\__/\       /\           .
+  ___/  \__/\___/      \_____/  \___
+        `-.      .  *  .  ·  .  *  .      .-'
+ ~~~  ~^~   ~~~    ~^~    ~~~   ~^~    ~~~
+      __..---.        ___
+ ___.'  _   _ `-.__.-'   `-.__      ~^~
+(    _/ `._/ `._   _.-.       )
+ `--'     /\     `-`   `.__.-'        .
+       __/  \__        .        +
+  .   /__    __\     .      .        ·
+         `--'      ~~~    ~^~    ~~~</pre>
+                <pre class="home-hero-ascii-scene__pixels">+   .       ·       .   *       ·       .
+   .   +       .       ·       *       .
+·       .   *       .       +       .</pre>
+            </div>
+
             <div class="hero-grid home-arcade-hero__grid">
                 <div class="hero-main home-arcade-hero__intro">
                     <p class="hero-eyebrow pixel-font"><?php echo esc_html( 'music // practical ai // weird useful tools' ); ?></p>
                     <h1 id="home-hero-title" class="hero-core-headline home-arcade-title"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>
                     <p class="home-arcade-subtitle"><?php echo esc_html( 'Musician, creative technologist, and technical systems operator.' ); ?></p>
                     <p class="hero-copy home-arcade-copy"><?php echo esc_html( 'I build practical AI workflows, outage and ops dashboards, music tools, and Vancouver-flavoured web experiments: playable, readable, and useful after the glow wears off.' ); ?></p>
-                    <div class="home-ascii-panel" aria-label="Decorative Vancouver coast terminal art">
-                        <pre class="home-ascii-panel__scene home-ascii-panel__scene--wide" aria-hidden="true">      ·        ✦        .          ·
-  .        /\        /\_      ✧        .
-     /\__/  \__/\__/   \__        ·
-  __/  \  NORTH SHORE  /  \___
- ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-     .  |  | .  |▵|  . |  |  .
-  . . . |__| .  | |  . |__| . .
-       signal ⇢ noise ⇢ song</pre>
-                        <pre class="home-ascii-panel__scene home-ascii-panel__scene--compact" aria-hidden="true">    ·  ✦   /\_/\
- /\_/  \_/ coast
- ~ ~ ~ ~ ~ ~ ~
-  . |▵| . | | .
- signal ⇢ song</pre>
-                        <p>Vancouver night coast rendered as terminal glow: mountains, water, city lights, and a signal path back to the work.</p>
-                    </div>
                     <div class="home-cta-row hero-cta-group home-arcade-start-row">
                         <a href="#mission-select" class="pixel-button hero-primary-cta home-arcade-start" data-arcade-start><?php echo esc_html( 'Enter the lab' ); ?></a>
                         <a href="<?php echo esc_url( home_url( '/lousy-outages/' ) ); ?>" class="pixel-button pixel-button--secondary"><?php echo esc_html( 'Check Lousy Outages' ); ?></a>

--- a/style.css
+++ b/style.css
@@ -5874,3 +5874,167 @@ body {
     font-size: clamp(0.62rem, 3.4vw, 0.82rem);
   }
 }
+
+/* Focused PR: ghosted Vancouver/BC text-mode hero mural. */
+.home-arcade-hero__cabinet {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.home-arcade-hero__marquee,
+.home-arcade-hero__grid {
+  position: relative;
+  z-index: 2;
+}
+
+.home-hero-ascii-scene {
+  position: absolute;
+  inset: clamp(3.6rem, 7vw, 5.2rem) clamp(0.6rem, 3vw, 2rem) 0 auto;
+  width: min(57rem, 72%);
+  min-height: 72%;
+  z-index: 1;
+  overflow: hidden;
+  color: rgba(126, 246, 209, 0.34);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+  line-height: 1.08;
+  pointer-events: none;
+  text-shadow: 0 0 10px rgba(126, 246, 209, 0.26), 0 0 26px rgba(87, 243, 255, 0.12);
+  transform: translateZ(0);
+  mask-image: linear-gradient(90deg, transparent 0%, rgba(0, 0, 0, 0.14) 16%, rgba(0, 0, 0, 0.78) 48%, rgba(0, 0, 0, 0.88) 100%), linear-gradient(180deg, rgba(0, 0, 0, 0.9), rgba(0, 0, 0, 0.78) 58%, transparent 100%);
+  mask-composite: intersect;
+}
+
+.home-hero-ascii-scene::before,
+.home-hero-ascii-scene::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.home-hero-ascii-scene::before {
+  background: repeating-linear-gradient(180deg, rgba(223, 255, 234, 0.07) 0 1px, transparent 1px 4px);
+  mix-blend-mode: screen;
+  opacity: 0.58;
+  animation: homeAsciiScan 7s linear infinite;
+}
+
+.home-hero-ascii-scene::after {
+  background:
+    radial-gradient(circle at 78% 10%, rgba(255, 255, 102, 0.22), transparent 0.7rem),
+    radial-gradient(circle at 46% 32%, rgba(87, 243, 255, 0.16), transparent 0.55rem),
+    radial-gradient(circle at 92% 58%, rgba(255, 72, 206, 0.12), transparent 0.9rem);
+  opacity: 0.82;
+  animation: homeAsciiGlow 5.8s ease-in-out infinite;
+}
+
+.home-hero-ascii-scene pre {
+  position: absolute;
+  margin: 0;
+  white-space: pre;
+  color: inherit;
+  font: inherit;
+}
+
+.home-hero-ascii-scene__stars {
+  top: 0;
+  right: 0;
+  font-size: clamp(0.56rem, 0.95vw, 0.8rem);
+  letter-spacing: 0.1em;
+  color: rgba(255, 255, 102, 0.34);
+  animation: homeAsciiStars 12s steps(6, end) infinite;
+}
+
+.home-hero-ascii-scene__coast {
+  right: 0;
+  bottom: clamp(0.5rem, 3vw, 2.25rem);
+  font-size: clamp(0.58rem, 1vw, 0.88rem);
+  color: rgba(203, 255, 231, 0.32);
+  animation: homeAsciiOcean 4.8s steps(3, end) infinite;
+}
+
+.home-hero-ascii-scene__pixels {
+  right: 4%;
+  bottom: 9%;
+  font-size: clamp(0.48rem, 0.8vw, 0.68rem);
+  letter-spacing: 0.24em;
+  color: rgba(87, 243, 255, 0.24);
+  animation: homeAsciiPixels 8s steps(4, end) infinite;
+}
+
+.home-ascii-panel {
+  display: none;
+}
+
+@keyframes homeAsciiStars {
+  0%, 100% { transform: translate3d(0, 0, 0); opacity: 0.52; }
+  50% { transform: translate3d(-0.55rem, 0.35rem, 0); opacity: 0.8; }
+}
+
+@keyframes homeAsciiOcean {
+  0%, 100% { transform: translate3d(0, 0, 0); opacity: 0.72; }
+  33% { transform: translate3d(0.22rem, 0, 0); opacity: 0.58; }
+  66% { transform: translate3d(-0.16rem, 0.08rem, 0); opacity: 0.78; }
+}
+
+@keyframes homeAsciiPixels {
+  0%, 100% { transform: translate3d(0, 0, 0); opacity: 0.32; }
+  50% { transform: translate3d(0.4rem, -0.2rem, 0); opacity: 0.58; }
+}
+
+@keyframes homeAsciiScan {
+  from { transform: translateY(-12px); }
+  to { transform: translateY(12px); }
+}
+
+@keyframes homeAsciiGlow {
+  0%, 100% { opacity: 0.58; filter: saturate(0.9); }
+  50% { opacity: 0.88; filter: saturate(1.25); }
+}
+
+@media (max-width: 980px) {
+  .home-hero-ascii-scene {
+    inset: auto -1rem 8rem auto;
+    width: min(48rem, 100%);
+    min-height: 22rem;
+    opacity: 0.72;
+    mask-image: linear-gradient(180deg, transparent 0%, rgba(0, 0, 0, 0.52) 26%, rgba(0, 0, 0, 0.58) 70%, transparent 100%);
+  }
+
+  .home-hero-ascii-scene__coast {
+    font-size: clamp(0.48rem, 1.55vw, 0.72rem);
+  }
+}
+
+@media (max-width: 680px) {
+  .home-hero-ascii-scene {
+    inset: auto -4.5rem 16rem auto;
+    width: 38rem;
+    min-height: 18rem;
+    opacity: 0.42;
+    mask-image: linear-gradient(180deg, transparent 0%, rgba(0, 0, 0, 0.42) 30%, transparent 100%);
+  }
+
+  .home-hero-ascii-scene__stars,
+  .home-hero-ascii-scene__pixels {
+    display: none;
+  }
+
+  .home-hero-ascii-scene__coast {
+    font-size: 0.48rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-hero-ascii-scene,
+  .home-hero-ascii-scene::before,
+  .home-hero-ascii-scene::after,
+  .home-hero-ascii-scene pre {
+    animation: none !important;
+  }
+
+  .home-hero-ascii-scene::before {
+    opacity: 0.28;
+  }
+}


### PR DESCRIPTION
### Motivation

- Make the homepage hero feel like an atmospheric Vancouver/BC text‑mode arcade mural (Galaga starfield + terminal glow + coastal horizon + subtle orca motif) that sits behind and supports the copy rather than as a boxed panel. 
- Replace the previous boxed ASCII panel with a ghosted background layer so CTAs and the hero copy remain visually dominant. 
- Provide lightweight motion (drifting stars, ocean shimmer, scanlines, subtle pixel drift) implemented with CSS and honoring `prefers-reduced-motion`.

### Description

- Added a new decorative layer `div.home-hero-ascii-scene` to `page-home.php` containing three hand‑authored `<pre>` layers (`__stars`, `__coast`, `__pixels`) and marked `aria-hidden="true"` to ensure the art is purely decorative. 
- Removed the previous boxed `.home-ascii-panel` markup and preserved all hero copy, CTAs, the Lousy Outages link, and existing arcade/Galaga elements. 
- Added CSS to `style.css` that positions the mural behind the hero, applies low‑contrast glow and scanline overlays, masks/fades edges for readability, provides responsive layout rules (desktop/tablet/mobile), and defines keyframes `homeAsciiStars`, `homeAsciiOcean`, `homeAsciiPixels`, `homeAsciiScan`, and `homeAsciiGlow` for subtle motion. 
- Ensured the mural is non‑interactive (`pointer-events: none`), uses low opacity and `steps()` timing for restrained motion, and disables animations when `prefers-reduced-motion: reduce` is set.

### Testing

- `php -l page-home.php` passed with no syntax errors. 
- `git diff --check` passed with no whitespace or diff issues. 
- `npm.cmd run test:e2e` could not be executed in this environment because `npm.cmd` is not available on the Linux shell. 
- `npm run test:e2e` invoked Playwright but the configured `webServer` failed to start because Docker is not installed here, so E2E browser tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3db62cd0a083318586c23c301f25ba)