### PR TITLE
Replace homepage ASCII hero with SVG two-orca sigil

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -7,32 +7,54 @@ get_header();
 
     <section class="home-orca-hero hero hero-section crt-block" aria-labelledby="home-hero-title">
         <div class="home-orca-stage">
-            <span class="screen-reader-text"><?php echo esc_html( 'ASCII art scene of a killer whale surfacing in Burrard Inlet with Vancouver mountains and city lights.' ); ?></span>
-            <pre class="home-orca-ascii" aria-hidden="true">        .        *        .              .        *
-   .        .        NORTH SHORE STATIC        .
-         /\       /\        /\__/\        /\
-    ____/  \_____/  \______/      \______/  \___
-       _|_      _|_       _|_  LIONS GATE  _|_
-      |:::| .  |:::|  .  |:::|____====____|:::|  .
-  .   |___|    |___|     |___|    ||    . |___|
-
- ~ ~ ~ ~ ~ ~ ~ ~ ~ BURRARD INLET ~ ~ ~ ~ ~ ~ ~ ~
-      .      .        .       .      .      .
- .        _..---""""---.._          .       +
-      .-'       _.._      '-.        PORT  :::
-    .'       .-'    '-.       '.       .   :::
-   /       .'  .-""-.  '.       \        __| |__
-  ;       /   /  o  o\   \       ;  .   |_____|_|
-  |      |   |    __  |   |      |      .  .  .
-  ;       \   \ .____./  /       ;
-   \       '.  '-.__.-' .'       /      *
-    '.       '-._____.-'       .'
-      '-._                 _.-'
-           """---...---"""        .
-        .       /|  |\\       .       CYAN WAKE
-              _/ |  | \\_
- ~ ~ ~ ~ ~ ~ /__/    \__\ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
-       *          .       .       *        .</pre>
+            <span class="screen-reader-text"><?php echo esc_html( 'Two orcas circling in a CRT-style Burrard Inlet title mark.' ); ?></span>
+            <div class="home-orca-mark" role="img" aria-label="<?php echo esc_attr( 'Two orcas circling in a CRT-style Burrard Inlet title mark.' ); ?>">
+                <svg class="home-orca-sigil" viewBox="0 0 520 520" aria-hidden="true" focusable="false">
+                    <defs>
+                        <filter id="home-orca-crt-glow" x="-35%" y="-35%" width="170%" height="170%">
+                            <feGaussianBlur stdDeviation="4" result="blur" />
+                            <feColorMatrix in="blur" type="matrix" values="0 0 0 0 0.2  0 0 0 0 1  0 0 0 0 0.82  0 0 0 .7 0" result="cyanGlow" />
+                            <feMerge>
+                                <feMergeNode in="cyanGlow" />
+                                <feMergeNode in="SourceGraphic" />
+                            </feMerge>
+                        </filter>
+                        <linearGradient id="home-orca-water" x1="0" x2="1" y1="0" y2="0">
+                            <stop offset="0" stop-color="#39ff14" stop-opacity="0" />
+                            <stop offset=".5" stop-color="#57f3ff" stop-opacity=".85" />
+                            <stop offset="1" stop-color="#39ff14" stop-opacity="0" />
+                        </linearGradient>
+                    </defs>
+                    <g class="home-orca-rings" fill="none">
+                        <circle cx="260" cy="260" r="196" />
+                        <circle cx="260" cy="260" r="150" />
+                    </g>
+                    <path class="home-orca-mountain" d="M72 160 132 96l38 42 34-58 56 78 44-46 46 54 42-34 56 54" />
+                    <g class="home-orca-pair" filter="url(#home-orca-crt-glow)">
+                        <g class="home-orca home-orca--upper">
+                            <path class="home-orca-body" d="M384 126c-89-31-188 5-239 86-18 29-25 59-18 82 59-58 126-76 206-54 28 8 56 5 75-9 21-15 27-39 16-62-7-16-20-31-40-43Z" />
+                            <path class="home-orca-tail" d="M424 169c29-8 54-25 72-52-34 4-59 13-76 28 10-23 12-47 3-72-21 21-33 48-39 80Z" />
+                            <path class="home-orca-belly" d="M173 243c48-30 106-37 171-20 27 7 50 3 66-12-8 29-42 48-84 42-58-9-107 4-153 47-10-16-10-35 0-57Z" />
+                            <path class="home-orca-saddle" d="M298 143c38 0 72 13 99 35-34-9-65-8-93 3-19 8-36-3-40-19 8-9 19-15 34-19Z" />
+                            <ellipse class="home-orca-eye" cx="366" cy="166" rx="12" ry="7" transform="rotate(22 366 166)" />
+                            <path class="home-orca-fin" d="M239 209c-11-48 0-86 34-114 10 47 2 85-34 114Z" />
+                        </g>
+                        <g class="home-orca home-orca--lower">
+                            <path class="home-orca-body" d="M136 394c89 31 188-5 239-86 18-29 25-59 18-82-59 58-126 76-206 54-28-8-56-5-75 9-21 15-27 39-16 62 7 16 20 31 40 43Z" />
+                            <path class="home-orca-tail" d="M96 351c-29 8-54 25-72 52 34-4 59-13 76-28-10 23-12 47-3 72 21-21 33-48 39-80Z" />
+                            <path class="home-orca-belly" d="M347 277c-48 30-106 37-171 20-27-7-50-3-66 12 8-29 42-48 84-42 58 9 107-4 153-47 10 16 10 35 0 57Z" />
+                            <path class="home-orca-saddle" d="M222 377c-38 0-72-13-99-35 34 9 65 8 93-3 19-8 36 3 40 19-8 9-19 15-34 19Z" />
+                            <ellipse class="home-orca-eye" cx="154" cy="354" rx="12" ry="7" transform="rotate(22 154 354)" />
+                            <path class="home-orca-fin" d="M281 311c11 48 0 86-34 114-10-47-2-85 34-114Z" />
+                        </g>
+                    </g>
+                    <g class="home-orca-waterlines">
+                        <path d="M74 404c46-12 78 12 124 0s78-12 124 0 78 12 124 0" />
+                        <path d="M102 430c34-8 58 8 92 0s58-8 92 0 58 8 92 0" />
+                    </g>
+                    <text class="home-orca-location" x="260" y="474" text-anchor="middle">BURRARD INLET</text>
+                </svg>
+            </div>
             <div class="home-orca-copy">
                 <p class="hero-eyebrow pixel-font"><?php echo esc_html( 'music // practical ai // weird useful tools' ); ?></p>
                 <h1 id="home-hero-title" class="hero-core-headline home-arcade-title"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>

--- a/style.css
+++ b/style.css
@@ -6093,23 +6093,104 @@ body,
   background: radial-gradient(ellipse at center, transparent 42%, rgba(0, 0, 0, 0.58) 100%);
 }
 
-.home-orca-ascii {
+.home-orca-mark {
   position: relative;
   z-index: 1;
   align-self: center;
   justify-self: center;
-  max-width: 100%;
-  margin: 0;
-  color: #a9ffd5;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
-  font-size: clamp(0.55rem, 1.08vw, 0.92rem);
-  font-weight: 700;
-  line-height: 1.05;
-  letter-spacing: 0.018em;
-  text-align: left;
-  text-shadow: 0 0 8px rgba(57, 255, 20, 0.52), 0 0 22px rgba(87, 243, 255, 0.22);
-  white-space: pre;
-  filter: drop-shadow(0 0 18px rgba(87, 243, 255, 0.14));
+  width: min(100%, clamp(300px, 58vw, 680px));
+  aspect-ratio: 1;
+  display: grid;
+  place-items: center;
+  color: #dfffea;
+  filter: drop-shadow(0 0 18px rgba(87, 243, 255, 0.28));
+}
+
+.home-orca-mark::before {
+  content: "";
+  position: absolute;
+  inset: 8%;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle, rgba(87, 243, 255, 0.16), transparent 58%),
+    conic-gradient(from 20deg, rgba(57, 255, 20, 0), rgba(57, 255, 20, 0.22), rgba(87, 243, 255, 0.28), rgba(57, 255, 20, 0));
+  opacity: 0.78;
+  animation: homeOrcaPulse 5s ease-in-out infinite;
+}
+
+.home-orca-sigil {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+.home-orca-rings circle {
+  stroke: rgba(87, 243, 255, 0.52);
+  stroke-width: 2;
+  stroke-dasharray: 10 16;
+  filter: drop-shadow(0 0 8px rgba(57, 255, 20, 0.42));
+}
+
+.home-orca-rings circle + circle {
+  stroke: rgba(57, 255, 20, 0.36);
+  stroke-dasharray: 3 13;
+}
+
+.home-orca-mountain {
+  fill: none;
+  stroke: rgba(169, 255, 213, 0.42);
+  stroke-width: 5;
+  stroke-linecap: square;
+  stroke-linejoin: miter;
+}
+
+.home-orca-body,
+.home-orca-tail,
+.home-orca-fin {
+  fill: #020202;
+  stroke: #dfffea;
+  stroke-width: 5;
+  stroke-linejoin: round;
+}
+
+.home-orca-belly,
+.home-orca-saddle,
+.home-orca-eye {
+  fill: #f5fff8;
+}
+
+.home-orca-belly,
+.home-orca-saddle {
+  stroke: #06110d;
+  stroke-width: 3;
+  stroke-linejoin: round;
+}
+
+.home-orca-fin {
+  fill: #050505;
+}
+
+.home-orca-pair {
+  transform-origin: 260px 260px;
+  animation: homeOrcaDrift 9s ease-in-out infinite;
+}
+
+.home-orca-waterlines path {
+  fill: none;
+  stroke: url(#home-orca-water);
+  stroke-width: 4;
+  stroke-linecap: square;
+  filter: drop-shadow(0 0 8px rgba(87, 243, 255, 0.6));
+}
+
+.home-orca-location {
+  fill: rgba(255, 255, 102, 0.72);
+  font-family: "Press Start 2P", monospace;
+  font-size: 14px;
+  letter-spacing: 0.16em;
+  text-shadow: 0 0 8px rgba(255, 255, 102, 0.38);
 }
 
 .home-orca-copy {
@@ -6167,13 +6248,23 @@ body,
   min-height: clamp(180px, 22vw, 270px);
 }
 
+@keyframes homeOrcaDrift {
+  0%, 100% { transform: rotate(-2deg) scale(1); }
+  50% { transform: rotate(2deg) scale(1.015); }
+}
+
+@keyframes homeOrcaPulse {
+  0%, 100% { opacity: 0.58; transform: scale(0.98); }
+  50% { opacity: 0.86; transform: scale(1.02); }
+}
+
 @media (max-width: 900px) {
   .home-orca-stage {
     min-height: clamp(520px, 78svh, 680px);
   }
 
-  .home-orca-ascii {
-    font-size: clamp(0.42rem, 1.6vw, 0.7rem);
+  .home-orca-mark {
+    width: min(100%, clamp(280px, 72vw, 520px));
   }
 
   .home-play-mode {
@@ -6192,12 +6283,15 @@ body,
     border-radius: 14px;
   }
 
-  .home-orca-ascii {
-    justify-self: start;
-    max-width: none;
-    font-size: clamp(0.34rem, 1.85vw, 0.48rem);
-    line-height: 1.08;
-    transform: translateX(-0.35rem);
+  .home-orca-mark {
+    align-self: start;
+    width: min(100%, 360px);
+    margin-top: 0.25rem;
+  }
+
+  .home-orca-location {
+    font-size: 12px;
+    letter-spacing: 0.1em;
   }
 
   .home-orca-copy {
@@ -6224,7 +6318,8 @@ body,
 
 @media (prefers-reduced-motion: reduce) {
   .home-orca-stage::before,
-  .home-orca-ascii,
+  .home-orca-mark::before,
+  .home-orca-pair,
   .home-arcade-start {
     animation: none !important;
   }


### PR DESCRIPTION
### Motivation
- The existing homepage hero used a freehand ASCII scene that read like a generic terminal dashboard rather than an iconic Vancouver title screen. 
- Deliver a clear, recognizable two-orca yin-yang mark with a CRT/pixel glow and subtle Burrard Inlet cue while keeping the page order and existing outage logic untouched. 

### Description
- Replaced the ASCII block in the homepage template with an inline accessible SVG mark and a short `screen-reader-text` description; the SVG includes an orca pair, waterlines, rings, and a CRT-style glow filter. (file: `page-home.php`) 
- Added scoped CSS rules for the new hero under `.home-orca-*` (including `home-orca-mark`, `home-orca-stage`, `home-orca-pair`, `home-orca-rings`, and `home-orca-location`) to provide CRT/cyan glow, responsive sizing, and a subtle waterline, while preventing horizontal overflow. (file: `style.css`) 
- Respect `prefers-reduced-motion` by disabling decorative animations (`home-orca-mark::before` and `.home-orca-pair`) when reduced motion is requested. 
- Kept hero copy, `Enter the lab` / `Check Lousy Outages` buttons, and the existing homepage order (Hero → Play Mode / Pacific Static → Lousy Outages → Select System → Music/tools/contact → Footer) unchanged, and avoided touching outage data logic and unrelated pages. 

### Testing
- Ran `php -l page-home.php` and it reported no syntax errors. 
- Ran the repository test suite with `npm test`; the suite executed but failed on pre-existing Gastown / generator / open-data related tests that are unrelated to the homepage hero change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3dc83a43c48331811f4330662ed1e1)