### PR TITLE
Polish homepage orca hero

### DIFF
--- a/header.php
+++ b/header.php
@@ -159,7 +159,17 @@
   if ( function_exists( 'wp_body_open' ) ) {
     wp_body_open();
   }
+
+  if ( is_front_page() ) :
 ?>
+<script>
+  document.body.childNodes.forEach(function (node) {
+    if (node.nodeType === Node.TEXT_NODE && node.textContent.trim() === '\\n\\n') {
+      node.remove();
+    }
+  });
+</script>
+<?php endif; ?>
 
 <header class="main-header">
   <!-- Header wordmark (compact bar) -->

--- a/style.css
+++ b/style.css
@@ -6049,7 +6049,7 @@ body,
 
 .home-orca-hero {
   width: 100%;
-  padding: clamp(0.65rem, 1.6vw, 1.35rem) clamp(0.75rem, 3vw, 2rem) clamp(1rem, 2.5vw, 2rem);
+  padding: clamp(0.25rem, 0.8vw, 0.75rem) clamp(0.75rem, 3vw, 2rem) clamp(0.85rem, 2vw, 1.5rem);
   overflow: hidden;
   scroll-margin-top: calc(var(--se-header-height, 72px) + 1rem);
 }
@@ -6057,7 +6057,7 @@ body,
 .home-orca-stage {
   position: relative;
   display: grid;
-  min-height: clamp(560px, calc(100svh - var(--se-header-height, 72px) - 2rem), 760px);
+  min-height: clamp(540px, calc(100svh - var(--se-header-height, 72px) - 3.25rem), 720px);
   max-width: 1180px;
   margin: 0 auto;
   padding: clamp(1rem, 3vw, 2rem);
@@ -6389,17 +6389,17 @@ body,
 .home-orca-starname {
   position: absolute;
   left: 50%;
-  top: clamp(1.5rem, 6vw, 4.4rem);
+  top: clamp(1.25rem, 5.2vw, 3.8rem);
   transform: translateX(-50%);
-  color: rgba(255, 255, 102, 0.32);
+  color: rgba(255, 255, 102, 0.42);
   font-family: "Press Start 2P", monospace;
   font-size: clamp(0.46rem, 1.12vw, 0.78rem);
-  letter-spacing: clamp(0.42em, 1.4vw, 0.9em);
+  letter-spacing: clamp(0.52em, 1.55vw, 1em);
   text-shadow:
-    0 0 7px rgba(255, 255, 102, 0.44),
+    0 0 10px rgba(255, 255, 102, 0.56),
     0.5rem 0.35rem 0 rgba(87, 243, 255, 0.18),
     -0.45rem 0.85rem 0 rgba(223, 255, 234, 0.14);
-  opacity: 0.66;
+  opacity: 0.74;
 }
 
 .home-orca-starname::before,
@@ -6424,8 +6424,8 @@ body,
   top: clamp(5.2rem, 13vw, 9.5rem);
   width: min(108%, 1260px);
   transform: translateX(-50%);
-  opacity: 0.62;
-  filter: drop-shadow(0 0 18px rgba(87, 243, 255, 0.13));
+  opacity: 0.7;
+  filter: drop-shadow(0 0 18px rgba(87, 243, 255, 0.18));
 }
 
 .home-orca-north-shore path {
@@ -6435,38 +6435,39 @@ body,
 }
 
 .home-orca-north-shore__back {
-  stroke: rgba(87, 243, 255, 0.18);
+  stroke: rgba(87, 243, 255, 0.24);
   stroke-width: 3;
 }
 
 .home-orca-north-shore__front {
-  stroke: rgba(203, 255, 231, 0.26);
+  stroke: rgba(203, 255, 231, 0.34);
   stroke-width: 4;
 }
 
 .home-orca-mark {
   align-self: start;
-  width: min(92%, clamp(290px, 48vw, 590px));
-  margin-top: clamp(4.8rem, 11vw, 7.8rem);
+  width: min(88%, clamp(280px, 44vw, 540px));
+  margin-top: clamp(4.15rem, 9.2vw, 6.6rem);
+  transform: translateX(clamp(0.4rem, 3vw, 2.4rem));
 }
 
 .home-orca-copy {
   left: clamp(1rem, 4vw, 3rem);
   right: auto;
-  max-width: min(42rem, calc(100% - clamp(2rem, 8vw, 6rem)));
-  padding: clamp(1rem, 2vw, 1.35rem);
+  max-width: min(36rem, calc(100% - clamp(2rem, 8vw, 6rem)));
+  padding: clamp(0.85rem, 1.55vw, 1.1rem);
   border: 1px solid rgba(87, 243, 255, 0.18);
   border-radius: 16px;
   background:
-    linear-gradient(180deg, rgba(0, 4, 3, 0.14), rgba(0, 4, 3, 0.52)),
+    linear-gradient(180deg, rgba(0, 4, 3, 0.08), rgba(0, 4, 3, 0.4)),
     radial-gradient(circle at 0 100%, rgba(87, 243, 255, 0.12), transparent 68%);
-  box-shadow: 0 0 28px rgba(0, 0, 0, 0.22);
+  box-shadow: 0 0 24px rgba(0, 0, 0, 0.16);
   backdrop-filter: blur(1px);
 }
 
 @media (min-width: 1020px) {
   .home-orca-copy {
-    max-width: 38rem;
+    max-width: 34rem;
   }
 }
 
@@ -6478,7 +6479,8 @@ body,
 
   .home-orca-mark {
     width: min(90%, clamp(270px, 66vw, 470px));
-    margin-top: clamp(4.2rem, 15vw, 6.5rem);
+    margin-top: clamp(3.9rem, 13vw, 5.8rem);
+    transform: translateX(clamp(0.25rem, 2vw, 1.25rem));
   }
 
   .home-orca-copy {
@@ -6498,7 +6500,7 @@ body,
     white-space: nowrap;
     font-size: 0.42rem;
     letter-spacing: 0.36em;
-    opacity: 0.44;
+    opacity: 0.58;
   }
 
   .home-orca-north-shore {
@@ -6508,14 +6510,15 @@ body,
   }
 
   .home-orca-mark {
-    width: min(88%, 330px);
-    margin-top: 4.9rem;
+    width: min(84%, 315px);
+    margin-top: 4.4rem;
+    transform: translateX(0.35rem);
   }
 
   .home-orca-copy {
     inset-inline: 0.75rem;
     max-width: none;
     padding: 0.85rem;
-    background: linear-gradient(180deg, rgba(0, 4, 3, 0.2), rgba(0, 4, 3, 0.68));
+    background: linear-gradient(180deg, rgba(0, 4, 3, 0.12), rgba(0, 4, 3, 0.56));
   }
 }


### PR DESCRIPTION
### Motivation
- Remove an accidental visible "\n\n" text node that was rendering above the header on the front page. 
- Final, conservative polish to the homepage hero so the two-orca sigil reads clearly while keeping the existing artwork, layout, and section order. 
- Make the hidden sky easter-egg “SUZY EASTON” feel like a subtle constellation (more intentional but not a competing headline). 
- Reduce the large empty black gap above the hero and shorten/lighten the copy panel while preserving Lousy Outages prominence and Play Mode placement.

### Description
- Remove stray text node on the front page by adding a front-page-only script after `wp_body_open()` that finds and removes a text node whose trimmed content equals `"\n\n"` (file: `header.php`).
- Tighten hero vertical spacing by reducing `.home-orca-hero` padding and lowering `.home-orca-stage` min-height so the hero begins sooner beneath the sticky header (file: `style.css`).
- Improve orca sigil composition by slightly reducing the sigil width, nudging it up/right (`.home-orca-mark` width/margin/transform), and preserving the existing SVG art and animation (file: `style.css`).
- Shorten and make the copy panel more transparent and slightly narrower by adjusting `.home-orca-copy` padding, `max-width`, background gradient, and box-shadow (file: `style.css`).
- Make the hidden star-name feel intentional by increasing opacity, letter-spacing, and glow of `.home-orca-starname` without turning it into a second headline (file: `style.css`).
- Strengthen North Shore linework subtly by increasing its opacity and stroke contrast so it reads as background atmosphere (file: `style.css`).
- Kept all existing structure and ordering intact so `Lousy Outages` remains directly after the hero and `Play Mode / Pacific Static` remains after that, with no broad CSS rewrite (files: `page-home.php`, `parts/lousy-outages-teaser.php`, `style.css`).

### Testing
- Ran `php -l header.php` and `php -l page-home.php` to verify no PHP syntax errors; both succeeded.
- Ran `git diff --check` to confirm no whitespace/merge issues; no problems reported.
- Ran `npm test`; the test run executed but reported unrelated existing failures in Gastown/Lousy Outages/Open Data tests (test summary: 49 passed, 18 failed), and failures are unrelated to the homepage hero polish.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3dd0d07d008331aff0e7a00a813c5f)