### PR TITLE
Redraw homepage hero into split copy/art layout with cleaned orca SVG

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -7,7 +7,7 @@ get_header();
 
     <section class="home-orca-hero hero hero-section crt-block" aria-labelledby="home-hero-title">
         <div class="home-orca-stage">
-            <span class="screen-reader-text"><?php echo esc_html( 'Two orcas circling in a CRT-style Burrard Inlet title mark.' ); ?></span>
+            <span class="screen-reader-text"><?php echo esc_html( 'Two distinct orcas circling with North Shore mountains and CRT stars.' ); ?></span>
             <div class="home-orca-sky" aria-hidden="true">
                 <span class="home-orca-starname">SUZY EASTON</span>
             </div>
@@ -15,53 +15,6 @@ get_header();
                 <path class="home-orca-north-shore__back" d="M0 176 74 154 142 102 208 137 283 58 353 134 428 84 508 145 579 92 642 132 714 64 796 142 878 96 940 138 1014 72 1094 146 1200 110" />
                 <path class="home-orca-north-shore__front" d="M0 205 96 174 176 146 253 166 334 112 420 174 498 139 585 178 668 132 753 176 846 126 930 172 1028 132 1114 180 1200 152" />
             </svg>
-            <div class="home-orca-mark" role="img" aria-label="<?php echo esc_attr( 'Two orcas circling in a CRT-style Burrard Inlet title mark.' ); ?>">
-                <svg class="home-orca-sigil" viewBox="0 0 520 520" aria-hidden="true" focusable="false">
-                    <defs>
-                        <filter id="home-orca-crt-glow" x="-35%" y="-35%" width="170%" height="170%">
-                            <feGaussianBlur stdDeviation="4" result="blur" />
-                            <feColorMatrix in="blur" type="matrix" values="0 0 0 0 0.2  0 0 0 0 1  0 0 0 0 0.82  0 0 0 .7 0" result="cyanGlow" />
-                            <feMerge>
-                                <feMergeNode in="cyanGlow" />
-                                <feMergeNode in="SourceGraphic" />
-                            </feMerge>
-                        </filter>
-                        <linearGradient id="home-orca-water" x1="0" x2="1" y1="0" y2="0">
-                            <stop offset="0" stop-color="#39ff14" stop-opacity="0" />
-                            <stop offset=".5" stop-color="#57f3ff" stop-opacity=".85" />
-                            <stop offset="1" stop-color="#39ff14" stop-opacity="0" />
-                        </linearGradient>
-                    </defs>
-                    <g class="home-orca-rings" fill="none">
-                        <circle cx="260" cy="260" r="196" />
-                        <circle cx="260" cy="260" r="150" />
-                    </g>
-                    <path class="home-orca-mountain" d="M72 160 132 96l38 42 34-58 56 78 44-46 46 54 42-34 56 54" />
-                    <g class="home-orca-pair" filter="url(#home-orca-crt-glow)">
-                        <g class="home-orca home-orca--upper">
-                            <path class="home-orca-body" d="M384 126c-89-31-188 5-239 86-18 29-25 59-18 82 59-58 126-76 206-54 28 8 56 5 75-9 21-15 27-39 16-62-7-16-20-31-40-43Z" />
-                            <path class="home-orca-tail" d="M424 169c29-8 54-25 72-52-34 4-59 13-76 28 10-23 12-47 3-72-21 21-33 48-39 80Z" />
-                            <path class="home-orca-belly" d="M173 243c48-30 106-37 171-20 27 7 50 3 66-12-8 29-42 48-84 42-58-9-107 4-153 47-10-16-10-35 0-57Z" />
-                            <path class="home-orca-saddle" d="M298 143c38 0 72 13 99 35-34-9-65-8-93 3-19 8-36-3-40-19 8-9 19-15 34-19Z" />
-                            <ellipse class="home-orca-eye" cx="366" cy="166" rx="12" ry="7" transform="rotate(22 366 166)" />
-                            <path class="home-orca-fin" d="M239 209c-11-48 0-86 34-114 10 47 2 85-34 114Z" />
-                        </g>
-                        <g class="home-orca home-orca--lower">
-                            <path class="home-orca-body" d="M136 394c89 31 188-5 239-86 18-29 25-59 18-82-59 58-126 76-206 54-28-8-56-5-75 9-21 15-27 39-16 62 7 16 20 31 40 43Z" />
-                            <path class="home-orca-tail" d="M96 351c-29 8-54 25-72 52 34-4 59-13 76-28-10 23-12 47-3 72 21-21 33-48 39-80Z" />
-                            <path class="home-orca-belly" d="M347 277c-48 30-106 37-171 20-27-7-50-3-66 12 8-29 42-48 84-42 58 9 107-4 153-47 10 16 10 35 0 57Z" />
-                            <path class="home-orca-saddle" d="M222 377c-38 0-72-13-99-35 34 9 65 8 93-3 19-8 36 3 40 19-8 9-19 15-34 19Z" />
-                            <ellipse class="home-orca-eye" cx="154" cy="354" rx="12" ry="7" transform="rotate(22 154 354)" />
-                            <path class="home-orca-fin" d="M281 311c11 48 0 86-34 114-10-47-2-85 34-114Z" />
-                        </g>
-                    </g>
-                    <g class="home-orca-waterlines">
-                        <path d="M74 404c46-12 78 12 124 0s78-12 124 0 78 12 124 0" />
-                        <path d="M102 430c34-8 58 8 92 0s58-8 92 0 58 8 92 0" />
-                    </g>
-                    <text class="home-orca-location" x="260" y="474" text-anchor="middle">BURRARD INLET</text>
-                </svg>
-            </div>
             <div class="home-orca-copy">
                 <p class="hero-eyebrow pixel-font"><?php echo esc_html( 'music // practical ai // weird useful tools' ); ?></p>
                 <h1 id="home-hero-title" class="hero-core-headline home-arcade-title"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>
@@ -69,6 +22,49 @@ get_header();
                 <div class="home-orca-actions home-cta-row hero-cta-group">
                     <a href="#mission-select" class="pixel-button hero-primary-cta"><?php echo esc_html( 'Enter the lab' ); ?></a>
                     <a href="<?php echo esc_url( home_url( '/lousy-outages/' ) ); ?>" class="pixel-button pixel-button--secondary"><?php echo esc_html( 'Check Lousy Outages' ); ?></a>
+                </div>
+            </div>
+            <div class="home-orca-art" aria-hidden="true">
+                <div class="home-orca-mark" role="img" aria-label="<?php echo esc_attr( 'Two distinct orcas circling in a CRT-style Burrard Inlet sigil.' ); ?>">
+                    <svg class="home-orca-sigil" viewBox="0 0 560 560" aria-hidden="true" focusable="false">
+                        <defs>
+                            <filter id="home-orca-crt-glow" x="-18%" y="-18%" width="136%" height="136%">
+                                <feGaussianBlur stdDeviation="2.2" result="blur" />
+                                <feColorMatrix in="blur" type="matrix" values="0 0 0 0 0.2  0 0 0 0 1  0 0 0 0 0.82  0 0 0 .42 0" result="cyanGlow" />
+                                <feMerge><feMergeNode in="cyanGlow" /><feMergeNode in="SourceGraphic" /></feMerge>
+                            </filter>
+                            <linearGradient id="home-orca-water" x1="0" x2="1" y1="0" y2="0">
+                                <stop offset="0" stop-color="#39ff14" stop-opacity="0" />
+                                <stop offset=".5" stop-color="#57f3ff" stop-opacity=".72" />
+                                <stop offset="1" stop-color="#39ff14" stop-opacity="0" />
+                            </linearGradient>
+                        </defs>
+                        <g class="home-orca-rings" fill="none">
+                            <circle cx="280" cy="280" r="214" />
+                            <circle cx="280" cy="280" r="158" />
+                        </g>
+                        <path class="home-orca-mountain" d="M88 164 144 104l38 44 38-64 58 82 48-54 42 54 42-34 64 62" />
+                        <g class="home-orca-pair" filter="url(#home-orca-crt-glow)">
+                            <g class="home-orca home-orca--upper">
+                                <path class="home-orca-body" d="M404 154c-79-45-178-28-242 39-28 30-44 66-43 96 45-50 101-77 169-82 52-4 93-23 116-53Z" />
+                                <path class="home-orca-tail" d="M417 142c33-29 68-43 105-44-18 28-39 47-65 59 28 4 51 17 70 40-39 4-76-6-111-31Z" />
+                                <path class="home-orca-belly" d="M154 250c42-31 86-47 133-48 35-1 66-10 91-27-14 32-49 55-96 62-52 8-94 31-127 70-9-17-9-36-1-57Z" />
+                                <path class="home-orca-saddle" d="M284 145c34-2 67 7 99 28-33-6-60-1-82 13-18 11-38 4-45-12 5-13 14-22 28-29Z" />
+                                <path class="home-orca-fin" d="M226 202c-6-50 10-87 48-112 4 50-12 88-48 112Z" />
+                                <ellipse class="home-orca-eye" cx="378" cy="160" rx="10" ry="6" transform="rotate(22 378 160)" />
+                            </g>
+                            <g class="home-orca home-orca--lower">
+                                <path class="home-orca-body" d="M154 402c69 40 157 28 214-31 25-26 39-58 38-85-40 44-90 68-150 73-46 4-82 20-102 43Z" />
+                                <path class="home-orca-tail" d="M141 414c-29 25-61 38-94 39 16-25 35-42 58-52-25-4-45-15-62-35 35-4 68 5 99 27Z" />
+                                <path class="home-orca-belly" d="M374 320c-37 27-76 41-118 43-31 1-58 9-80 24 13-29 44-49 85-55 46-7 84-27 113-62 8 15 8 32 0 50Z" />
+                                <path class="home-orca-saddle" d="M262 410c-31 2-60-7-88-25 29 5 53 1 73-11 16-10 34-4 40 10-4 11-12 20-25 26Z" />
+                                <path class="home-orca-fin" d="M316 360c5 44-9 77-43 99-3-44 11-78 43-99Z" />
+                                <ellipse class="home-orca-eye" cx="176" cy="398" rx="9" ry="5.5" transform="rotate(202 176 398)" />
+                            </g>
+                        </g>
+                        <g class="home-orca-waterlines"><path d="M88 444c44-12 74 12 118 0s74-12 118 0 74 12 118 0" /><path d="M116 470c32-8 54 8 86 0s54-8 86 0 54 8 86 0" /></g>
+                        <text class="home-orca-location" x="280" y="514" text-anchor="middle">BURRARD INLET</text>
+                    </svg>
                 </div>
             </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -6522,3 +6522,181 @@ body,
     background: linear-gradient(180deg, rgba(0, 4, 3, 0.12), rgba(0, 4, 3, 0.56));
   }
 }
+
+/* Homepage hero split-layout redraw: copy and orca art occupy distinct cinematic zones. */
+.home-orca-hero {
+  padding-top: clamp(0.1rem, 0.45vw, 0.45rem);
+}
+
+.home-orca-stage {
+  grid-template-columns: minmax(0, 0.92fr) minmax(320px, 1.08fr);
+  gap: clamp(1.5rem, 4vw, 4rem);
+  align-items: center;
+  min-height: clamp(500px, calc(100svh - var(--se-header-height, 72px) - 4.5rem), 680px);
+  padding: clamp(1.1rem, 3.2vw, 3.2rem);
+  background:
+    radial-gradient(circle at 72% 48%, rgba(87, 243, 255, 0.16), transparent 28%),
+    radial-gradient(circle at 17% 22%, rgba(57, 255, 20, 0.13), transparent 24%),
+    radial-gradient(circle at 88% 18%, rgba(255, 72, 206, 0.08), transparent 18%),
+    linear-gradient(180deg, #020a08 0%, #000403 58%, #010009 100%);
+}
+
+.home-orca-sky {
+  height: 58%;
+  opacity: 0.78;
+}
+
+.home-orca-starname {
+  left: 73%;
+  top: clamp(1.2rem, 3.6vw, 2.8rem);
+  letter-spacing: clamp(0.42em, 1.05vw, 0.8em);
+  opacity: 0.32;
+}
+
+.home-orca-north-shore {
+  top: auto;
+  bottom: clamp(1.7rem, 5vw, 3.9rem);
+  width: min(116%, 1320px);
+  opacity: 0.5;
+}
+
+.home-orca-copy {
+  position: relative;
+  inset: auto;
+  z-index: 3;
+  grid-column: 1;
+  align-self: center;
+  max-width: 36rem;
+  padding: clamp(1rem, 2.4vw, 1.65rem);
+  border-color: rgba(87, 243, 255, 0.28);
+  background:
+    linear-gradient(135deg, rgba(0, 12, 11, 0.82), rgba(0, 4, 3, 0.42)),
+    radial-gradient(circle at 0 100%, rgba(87, 243, 255, 0.15), transparent 62%);
+  box-shadow: 0 18px 56px rgba(0, 0, 0, 0.32), inset 0 0 26px rgba(57, 255, 20, 0.055);
+}
+
+.home-orca-copy .home-arcade-title {
+  font-size: clamp(2.7rem, 6vw, 5.8rem);
+  line-height: 0.95;
+}
+
+.home-orca-copy .home-arcade-copy {
+  max-width: 34rem;
+  font-size: clamp(1rem, 1.5vw, 1.18rem);
+}
+
+.home-orca-art {
+  position: relative;
+  z-index: 1;
+  grid-column: 2;
+  display: grid;
+  place-items: center;
+  min-width: 0;
+}
+
+.home-orca-art::before {
+  content: "";
+  position: absolute;
+  inset: 5% 2% 7%;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(87, 243, 255, 0.13), transparent 64%);
+  filter: blur(0.3px);
+  opacity: 0.84;
+}
+
+.home-orca-mark {
+  align-self: center;
+  justify-self: center;
+  width: min(100%, clamp(320px, 41vw, 560px));
+  margin-top: 0;
+  transform: none;
+  filter: drop-shadow(0 0 18px rgba(87, 243, 255, 0.34)) drop-shadow(0 0 34px rgba(57, 255, 20, 0.12));
+}
+
+.home-orca-mark::before {
+  inset: 10%;
+  opacity: 0.62;
+  filter: none;
+}
+
+.home-orca-rings circle {
+  stroke-width: 2;
+  filter: drop-shadow(0 0 8px rgba(87, 243, 255, 0.32));
+}
+
+.home-orca-body,
+.home-orca-tail,
+.home-orca-fin {
+  stroke-width: 4.25;
+}
+
+.home-orca-belly,
+.home-orca-saddle {
+  stroke-width: 2.4;
+}
+
+.home-orca-pair {
+  filter: drop-shadow(0 0 9px rgba(87, 243, 255, 0.2));
+}
+
+@media (max-width: 900px) {
+  .home-orca-stage {
+    grid-template-columns: 1fr;
+    gap: clamp(1rem, 4vw, 1.8rem);
+    min-height: auto;
+  }
+
+  .home-orca-copy,
+  .home-orca-art {
+    grid-column: 1;
+  }
+
+  .home-orca-art {
+    order: 1;
+  }
+
+  .home-orca-copy {
+    order: 2;
+    justify-self: center;
+    max-width: 42rem;
+  }
+
+  .home-orca-mark {
+    width: min(100%, clamp(300px, 72vw, 500px));
+  }
+
+  .home-orca-starname {
+    left: 50%;
+    opacity: 0.25;
+  }
+
+  .home-orca-north-shore {
+    bottom: auto;
+    top: clamp(4.3rem, 16vw, 7.2rem);
+    width: 132%;
+  }
+}
+
+@media (max-width: 640px) {
+  .home-orca-stage {
+    padding: 0.8rem;
+  }
+
+  .home-orca-sky {
+    height: 42%;
+  }
+
+  .home-orca-mark {
+    width: min(100%, 340px);
+  }
+
+  .home-orca-copy {
+    inset: auto;
+    padding: 0.95rem;
+    background: linear-gradient(180deg, rgba(0, 12, 11, 0.84), rgba(0, 4, 3, 0.64));
+  }
+
+  .home-orca-copy .home-arcade-title {
+    font-size: clamp(2.4rem, 15vw, 3.65rem);
+  }
+}


### PR DESCRIPTION
### Motivation

- The previous homepage hero used a compact SVG composition that produced visually fused whales and placed the large `SUZY EASTON` headline on top of the art, creating clutter and unreadable forms.
- The intent is to redraw and restructure the hero into a more stable split-layout so copy and artwork occupy separate cinematic zones while preserving the Vancouver CRT/orca atmosphere.

### Description

- Updated `page-home.php` to restructure the hero into a split layout with a left-side copy block (`.home-orca-copy`) and a right-side art block (`.home-orca-art`) and added a new, cleaner two-orca SVG with separated upper/lower whale groups, clear fins/tails/white patches, rings, waterlines, and North Shore linework.
- Added homepage-scoped CSS to `style.css` implementing the desktop two-column grid, responsive stacking for mobile, tuned spacing/min-height, adjusted starfield and mountain placement, and reduced top dead space so the headline no longer sits on the artwork.
- Kept existing flow and order so the `Lousy Outages` teaser remains directly below the hero and `Play Mode` stays below that, and kept class names scoped to the homepage to avoid affecting unrelated sections.
- Improved accessibility labels and `screen-reader-text` to reflect the new artwork and composition.

### Testing

- `php -l page-home.php` ran and returned no syntax errors when checking the modified template.
- `git diff --check` (style/whitespace checks) ran cleanly against the modified files without reported issues.
- `npm test` was executed: the test run completed with `49` passing and `18` failing tests, and the failures are from unrelated Gastown/world-generation/refresh tests not connected to the homepage hero changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3dd3a6a82083319f82cb925a5175ef)