### PR TITLE
Homepage: Orca ASCII title-screen hero & relocate Pacific Static

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -5,66 +5,65 @@ get_header();
 
 <main id="homepage-content" class="home-layout home-arcade-layout">
 
-    <section class="home-hero home-arcade-hero hero hero-section crt-block" aria-labelledby="home-hero-title">
-        <div class="home-arcade-hero__cabinet" aria-label="Suzy Easton Pacific Static arcade screen">
-            <div class="home-arcade-hero__marquee pixel-font" aria-hidden="true">
-                <span><?php echo esc_html( 'PACIFIC STATIC' ); ?></span>
-                <span><?php echo esc_html( '1UP: SUZY' ); ?></span>
-                <span><?php echo esc_html( 'VANCOUVER' ); ?></span>
-            </div>
+    <section class="home-orca-hero hero hero-section crt-block" aria-labelledby="home-hero-title">
+        <div class="home-orca-stage">
+            <span class="screen-reader-text"><?php echo esc_html( 'ASCII art scene of a killer whale surfacing in Burrard Inlet with Vancouver mountains and city lights.' ); ?></span>
+            <pre class="home-orca-ascii" aria-hidden="true">        .        *        .              .        *
+   .        .        NORTH SHORE STATIC        .
+         /\       /\        /\__/\        /\
+    ____/  \_____/  \______/      \______/  \___
+       _|_      _|_       _|_  LIONS GATE  _|_
+      |:::| .  |:::|  .  |:::|____====____|:::|  .
+  .   |___|    |___|     |___|    ||    . |___|
 
-            <div class="home-hero-ascii-scene" aria-hidden="true">
-                <pre class="home-hero-ascii-scene__stars">  ·          *        .          +          ·        .
-       .          ·        /\        .          *
-   *        .        /__\      ·        .          +
-        ·       .     /  \          *        .
- .          +        ^    ^       .          ·</pre>
-                <pre class="home-hero-ascii-scene__coast">        .        ·             *                 .
-   ^        .          ·              .        ^
-      /\          /\__/\       /\           .
-  ___/  \__/\___/      \_____/  \___
-        `-.      .  *  .  ·  .  *  .      .-'
- ~~~  ~^~   ~~~    ~^~    ~~~   ~^~    ~~~
-      __..---.        ___
- ___.'  _   _ `-.__.-'   `-.__      ~^~
-(    _/ `._/ `._   _.-.       )
- `--'     /\     `-`   `.__.-'        .
-       __/  \__        .        +
-  .   /__    __\     .      .        ·
-         `--'      ~~~    ~^~    ~~~</pre>
-                <pre class="home-hero-ascii-scene__pixels">+   .       ·       .   *       ·       .
-   .   +       .       ·       *       .
-·       .   *       .       +       .</pre>
-            </div>
-
-            <div class="hero-grid home-arcade-hero__grid">
-                <div class="hero-main home-arcade-hero__intro">
-                    <p class="hero-eyebrow pixel-font"><?php echo esc_html( 'music // practical ai // weird useful tools' ); ?></p>
-                    <h1 id="home-hero-title" class="hero-core-headline home-arcade-title"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>
-                    <p class="home-arcade-subtitle"><?php echo esc_html( 'Musician, creative technologist, and technical systems operator.' ); ?></p>
-                    <p class="hero-copy home-arcade-copy"><?php echo esc_html( 'I build practical AI workflows, outage and ops dashboards, music tools, and Vancouver-flavoured web experiments: playable, readable, and useful after the glow wears off.' ); ?></p>
-                    <div class="home-cta-row hero-cta-group home-arcade-start-row">
-                        <a href="#mission-select" class="pixel-button hero-primary-cta home-arcade-start" data-arcade-start><?php echo esc_html( 'Enter the lab' ); ?></a>
-                        <a href="<?php echo esc_url( home_url( '/lousy-outages/' ) ); ?>" class="pixel-button pixel-button--secondary"><?php echo esc_html( 'Check Lousy Outages' ); ?></a>
-                    </div>
+ ~ ~ ~ ~ ~ ~ ~ ~ ~ BURRARD INLET ~ ~ ~ ~ ~ ~ ~ ~
+      .      .        .       .      .      .
+ .        _..---""""---.._          .       +
+      .-'       _.._      '-.        PORT  :::
+    .'       .-'    '-.       '.       .   :::
+   /       .'  .-""-.  '.       \        __| |__
+  ;       /   /  o  o\   \       ;  .   |_____|_|
+  |      |   |    __  |   |      |      .  .  .
+  ;       \   \ .____./  /       ;
+   \       '.  '-.__.-' .'       /      *
+    '.       '-._____.-'       .'
+      '-._                 _.-'
+           """---...---"""        .
+        .       /|  |\\       .       CYAN WAKE
+              _/ |  | \\_
+ ~ ~ ~ ~ ~ ~ /__/    \__\ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
+       *          .       .       *        .</pre>
+            <div class="home-orca-copy">
+                <p class="hero-eyebrow pixel-font"><?php echo esc_html( 'music // practical ai // weird useful tools' ); ?></p>
+                <h1 id="home-hero-title" class="hero-core-headline home-arcade-title"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>
+                <p class="hero-copy home-arcade-copy"><?php echo esc_html( 'I build practical AI workflows, music tools, outage dashboards, and strange Vancouver web experiments.' ); ?></p>
+                <div class="home-orca-actions home-cta-row hero-cta-group">
+                    <a href="#mission-select" class="pixel-button hero-primary-cta"><?php echo esc_html( 'Enter the lab' ); ?></a>
+                    <a href="<?php echo esc_url( home_url( '/lousy-outages/' ) ); ?>" class="pixel-button pixel-button--secondary"><?php echo esc_html( 'Check Lousy Outages' ); ?></a>
                 </div>
-
-                <aside class="hero-side home-arcade-hero__screen" aria-label="Pacific Static arcade monitor">
-                    <div class="hero-game-stage home-arcade-game" aria-label="Pacific Static mini arcade game. Press Enter the lab, then use WASD or arrow keys to move, Space to fire, and Escape to quit." data-arcade-stage>
-                        <p class="hero-game-stage__header pixel-font"><?php echo esc_html( 'PACIFIC STATIC' ); ?></p>
-                        <div class="hero-game-stage__screen" role="img" aria-label="A green CRT arcade screen with stars, a small player ship, and outage alert blips.">
-                            <p class="hero-game-stage__idle pixel-font"><?php echo wp_kses_post( 'OUTAGE BLIP SWEEP<br>WASD move // Space fire // Esc quit<br>No sleep till deploy' ); ?></p>
-                            <div class="home-static-sprites" aria-hidden="true">
-                                <span class="home-static-sprites__ship"></span>
-                                <span class="home-static-sprites__enemy home-static-sprites__enemy--one"></span>
-                                <span class="home-static-sprites__enemy home-static-sprites__enemy--two"></span>
-                                <span class="home-static-sprites__reticle"></span>
-                            </div>
-                        </div>
-                        <p class="hero-game-stage__mobile-note pixel-font"><?php echo esc_html( 'Tap Enter the lab on a keyboard screen to play.' ); ?></p>
-                    </div>
-                </aside>
             </div>
+        </div>
+    </section>
+
+    <section class="home-play-mode crt-block" aria-labelledby="home-play-mode-title">
+        <div class="home-play-mode__copy">
+            <p class="home-section-kicker pixel-font"><?php echo esc_html( 'PLAY MODE' ); ?></p>
+            <h2 id="home-play-mode-title" class="pixel-font"><?php echo esc_html( 'Pacific Static' ); ?></h2>
+            <p><?php echo esc_html( 'A compact outage-blip arcade sketch: move with WASD or arrow keys, fire with Space, quit with Escape.' ); ?></p>
+            <button type="button" class="pixel-button home-arcade-start" data-arcade-start><?php echo esc_html( 'Play Pacific Static' ); ?></button>
+        </div>
+        <div class="hero-game-stage home-arcade-game" aria-label="Pacific Static mini arcade game. Use WASD or arrow keys to move, Space to fire, and Escape to quit." data-arcade-stage>
+            <p class="hero-game-stage__header pixel-font"><?php echo esc_html( 'PACIFIC STATIC' ); ?></p>
+            <div class="hero-game-stage__screen" role="img" aria-label="A green CRT arcade screen with stars, a small player ship, and outage alert blips.">
+                <p class="hero-game-stage__idle pixel-font"><?php echo wp_kses_post( 'OUTAGE BLIP SWEEP<br>WASD move // Space fire // Esc quit<br>No sleep till deploy' ); ?></p>
+                <div class="home-static-sprites" aria-hidden="true">
+                    <span class="home-static-sprites__ship"></span>
+                    <span class="home-static-sprites__enemy home-static-sprites__enemy--one"></span>
+                    <span class="home-static-sprites__enemy home-static-sprites__enemy--two"></span>
+                    <span class="home-static-sprites__reticle"></span>
+                </div>
+            </div>
+            <p class="hero-game-stage__mobile-note pixel-font"><?php echo esc_html( 'Best on a keyboard screen.' ); ?></p>
         </div>
     </section>
 

--- a/style.css
+++ b/style.css
@@ -6038,3 +6038,194 @@ body {
     opacity: 0.28;
   }
 }
+
+/* Vancouver orca title-screen homepage hero. */
+html,
+body,
+.home-arcade-layout {
+  max-width: 100%;
+  overflow-x: clip;
+}
+
+.home-orca-hero {
+  width: 100%;
+  padding: clamp(0.65rem, 1.6vw, 1.35rem) clamp(0.75rem, 3vw, 2rem) clamp(1rem, 2.5vw, 2rem);
+  overflow: hidden;
+  scroll-margin-top: calc(var(--se-header-height, 72px) + 1rem);
+}
+
+.home-orca-stage {
+  position: relative;
+  display: grid;
+  min-height: clamp(560px, calc(100svh - var(--se-header-height, 72px) - 2rem), 760px);
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: clamp(1rem, 3vw, 2rem);
+  overflow: hidden;
+  isolation: isolate;
+  border: 1px solid rgba(87, 243, 255, 0.48);
+  border-radius: 18px;
+  background:
+    radial-gradient(circle at 50% 58%, rgba(87, 243, 255, 0.13), transparent 30%),
+    radial-gradient(circle at 18% 12%, rgba(57, 255, 20, 0.14), transparent 24%),
+    radial-gradient(circle at 86% 26%, rgba(255, 72, 206, 0.09), transparent 20%),
+    linear-gradient(180deg, #020a08 0%, #000403 56%, #010009 100%);
+  box-shadow: 0 22px 70px rgba(0, 0, 0, 0.62), inset 0 0 44px rgba(57, 255, 20, 0.08), 0 0 32px rgba(87, 243, 255, 0.14);
+}
+
+.home-orca-stage::before,
+.home-orca-stage::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.home-orca-stage::before {
+  background: repeating-linear-gradient(180deg, rgba(223, 255, 234, 0.055) 0 1px, transparent 1px 4px);
+  mix-blend-mode: screen;
+  opacity: 0.62;
+  animation: homeAsciiScan 8s linear infinite;
+}
+
+.home-orca-stage::after {
+  background: radial-gradient(ellipse at center, transparent 42%, rgba(0, 0, 0, 0.58) 100%);
+}
+
+.home-orca-ascii {
+  position: relative;
+  z-index: 1;
+  align-self: center;
+  justify-self: center;
+  max-width: 100%;
+  margin: 0;
+  color: #a9ffd5;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: clamp(0.55rem, 1.08vw, 0.92rem);
+  font-weight: 700;
+  line-height: 1.05;
+  letter-spacing: 0.018em;
+  text-align: left;
+  text-shadow: 0 0 8px rgba(57, 255, 20, 0.52), 0 0 22px rgba(87, 243, 255, 0.22);
+  white-space: pre;
+  filter: drop-shadow(0 0 18px rgba(87, 243, 255, 0.14));
+}
+
+.home-orca-copy {
+  position: absolute;
+  inset: auto clamp(1rem, 4vw, 3rem) clamp(1.25rem, 4vw, 3rem) clamp(1rem, 4vw, 3rem);
+  z-index: 3;
+  max-width: 52rem;
+  padding-top: clamp(5rem, 19vw, 11rem);
+  background: linear-gradient(180deg, transparent, rgba(0, 4, 3, 0.78) 30%, rgba(0, 4, 3, 0.94));
+}
+
+.home-orca-copy .hero-eyebrow {
+  color: #57f3ff;
+}
+
+.home-orca-copy .home-arcade-title {
+  margin: 0.25rem 0 0;
+  font-size: clamp(3rem, 9vw, 7rem);
+}
+
+.home-orca-copy .home-arcade-copy {
+  max-width: 47rem;
+  margin: 0.85rem 0 0;
+}
+
+.home-orca-actions {
+  justify-content: flex-start;
+  margin-top: 1.35rem;
+}
+
+.home-play-mode {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(280px, 1.1fr);
+  gap: clamp(1rem, 3vw, 2rem);
+  align-items: center;
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto clamp(1rem, 3vw, 2rem);
+  padding: clamp(1rem, 3vw, 1.5rem);
+  overflow: hidden;
+  border-color: rgba(255, 255, 102, 0.34);
+}
+
+.home-play-mode__copy p:not(.home-section-kicker) {
+  color: rgba(223, 255, 234, 0.86);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+  line-height: 1.65;
+}
+
+.home-play-mode .home-arcade-game {
+  max-width: none;
+  width: 100%;
+}
+
+.home-play-mode .hero-game-stage__screen {
+  min-height: clamp(180px, 22vw, 270px);
+}
+
+@media (max-width: 900px) {
+  .home-orca-stage {
+    min-height: clamp(520px, 78svh, 680px);
+  }
+
+  .home-orca-ascii {
+    font-size: clamp(0.42rem, 1.6vw, 0.7rem);
+  }
+
+  .home-play-mode {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .home-orca-hero {
+    padding-inline: 0.5rem;
+  }
+
+  .home-orca-stage {
+    min-height: 620px;
+    padding: 0.75rem;
+    border-radius: 14px;
+  }
+
+  .home-orca-ascii {
+    justify-self: start;
+    max-width: none;
+    font-size: clamp(0.34rem, 1.85vw, 0.48rem);
+    line-height: 1.08;
+    transform: translateX(-0.35rem);
+  }
+
+  .home-orca-copy {
+    inset-inline: 0.85rem;
+    bottom: 1rem;
+    padding-top: 6.5rem;
+  }
+
+  .home-orca-actions,
+  .home-play-mode .home-cta-row {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .home-orca-actions .pixel-button,
+  .home-play-mode .pixel-button {
+    width: 100%;
+  }
+
+  .home-play-mode {
+    width: min(100% - 1rem, 1180px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-orca-stage::before,
+  .home-orca-ascii,
+  .home-arcade-start {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
### Motivation
- Replace the small cabinet/dashboard-first hero with a cinematic, Vancouver-specific ASCII title screen that reads like a CRT terminal intro. 
- Make the killer whale the primary visual identity above the fold while keeping key content (SUZY EASTON, CTAs) immediately visible.
- Reduce empty hero space, prevent clipping under the sticky header, and avoid horizontal scrolling on desktop/mobile.

### Description
- Replaced the old hero markup in `page-home.php` with a semantic orca hero component using `home-orca-hero`, `home-orca-stage`, `home-orca-ascii`, `home-orca-copy`, and `home-orca-actions`, and kept the ASCII art inside a `<pre aria-hidden="true">` while adding a visible screen-reader description. 
- Moved the `Pacific Static` mini-game out of the primary hero into a secondary `home-play-mode` section (compact panel with a `data-arcade-start` trigger) so it no longer competes with the title screen while remaining playable. 
- Preserved `get_template_part( 'parts/lousy-outages-teaser' );` directly below the hero as required. 
- Added responsive CRT/terminal CSS to `style.css` for full-width black stage, max-width ~1180px, scanlines/glow, overflow hidden (no horizontal scroll), large responsive ASCII sizing, mobile compact layout, and `prefers-reduced-motion` support.

### Testing
- Ran `php -l page-home.php` and it returned no syntax errors. (passed)
- Ran `git diff --check` to validate whitespace and basic stylesheet output (passed).
- Ran `npm test` (project test suite); the run completed but multiple unrelated Gastown/Lousy Outages tests failed (49 passed, 18 failed), indicating existing test-suite failures that are unrelated to the homepage markup/CSS changes. (tests failed, failures appear pre-existing and not caused by this hero change)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3dc4a64efc8331bcc1ebf4ee7e4328)