### PR TITLE
Fix homepage teaser: surface current provider signals when no incidents present

### DIFF
--- a/lousy-outages/includes/Summary.php
+++ b/lousy-outages/includes/Summary.php
@@ -97,16 +97,39 @@ class Summary {
             $incidents = isset($provider['incidents']) && is_array($provider['incidents'])
                 ? array_values(array_filter($provider['incidents'], 'is_array'))
                 : [];
-            if (!$incidents) {
-                continue;
-            }
-
             $providerId = sanitize_key((string) ($provider['id'] ?? $provider['provider'] ?? $provider['name'] ?? ''));
             $providerName = trim((string) ($provider['name'] ?? $provider['provider'] ?? $providerId));
             if ('' === $providerName) {
                 $providerName = 'Unknown provider';
             }
             $providerStatus = strtolower((string) ($provider['stateCode'] ?? $provider['status'] ?? 'incident'));
+            $tileKind = strtolower((string) ($provider['tile_kind'] ?? $provider['tileKind'] ?? ''));
+
+            if (!$incidents) {
+                $hasCurrentSignal = in_array($tileKind, ['outage', 'signal'], true)
+                    || !in_array($providerStatus, ['', 'operational', 'ok', 'none', 'unknown'], true);
+                if (!$hasCurrentSignal) {
+                    continue;
+                }
+
+                $updated = (string) ($provider['updatedAt'] ?? $provider['updated_at'] ?? '');
+                $records[] = [
+                    'id' => sha1($providerId . '|provider-current|' . $providerStatus . '|' . $updated),
+                    'provider_id' => $providerId,
+                    'provider' => $providerName,
+                    'status' => $providerStatus ?: 'incident',
+                    'status_label' => Fetcher::status_label($providerStatus ?: 'incident'),
+                    'severity' => in_array($providerStatus, ['outage', 'major', 'critical'], true) ? 'outage' : 'degraded',
+                    'important' => true,
+                    'summary' => (string) ($provider['summary'] ?? $provider['message'] ?? Fetcher::status_label($providerStatus ?: 'incident')),
+                    'started_at' => self::format_incident_time($updated),
+                    'updated_at' => self::format_incident_time($updated),
+                    'first_seen' => self::parse_time($updated) ?? 0,
+                    'last_seen' => self::parse_time($updated) ?? 0,
+                    'url' => (string) ($provider['url'] ?? ''),
+                ];
+                continue;
+            }
 
             usort($incidents, static function (array $left, array $right): int {
                 return self::incident_timestamp($right) <=> self::incident_timestamp($left);

--- a/plugins/lousy-outages/includes/Summary.php
+++ b/plugins/lousy-outages/includes/Summary.php
@@ -97,16 +97,39 @@ class Summary {
             $incidents = isset($provider['incidents']) && is_array($provider['incidents'])
                 ? array_values(array_filter($provider['incidents'], 'is_array'))
                 : [];
-            if (!$incidents) {
-                continue;
-            }
-
             $providerId = sanitize_key((string) ($provider['id'] ?? $provider['provider'] ?? $provider['name'] ?? ''));
             $providerName = trim((string) ($provider['name'] ?? $provider['provider'] ?? $providerId));
             if ('' === $providerName) {
                 $providerName = 'Unknown provider';
             }
             $providerStatus = strtolower((string) ($provider['stateCode'] ?? $provider['status'] ?? 'incident'));
+            $tileKind = strtolower((string) ($provider['tile_kind'] ?? $provider['tileKind'] ?? ''));
+
+            if (!$incidents) {
+                $hasCurrentSignal = in_array($tileKind, ['outage', 'signal'], true)
+                    || !in_array($providerStatus, ['', 'operational', 'ok', 'none', 'unknown'], true);
+                if (!$hasCurrentSignal) {
+                    continue;
+                }
+
+                $updated = (string) ($provider['updatedAt'] ?? $provider['updated_at'] ?? '');
+                $records[] = [
+                    'id' => sha1($providerId . '|provider-current|' . $providerStatus . '|' . $updated),
+                    'provider_id' => $providerId,
+                    'provider' => $providerName,
+                    'status' => $providerStatus ?: 'incident',
+                    'status_label' => Fetcher::status_label($providerStatus ?: 'incident'),
+                    'severity' => in_array($providerStatus, ['outage', 'major', 'critical'], true) ? 'outage' : 'degraded',
+                    'important' => true,
+                    'summary' => (string) ($provider['summary'] ?? $provider['message'] ?? Fetcher::status_label($providerStatus ?: 'incident')),
+                    'started_at' => self::format_incident_time($updated),
+                    'updated_at' => self::format_incident_time($updated),
+                    'first_seen' => self::parse_time($updated) ?? 0,
+                    'last_seen' => self::parse_time($updated) ?? 0,
+                    'url' => (string) ($provider['url'] ?? ''),
+                ];
+                continue;
+            }
 
             usort($incidents, static function (array $left, array $right): int {
                 return self::incident_timestamp($right) <=> self::incident_timestamp($left);


### PR DESCRIPTION
### Motivation
- The homepage teaser was showing the empty "all quiet" state when the live status snapshot contained non-operational provider tiles with no explicit `incidents` entries, causing active signals on `/lousy-outages/` to be missed by the home teaser.
- Previous attempts changed the history/current incident loaders but did not surface provider-level signals from the live snapshot when `incidents` was empty.

### Description
- Update `Summary::ordered_current_incidents()` to treat provider tiles without `incidents` as current signals when the provider `tile_kind` indicates a signal/outage or the provider `stateCode` is non-operational, and synthesize a normalized record so the homepage teaser can display it.
- Generate a stable `id` for synthesized provider-current records, map `status_label`/`severity` using existing helpers, and populate `started_at`/`updated_at` with the provider `updatedAt` value to match the incident record shape.
- Apply the same change to both the theme-bundled `lousy-outages/includes/Summary.php` and the standalone plugin `plugins/lousy-outages/includes/Summary.php` so either WordPress load path surfaces signals identically.
- Keep the existing incident-path behavior unchanged so explicit incidents still produce the usual normalized records.

### Testing
- Ran syntax checks `php -l lousy-outages/includes/Summary.php` and `php -l plugins/lousy-outages/includes/Summary.php`, both succeeded.
- Executed a focused runtime test script (`/tmp/summary-current-test.php`) that loads the modified `Summary` and a synthetic snapshot, which verified a provider-level current signal was surfaced as expected.
- Attempted to bring up the local WordPress stack with `docker compose up -d db wordpress wpcli`, but Docker is not available in this environment so the full integration server could not be started.
- Attempted to validate the rendered homepage via `curl` against `http://localhost:8080/`, but the local WordPress request path was not reachable so the real-request verification is still pending.

This PR contains a candidate fix but is intentionally not marked complete until the homepage teaser is validated through the real WordPress request path (live Docker/local WP run and a successful homepage request).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6bdb8fd8833184c775a5d883aab2)