### PR TITLE
Homepage: replace two-orca sigil with single retro-arcade orca

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -7,7 +7,7 @@ get_header();
 
     <section class="home-orca-hero hero hero-section crt-block" aria-labelledby="home-hero-title">
         <div class="home-orca-stage">
-            <span class="screen-reader-text"><?php echo esc_html( 'Two distinct orcas circling with North Shore mountains and CRT stars.' ); ?></span>
+            <span class="screen-reader-text"><?php echo esc_html( 'One retro arcade killer whale gliding beside North Shore mountains, CRT stars, and Burrard Inlet water.' ); ?></span>
             <div class="home-orca-sky" aria-hidden="true">
                 <span class="home-orca-starname">SUZY EASTON</span>
             </div>
@@ -25,45 +25,35 @@ get_header();
                 </div>
             </div>
             <div class="home-orca-art" aria-hidden="true">
-                <div class="home-orca-mark" role="img" aria-label="<?php echo esc_attr( 'Two distinct orcas circling in a CRT-style Burrard Inlet sigil.' ); ?>">
-                    <svg class="home-orca-sigil" viewBox="0 0 560 560" aria-hidden="true" focusable="false">
+                <div class="home-orca-mark" role="img" aria-label="<?php echo esc_attr( 'One retro arcade killer whale gliding through Burrard Inlet with CRT glow.' ); ?>">
+                    <svg class="home-orca-sigil" viewBox="0 0 620 430" aria-hidden="true" focusable="false">
                         <defs>
-                            <filter id="home-orca-crt-glow" x="-18%" y="-18%" width="136%" height="136%">
-                                <feGaussianBlur stdDeviation="2.2" result="blur" />
-                                <feColorMatrix in="blur" type="matrix" values="0 0 0 0 0.2  0 0 0 0 1  0 0 0 0 0.82  0 0 0 .42 0" result="cyanGlow" />
+                            <filter id="home-orca-crt-glow" x="-18%" y="-28%" width="136%" height="156%">
+                                <feGaussianBlur stdDeviation="2.1" result="blur" />
+                                <feColorMatrix in="blur" type="matrix" values="0 0 0 0 0.2  0 0 0 0 1  0 0 0 0 0.82  0 0 0 .48 0" result="cyanGlow" />
                                 <feMerge><feMergeNode in="cyanGlow" /><feMergeNode in="SourceGraphic" /></feMerge>
                             </filter>
                             <linearGradient id="home-orca-water" x1="0" x2="1" y1="0" y2="0">
                                 <stop offset="0" stop-color="#39ff14" stop-opacity="0" />
-                                <stop offset=".5" stop-color="#57f3ff" stop-opacity=".72" />
+                                <stop offset=".45" stop-color="#57f3ff" stop-opacity=".72" />
                                 <stop offset="1" stop-color="#39ff14" stop-opacity="0" />
                             </linearGradient>
                         </defs>
-                        <g class="home-orca-rings" fill="none">
-                            <circle cx="280" cy="280" r="214" />
-                            <circle cx="280" cy="280" r="158" />
+                        <g class="home-orca-sprite" filter="url(#home-orca-crt-glow)">
+                            <path class="home-orca-tail home-orca-tail--top" d="M444 162c43-50 86-76 132-78-21 41-50 70-86 86 39 6 72 24 99 55-52 7-102-7-150-42Z" />
+                            <path class="home-orca-tail home-orca-tail--bottom" d="M439 184c45 28 89 40 133 34-26 34-59 52-98 55 20 21 30 47 30 78-40-20-68-56-83-108Z" />
+                            <path class="home-orca-body" d="M70 246c61-86 145-139 252-158 72-13 135 0 185 39-37 68-96 111-178 129-96 21-180 17-259-10Z" />
+                            <path class="home-orca-belly" d="M114 249c65 10 132 5 202-14 56-15 101-43 134-84-16 64-62 111-137 140-72 28-139 28-199-42Z" />
+                            <path class="home-orca-saddle" d="M328 103c43 3 81 17 114 42-38-5-68 3-91 25-23 21-56 12-66-18 7-24 21-40 43-49Z" />
+                            <path class="home-orca-fin" d="M260 124c1-70 27-119 78-147 11 69-15 118-78 147Z" />
+                            <path class="home-orca-eye" d="M127 214c20-19 45-25 75-19-16 23-39 32-70 27Z" />
+                            <path class="home-orca-pixel-glint" d="M152 205h18v10h-18zM210 258h24v10h-24zM315 82h16v10h-16z" />
                         </g>
-                        <path class="home-orca-mountain" d="M88 164 144 104l38 44 38-64 58 82 48-54 42 54 42-34 64 62" />
-                        <g class="home-orca-pair" filter="url(#home-orca-crt-glow)">
-                            <g class="home-orca home-orca--upper">
-                                <path class="home-orca-body" d="M404 154c-79-45-178-28-242 39-28 30-44 66-43 96 45-50 101-77 169-82 52-4 93-23 116-53Z" />
-                                <path class="home-orca-tail" d="M417 142c33-29 68-43 105-44-18 28-39 47-65 59 28 4 51 17 70 40-39 4-76-6-111-31Z" />
-                                <path class="home-orca-belly" d="M154 250c42-31 86-47 133-48 35-1 66-10 91-27-14 32-49 55-96 62-52 8-94 31-127 70-9-17-9-36-1-57Z" />
-                                <path class="home-orca-saddle" d="M284 145c34-2 67 7 99 28-33-6-60-1-82 13-18 11-38 4-45-12 5-13 14-22 28-29Z" />
-                                <path class="home-orca-fin" d="M226 202c-6-50 10-87 48-112 4 50-12 88-48 112Z" />
-                                <ellipse class="home-orca-eye" cx="378" cy="160" rx="10" ry="6" transform="rotate(22 378 160)" />
-                            </g>
-                            <g class="home-orca home-orca--lower">
-                                <path class="home-orca-body" d="M154 402c69 40 157 28 214-31 25-26 39-58 38-85-40 44-90 68-150 73-46 4-82 20-102 43Z" />
-                                <path class="home-orca-tail" d="M141 414c-29 25-61 38-94 39 16-25 35-42 58-52-25-4-45-15-62-35 35-4 68 5 99 27Z" />
-                                <path class="home-orca-belly" d="M374 320c-37 27-76 41-118 43-31 1-58 9-80 24 13-29 44-49 85-55 46-7 84-27 113-62 8 15 8 32 0 50Z" />
-                                <path class="home-orca-saddle" d="M262 410c-31 2-60-7-88-25 29 5 53 1 73-11 16-10 34-4 40 10-4 11-12 20-25 26Z" />
-                                <path class="home-orca-fin" d="M316 360c5 44-9 77-43 99-3-44 11-78 43-99Z" />
-                                <ellipse class="home-orca-eye" cx="176" cy="398" rx="9" ry="5.5" transform="rotate(202 176 398)" />
-                            </g>
+                        <g class="home-orca-waterlines">
+                            <path d="M34 314c42-12 70 12 112 0s70-12 112 0 70 12 112 0 70-12 112 0" />
+                            <path d="M82 348c32-8 54 8 86 0s54-8 86 0 54 8 86 0 54-8 86 0" />
+                            <path d="M146 378c24-6 40 6 64 0s40-6 64 0 40 6 64 0" />
                         </g>
-                        <g class="home-orca-waterlines"><path d="M88 444c44-12 74 12 118 0s74-12 118 0 74 12 118 0" /><path d="M116 470c32-8 54 8 86 0s54-8 86 0 54 8 86 0" /></g>
-                        <text class="home-orca-location" x="280" y="514" text-anchor="middle">BURRARD INLET</text>
                     </svg>
                 </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -6700,3 +6700,142 @@ body,
     font-size: clamp(2.4rem, 15vw, 3.65rem);
   }
 }
+
+/* Single-orca arcade title-screen refinement. */
+.home-orca-stage {
+  grid-template-columns: minmax(0, 0.95fr) minmax(300px, 0.9fr);
+  background:
+    radial-gradient(circle at 74% 44%, rgba(87, 243, 255, 0.16), transparent 24%),
+    radial-gradient(circle at 20% 22%, rgba(57, 255, 20, 0.1), transparent 22%),
+    linear-gradient(180deg, #020a12 0%, #00110f 56%, #02030a 100%);
+}
+
+.home-orca-art {
+  align-self: center;
+}
+
+.home-orca-art::before {
+  inset: 13% 7% 16%;
+  border-radius: 34% 54% 42% 58%;
+  background:
+    radial-gradient(circle at 58% 45%, rgba(87, 243, 255, 0.2), transparent 48%),
+    linear-gradient(180deg, rgba(57, 255, 20, 0.08), transparent 62%);
+}
+
+.home-orca-mark {
+  width: min(100%, clamp(300px, 34vw, 460px));
+  aspect-ratio: 620 / 430;
+  filter: drop-shadow(0 0 18px rgba(87, 243, 255, 0.44)) drop-shadow(0 0 26px rgba(57, 255, 20, 0.16));
+}
+
+.home-orca-mark::before {
+  inset: 14% 4% 13%;
+  border-radius: 38% 58% 45% 55%;
+  background:
+    repeating-linear-gradient(0deg, rgba(223, 255, 234, 0.045) 0 2px, transparent 2px 8px),
+    radial-gradient(circle at 50% 48%, rgba(87, 243, 255, 0.16), transparent 60%);
+  animation: homeOrcaSpriteGlow 4.8s steps(4, end) infinite;
+}
+
+.home-orca-sigil {
+  overflow: visible;
+}
+
+.home-orca-sprite {
+  transform-origin: 315px 210px;
+  animation: homeOrcaBob 5.6s steps(6, end) infinite;
+}
+
+.home-orca-body,
+.home-orca-tail,
+.home-orca-fin {
+  fill: #030507;
+  stroke: #e8fff3;
+  stroke-width: 6;
+  stroke-linejoin: miter;
+}
+
+.home-orca-tail--bottom {
+  fill: #050607;
+}
+
+.home-orca-belly,
+.home-orca-saddle,
+.home-orca-eye {
+  fill: #f3fff8;
+  stroke: #06110d;
+  stroke-width: 4;
+  stroke-linejoin: miter;
+}
+
+.home-orca-pixel-glint {
+  fill: rgba(87, 243, 255, 0.78);
+  animation: homeOrcaFlicker 3.2s steps(2, end) infinite;
+}
+
+.home-orca-waterlines path {
+  stroke-dasharray: 34 18;
+  animation: homeOrcaWaterSignal 4.8s steps(5, end) infinite;
+}
+
+.home-orca-north-shore {
+  bottom: clamp(0.8rem, 3.4vw, 2.8rem);
+  opacity: 0.46;
+}
+
+.home-orca-sky {
+  animation: homeOrcaStarTwinkle 7s steps(4, end) infinite;
+}
+
+@keyframes homeOrcaBob {
+  0%, 100% { transform: translate(0, 0) rotate(-1deg); }
+  50% { transform: translate(0, -10px) rotate(1deg); }
+}
+
+@keyframes homeOrcaSpriteGlow {
+  0%, 100% { opacity: 0.5; transform: scale(0.98); }
+  50% { opacity: 0.78; transform: scale(1.02); }
+}
+
+@keyframes homeOrcaFlicker {
+  0%, 100% { opacity: 0.35; }
+  50% { opacity: 1; }
+}
+
+@keyframes homeOrcaStarTwinkle {
+  0%, 100% { opacity: 0.62; }
+  50% { opacity: 0.86; }
+}
+
+@media (max-width: 900px) {
+  .home-orca-stage {
+    grid-template-columns: 1fr;
+  }
+
+  .home-orca-mark {
+    width: min(100%, clamp(300px, 72vw, 440px));
+  }
+}
+
+@media (max-width: 640px) {
+  .home-orca-stage {
+    gap: 1rem;
+  }
+
+  .home-orca-mark {
+    width: min(100%, 330px);
+  }
+
+  .home-orca-art {
+    padding-top: 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-orca-sprite,
+  .home-orca-mark::before,
+  .home-orca-pixel-glint,
+  .home-orca-sky {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
### Motivation
- The existing two-whale hero felt oversized, logo-like, and distracted from the text, so the hero should present a single, readable killer whale with retro arcade vibes. 
- The intent is to keep the homepage layout and content (copy, CTAs, and `Lousy Outages` teaser) intact while improving legibility and visual tone.

### Description
- Replaced the two-orca/yin-yang SVG with a single inline SVG arcade-style killer whale in `page-home.php`, including CRT glow filter, pixel glints, and simplified waterlines.  
- Restored and preserved the North Shore mountain SVG and hero copy/CTA markup so `Lousy Outages` and the rest of the homepage remain in the same order.  
- Added scoped, homepage-only styles in `style.css` to reduce art scale, implement split layout behavior, add sprite-like bobbing and subtle star/water animations, and respect `prefers-reduced-motion`.  
- Kept the change narrowly scoped to homepage files only (`page-home.php` and `style.css`) and avoided broad redesigns or changes to unrelated features.

### Testing
- Ran `php -l page-home.php` and it returned no syntax errors.  
- Ran `git diff --check` and there were no whitespace/patch errors.  
- Ran `npm test`; the command executed but the test suite reported failures (18 failing tests) in pre-existing Gastown / Lousy Outages / CoV open-data tests that are unrelated to the homepage hero changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e0622a558833182f9b9bfffc47dca)