### PR TITLE
Fix Pacific Static start + surface Lousy Outages under the hero

### DIFF
--- a/assets/css/lousy-outages-teaser.css
+++ b/assets/css/lousy-outages-teaser.css
@@ -210,3 +210,116 @@
     text-align: left;
   }
 }
+
+/* Homepage live-alert emphasis: make active signals read as the page nervous system. */
+#lousy-outages-teaser.lo-home-teaser--active {
+  gap: clamp(1rem, 2vw, 1.35rem);
+  border-color: rgba(255, 207, 102, 0.72);
+  background:
+    radial-gradient(circle at 12% 0%, rgba(255, 72, 206, 0.22), transparent 22rem),
+    radial-gradient(circle at 86% 12%, rgba(255, 207, 102, 0.16), transparent 20rem),
+    linear-gradient(180deg, rgba(17, 0, 19, 0.96), rgba(0, 14, 10, 0.94));
+  box-shadow:
+    0 0 0 1px rgba(255, 72, 206, 0.2),
+    0 0 42px rgba(255, 72, 206, 0.22),
+    0 22px 70px rgba(0, 0, 0, 0.42),
+    inset 0 0 34px rgba(255, 207, 102, 0.08);
+}
+
+#lousy-outages-teaser.lo-home-teaser--active .lo-home-heading {
+  color: #fff7df;
+  text-shadow: 0 0 12px rgba(255, 207, 102, 0.34);
+}
+
+#lousy-outages-teaser.lo-home-teaser--active .lo-home-status-light {
+  width: 1.15rem;
+  height: 1.15rem;
+  border: 2px solid rgba(255, 247, 223, 0.8);
+  background: #ff3fa7;
+  box-shadow: 0 0 0 0 rgba(255, 63, 167, 0.7), 0 0 24px rgba(255, 63, 167, 0.95), 0 0 42px rgba(255, 207, 102, 0.5);
+  animation: loHomeAlertPulse 1.2s ease-out infinite;
+}
+
+#lousy-outages-teaser .lo-home-live-band {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: clamp(0.75rem, 2vw, 1rem);
+  align-items: center;
+  margin-bottom: 0.9rem;
+  padding: clamp(0.85rem, 2vw, 1.1rem);
+  border: 1px solid rgba(255, 207, 102, 0.72);
+  border-radius: 16px;
+  background:
+    linear-gradient(90deg, rgba(255, 72, 206, 0.24), rgba(255, 207, 102, 0.13)),
+    rgba(10, 0, 18, 0.82);
+  box-shadow: inset 0 0 22px rgba(255, 207, 102, 0.08), 0 0 24px rgba(255, 72, 206, 0.16);
+}
+
+#lousy-outages-teaser .lo-home-live-band__dot {
+  width: clamp(1.35rem, 3vw, 1.8rem);
+  height: clamp(1.35rem, 3vw, 1.8rem);
+  border-radius: 999px;
+  background: radial-gradient(circle, #fff7df 0 18%, #ffcf66 20% 42%, #ff3fa7 44% 100%);
+  box-shadow: 0 0 20px rgba(255, 63, 167, 0.88), 0 0 42px rgba(255, 207, 102, 0.46);
+  animation: loHomeAlertPulse 1s ease-out infinite;
+}
+
+#lousy-outages-teaser .lo-home-live-band__label,
+#lousy-outages-teaser .lo-home-live-band__count,
+#lousy-outages-teaser .lo-home-live-band__providers {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+#lousy-outages-teaser .lo-home-live-band__label,
+#lousy-outages-teaser .lo-home-live-band__providers {
+  font-family: 'Press Start 2P', monospace;
+}
+
+#lousy-outages-teaser .lo-home-live-band__label {
+  color: #ffcf66;
+  font-size: clamp(0.62rem, 1.2vw, 0.78rem);
+  letter-spacing: 0.08em;
+  text-shadow: 0 0 10px rgba(255, 207, 102, 0.48);
+}
+
+#lousy-outages-teaser .lo-home-live-band__count {
+  margin-top: 0.35rem;
+  color: #fff7df;
+  font-size: clamp(1.05rem, 2.8vw, 1.55rem);
+  font-weight: 900;
+  line-height: 1.1;
+}
+
+#lousy-outages-teaser .lo-home-live-band__providers {
+  margin-top: 0.45rem;
+  color: #7ef6d1;
+  font-size: clamp(0.58rem, 1.1vw, 0.7rem);
+  line-height: 1.5;
+}
+
+#lousy-outages-teaser.lo-home-teaser--active .lo-home-alert {
+  border: 1px solid rgba(255, 207, 102, 0.34);
+  border-left: 7px solid #ffcf66;
+  background:
+    linear-gradient(90deg, rgba(255, 72, 206, 0.16), rgba(255, 255, 255, 0.06)),
+    rgba(6, 11, 17, 0.9);
+  box-shadow: 0 0 18px rgba(255, 72, 206, 0.12), inset 0 0 18px rgba(255, 207, 102, 0.04);
+}
+
+#lousy-outages-teaser.lo-home-teaser--active .lo-home-alert--outage { border-left-color: #ff3fa7; }
+#lousy-outages-teaser.lo-home-teaser--active .lo-home-alert--signal { border-left-color: #ffcf66; }
+#lousy-outages-teaser.lo-home-teaser--active .lo-home-alert--unknown { border-left-color: #57f3ff; }
+
+@keyframes loHomeAlertPulse {
+  0% { transform: scale(0.94); box-shadow: 0 0 0 0 rgba(255, 63, 167, 0.58), 0 0 24px rgba(255, 63, 167, 0.75); }
+  70% { transform: scale(1); box-shadow: 0 0 0 10px rgba(255, 63, 167, 0), 0 0 34px rgba(255, 207, 102, 0.52); }
+  100% { transform: scale(0.94); box-shadow: 0 0 0 0 rgba(255, 63, 167, 0), 0 0 24px rgba(255, 63, 167, 0.75); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #lousy-outages-teaser.lo-home-teaser--active .lo-home-status-light,
+  #lousy-outages-teaser .lo-home-live-band__dot {
+    animation: none !important;
+  }
+}

--- a/js/hero-galaga.js
+++ b/js/hero-galaga.js
@@ -1,9 +1,8 @@
 (function () {
   function initHeroGalaga() {
-    const heroGrid = document.querySelector('.hero-grid');
     const gameStage = document.querySelector('.hero-game-stage');
     const gameScreen = document.querySelector('.hero-game-stage__screen');
-    const desktopQuery = window.matchMedia('(min-width: 860px)');
+    const desktopQuery = window.matchMedia('(min-width: 700px)');
     const reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
     const DEBUG_GALAGA = false;
     const debugEnabled = DEBUG_GALAGA || Boolean(window.__SE_GALAGA_DEBUG);
@@ -20,7 +19,7 @@
       }
     }
 
-    if (!heroGrid || !gameStage || !gameScreen || !desktopQuery.matches) {
+    if (!gameStage || !gameScreen) {
       return;
     }
 
@@ -137,6 +136,7 @@
       waveCallUntil: 0,
       nextWaveAt: 0,
       gameOverReason: '',
+      idleMessage: '',
       playfield: {
         x: 0,
         y: 0,
@@ -282,7 +282,7 @@
       idlePanelEl.hidden = !isIdle;
       gameOverPanelEl.hidden = !isGameOver;
 
-      hintTextEl.innerHTML = 'OUTAGE BLIPS<br>Provider alerts as arcade static.<br>Click to play, or ignore it.<br>WASD move // Space fire // Esc quit';
+      hintTextEl.innerHTML = state.idleMessage || 'OUTAGE BLIPS<br>Provider alerts as arcade static.<br>Click to play, or ignore it.<br>WASD move // Space fire // Esc quit';
       if (startButton) {
         startButton.hidden = !isIdle;
       }
@@ -290,9 +290,7 @@
     }
 
     function showMessage(message) {
-      if (hintTextEl) {
-        hintTextEl.innerHTML = message;
-      }
+      state.idleMessage = message;
       setGameMode('idle');
     }
 
@@ -453,6 +451,9 @@
       state.keys.right = false;
       state.keys.fire = false;
       state.idleTick = 0;
+      if (desktopQuery.matches) {
+        state.idleMessage = '';
+      }
       clearTransientFx();
 
       window.__SE_GALAGA_ACTIVE = false;
@@ -472,7 +473,12 @@
     }
 
     function restartGame() {
-      if (!desktopQuery.matches || isPlaying()) {
+      if (isPlaying()) {
+        return;
+      }
+
+      if (!desktopQuery.matches) {
+        showMessage('Pacific Static needs a wider keyboard screen. Try a screen at least 700px wide.');
         return;
       }
 
@@ -480,7 +486,7 @@
       const hasUsablePlayfield = refreshPlayfield();
       if (!hasUsablePlayfield) {
         debugWarn('Game start blocked due to invalid game dimensions.');
-        enterIdleMode();
+        showMessage('Pacific Static needs a wider keyboard screen.');
         return;
       }
       canvas.tabIndex = 0;
@@ -1115,9 +1121,7 @@
 
     externalStartButtons.forEach(function (button) {
       button.addEventListener('click', function () {
-        if (desktopQuery.matches && !reducedMotionQuery.matches) {
-          restartGame();
-        }
+        restartGame();
       });
     });
 

--- a/page-home.php
+++ b/page-home.php
@@ -67,6 +67,8 @@ get_header();
         </div>
     </section>
 
+    <?php get_template_part( 'parts/lousy-outages-teaser' ); ?>
+
     <section class="home-play-mode crt-block" aria-labelledby="home-play-mode-title">
         <div class="home-play-mode__copy">
             <p class="home-section-kicker pixel-font"><?php echo esc_html( 'PLAY MODE' ); ?></p>
@@ -88,8 +90,6 @@ get_header();
             <p class="hero-game-stage__mobile-note pixel-font"><?php echo esc_html( 'Best on a keyboard screen.' ); ?></p>
         </div>
     </section>
-
-    <?php get_template_part( 'parts/lousy-outages-teaser' ); ?>
 
     <section id="mission-select" class="home-project-grid home-mission-select crt-block" aria-labelledby="selected-projects-title">
         <p class="home-section-kicker pixel-font"><?php echo esc_html( 'SELECT SYSTEM' ); ?></p>

--- a/parts/lousy-outages-teaser.php
+++ b/parts/lousy-outages-teaser.php
@@ -15,8 +15,20 @@ $teaser_data  = function_exists( 'get_lousy_outages_home_teaser_data' )
 $teaser_href = $teaser_data['href'] ?? home_url( '/lousy-outages/' );
 $rows = isset( $teaser_data['rows'] ) && is_array( $teaser_data['rows'] ) ? array_slice( $teaser_data['rows'], 0, 4 ) : [];
 $last_checked = $teaser_data['last_checked'] ?? '';
+$active_count = count( $rows );
+$provider_names = [];
+foreach ( $rows as $row ) {
+    $provider = trim( (string) ( $row['provider'] ?? '' ) );
+    if ( '' !== $provider && ! in_array( $provider, $provider_names, true ) ) {
+        $provider_names[] = $provider;
+    }
+}
+$provider_summary = implode( ' + ', array_slice( $provider_names, 0, 3 ) );
+if ( count( $provider_names ) > 3 ) {
+    $provider_summary .= ' +' . ( count( $provider_names ) - 3 ) . ' more';
+}
 ?>
-<section id="lousy-outages-teaser" class="lo-home-teaser" aria-labelledby="lo-home-heading">
+<section id="lousy-outages-teaser" class="lo-home-teaser<?php echo esc_attr( empty( $rows ) ? ' lo-home-teaser--clear' : ' lo-home-teaser--active' ); ?>" aria-labelledby="lo-home-heading">
     <div class="lo-home-teaser__titlebar">
         <p class="lo-home-kicker">lousy outages</p>
         <h2 id="lo-home-heading" class="lo-home-heading">status board for modern chaos</h2>
@@ -32,6 +44,16 @@ $last_checked = $teaser_data['last_checked'] ?? '';
                 <p><?php echo esc_html( $last_checked ? 'last checked: ' . $last_checked : 'last checked: recently' ); ?></p>
             </div>
         <?php else : ?>
+            <div class="lo-home-live-band" role="status" aria-live="polite">
+                <span class="lo-home-live-band__dot" aria-hidden="true"></span>
+                <div>
+                    <p class="lo-home-live-band__label">LIVE OUTAGE SIGNAL</p>
+                    <p class="lo-home-live-band__count"><?php echo esc_html( $active_count . ' active provider ' . ( 1 === $active_count ? 'signal' : 'signals' ) ); ?></p>
+                    <?php if ( $provider_summary ) : ?>
+                        <p class="lo-home-live-band__providers"><?php echo esc_html( $provider_summary ); ?></p>
+                    <?php endif; ?>
+                </div>
+            </div>
             <ul class="lo-home-alert-list">
                 <?php foreach ( $rows as $row ) : ?>
                     <li class="lo-home-alert lo-home-alert--<?php echo esc_attr( $row['tone'] ?? 'unknown' ); ?>">

--- a/style.css
+++ b/style.css
@@ -6324,3 +6324,37 @@ body,
     animation: none !important;
   }
 }
+
+/* Surgical homepage energy polish: strengthen the existing orca sigil without changing the hero. */
+.home-orca-mark {
+  filter: drop-shadow(0 0 24px rgba(87, 243, 255, 0.42)) drop-shadow(0 0 46px rgba(57, 255, 20, 0.18));
+}
+
+.home-orca-mark::before {
+  opacity: 0.92;
+  filter: blur(0.2px) saturate(1.18);
+}
+
+.home-orca-rings circle {
+  stroke-width: 2.5;
+  filter: drop-shadow(0 0 12px rgba(57, 255, 20, 0.55)) drop-shadow(0 0 20px rgba(87, 243, 255, 0.22));
+}
+
+.home-orca-pair {
+  filter: drop-shadow(0 0 14px rgba(87, 243, 255, 0.22));
+}
+
+.home-orca-waterlines path {
+  animation: homeOrcaWaterSignal 4.8s ease-in-out infinite;
+}
+
+@keyframes homeOrcaWaterSignal {
+  0%, 100% { opacity: 0.72; stroke-dashoffset: 0; }
+  50% { opacity: 1; stroke-dashoffset: -18; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-orca-waterlines path {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
### Motivation
- The homepage Play Mode button stopped working because the game JS required a removed `.hero-grid` element and the game start felt dead on small screens. 
- Lousy Outages needs to be visually more prominent and feel like the live nervous system of the page. 
- The hero should keep the existing orca art but gain a little motion/presence without breaking reduced-motion preferences.

### Description
- Update `js/hero-galaga.js` to initialize from the current `.hero-game-stage` / `.hero-game-stage__screen`, remove the `.hero-grid` dependency, lower the desktop breakpoint to `700px`, and surface an inline idle message when the viewport is too small so the external `[data-arcade-start]` button never appears dead; the external start button now always invokes the game start path. 
- Move the Lousy Outages teaser so `parts/lousy-outages-teaser` is rendered immediately after the hero and before Play Mode in `page-home.php`. 
- Enhance `parts/lousy-outages-teaser.php` to compute a live summary (active count and provider names) from real row data and render a `LIVE OUTAGE SIGNAL` band when rows are present. 
- Add stronger, motion-safe alert styling to `assets/css/lousy-outages-teaser.css` for active states (larger pulsing dot, magenta/yellow accents, more urgent alert rows). 
- Apply a small, prefers-reduced-motion–respecting visual polish to the orca sigil in `style.css` to give the hero a bit more glow/presence without changing content.

### Testing
- Ran `php -l page-home.php` and it returned no syntax errors. (pass)
- Ran `php -l parts/lousy-outages-teaser.php` and it returned no syntax errors. (pass)
- Ran `node --check js/hero-galaga.js` and the file passed a syntax check. (pass)
- Ran `npm test`; the test run exposed multiple unrelated failing tests in the Gastown/world generator and Lousy Outages sync areas that pre-existed these homepage changes, so the repo test suite did not fully pass but failures are unrelated to the homepage fixes. (fail; unrelated failures)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3dcb201de88331944a22d372fcaee2)