### PR TITLE
Arcade title-screen homepage

### DIFF
--- a/js/home-arcade-start.js
+++ b/js/home-arcade-start.js
@@ -23,22 +23,22 @@
       started = true;
       document.body.classList.add('is-game-started');
       hero.classList.add('is-starting');
-      button.textContent = 'STARTING';
+      button.textContent = 'PLAYER 1 READY';
       button.setAttribute('aria-disabled', 'true');
       if (status) status.textContent = 'COIN ACCEPTED';
 
       if (reduceMotion) {
-        if (status) status.textContent = 'LOADING SYSTEMS';
+        if (status) status.textContent = 'LEVEL 01';
         scrollToLevel();
         return;
       }
 
       window.setTimeout(function () {
         hero.classList.add('is-signal-locking');
-        if (status) status.textContent = 'LOADING SYSTEMS';
+        if (status) status.textContent = 'LEVEL 01';
       }, 420);
       window.setTimeout(function () {
-        if (status) status.textContent = 'LEVEL 01 READY';
+        if (status) status.textContent = 'LEVEL 01 // LOUSY OUTAGES';
         scrollToLevel();
       }, 980);
       window.setTimeout(function () {

--- a/page-home.php
+++ b/page-home.php
@@ -5,105 +5,28 @@ get_header();
 
 <main id="homepage-content" class="home-layout home-arcade-layout">
 
-    <section class="home-orca-hero hero hero-section crt-block" aria-labelledby="home-hero-title" data-arcade-hero>
-        <div class="home-orca-stage">
-            <span class="screen-reader-text"><?php echo esc_html( 'One retro arcade killer whale gliding beside North Shore mountains, CRT stars, and Burrard Inlet water.' ); ?></span>
-            <div class="home-orca-sky" aria-hidden="true">
-                <span class="home-orca-starname">SUZY EASTON</span>
-            </div>
-            <svg class="home-orca-north-shore" viewBox="0 0 1200 260" aria-hidden="true" focusable="false">
-                <path class="home-orca-north-shore__back" d="M0 176 74 154 142 102 208 137 283 58 353 134 428 84 508 145 579 92 642 132 714 64 796 142 878 96 940 138 1014 72 1094 146 1200 110" />
-                <path class="home-orca-north-shore__front" d="M0 205 96 174 176 146 253 166 334 112 420 174 498 139 585 178 668 132 753 176 846 126 930 172 1028 132 1114 180 1200 152" />
+    <section class="home-arcade-title-screen crt-block" aria-labelledby="home-hero-title" data-arcade-hero>
+        <div class="home-arcade-screen__backdrop" aria-hidden="true">
+            <span class="home-pixel-star home-pixel-star--one"></span>
+            <span class="home-pixel-star home-pixel-star--two"></span>
+            <span class="home-pixel-star home-pixel-star--three"></span>
+            <span class="home-pixel-rain home-pixel-rain--one"></span>
+            <span class="home-pixel-rain home-pixel-rain--two"></span>
+            <span class="home-arcade-moon"></span>
+            <svg class="home-arcade-vancouver" viewBox="0 0 1200 280" focusable="false">
+                <path class="home-arcade-vancouver__mountains" d="M0 154 78 126 146 82 215 122 286 48 360 132 428 84 508 140 584 76 646 126 718 52 794 136 878 82 948 130 1016 58 1094 136 1200 94 1200 280 0 280Z" />
+                <path class="home-arcade-vancouver__city" d="M0 214h46v-34h34v-24h28v58h34v-82h38v82h24v-48h36v48h24v-92h40v92h24v-58h34v58h22v-40h28v40h30v-74h22v-20h30v20h22v74h18v-42h28v42h30l18-38 18 38h20l22-52 24 52h18l18-34 24 34h26v-62h44v62h30v48h112v66H0Z" />
+                <path class="home-arcade-vancouver__sails" d="M760 204 790 138 820 204Zm48 0 36-82 34 82Zm58 0 40-68 30 68Z" />
+                <path class="home-arcade-vancouver__water" d="M64 242h164M282 252h240M580 240h332M182 266h190M464 270h310" />
             </svg>
-            <div class="home-orca-copy">
-                <p class="hero-eyebrow pixel-font"><?php echo esc_html( 'music // ai strategy // creative technology' ); ?></p>
-                <h1 id="home-hero-title" class="hero-core-headline home-arcade-title"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>
-                <div class="home-title-screen-stack pixel-font" aria-label="music // ai strategy, creative technology, vancouver systems"><span><?php echo esc_html( 'music // ai strategy' ); ?></span><span><?php echo esc_html( 'creative technology' ); ?></span><span><?php echo esc_html( 'vancouver systems' ); ?></span></div>
-                <p class="hero-copy home-arcade-copy"><?php echo esc_html( 'I build practical AI workflows, music tools, outage dashboards, and digital systems for creative and technical teams.' ); ?></p>
-                <div class="home-title-screen-prompt pixel-font" role="status" aria-live="polite" data-arcade-status><?php echo esc_html( 'INSERT COIN' ); ?></div>
-                <div class="home-title-screen-meta pixel-font" aria-hidden="true"><span>1 PLAYER</span><span>VANCOUVER SYSTEMS ONLINE</span><span>AI / MUSIC / SYSTEMS</span></div>
-                <div class="home-orca-actions home-cta-row hero-cta-group">
-                    <button type="button" class="pixel-button hero-primary-cta home-press-start" data-home-start data-start-label="PRESS START"><?php echo esc_html( 'PRESS START' ); ?></button>
-                    <a href="#lousy-outages-teaser" class="pixel-button pixel-button--secondary"><?php echo esc_html( 'CHECK LOUSY OUTAGES' ); ?></a>
-                    <a href="#mission-select" class="pixel-button pixel-button--secondary"><?php echo esc_html( 'SELECT SYSTEM' ); ?></a>
-                    <button class="pixel-button pixel-button--secondary" type="button" data-contact-trigger aria-haspopup="dialog" aria-controls="contact-suzy-modal"><?php echo esc_html( 'CONTACT SUZY' ); ?></button>
-                </div>
-            </div>
-            <div class="home-orca-art" aria-hidden="true">
-                <div class="home-orca-mark" role="img" aria-label="<?php echo esc_attr( 'One retro arcade killer whale gliding through Burrard Inlet with CRT glow.' ); ?>">
-                    <svg class="home-orca-sigil" viewBox="0 0 760 520" aria-hidden="true" focusable="false">
-                        <defs>
-                            <filter id="home-orca-crt-glow" x="-18%" y="-28%" width="136%" height="156%">
-                                <feGaussianBlur stdDeviation="2.2" result="blur" />
-                                <feColorMatrix in="blur" type="matrix" values="0 0 0 0 0.2  0 0 0 0 1  0 0 0 0 0.82  0 0 0 .52 0" result="cyanGlow" />
-                                <feMerge><feMergeNode in="cyanGlow" /><feMergeNode in="SourceGraphic" /></feMerge>
-                            </filter>
-                            <linearGradient id="home-harbour-skyline" x1="0" x2="1" y1="0" y2="0">
-                                <stop offset="0" stop-color="#030914" />
-                                <stop offset=".5" stop-color="#07303a" />
-                                <stop offset="1" stop-color="#02040c" />
-                            </linearGradient>
-                            <linearGradient id="home-harbour-mountain-glow" x1="0" x2="0" y1="0" y2="1">
-                                <stop offset="0" stop-color="#17285a" stop-opacity=".9" />
-                                <stop offset="1" stop-color="#050d1f" stop-opacity=".96" />
-                            </linearGradient>
-                            <linearGradient id="home-orca-water" x1="0" x2="1" y1="0" y2="0">
-                                <stop offset="0" stop-color="#39ff14" stop-opacity="0" />
-                                <stop offset=".45" stop-color="#57f3ff" stop-opacity=".74" />
-                                <stop offset=".68" stop-color="#ff4fd8" stop-opacity=".28" />
-                                <stop offset="1" stop-color="#39ff14" stop-opacity="0" />
-                            </linearGradient>
-                        </defs>
-                        <g class="home-harbour-stars">
-                            <circle cx="74" cy="55" r="2" /><circle cx="178" cy="88" r="1.6" /><circle cx="304" cy="44" r="1.8" /><circle cx="510" cy="70" r="1.5" /><circle cx="642" cy="38" r="2" />
-                            <circle cx="704" cy="92" r="1.4" /><circle cx="590" cy="126" r="1.4" /><circle cx="420" cy="108" r="1.2" /><circle cx="236" cy="34" r="1.1" /><circle cx="118" cy="154" r="1.2" />
-                        </g>
-                        <g class="home-harbour-gulls">
-                            <path d="M108 132q14-11 28 0q14-11 28 0" />
-                            <path d="M548 112q12-9 24 0q12-9 24 0" />
-                            <path d="M642 158q10-7 20 0q10-7 20 0" />
-                            <path d="M430 174q8-6 16 0q8-6 16 0" />
-                        </g>
-                        <path class="home-harbour-mountains" d="M0 240 68 204 122 218 188 168 244 214 314 145 382 226 448 156 520 232 600 150 674 216 760 184 760 315 0 315Z" />
-                        <g class="home-harbour-skyline">
-                            <path class="home-harbour-city" d="M0 306h34v-38h38v-28h30v66h28v-92h42v92h22v-58h36v58h24v-104h38v104h22v-72h34v72h18v-42h28v42h24v-86h20v-20h24v20h20v86h18v-46h24v46h22v-34h18l18-40 18 40h12l20-52 20 52h14l20-44 22 44h18l18-34 22 34h28v-70h42v70h28v52h84v62H0Z" />
-                            <g class="home-harbour-lookout">
-                                <path d="M444 306V210" />
-                                <path d="M412 210h64l-12-18h-40Z" />
-                                <path d="M426 190h36v-12h-36Z" />
-                            </g>
-                            <g class="home-harbour-sails">
-                                <path d="M536 285 558 226 582 285Z" />
-                                <path d="M572 285 598 216 622 285Z" />
-                                <path d="M610 285 640 224 664 285Z" />
-                                <path d="M650 285 680 236 700 285Z" />
-                            </g>
-                            <path class="home-harbour-lights" d="M58 292h10M146 286h10M282 276h10M392 288h10M712 290h10" />
-                            <path class="home-harbour-ferry" d="M86 322h62l18-14h34l10 14h34l-14 18H100Z" />
-                        </g>
-                        <g class="home-harbour-reflection">
-                            <path d="M34 346h138M204 356h196M438 348h254" />
-                            <path d="M72 376h110M232 390h164M480 382h144" />
-                            <path d="M532 314l-20 44M572 314l-28 82M614 316l-34 92M658 322l-22 58" />
-                            <path d="M414 318h70M424 335h46" />
-                        </g>
-                        <g class="home-orca-sprite" filter="url(#home-orca-crt-glow)">
-                            <path class="home-orca-tail" d="M490 306c28-24 58-39 92-45-7 27-22 47-45 60 24 12 41 31 52 56-34-3-64-16-90-39l-37-12 2-17Z" />
-                            <path class="home-orca-body" d="M182 314c12-40 54-70 116-85 64-15 130-1 198 44 24 15 39 29 47 40-17 15-41 26-71 33-59 13-120 19-182 20-52 0-88-17-108-52Z" />
-                            <path class="home-orca-belly" d="M200 322c24 19 57 29 101 27 57-2 111-12 160-30-29 32-72 51-131 58-57 7-100-12-130-55Z" />
-                            <path class="home-orca-saddle" d="M370 240c35 5 65 17 91 35-29-3-50 3-66 17-18 16-42 10-52-13 4-17 13-30 27-39Z" />
-                            <path class="home-orca-dorsal" d="M336 232c8-45 32-75 69-91 2 49-23 79-69 91Z" />
-                            <path class="home-orca-pectoral" d="M328 356c-7 35-29 60-66 77-2-41 20-66 66-77Z" />
-                            <path class="home-orca-eye" d="M220 290c20-17 47-21 77-12-17 20-43 27-74 21Z" />
-                            <path class="home-orca-eye-dot" d="M244 290h7v7h-7z" />
-                        </g>
-                        <g class="home-orca-waterlines">
-                            <path d="M98 404c42-12 70 12 112 0s70-12 112 0 70 12 112 0 70-12 112 0" />
-                            <path d="M156 434c32-8 54 8 86 0s54-8 86 0 54 8 86 0 54-8 86 0" />
-                        </g>
-                    </svg>
-                </div>
-            </div>
+        </div>
+        <div class="home-arcade-screen__panel">
+            <p class="home-arcade-kicker pixel-font"><?php echo esc_html( 'VANCOUVER CABINET // SYSTEM BOOT' ); ?></p>
+            <h1 id="home-hero-title" class="home-arcade-title pixel-font"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>
+            <p class="home-arcade-subtitle pixel-font"><?php echo esc_html( 'music // AI strategy // creative technology' ); ?></p>
+            <div class="home-title-screen-prompt pixel-font" role="status" aria-live="polite" data-arcade-status><?php echo esc_html( 'INSERT COIN' ); ?></div>
+            <button type="button" class="pixel-button home-press-start" data-home-start data-start-label="PRESS START"><?php echo esc_html( 'PRESS START' ); ?></button>
+            <div class="home-title-screen-meta pixel-font" aria-hidden="true"><span>1 PLAYER</span><span>RAIN CITY</span><span>MUSIC / AI / TOOLS</span></div>
         </div>
     </section>
 

--- a/style.css
+++ b/style.css
@@ -6039,7 +6039,7 @@ body {
   }
 }
 
-/* Vancouver orca title-screen homepage hero. */
+/* Homepage arcade title screen. */
 html,
 body,
 .home-arcade-layout {
@@ -6047,921 +6047,154 @@ body,
   overflow-x: clip;
 }
 
-.home-orca-hero {
-  width: 100%;
-  padding: clamp(0.25rem, 0.8vw, 0.75rem) clamp(0.75rem, 3vw, 2rem) clamp(0.85rem, 2vw, 1.5rem);
+.home-arcade-title-screen {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: calc(100svh - var(--se-header-height, 72px));
+  width: min(1220px, calc(100% - clamp(1rem, 3vw, 2.5rem)));
+  margin: 0 auto clamp(1rem, 2vw, 1.5rem);
+  padding: clamp(1rem, 3vw, 2.25rem);
   overflow: hidden;
+  isolation: isolate;
+  border: 3px solid #39ff14;
+  border-radius: 18px;
+  background:
+    radial-gradient(circle at 50% 34%, rgba(87, 243, 255, 0.18), transparent 25%),
+    radial-gradient(circle at 50% 58%, rgba(255, 79, 216, 0.14), transparent 28%),
+    linear-gradient(180deg, #05071b 0%, #071027 42%, #02191e 68%, #020308 100%);
+  box-shadow:
+    0 0 0 5px rgba(0, 0, 0, 0.88),
+    0 28px 90px rgba(0, 0, 0, 0.72),
+    inset 0 0 54px rgba(57, 255, 20, 0.12),
+    0 0 44px rgba(87, 243, 255, 0.18);
   scroll-margin-top: calc(var(--se-header-height, 72px) + 1rem);
 }
 
-.home-orca-stage {
-  position: relative;
-  display: grid;
-  min-height: clamp(540px, calc(100svh - var(--se-header-height, 72px) - 3.25rem), 720px);
-  max-width: 1180px;
-  margin: 0 auto;
-  padding: clamp(1rem, 3vw, 2rem);
-  overflow: hidden;
-  isolation: isolate;
-  border: 1px solid rgba(87, 243, 255, 0.48);
-  border-radius: 18px;
-  background:
-    radial-gradient(circle at 50% 58%, rgba(87, 243, 255, 0.13), transparent 30%),
-    radial-gradient(circle at 18% 12%, rgba(57, 255, 20, 0.14), transparent 24%),
-    radial-gradient(circle at 86% 26%, rgba(255, 72, 206, 0.09), transparent 20%),
-    linear-gradient(180deg, #020a08 0%, #000403 56%, #010009 100%);
-  box-shadow: 0 22px 70px rgba(0, 0, 0, 0.62), inset 0 0 44px rgba(57, 255, 20, 0.08), 0 0 32px rgba(87, 243, 255, 0.14);
-}
-
-.home-orca-stage::before,
-.home-orca-stage::after {
+.home-arcade-title-screen::before,
+.home-arcade-title-screen::after {
   content: "";
   position: absolute;
   inset: 0;
-  z-index: 2;
+  z-index: 4;
   pointer-events: none;
 }
 
-.home-orca-stage::before {
-  background: repeating-linear-gradient(180deg, rgba(223, 255, 234, 0.055) 0 1px, transparent 1px 4px);
+.home-arcade-title-screen::before {
+  background: repeating-linear-gradient(180deg, rgba(223,255,234,.06) 0 1px, transparent 1px 4px);
   mix-blend-mode: screen;
-  opacity: 0.62;
   animation: homeAsciiScan 8s linear infinite;
 }
 
-.home-orca-stage::after {
-  background: radial-gradient(ellipse at center, transparent 42%, rgba(0, 0, 0, 0.58) 100%);
-}
-
-.home-orca-mark {
-  position: relative;
-  z-index: 1;
-  align-self: center;
-  justify-self: center;
-  width: min(100%, clamp(300px, 58vw, 680px));
-  aspect-ratio: 1;
-  display: grid;
-  place-items: center;
-  color: #dfffea;
-  filter: drop-shadow(0 0 18px rgba(87, 243, 255, 0.28));
-}
-
-.home-orca-mark::before {
-  content: "";
-  position: absolute;
-  inset: 8%;
-  border-radius: 50%;
+.home-arcade-title-screen::after {
   background:
-    radial-gradient(circle, rgba(87, 243, 255, 0.16), transparent 58%),
-    conic-gradient(from 20deg, rgba(57, 255, 20, 0), rgba(57, 255, 20, 0.22), rgba(87, 243, 255, 0.28), rgba(57, 255, 20, 0));
-  opacity: 0.78;
-  animation: homeOrcaPulse 5s ease-in-out infinite;
+    linear-gradient(90deg, rgba(57,255,20,.12), transparent 10%, transparent 90%, rgba(87,243,255,.12)),
+    radial-gradient(ellipse at center, transparent 40%, rgba(0,0,0,.7) 100%);
 }
 
-.home-orca-sigil {
-  position: relative;
+.home-arcade-screen__backdrop {
+  position: absolute;
+  inset: 0;
   z-index: 1;
-  width: 100%;
-  height: auto;
-  overflow: visible;
-}
-
-.home-orca-rings circle {
-  stroke: rgba(87, 243, 255, 0.52);
-  stroke-width: 2;
-  stroke-dasharray: 10 16;
-  filter: drop-shadow(0 0 8px rgba(57, 255, 20, 0.42));
-}
-
-.home-orca-rings circle + circle {
-  stroke: rgba(57, 255, 20, 0.36);
-  stroke-dasharray: 3 13;
-}
-
-.home-orca-mountain {
-  fill: none;
-  stroke: rgba(169, 255, 213, 0.42);
-  stroke-width: 5;
-  stroke-linecap: square;
-  stroke-linejoin: miter;
-}
-
-.home-orca-body,
-.home-orca-tail,
-.home-orca-fin {
-  fill: #020202;
-  stroke: #dfffea;
-  stroke-width: 5;
-  stroke-linejoin: round;
-}
-
-.home-orca-belly,
-.home-orca-saddle,
-.home-orca-eye {
-  fill: #f5fff8;
-}
-
-.home-orca-belly,
-.home-orca-saddle {
-  stroke: #06110d;
-  stroke-width: 3;
-  stroke-linejoin: round;
-}
-
-.home-orca-fin {
-  fill: #050505;
-}
-
-.home-orca-pair {
-  transform-origin: 260px 260px;
-  animation: homeOrcaDrift 9s ease-in-out infinite;
-}
-
-.home-orca-waterlines path {
-  fill: none;
-  stroke: url(#home-orca-water);
-  stroke-width: 4;
-  stroke-linecap: square;
-  filter: drop-shadow(0 0 8px rgba(87, 243, 255, 0.6));
-}
-
-.home-orca-location {
-  fill: rgba(255, 255, 102, 0.72);
-  font-family: "Press Start 2P", monospace;
-  font-size: 14px;
-  letter-spacing: 0.16em;
-  text-shadow: 0 0 8px rgba(255, 255, 102, 0.38);
-}
-
-.home-orca-copy {
-  position: absolute;
-  inset: auto clamp(1rem, 4vw, 3rem) clamp(1.25rem, 4vw, 3rem) clamp(1rem, 4vw, 3rem);
-  z-index: 3;
-  max-width: 52rem;
-  padding-top: clamp(5rem, 19vw, 11rem);
-  background: linear-gradient(180deg, transparent, rgba(0, 4, 3, 0.78) 30%, rgba(0, 4, 3, 0.94));
-}
-
-.home-orca-copy .hero-eyebrow {
-  color: #57f3ff;
-}
-
-.home-orca-copy .home-arcade-title {
-  margin: 0.25rem 0 0;
-  font-size: clamp(3rem, 9vw, 7rem);
-}
-
-.home-orca-copy .home-arcade-copy {
-  max-width: 47rem;
-  margin: 0.85rem 0 0;
-}
-
-.home-orca-actions {
-  justify-content: flex-start;
-  margin-top: 1.35rem;
-}
-
-.home-play-mode {
-  display: grid;
-  grid-template-columns: minmax(0, 0.9fr) minmax(280px, 1.1fr);
-  gap: clamp(1rem, 3vw, 2rem);
-  align-items: center;
-  width: min(1180px, calc(100% - 2rem));
-  margin: 0 auto clamp(1rem, 3vw, 2rem);
-  padding: clamp(1rem, 3vw, 1.5rem);
-  overflow: hidden;
-  border-color: rgba(255, 255, 102, 0.34);
-}
-
-.home-play-mode__copy p:not(.home-section-kicker) {
-  color: rgba(223, 255, 234, 0.86);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
-  line-height: 1.65;
-}
-
-.home-play-mode .home-arcade-game {
-  max-width: none;
-  width: 100%;
-}
-
-.home-play-mode .hero-game-stage__screen {
-  min-height: clamp(180px, 22vw, 270px);
-}
-
-@keyframes homeOrcaDrift {
-  0%, 100% { transform: rotate(-2deg) scale(1); }
-  50% { transform: rotate(2deg) scale(1.015); }
-}
-
-@keyframes homeOrcaPulse {
-  0%, 100% { opacity: 0.58; transform: scale(0.98); }
-  50% { opacity: 0.86; transform: scale(1.02); }
-}
-
-@media (max-width: 900px) {
-  .home-orca-stage {
-    min-height: clamp(520px, 78svh, 680px);
-  }
-
-  .home-orca-mark {
-    width: min(100%, clamp(280px, 72vw, 520px));
-  }
-
-  .home-play-mode {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (max-width: 640px) {
-  .home-orca-hero {
-    padding-inline: 0.5rem;
-  }
-
-  .home-orca-stage {
-    min-height: 620px;
-    padding: 0.75rem;
-    border-radius: 14px;
-  }
-
-  .home-orca-mark {
-    align-self: start;
-    width: min(100%, 360px);
-    margin-top: 0.25rem;
-  }
-
-  .home-orca-location {
-    font-size: 12px;
-    letter-spacing: 0.1em;
-  }
-
-  .home-orca-copy {
-    inset-inline: 0.85rem;
-    bottom: 1rem;
-    padding-top: 6.5rem;
-  }
-
-  .home-orca-actions,
-  .home-play-mode .home-cta-row {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .home-orca-actions .pixel-button,
-  .home-play-mode .pixel-button {
-    width: 100%;
-  }
-
-  .home-play-mode {
-    width: min(100% - 1rem, 1180px);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .home-orca-stage::before,
-  .home-orca-mark::before,
-  .home-orca-pair,
-  .home-arcade-start {
-    animation: none !important;
-  }
-}
-
-/* Surgical homepage energy polish: strengthen the existing orca sigil without changing the hero. */
-.home-orca-mark {
-  filter: drop-shadow(0 0 24px rgba(87, 243, 255, 0.42)) drop-shadow(0 0 46px rgba(57, 255, 20, 0.18));
-}
-
-.home-orca-mark::before {
-  opacity: 0.92;
-  filter: blur(0.2px) saturate(1.18);
-}
-
-.home-orca-rings circle {
-  stroke-width: 2.5;
-  filter: drop-shadow(0 0 12px rgba(57, 255, 20, 0.55)) drop-shadow(0 0 20px rgba(87, 243, 255, 0.22));
-}
-
-.home-orca-pair {
-  filter: drop-shadow(0 0 14px rgba(87, 243, 255, 0.22));
-}
-
-.home-orca-waterlines path {
-  animation: homeOrcaWaterSignal 4.8s ease-in-out infinite;
-}
-
-@keyframes homeOrcaWaterSignal {
-  0%, 100% { opacity: 0.72; stroke-dashoffset: 0; }
-  50% { opacity: 1; stroke-dashoffset: -18; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .home-orca-waterlines path {
-    animation: none !important;
-  }
-}
-
-/* Homepage orca hero composition pass: clearer circling whales, North Shore atmosphere, and star-map wordmark. */
-.home-orca-sky,
-.home-orca-north-shore {
-  position: absolute;
   pointer-events: none;
-  z-index: 0;
 }
 
-.home-orca-sky {
-  inset: 0 0 auto;
-  height: 46%;
-  overflow: hidden;
-  background:
-    radial-gradient(circle at 11% 18%, rgba(255, 255, 102, 0.68) 0 1px, transparent 1.8px),
-    radial-gradient(circle at 19% 34%, rgba(87, 243, 255, 0.52) 0 1px, transparent 1.8px),
-    radial-gradient(circle at 31% 16%, rgba(223, 255, 234, 0.54) 0 1px, transparent 2px),
-    radial-gradient(circle at 43% 29%, rgba(255, 72, 206, 0.42) 0 1px, transparent 1.9px),
-    radial-gradient(circle at 58% 12%, rgba(255, 255, 102, 0.56) 0 1px, transparent 2px),
-    radial-gradient(circle at 74% 24%, rgba(87, 243, 255, 0.5) 0 1px, transparent 1.8px),
-    radial-gradient(circle at 88% 17%, rgba(223, 255, 234, 0.46) 0 1px, transparent 2px),
-    radial-gradient(circle at 92% 39%, rgba(255, 255, 102, 0.42) 0 1px, transparent 1.8px),
-    radial-gradient(circle at 8% 47%, rgba(87, 243, 255, 0.32) 0 1px, transparent 1.8px),
-    radial-gradient(circle at 66% 43%, rgba(223, 255, 234, 0.38) 0 1px, transparent 1.8px);
-  opacity: 0.9;
-  mask-image: linear-gradient(180deg, #000 0%, rgba(0, 0, 0, 0.82) 62%, transparent 100%);
-}
-
-.home-orca-starname {
+.home-arcade-vancouver {
   position: absolute;
-  left: 50%;
-  top: clamp(1.25rem, 5.2vw, 3.8rem);
-  transform: translateX(-50%);
-  color: rgba(255, 255, 102, 0.42);
-  font-family: "Press Start 2P", monospace;
-  font-size: clamp(0.46rem, 1.12vw, 0.78rem);
-  letter-spacing: clamp(0.52em, 1.55vw, 1em);
-  text-shadow:
-    0 0 10px rgba(255, 255, 102, 0.56),
-    0.5rem 0.35rem 0 rgba(87, 243, 255, 0.18),
-    -0.45rem 0.85rem 0 rgba(223, 255, 234, 0.14);
-  opacity: 0.74;
+  inset: auto -3% 0;
+  width: 106%;
+  height: min(32vh, 280px);
+  opacity: .55;
+  filter: drop-shadow(0 0 16px rgba(87,243,255,.24));
 }
 
-.home-orca-starname::before,
-.home-orca-starname::after {
-  content: "";
+.home-arcade-vancouver__mountains { fill: rgba(8, 23, 54, .88); stroke: rgba(87,243,255,.34); stroke-width: 4; }
+.home-arcade-vancouver__city { fill: rgba(2, 7, 16, .96); stroke: rgba(57,255,20,.28); stroke-width: 3; }
+.home-arcade-vancouver__sails { fill: rgba(232,255,243,.82); stroke: rgba(87,243,255,.85); stroke-width: 4; }
+.home-arcade-vancouver__water { fill: none; stroke: rgba(87,243,255,.72); stroke-width: 5; stroke-linecap: square; stroke-dasharray: 90 34; animation: homeOrcaWaterSignal 4.8s steps(5, end) infinite; }
+
+.home-pixel-star,
+.home-pixel-rain,
+.home-arcade-moon {
   position: absolute;
-  left: 4%;
-  right: 8%;
-  border-top: 1px dotted rgba(87, 243, 255, 0.22);
-  transform: translateY(-0.55rem) rotate(-1.5deg);
+  display: block;
 }
 
-.home-orca-starname::after {
-  left: 16%;
-  right: 18%;
-  transform: translateY(1.05rem) rotate(1.2deg);
-  border-color: rgba(255, 255, 102, 0.16);
-}
+.home-pixel-star { width: 7px; height: 7px; background: #ffff66; box-shadow: 0 0 16px rgba(255,255,102,.8); animation: homeOrcaStarTwinkle 3s steps(2,end) infinite; }
+.home-pixel-star--one { left: 12%; top: 14%; }
+.home-pixel-star--two { right: 18%; top: 18%; background: #57f3ff; animation-delay: .6s; }
+.home-pixel-star--three { left: 78%; top: 38%; background: #ff4fd8; animation-delay: 1.1s; }
+.home-pixel-rain { width: 3px; height: 58px; background: linear-gradient(#57f3ff, transparent); opacity: .32; transform: rotate(14deg); animation: homeSignalLock 1.4s linear infinite; }
+.home-pixel-rain--one { left: 24%; top: 5%; }
+.home-pixel-rain--two { right: 28%; top: 7%; animation-delay: .5s; }
+.home-arcade-moon { right: 9%; top: 10%; width: clamp(52px, 8vw, 92px); aspect-ratio: 1; border-radius: 50%; background: radial-gradient(circle at 35% 35%, #fff8aa, #57f3ff 65%, transparent 67%); opacity: .35; }
 
-.home-orca-north-shore {
-  left: 50%;
-  top: clamp(5.2rem, 13vw, 9.5rem);
-  width: min(108%, 1260px);
-  transform: translateX(-50%);
-  opacity: 0.7;
-  filter: drop-shadow(0 0 18px rgba(87, 243, 255, 0.18));
-}
-
-.home-orca-north-shore path {
-  fill: none;
-  stroke-linecap: square;
-  stroke-linejoin: miter;
-}
-
-.home-orca-north-shore__back {
-  stroke: rgba(87, 243, 255, 0.24);
-  stroke-width: 3;
-}
-
-.home-orca-north-shore__front {
-  stroke: rgba(203, 255, 231, 0.34);
-  stroke-width: 4;
-}
-
-.home-orca-mark {
-  align-self: start;
-  width: min(88%, clamp(280px, 44vw, 540px));
-  margin-top: clamp(4.15rem, 9.2vw, 6.6rem);
-  transform: translateX(clamp(0.4rem, 3vw, 2.4rem));
-}
-
-.home-orca-copy {
-  left: clamp(1rem, 4vw, 3rem);
-  right: auto;
-  max-width: min(36rem, calc(100% - clamp(2rem, 8vw, 6rem)));
-  padding: clamp(0.85rem, 1.55vw, 1.1rem);
-  border: 1px solid rgba(87, 243, 255, 0.18);
-  border-radius: 16px;
-  background:
-    linear-gradient(180deg, rgba(0, 4, 3, 0.08), rgba(0, 4, 3, 0.4)),
-    radial-gradient(circle at 0 100%, rgba(87, 243, 255, 0.12), transparent 68%);
-  box-shadow: 0 0 24px rgba(0, 0, 0, 0.16);
-  backdrop-filter: blur(1px);
-}
-
-@media (min-width: 1020px) {
-  .home-orca-copy {
-    max-width: 34rem;
-  }
-}
-
-@media (max-width: 900px) {
-  .home-orca-north-shore {
-    top: clamp(4.5rem, 16vw, 7.2rem);
-    width: 132%;
-  }
-
-  .home-orca-mark {
-    width: min(90%, clamp(270px, 66vw, 470px));
-    margin-top: clamp(3.9rem, 13vw, 5.8rem);
-    transform: translateX(clamp(0.25rem, 2vw, 1.25rem));
-  }
-
-  .home-orca-copy {
-    max-width: min(38rem, calc(100% - 2rem));
-  }
-}
-
-@media (max-width: 640px) {
-  .home-orca-sky {
-    height: 38%;
-    opacity: 0.7;
-  }
-
-  .home-orca-starname {
-    max-width: 88%;
-    overflow: hidden;
-    white-space: nowrap;
-    font-size: 0.42rem;
-    letter-spacing: 0.36em;
-    opacity: 0.58;
-  }
-
-  .home-orca-north-shore {
-    top: 4.6rem;
-    width: 160%;
-    opacity: 0.45;
-  }
-
-  .home-orca-mark {
-    width: min(84%, 315px);
-    margin-top: 4.4rem;
-    transform: translateX(0.35rem);
-  }
-
-  .home-orca-copy {
-    inset-inline: 0.75rem;
-    max-width: none;
-    padding: 0.85rem;
-    background: linear-gradient(180deg, rgba(0, 4, 3, 0.12), rgba(0, 4, 3, 0.56));
-  }
-}
-
-/* Homepage hero split-layout redraw: copy and orca art occupy distinct cinematic zones. */
-.home-orca-hero {
-  padding-top: clamp(0.1rem, 0.45vw, 0.45rem);
-}
-
-.home-orca-stage {
-  grid-template-columns: minmax(0, 0.92fr) minmax(320px, 1.08fr);
-  gap: clamp(1.5rem, 4vw, 4rem);
-  align-items: center;
-  min-height: clamp(500px, calc(100svh - var(--se-header-height, 72px) - 4.5rem), 680px);
-  padding: clamp(1.1rem, 3.2vw, 3.2rem);
-  background:
-    radial-gradient(circle at 72% 48%, rgba(87, 243, 255, 0.16), transparent 28%),
-    radial-gradient(circle at 17% 22%, rgba(57, 255, 20, 0.13), transparent 24%),
-    radial-gradient(circle at 88% 18%, rgba(255, 72, 206, 0.08), transparent 18%),
-    linear-gradient(180deg, #020a08 0%, #000403 58%, #010009 100%);
-}
-
-.home-orca-sky {
-  height: 58%;
-  opacity: 0.78;
-}
-
-.home-orca-starname {
-  left: 73%;
-  top: clamp(1.2rem, 3.6vw, 2.8rem);
-  letter-spacing: clamp(0.42em, 1.05vw, 0.8em);
-  opacity: 0.32;
-}
-
-.home-orca-north-shore {
-  top: auto;
-  bottom: clamp(1.7rem, 5vw, 3.9rem);
-  width: min(116%, 1320px);
-  opacity: 0.5;
-}
-
-.home-orca-copy {
+.home-arcade-screen__panel {
   position: relative;
-  inset: auto;
-  z-index: 3;
-  grid-column: 1;
-  align-self: center;
-  max-width: 36rem;
-  padding: clamp(1rem, 2.4vw, 1.65rem);
-  border-color: rgba(87, 243, 255, 0.28);
-  background:
-    linear-gradient(135deg, rgba(0, 12, 11, 0.82), rgba(0, 4, 3, 0.42)),
-    radial-gradient(circle at 0 100%, rgba(87, 243, 255, 0.15), transparent 62%);
-  box-shadow: 0 18px 56px rgba(0, 0, 0, 0.32), inset 0 0 26px rgba(57, 255, 20, 0.055);
-}
-
-.home-orca-copy .home-arcade-title {
-  font-size: clamp(2.7rem, 6vw, 5.8rem);
-  line-height: 0.95;
-}
-
-.home-orca-copy .home-arcade-copy {
-  max-width: 34rem;
-  font-size: clamp(1rem, 1.5vw, 1.18rem);
-}
-
-.home-orca-art {
-  position: relative;
-  z-index: 1;
-  grid-column: 2;
+  z-index: 5;
   display: grid;
-  place-items: center;
-  min-width: 0;
+  justify-items: center;
+  gap: clamp(.65rem, 1.8vw, 1.1rem);
+  width: min(100%, 980px);
+  padding: clamp(1rem, 3vw, 2rem) clamp(.75rem, 2vw, 1.5rem);
+  text-align: center;
 }
 
-.home-orca-art::before {
-  content: "";
-  position: absolute;
-  inset: 5% 2% 7%;
-  border-radius: 50%;
-  background: radial-gradient(circle, rgba(87, 243, 255, 0.13), transparent 64%);
-  filter: blur(0.3px);
-  opacity: 0.84;
+.home-arcade-kicker { margin: 0; color: #57f3ff; font-size: clamp(.52rem, 1.2vw, .78rem); letter-spacing: .12em; }
+.home-arcade-title { margin: 0; color: #ffff66; font-size: clamp(2.75rem, 11vw, 8.6rem); line-height: .95; letter-spacing: .03em; text-shadow: .06em .06em 0 #ff4fd8, -.035em -.035em 0 #57f3ff, 0 0 24px rgba(255,255,102,.5); }
+.home-arcade-subtitle { margin: 0; color: #dfffea; font-size: clamp(.62rem, 1.7vw, 1rem); line-height: 1.65; letter-spacing: .08em; text-transform: uppercase; }
+
+.home-title-screen-prompt { margin-top: clamp(.25rem, 1vw, .75rem); padding: .5rem .85rem; color: #ffff66; border: 2px solid rgba(255,255,102,.62); background: rgba(0,0,0,.52); box-shadow: 0 0 18px rgba(255,255,102,.22); font-size: clamp(.72rem, 2.2vw, 1.15rem); animation: homeInsertCoinBlink 1.05s steps(2,end) infinite; }
+.home-press-start { min-width: min(100%, 320px); padding: .9rem 1.35rem; color: #020805; background: #39ff14; border-color: #ffff66; font-size: clamp(.78rem, 2.1vw, 1.08rem); box-shadow: 0 0 18px rgba(57,255,20,.48), inset 0 0 0 2px rgba(255,255,102,.32); animation: homeStartPulse 1.1s steps(2,end) infinite; }
+.home-press-start:focus-visible { outline: 4px solid #ff4fd8; outline-offset: 4px; }
+.home-title-screen-meta { display: flex; flex-wrap: wrap; justify-content: center; gap: .5rem .75rem; color: rgba(126,246,209,.86); font-size: clamp(.48rem, 1.2vw, .62rem); letter-spacing: .08em; }
+.home-title-screen-meta span { padding: .28rem .45rem; border: 1px solid rgba(87,243,255,.34); background: rgba(0,20,18,.5); }
+
+.home-arcade-title-screen.is-starting { animation: homeCoinAccepted 900ms steps(4,end) 1; }
+.home-arcade-title-screen.is-signal-locking::before { opacity: .96; animation: homeSignalLock 280ms steps(3,end) infinite; }
+
+.home-level-intro { display: grid; gap: .35rem; width: min(1180px, calc(100% - 2rem)); margin: clamp(.25rem, 1vw, .75rem) auto .75rem; padding: .75rem 1rem; border: 1px solid rgba(255,255,102,.42); border-radius: 12px; background: linear-gradient(90deg, rgba(255,72,206,.12), rgba(0,20,12,.84)); color: #dfffea; }
+.home-level-intro span, .home-play-mode .home-section-kicker, .home-mission-select .home-section-kicker, .home-unlocks .home-section-kicker { color: #ff4dce; }
+.home-level-intro strong { color: #ffff66; }
+.home-level-intro em { color: #57f3ff; font-style: normal; }
+#lousy-outages-teaser { scroll-margin-top: calc(var(--se-header-height, 72px) + 1rem); }
+.home-play-mode { margin-top: clamp(1.25rem, 3vw, 2.25rem); }
+.home-play-mode__copy h2::before, .home-mission-select h2::before, .home-unlocks h2::before { content: "// "; color: #39ff14; }
+.site-footer::before { content: "CREDITS // MADE IN VANCOUVER"; display: block; margin: 0 auto 1rem; color: #ffff66; font-family: "Press Start 2P", monospace; font-size: clamp(.58rem, 1vw, .75rem); letter-spacing: .08em; text-align: center; }
+
+@keyframes homeInsertCoinBlink { 0%, 48% { opacity: 1; } 49%, 100% { opacity: .35; } }
+@keyframes homeStartPulse { 0%, 48% { transform: translateY(0); filter: brightness(1); } 49%, 100% { transform: translateY(-2px); filter: brightness(1.22); } }
+@keyframes homeCoinAccepted { 0%, 100% { filter: none; } 20% { filter: brightness(1.45) saturate(1.4); transform: translateY(-1px); } 38% { filter: hue-rotate(24deg) contrast(1.25); transform: translateX(2px); } 56% { filter: brightness(1.25); transform: translateX(-2px); } }
+@keyframes homeSignalLock { from { transform: translateY(-18px); } to { transform: translateY(18px); } }
+@keyframes homeOrcaWaterSignal { 0%, 100% { opacity: .5; stroke-dashoffset: 0; } 50% { opacity: 1; stroke-dashoffset: -48; } }
+@keyframes homeOrcaStarTwinkle { 0%, 100% { opacity: .45; } 50% { opacity: 1; } }
+
+@media (max-width: 700px) {
+  .home-arcade-title-screen { min-height: calc(100svh - var(--se-header-height, 72px)); width: min(100% - .75rem, 1220px); padding: .75rem; border-radius: 14px; }
+  .home-arcade-screen__panel { gap: .62rem; padding: .7rem .35rem 5.25rem; }
+  .home-arcade-title { font-size: clamp(2.55rem, 15vw, 4.2rem); max-width: 7ch; overflow-wrap: normal; }
+  .home-arcade-subtitle { max-width: 28ch; }
+  .home-title-screen-prompt, .home-press-start { width: min(100%, 300px); }
+  .home-title-screen-meta { display: grid; }
+  .home-arcade-vancouver { height: 24vh; opacity: .42; }
+  .home-arcade-moon { opacity: .22; }
+  .home-level-intro { width: min(100% - 1rem, 1180px); }
 }
 
-.home-orca-mark {
-  align-self: center;
-  justify-self: center;
-  width: min(100%, clamp(320px, 41vw, 560px));
-  margin-top: 0;
-  transform: none;
-  filter: drop-shadow(0 0 18px rgba(87, 243, 255, 0.34)) drop-shadow(0 0 34px rgba(57, 255, 20, 0.12));
-}
-
-.home-orca-mark::before {
-  inset: 10%;
-  opacity: 0.62;
-  filter: none;
-}
-
-.home-orca-rings circle {
-  stroke-width: 2;
-  filter: drop-shadow(0 0 8px rgba(87, 243, 255, 0.32));
-}
-
-.home-orca-body,
-.home-orca-tail,
-.home-orca-fin {
-  stroke-width: 4.25;
-}
-
-.home-orca-belly,
-.home-orca-saddle {
-  stroke-width: 2.4;
-}
-
-.home-orca-pair {
-  filter: drop-shadow(0 0 9px rgba(87, 243, 255, 0.2));
-}
-
-@media (max-width: 900px) {
-  .home-orca-stage {
-    grid-template-columns: 1fr;
-    gap: clamp(1rem, 4vw, 1.8rem);
-    min-height: auto;
-  }
-
-  .home-orca-copy,
-  .home-orca-art {
-    grid-column: 1;
-  }
-
-  .home-orca-art {
-    order: 1;
-  }
-
-  .home-orca-copy {
-    order: 2;
-    justify-self: center;
-    max-width: 42rem;
-  }
-
-  .home-orca-mark {
-    width: min(100%, clamp(300px, 72vw, 500px));
-  }
-
-  .home-orca-starname {
-    left: 50%;
-    opacity: 0.25;
-  }
-
-  .home-orca-north-shore {
-    bottom: auto;
-    top: clamp(4.3rem, 16vw, 7.2rem);
-    width: 132%;
-  }
-}
-
-@media (max-width: 640px) {
-  .home-orca-stage {
-    padding: 0.8rem;
-  }
-
-  .home-orca-sky {
-    height: 42%;
-  }
-
-  .home-orca-mark {
-    width: min(100%, 340px);
-  }
-
-  .home-orca-copy {
-    inset: auto;
-    padding: 0.95rem;
-    background: linear-gradient(180deg, rgba(0, 12, 11, 0.84), rgba(0, 4, 3, 0.64));
-  }
-
-  .home-orca-copy .home-arcade-title {
-    font-size: clamp(2.4rem, 15vw, 3.65rem);
-  }
-}
-
-/* Single-orca arcade title-screen refinement. */
-.home-orca-stage {
-  grid-template-columns: minmax(0, 0.95fr) minmax(300px, 0.9fr);
-  background:
-    radial-gradient(circle at 74% 44%, rgba(87, 243, 255, 0.16), transparent 24%),
-    radial-gradient(circle at 20% 22%, rgba(57, 255, 20, 0.1), transparent 22%),
-    linear-gradient(180deg, #020a12 0%, #00110f 56%, #02030a 100%);
-}
-
-.home-orca-art {
-  align-self: center;
-}
-
-.home-orca-art::before {
-  inset: 13% 7% 16%;
-  border-radius: 34% 54% 42% 58%;
-  background:
-    radial-gradient(circle at 58% 45%, rgba(87, 243, 255, 0.2), transparent 48%),
-    linear-gradient(180deg, rgba(57, 255, 20, 0.08), transparent 62%);
-}
-
-.home-orca-mark {
-  width: min(100%, clamp(300px, 34vw, 460px));
-  aspect-ratio: 620 / 430;
-  filter: drop-shadow(0 0 18px rgba(87, 243, 255, 0.44)) drop-shadow(0 0 26px rgba(57, 255, 20, 0.16));
-}
-
-.home-orca-mark::before {
-  inset: 14% 4% 13%;
-  border-radius: 38% 58% 45% 55%;
-  background:
-    repeating-linear-gradient(0deg, rgba(223, 255, 234, 0.045) 0 2px, transparent 2px 8px),
-    radial-gradient(circle at 50% 48%, rgba(87, 243, 255, 0.16), transparent 60%);
-  animation: homeOrcaSpriteGlow 4.8s steps(4, end) infinite;
-}
-
-.home-orca-sigil {
-  overflow: visible;
-}
-
-.home-orca-sprite {
-  transform-origin: 315px 210px;
-  animation: homeOrcaBob 5.6s steps(6, end) infinite;
-}
-
-.home-orca-body,
-.home-orca-tail,
-.home-orca-fin,
-.home-orca-dorsal,
-.home-orca-pectoral {
-  fill: #030507;
-  stroke: #e8fff3;
-  stroke-width: 6;
-  stroke-linejoin: miter;
-}
-
-.home-orca-tail {
-  stroke-width: 5;
-}
-
-.home-orca-belly,
-.home-orca-saddle,
-.home-orca-eye {
-  fill: #f3fff8;
-  stroke: #06110d;
-  stroke-width: 4;
-  stroke-linejoin: miter;
-}
-
-.home-orca-eye-dot {
-  fill: #06110d;
-}
-
-.home-orca-pixel-glint {
-  fill: rgba(87, 243, 255, 0.78);
-  animation: homeOrcaFlicker 3.2s steps(2, end) infinite;
-}
-
-.home-orca-waterlines path {
-  stroke-dasharray: 34 18;
-  animation: homeOrcaWaterSignal 4.8s steps(5, end) infinite;
-}
-
-.home-orca-north-shore {
-  bottom: clamp(0.8rem, 3.4vw, 2.8rem);
-  opacity: 0.46;
-}
-
-.home-orca-sky {
-  animation: homeOrcaStarTwinkle 7s steps(4, end) infinite;
-}
-
-@keyframes homeOrcaBob {
-  0%, 100% { transform: translate(0, 0) rotate(-1deg); }
-  50% { transform: translate(0, -10px) rotate(1deg); }
-}
-
-@keyframes homeOrcaSpriteGlow {
-  0%, 100% { opacity: 0.5; transform: scale(0.98); }
-  50% { opacity: 0.78; transform: scale(1.02); }
-}
-
-@keyframes homeOrcaFlicker {
-  0%, 100% { opacity: 0.35; }
-  50% { opacity: 1; }
-}
-
-@keyframes homeOrcaStarTwinkle {
-  0%, 100% { opacity: 0.62; }
-  50% { opacity: 0.86; }
-}
-
-@media (max-width: 900px) {
-  .home-orca-stage {
-    grid-template-columns: 1fr;
-  }
-
-  .home-orca-mark {
-    width: min(100%, clamp(300px, 72vw, 440px));
-  }
-}
-
-@media (max-width: 640px) {
-  .home-orca-stage {
-    gap: 1rem;
-  }
-
-  .home-orca-mark {
-    width: min(100%, 330px);
-  }
-
-  .home-orca-art {
-    padding-top: 1rem;
-  }
+@media (max-height: 620px) {
+  .home-arcade-title-screen { min-height: 560px; }
+  .home-arcade-title { font-size: clamp(2.35rem, 9vw, 6rem); }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .home-orca-sprite,
-  .home-orca-mark::before,
-  .home-orca-pixel-glint,
-  .home-orca-sky {
-    animation: none !important;
-  }
-}
-
-/* Vancouver cosmic harbour title-screen hero polish. */
-.home-orca-stage {
-  grid-template-columns: minmax(0, 0.9fr) minmax(330px, 1fr);
-  overflow: hidden;
-  background:
-    radial-gradient(circle at 72% 24%, rgba(126, 82, 255, 0.2), transparent 24%),
-    radial-gradient(circle at 84% 58%, rgba(255, 79, 216, 0.12), transparent 20%),
-    radial-gradient(circle at 66% 56%, rgba(87, 243, 255, 0.18), transparent 28%),
-    linear-gradient(180deg, #020714 0%, #06112b 44%, #031815 70%, #02030a 100%);
-}
-.home-orca-copy { z-index: 5; }
-.home-orca-art { position: relative; z-index: 2; min-width: 0; }
-.home-orca-mark { width: min(100%, clamp(330px, 43vw, 560px)); aspect-ratio: 720 / 500; }
-.home-orca-sigil { max-width: 100%; height: auto; }
-.home-harbour-stars circle { fill: #fff2a8; opacity: .78; animation: homeHarbourTwinkle 4s steps(3,end) infinite; }
-.home-harbour-stars circle:nth-child(2n) { animation-delay: 1.1s; fill: #57f3ff; }
-.home-harbour-gulls { fill: none; stroke: rgba(230,255,246,.74); stroke-width: 4; stroke-linecap: round; animation: homeHarbourGulls 8s ease-in-out infinite; }
-.home-harbour-mountains { fill: rgba(7, 18, 36, .92); stroke: rgba(87, 243, 255, .26); stroke-width: 2; }
-.home-harbour-city { fill: url(#home-harbour-skyline); stroke: rgba(87,243,255,.38); stroke-width: 2; }
-.home-harbour-sails { fill: rgba(232,255,243,.78); stroke: rgba(87,243,255,.9); stroke-width: 3; stroke-linejoin: round; filter: drop-shadow(0 0 8px rgba(87,243,255,.6)); }
-.home-harbour-lights { stroke: #fff2a8; stroke-width: 5; stroke-linecap: square; opacity: .84; }
-.home-harbour-reflection { stroke: url(#home-orca-water); stroke-width: 4; stroke-linecap: round; opacity: .8; animation: homeHarbourShimmer 5.6s steps(6,end) infinite; }
-.home-orca-sprite { transform-origin: 330px 300px; animation: homeOrcaBob 5.6s ease-in-out infinite; }
-.home-orca-waterlines path { stroke-width: 4; opacity: .78; }
-.home-orca-mark::before { animation: homeOrcaSpriteGlow 5.2s ease-in-out infinite; }
-@keyframes homeHarbourTwinkle { 0%,100%{opacity:.45} 50%{opacity:1} }
-@keyframes homeHarbourGulls { 0%,100%{transform:translateX(0)} 50%{transform:translateX(10px) translateY(-3px)} }
-@keyframes homeHarbourShimmer { 0%,100%{opacity:.45;transform:translateX(0)} 50%{opacity:.9;transform:translateX(8px)} }
-@media (max-width: 900px) { .home-orca-stage { grid-template-columns: 1fr; } .home-orca-art { justify-self: center; } .home-orca-mark { width: min(100%, 540px); } }
-@media (prefers-reduced-motion: reduce) { .home-harbour-stars circle, .home-harbour-gulls, .home-harbour-reflection { animation: none !important; } }
-
-/* Focused Vancouver harbour hero refinement: balanced title and recognizable waterfront cues. */
-.home-orca-copy .home-arcade-title {
-  max-width: 12ch;
-  font-size: clamp(2.05rem, 4.45vw, 4.35rem);
-  line-height: 1.03;
-  letter-spacing: clamp(0.015em, 0.35vw, 0.055em);
-  text-wrap: balance;
-}
-
-.home-orca-stage {
-  grid-template-columns: minmax(0, 0.82fr) minmax(360px, 1.18fr);
-  gap: clamp(2rem, 5vw, 5rem);
-  background:
-    radial-gradient(circle at 74% 18%, rgba(126, 82, 255, 0.24), transparent 22%),
-    radial-gradient(circle at 89% 46%, rgba(255, 79, 216, 0.14), transparent 18%),
-    radial-gradient(circle at 70% 60%, rgba(87, 243, 255, 0.2), transparent 30%),
-    linear-gradient(180deg, #010512 0%, #07102b 42%, #021a22 68%, #02030a 100%);
-}
-
-.home-orca-copy {
-  max-width: 31rem;
-}
-
-.home-orca-mark {
-  width: min(100%, clamp(380px, 48vw, 660px));
-  aspect-ratio: 760 / 520;
-}
-
-.home-harbour-mountains {
-  fill: url(#home-harbour-mountain-glow);
-  opacity: .86;
-}
-
-.home-harbour-lookout {
-  fill: rgba(3, 7, 14, .94);
-  stroke: rgba(87, 243, 255, .56);
-  stroke-width: 3;
-  stroke-linejoin: miter;
-  filter: drop-shadow(0 0 7px rgba(87, 243, 255, .32));
-}
-
-.home-harbour-sails path {
-  fill: rgba(234, 255, 246, .86);
-  stroke: rgba(87, 243, 255, .92);
-  stroke-width: 3;
-  stroke-linejoin: miter;
-}
-
-.home-harbour-ferry {
-  fill: rgba(5, 12, 18, .88);
-  stroke: rgba(255, 242, 168, .5);
-  stroke-width: 2;
-  opacity: .78;
-}
-
-.home-orca-sprite {
-  transform-origin: 380px 330px;
-}
-
-@media (max-width: 900px) {
-  .home-orca-stage {
-    grid-template-columns: 1fr;
-  }
-
-  .home-orca-copy .home-arcade-title {
-    font-size: clamp(2.15rem, 8vw, 4rem);
-  }
-
-  .home-orca-mark {
-    width: min(100%, 600px);
-  }
-}
-
-@media (max-width: 640px) {
-  .home-orca-copy .home-arcade-title {
-    max-width: 6ch;
-    font-size: clamp(2.25rem, 13vw, 3.35rem);
-    line-height: 1.08;
-    word-break: normal;
-    overflow-wrap: normal;
-  }
-
-  .home-orca-mark {
-    width: min(100%, 360px);
-  }
+  .home-arcade-title-screen::before,
+  .home-title-screen-prompt,
+  .home-press-start,
+  .home-arcade-vancouver__water,
+  .home-pixel-star,
+  .home-pixel-rain,
+  .home-arcade-title-screen.is-starting,
+  .home-arcade-title-screen.is-signal-locking::before { animation: none !important; }
 }
 
 /* Pacific Power Play homepage arcade rink. */
@@ -7157,168 +6390,5 @@ body,
   .home .home-play-mode,
   .front-page .home-play-mode {
     grid-template-columns: 1fr;
-  }
-}
-
-/* Focused arcade title-screen art direction pass. */
-.home-orca-hero .home-orca-stage {
-  border-width: 2px;
-  border-color: rgba(57, 255, 20, 0.58);
-  box-shadow: 0 0 0 4px rgba(0, 0, 0, 0.78), 0 24px 80px rgba(0, 0, 0, 0.72), inset 0 0 52px rgba(57, 255, 20, 0.1), 0 0 42px rgba(87, 243, 255, 0.18);
-}
-
-.home-orca-stage::after {
-  background:
-    linear-gradient(90deg, rgba(57, 255, 20, 0.08), transparent 9%, transparent 91%, rgba(87, 243, 255, 0.08)),
-    radial-gradient(ellipse at center, transparent 42%, rgba(0, 0, 0, 0.64) 100%);
-}
-
-.home-title-screen-stack {
-  display: grid;
-  gap: 0.35rem;
-  margin-top: 0.75rem;
-  color: #ffff66;
-  font-size: clamp(0.62rem, 1.1vw, 0.82rem);
-  letter-spacing: 0.08em;
-  line-height: 1.55;
-  text-transform: uppercase;
-}
-
-.home-title-screen-prompt {
-  width: fit-content;
-  margin-top: 1rem;
-  padding: 0.45rem 0.7rem;
-  border: 1px solid rgba(255, 255, 102, 0.48);
-  color: #ffff66;
-  background: rgba(0, 0, 0, 0.46);
-  box-shadow: 0 0 18px rgba(255, 255, 102, 0.16);
-  animation: homeInsertCoinBlink 1.25s steps(2, end) infinite;
-}
-
-.home-title-screen-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem 0.75rem;
-  margin-top: 0.85rem;
-  color: rgba(126, 246, 209, 0.82);
-  font-size: clamp(0.5rem, 0.85vw, 0.62rem);
-  letter-spacing: 0.08em;
-}
-
-.home-title-screen-meta span {
-  padding: 0.25rem 0.45rem;
-  border: 1px solid rgba(87, 243, 255, 0.24);
-  background: rgba(0, 20, 18, 0.5);
-}
-
-.home-press-start {
-  color: #020805;
-  background: #39ff14;
-  border-color: #ffff66;
-  box-shadow: 0 0 18px rgba(57, 255, 20, 0.45), inset 0 0 0 2px rgba(255, 255, 102, 0.32);
-  animation: homeStartPulse 1.2s steps(2, end) infinite;
-}
-
-.home-orca-hero.is-starting .home-orca-stage {
-  animation: homeCoinAccepted 900ms steps(4, end) 1;
-}
-
-.home-orca-hero.is-signal-locking .home-orca-stage::before {
-  opacity: 0.95;
-  animation: homeSignalLock 280ms steps(3, end) infinite;
-}
-
-.home-level-intro {
-  display: grid;
-  gap: 0.35rem;
-  width: min(1180px, calc(100% - 2rem));
-  margin: clamp(0.25rem, 1vw, 0.75rem) auto 0.75rem;
-  padding: 0.75rem 1rem;
-  border: 1px solid rgba(255, 255, 102, 0.42);
-  border-radius: 12px;
-  background: linear-gradient(90deg, rgba(255, 72, 206, 0.12), rgba(0, 20, 12, 0.84));
-  color: #dfffea;
-}
-
-.home-level-intro span,
-.home-play-mode .home-section-kicker,
-.home-mission-select .home-section-kicker,
-.home-unlocks .home-section-kicker {
-  color: #ff4dce;
-}
-
-.home-level-intro strong {
-  color: #ffff66;
-}
-
-.home-level-intro em {
-  color: #57f3ff;
-  font-style: normal;
-}
-
-#lousy-outages-teaser {
-  scroll-margin-top: calc(var(--se-header-height, 72px) + 1rem);
-}
-
-.home-play-mode {
-  margin-top: clamp(1.25rem, 3vw, 2.25rem);
-}
-
-.home-play-mode__copy h2::before,
-.home-mission-select h2::before,
-.home-unlocks h2::before {
-  content: "// ";
-  color: #39ff14;
-}
-
-.site-footer::before {
-  content: "CREDITS // MADE IN VANCOUVER";
-  display: block;
-  margin: 0 auto 1rem;
-  color: #ffff66;
-  font-family: "Press Start 2P", monospace;
-  font-size: clamp(0.58rem, 1vw, 0.75rem);
-  letter-spacing: 0.08em;
-  text-align: center;
-}
-
-@keyframes homeInsertCoinBlink {
-  0%, 48% { opacity: 1; }
-  49%, 100% { opacity: 0.42; }
-}
-
-@keyframes homeCoinAccepted {
-  0%, 100% { filter: none; }
-  20% { filter: brightness(1.45) saturate(1.4); transform: translateY(-1px); }
-  38% { filter: hue-rotate(24deg) contrast(1.25); transform: translateX(2px); }
-  56% { filter: brightness(1.25); transform: translateX(-2px); }
-}
-
-@keyframes homeSignalLock {
-  from { transform: translateY(-18px); }
-  to { transform: translateY(18px); }
-}
-
-@media (max-width: 640px) {
-  .home-title-screen-prompt {
-    width: 100%;
-    text-align: center;
-  }
-
-  .home-title-screen-meta {
-    display: grid;
-  }
-
-  .home-level-intro {
-    width: min(100% - 1rem, 1180px);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .home-title-screen-prompt,
-  .home-press-start,
-  .home-orca-hero.is-starting .home-orca-stage,
-  .home-orca-hero.is-signal-locking .home-orca-stage::before {
-    animation: none !important;
   }
 }


### PR DESCRIPTION
### Motivation
- Replace the competing split hero layout with a true arcade cabinet first screen that foregrounds the game title and start prompt. 
- Make `SUZY EASTON` the visual focus with an obvious blinking `INSERT COIN` and a `PRESS START` control above the fold on desktop and mobile. 
- Treat Vancouver skyline and arcade-world details as subtle background scenery rather than primary hero elements. 
- Transition entering the site into an arcade-style flow that animates into “LEVEL 01” and reveals sections as game levels (Lousy Outages → Level 01, Pacific Power Play → Bonus Level, Projects → Level Select, Music/Tools/Contact → Unlocks). 

### Description
- Reworked homepage markup in `page-home.php` to remove the split orca hero and insert a full-viewport arcade title screen (`.home-arcade-title-screen`) with background SVG scenery, pixel stars/rain, `INSERT COIN` status, and a prominent `PRESS START` button. 
- Replaced and consolidated the homepage CSS: removed the large duplicate/stale orca/hero rules and added focused cabinet/title-screen styles in `style.css` to ensure the title/prompt/button remain visible and responsive on desktop and mobile. 
- Updated `js/home-arcade-start.js` to change start-button copy/status progression, animate the title-screen into a signal/lock state, set `LEVEL 01 // LOUSY OUTAGES` as the first revealed section, and scroll/focus the Lousy Outages teaser. 
- Kept Pacific Power Play/power-play rules and the rest of the homepage sections intact, preserved ARIA roles/labels for accessibility, and removed conflicting or redundant homepage hero rules to simplify stylesheet precedence. 

### Testing
- Ran PHP lint with `php -l page-home.php`, which succeeded. 
- Ran JavaScript syntax check with `node --check js/home-arcade-start.js`, which succeeded. 
- Ran repository tests with `npm test`, which executed but reported unrelated existing failures in the Gastown/Lousy Outages test suite (49 passing, 18 failing) and therefore did not pass end-to-end. 
- Attempted containerized/manual verification (`docker compose up -d`) but Docker is not available in this environment, so visual/manual browser checks were not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41f8e6d6588331a84c31a49eb8dedc)