### PR TITLE
Reframe homepage as arcade title screen

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -83,6 +83,13 @@ function retro_game_music_theme_scripts() {
             filemtime( get_template_directory() . '/js/pacific-power-play.js' ),
             true
         );
+        wp_enqueue_script(
+            'home-arcade-start',
+            get_template_directory_uri() . '/js/home-arcade-start.js',
+            array(),
+            filemtime( get_template_directory() . '/js/home-arcade-start.js' ),
+            true
+        );
 
         $teaser_css = get_template_directory() . '/assets/css/lousy-outages-teaser.css';
         if ( file_exists( $teaser_css ) ) {

--- a/js/home-arcade-start.js
+++ b/js/home-arcade-start.js
@@ -1,0 +1,54 @@
+(function () {
+  function initHomeArcadeStart() {
+    var hero = document.querySelector('[data-arcade-hero]');
+    var button = document.querySelector('[data-home-start]');
+    var status = document.querySelector('[data-arcade-status]');
+    var target = document.getElementById('lousy-outages-teaser');
+    if (!hero || !button || !target) return;
+
+    var reduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    var started = false;
+
+    function scrollToLevel() {
+      target.setAttribute('tabindex', '-1');
+      target.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'start' });
+      window.setTimeout(function () { target.focus({ preventScroll: true }); }, reduceMotion ? 0 : 520);
+    }
+
+    button.addEventListener('click', function () {
+      if (started) {
+        scrollToLevel();
+        return;
+      }
+      started = true;
+      document.body.classList.add('is-game-started');
+      hero.classList.add('is-starting');
+      button.textContent = 'STARTING';
+      button.setAttribute('aria-disabled', 'true');
+      if (status) status.textContent = 'COIN ACCEPTED';
+
+      if (reduceMotion) {
+        if (status) status.textContent = 'LOADING SYSTEMS';
+        scrollToLevel();
+        return;
+      }
+
+      window.setTimeout(function () {
+        hero.classList.add('is-signal-locking');
+        if (status) status.textContent = 'LOADING SYSTEMS';
+      }, 420);
+      window.setTimeout(function () {
+        if (status) status.textContent = 'LEVEL 01 READY';
+        scrollToLevel();
+      }, 980);
+      window.setTimeout(function () {
+        hero.classList.remove('is-starting', 'is-signal-locking');
+        button.removeAttribute('aria-disabled');
+        button.textContent = button.getAttribute('data-start-label') || 'PRESS START';
+      }, 1500);
+    });
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initHomeArcadeStart);
+  else initHomeArcadeStart();
+}());

--- a/page-home.php
+++ b/page-home.php
@@ -5,7 +5,7 @@ get_header();
 
 <main id="homepage-content" class="home-layout home-arcade-layout">
 
-    <section class="home-orca-hero hero hero-section crt-block" aria-labelledby="home-hero-title">
+    <section class="home-orca-hero hero hero-section crt-block" aria-labelledby="home-hero-title" data-arcade-hero>
         <div class="home-orca-stage">
             <span class="screen-reader-text"><?php echo esc_html( 'One retro arcade killer whale gliding beside North Shore mountains, CRT stars, and Burrard Inlet water.' ); ?></span>
             <div class="home-orca-sky" aria-hidden="true">
@@ -18,10 +18,15 @@ get_header();
             <div class="home-orca-copy">
                 <p class="hero-eyebrow pixel-font"><?php echo esc_html( 'music // ai strategy // creative technology' ); ?></p>
                 <h1 id="home-hero-title" class="hero-core-headline home-arcade-title"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>
+                <div class="home-title-screen-stack pixel-font" aria-label="music // ai strategy, creative technology, vancouver systems"><span><?php echo esc_html( 'music // ai strategy' ); ?></span><span><?php echo esc_html( 'creative technology' ); ?></span><span><?php echo esc_html( 'vancouver systems' ); ?></span></div>
                 <p class="hero-copy home-arcade-copy"><?php echo esc_html( 'I build practical AI workflows, music tools, outage dashboards, and digital systems for creative and technical teams.' ); ?></p>
+                <div class="home-title-screen-prompt pixel-font" role="status" aria-live="polite" data-arcade-status><?php echo esc_html( 'INSERT COIN' ); ?></div>
+                <div class="home-title-screen-meta pixel-font" aria-hidden="true"><span>1 PLAYER</span><span>VANCOUVER SYSTEMS ONLINE</span><span>AI / MUSIC / SYSTEMS</span></div>
                 <div class="home-orca-actions home-cta-row hero-cta-group">
-                    <a href="#mission-select" class="pixel-button hero-primary-cta"><?php echo esc_html( 'Enter the lab' ); ?></a>
-                    <a href="<?php echo esc_url( home_url( '/lousy-outages/' ) ); ?>" class="pixel-button pixel-button--secondary"><?php echo esc_html( 'Check Lousy Outages' ); ?></a>
+                    <button type="button" class="pixel-button hero-primary-cta home-press-start" data-home-start data-start-label="PRESS START"><?php echo esc_html( 'PRESS START' ); ?></button>
+                    <a href="#lousy-outages-teaser" class="pixel-button pixel-button--secondary"><?php echo esc_html( 'CHECK LOUSY OUTAGES' ); ?></a>
+                    <a href="#mission-select" class="pixel-button pixel-button--secondary"><?php echo esc_html( 'SELECT SYSTEM' ); ?></a>
+                    <button class="pixel-button pixel-button--secondary" type="button" data-contact-trigger aria-haspopup="dialog" aria-controls="contact-suzy-modal"><?php echo esc_html( 'CONTACT SUZY' ); ?></button>
                 </div>
             </div>
             <div class="home-orca-art" aria-hidden="true">
@@ -102,11 +107,13 @@ get_header();
         </div>
     </section>
 
+    <div class="home-level-intro home-level-intro--outages pixel-font" aria-hidden="true"><span>LEVEL 01</span><strong>STATUS BOARD FOR MODERN CHAOS</strong><em>LIVE OUTAGE SIGNAL</em></div>
+
     <?php get_template_part( 'parts/lousy-outages-teaser' ); ?>
 
     <section class="home-play-mode crt-block" aria-labelledby="home-play-mode-title">
         <div class="home-play-mode__copy">
-            <p class="home-section-kicker pixel-font"><?php echo esc_html( 'PLAY MODE' ); ?></p>
+            <p class="home-section-kicker pixel-font"><?php echo esc_html( 'BONUS LEVEL' ); ?></p>
             <h2 id="home-play-mode-title" class="pixel-font"><?php echo esc_html( 'Pacific Power Play' ); ?></h2>
             <p><?php echo esc_html( 'Choose your line, drop the puck, and survive the rain city static.' ); ?></p>
             <button type="button" class="pixel-button home-arcade-start" data-arcade-start><?php echo esc_html( 'Choose Your Line' ); ?></button>
@@ -127,8 +134,8 @@ get_header();
     </section>
 
     <section id="mission-select" class="home-project-grid home-mission-select crt-block" aria-labelledby="selected-projects-title">
-        <p class="home-section-kicker pixel-font"><?php echo esc_html( 'SELECT SYSTEM' ); ?></p>
-        <h2 id="selected-projects-title" class="pixel-font"><?php echo esc_html( 'SELECT SYSTEM' ); ?></h2>
+        <p class="home-section-kicker pixel-font"><?php echo esc_html( 'LEVEL SELECT' ); ?></p>
+        <h2 id="selected-projects-title" class="pixel-font"><?php echo esc_html( 'CHOOSE YOUR SYSTEM' ); ?></h2>
         <div class="selected-work__grid home-mission-grid">
             <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'status weather' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Lousy Outages' ); ?></h3><p><?php echo esc_html( 'A status board for SaaS weirdness, provider incidents, and the moments official pages get too polite.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/lousy-outages/' ) ); ?>"><?php echo esc_html( 'Check status' ); ?></a></article>
             <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'civic arcade world' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Gastown Simulator' ); ?></h3><p><?php echo esc_html( 'A playable Vancouver corridor built from civic data, route logic, street mood, and arcade-map obsession.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/gastown-sim/' ) ); ?>"><?php echo esc_html( 'Walk Gastown' ); ?></a></article>
@@ -140,8 +147,8 @@ get_header();
     </section>
 
     <section id="music" class="music-world home-unlocks crt-block" aria-labelledby="music-world-title">
-        <p class="home-section-kicker pixel-font"><?php echo esc_html( 'music / tools / contact' ); ?></p>
-        <h2 id="music-world-title" class="pixel-font"><?php echo esc_html( 'Music, tools, contact' ); ?></h2>
+        <p class="home-section-kicker pixel-font"><?php echo esc_html( 'UNLOCKS' ); ?></p>
+        <h2 id="music-world-title" class="pixel-font"><?php echo esc_html( 'Music / tools / contact' ); ?></h2>
         <p><?php echo esc_html( 'The records, the builds, and the places where those two things start interfering with each other.' ); ?></p>
         <div class="home-cta-row">
             <a class="pixel-button" href="https://suzyeaston.bandcamp.com" target="_blank" rel="noopener noreferrer"><?php echo esc_html( 'Bandcamp' ); ?></a>

--- a/style.css
+++ b/style.css
@@ -7159,3 +7159,166 @@ body,
     grid-template-columns: 1fr;
   }
 }
+
+/* Focused arcade title-screen art direction pass. */
+.home-orca-hero .home-orca-stage {
+  border-width: 2px;
+  border-color: rgba(57, 255, 20, 0.58);
+  box-shadow: 0 0 0 4px rgba(0, 0, 0, 0.78), 0 24px 80px rgba(0, 0, 0, 0.72), inset 0 0 52px rgba(57, 255, 20, 0.1), 0 0 42px rgba(87, 243, 255, 0.18);
+}
+
+.home-orca-stage::after {
+  background:
+    linear-gradient(90deg, rgba(57, 255, 20, 0.08), transparent 9%, transparent 91%, rgba(87, 243, 255, 0.08)),
+    radial-gradient(ellipse at center, transparent 42%, rgba(0, 0, 0, 0.64) 100%);
+}
+
+.home-title-screen-stack {
+  display: grid;
+  gap: 0.35rem;
+  margin-top: 0.75rem;
+  color: #ffff66;
+  font-size: clamp(0.62rem, 1.1vw, 0.82rem);
+  letter-spacing: 0.08em;
+  line-height: 1.55;
+  text-transform: uppercase;
+}
+
+.home-title-screen-prompt {
+  width: fit-content;
+  margin-top: 1rem;
+  padding: 0.45rem 0.7rem;
+  border: 1px solid rgba(255, 255, 102, 0.48);
+  color: #ffff66;
+  background: rgba(0, 0, 0, 0.46);
+  box-shadow: 0 0 18px rgba(255, 255, 102, 0.16);
+  animation: homeInsertCoinBlink 1.25s steps(2, end) infinite;
+}
+
+.home-title-screen-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem 0.75rem;
+  margin-top: 0.85rem;
+  color: rgba(126, 246, 209, 0.82);
+  font-size: clamp(0.5rem, 0.85vw, 0.62rem);
+  letter-spacing: 0.08em;
+}
+
+.home-title-screen-meta span {
+  padding: 0.25rem 0.45rem;
+  border: 1px solid rgba(87, 243, 255, 0.24);
+  background: rgba(0, 20, 18, 0.5);
+}
+
+.home-press-start {
+  color: #020805;
+  background: #39ff14;
+  border-color: #ffff66;
+  box-shadow: 0 0 18px rgba(57, 255, 20, 0.45), inset 0 0 0 2px rgba(255, 255, 102, 0.32);
+  animation: homeStartPulse 1.2s steps(2, end) infinite;
+}
+
+.home-orca-hero.is-starting .home-orca-stage {
+  animation: homeCoinAccepted 900ms steps(4, end) 1;
+}
+
+.home-orca-hero.is-signal-locking .home-orca-stage::before {
+  opacity: 0.95;
+  animation: homeSignalLock 280ms steps(3, end) infinite;
+}
+
+.home-level-intro {
+  display: grid;
+  gap: 0.35rem;
+  width: min(1180px, calc(100% - 2rem));
+  margin: clamp(0.25rem, 1vw, 0.75rem) auto 0.75rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(255, 255, 102, 0.42);
+  border-radius: 12px;
+  background: linear-gradient(90deg, rgba(255, 72, 206, 0.12), rgba(0, 20, 12, 0.84));
+  color: #dfffea;
+}
+
+.home-level-intro span,
+.home-play-mode .home-section-kicker,
+.home-mission-select .home-section-kicker,
+.home-unlocks .home-section-kicker {
+  color: #ff4dce;
+}
+
+.home-level-intro strong {
+  color: #ffff66;
+}
+
+.home-level-intro em {
+  color: #57f3ff;
+  font-style: normal;
+}
+
+#lousy-outages-teaser {
+  scroll-margin-top: calc(var(--se-header-height, 72px) + 1rem);
+}
+
+.home-play-mode {
+  margin-top: clamp(1.25rem, 3vw, 2.25rem);
+}
+
+.home-play-mode__copy h2::before,
+.home-mission-select h2::before,
+.home-unlocks h2::before {
+  content: "// ";
+  color: #39ff14;
+}
+
+.site-footer::before {
+  content: "CREDITS // MADE IN VANCOUVER";
+  display: block;
+  margin: 0 auto 1rem;
+  color: #ffff66;
+  font-family: "Press Start 2P", monospace;
+  font-size: clamp(0.58rem, 1vw, 0.75rem);
+  letter-spacing: 0.08em;
+  text-align: center;
+}
+
+@keyframes homeInsertCoinBlink {
+  0%, 48% { opacity: 1; }
+  49%, 100% { opacity: 0.42; }
+}
+
+@keyframes homeCoinAccepted {
+  0%, 100% { filter: none; }
+  20% { filter: brightness(1.45) saturate(1.4); transform: translateY(-1px); }
+  38% { filter: hue-rotate(24deg) contrast(1.25); transform: translateX(2px); }
+  56% { filter: brightness(1.25); transform: translateX(-2px); }
+}
+
+@keyframes homeSignalLock {
+  from { transform: translateY(-18px); }
+  to { transform: translateY(18px); }
+}
+
+@media (max-width: 640px) {
+  .home-title-screen-prompt {
+    width: 100%;
+    text-align: center;
+  }
+
+  .home-title-screen-meta {
+    display: grid;
+  }
+
+  .home-level-intro {
+    width: min(100% - 1rem, 1180px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-title-screen-prompt,
+  .home-press-start,
+  .home-orca-hero.is-starting .home-orca-stage,
+  .home-orca-hero.is-signal-locking .home-orca-stage::before {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
### Motivation
- Turn the top hero into a stronger 1990s arcade title screen so the site reads like a playable cabinet while keeping existing content and navigation accessible. 
- Preserve Lousy Outages, Select System, Music/tools/contact, the footer, and the orca identity while reframing them as parts of an arcade world. 
- Provide a progressive-enhancement start interaction that feels playful without blocking access or adding heavy dependencies.

### Description
- Made the hero an arcade title-screen and added the subtitle stack, `INSERT COIN` prompt, tiny cabinet meta (`1 PLAYER`, `VANCOUVER SYSTEMS ONLINE`, `AI / MUSIC / SYSTEMS`), and a primary `PRESS START` control in `page-home.php` (added `data-arcade-hero`, `data-arcade-status`, and `data-home-start` hooks). 
- Added a small vanilla JS start flow `js/home-arcade-start.js` that updates the prompt to `COIN ACCEPTED` → `LOADING SYSTEMS` with brief CRT/glitch classes, respects `prefers-reduced-motion`, and scrolls/focuses the Lousy Outages teaser (`#lousy-outages-teaser`) as `LEVEL 01`. 
- Kept Pacific Power Play as the `BONUS LEVEL` (no new hockey features), preserved its `Choose Your Line` affordance, and ensured the new start script does not interfere with existing game scripts. 
- Updated script enqueues to include the new script in `functions.php` and added focused CSS to `style.css` for title-screen visuals, button pulses, level intro label, footer credits, and reduced-motion overrides. 
- Files changed: `page-home.php`, `style.css`, `functions.php`, and added `js/home-arcade-start.js`.

### Testing
- Ran `php -l page-home.php` and `php -l functions.php` and both reported no syntax errors. 
- Ran `node --check js/home-arcade-start.js` and `node --check js/pacific-power-play.js` and both reported no syntax errors. 
- Manual QA checklist exercised locally: page loads, hero reads as title-screen, `INSERT COIN / PRESS START` visible, clicking `PRESS START` triggers the short start sequence and scrolls to Lousy Outages, and all major sections remain visible and usable (no automated failures observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41f1cc12c8833191966997f27da4d9)