### PR TITLE
Fix Lousy Outages homepage live teaser

### DIFF
--- a/__tests__/lousy-outages-teaser.test.js
+++ b/__tests__/lousy-outages-teaser.test.js
@@ -1,0 +1,30 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+function load() {
+  const listeners = {};
+  const sandbox = { window: {}, document: { addEventListener: (n, cb) => { listeners[n] = cb; }, getElementById: () => null, hidden: false }, console, URL, Date, setInterval: () => 1 };
+  sandbox.window = sandbox;
+  vm.runInNewContext(fs.readFileSync('assets/js/lousy-outages-teaser.js', 'utf8'), sandbox);
+  return sandbox.window.LousyOutagesTeaser;
+}
+
+test('selector includes active incident, limits and dedupes', () => {
+  const teaser = load();
+  const providers = Array.from({ length: 6 }, (_, i) => ({ id: `p${i}`, name: `P${i}`, tile_kind: 'outage', stateCode: 'degraded', updatedAt: `2026-07-19T0${i}:00:00Z`, incidents: [{ title: `Incident ${i}`, status: 'investigating', startedAt: `2026-07-19T0${i}:00:00Z`, updatedAt: `2026-07-19T0${i}:30:00Z` }] }));
+  providers.push({ id: 'p0', name: 'P0', tile_kind: 'outage', stateCode: 'degraded', incidents: [{ title: 'Incident 0 details', status: 'identified', startedAt: '2026-07-19T00:00:10Z', updatedAt: '2026-07-19T00:40:00Z' }] });
+  const items = teaser.currentItems({ providers });
+  assert.equal(items.length, 5);
+  assert.equal(items[0].provider, 'P5');
+  assert.equal(items.filter((i) => i.provider === 'P0').length, 0);
+});
+
+test('clear, degraded signal, unknown and resolved states are distinct', () => {
+  const teaser = load();
+  assert.equal(teaser.currentItems({ providers: [{ id: 'ok', name: 'OK', tile_kind: 'operational', stateCode: 'operational', incidents: [] }] }).length, 0);
+  assert.equal(teaser.currentItems({ providers: [{ id: 'slow', name: 'Slow', tile_kind: 'signal', stateCode: 'degraded', summary: 'Latency', incidents: [] }] })[0].type, 'signal');
+  assert.equal(teaser.currentItems({ providers: [{ id: 'u', name: 'Unknown', tile_kind: 'unknown', stateCode: 'unknown', error: 'failed', incidents: [] }] }).length, 0);
+  assert.equal(teaser.currentItems({ providers: [{ id: 'r', name: 'Resolved', tile_kind: 'operational', stateCode: 'operational', incidents: [{ title: 'Old', status: 'resolved' }] }] }).length, 0);
+});

--- a/assets/css/lousy-outages-teaser.css
+++ b/assets/css/lousy-outages-teaser.css
@@ -35,3 +35,15 @@
 @media (max-width:700px){#lousy-outages-teaser .lo-home-alert{grid-template-columns:1fr;align-items:start}#lousy-outages-teaser .lo-home-alert__times{grid-column:auto;grid-row:auto}#lousy-outages-teaser .lo-home-alert__details{justify-self:start}}
 @media (max-width:560px){#lousy-outages-teaser.lo-home-teaser{width:min(100% - 1rem,1180px);padding:.85rem}#lousy-outages-teaser .lo-home-teaser__titlebar,#lousy-outages-teaser .lo-home-live-band{grid-template-columns:1fr;display:grid}}
 @media (prefers-reduced-motion:reduce){#lousy-outages-teaser *,#lousy-outages-teaser *::before,#lousy-outages-teaser *::after{animation:none!important;transition:none!important}}
+
+.lo-home-teaser--delayed .lo-home-status-light {
+  box-shadow: 0 0 0 2px rgba(255, 210, 102, 0.4), 0 0 18px rgba(255, 210, 102, 0.35);
+}
+
+.lo-home-delayed {
+  margin: 0.75rem 0 0;
+  color: #ffd266;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}

--- a/assets/js/lousy-outages-teaser.js
+++ b/assets/js/lousy-outages-teaser.js
@@ -1,45 +1,139 @@
-(function(){
-  const container = document.getElementById('lousy-outages-teaser');
-  if (!container) return;
+(function () {
+  'use strict';
 
-  const summaryEl = container.querySelector('[data-lo-summary]');
-  if (!summaryEl) return;
+  const DEFAULT_INTERVAL = 300000;
+  let timer = null;
+  let inFlight = false;
 
-  const iso = summaryEl.getAttribute('data-incident-start');
-  if (!iso) return;
+  function parseConfig(container) {
+    const globalConfig = window.lousyOutagesTeaser || {};
+    return {
+      endpoint: container.dataset.loEndpoint || globalConfig.endpoint || '',
+      interval: Math.max(60000, parseInt(container.dataset.loRefreshInterval || globalConfig.refreshInterval || DEFAULT_INTERVAL, 10) || DEFAULT_INTERVAL),
+      dashboardUrl: container.dataset.loDashboardUrl || globalConfig.dashboardUrl || '/lousy-outages/'
+    };
+  }
 
-  function formatRelative(date) {
-    const now = new Date();
-    const diff = now.getTime() - date.getTime();
-    if (!isFinite(diff) || diff < 0) {
-      return 'just now';
-    }
-    const minutes = Math.floor(diff / 60000);
-    if (minutes < 1) {
-      return 'just now';
-    }
-    if (minutes < 60) {
-      return minutes + ' minute' + (minutes === 1 ? '' : 's') + ' ago';
-    }
-    const hours = Math.floor(minutes / 60);
-    if (hours < 24) {
-      const rem = minutes % 60;
-      if (rem === 0) {
-        return hours + ' hour' + (hours === 1 ? '' : 's') + ' ago';
+  function formatTime(value) {
+    if (!value) return '';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return '';
+    return date.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+  }
+
+  function isUnresolvedIncident(incident) {
+    const status = String(incident.status || incident.eta || '').toLowerCase();
+    return !['resolved', 'completed', 'postmortem', 'operational', 'ok', 'none'].includes(status);
+  }
+
+  function keyFor(item) {
+    return [item.providerId, item.summary.toLowerCase(), item.started || ''].join('|');
+  }
+
+  function currentItems(payload) {
+    const providers = Array.isArray(payload && payload.providers) ? payload.providers : [];
+    const items = [];
+    providers.forEach((provider) => {
+      if (!provider || typeof provider !== 'object') return;
+      const providerId = String(provider.id || provider.provider || provider.name || '');
+      const providerName = String(provider.name || provider.provider || providerId || 'Unknown provider');
+      const tileKind = String(provider.tile_kind || provider.tileKind || '').toLowerCase();
+      const stateCode = String(provider.stateCode || provider.status || 'unknown').toLowerCase();
+      const stateLabel = String(provider.state || provider.status_label || stateCode || 'Status');
+      const incidents = Array.isArray(provider.incidents) ? provider.incidents.filter((incident) => incident && typeof incident === 'object' && isUnresolvedIncident(incident)) : [];
+      incidents.forEach((incident) => {
+        const started = incident.startedAt || incident.started_at || incident.created_at || '';
+        const updated = incident.updatedAt || incident.updated_at || started || provider.updatedAt || provider.updated_at || '';
+        items.push({
+          type: 'outage', tone: 'outage', providerId, provider: providerName, label: stateLabel,
+          summary: String(incident.title || incident.summary || provider.summary || 'Incident reported'),
+          href: String(incident.url || provider.url || ''), started, updated,
+          sort: Date.parse(updated) || Date.parse(started) || 0
+        });
+      });
+      if (incidents.length === 0 && tileKind === 'outage') {
+        const updated = provider.updatedAt || provider.updated_at || '';
+        items.push({ type: 'outage', tone: 'outage', providerId, provider: providerName, label: stateLabel, summary: String(provider.summary || stateLabel || 'Active outage'), href: String(provider.url || ''), started: updated, updated, sort: Date.parse(updated) || 0 });
+      } else if (incidents.length === 0 && tileKind === 'signal') {
+        const updated = provider.updatedAt || provider.updated_at || '';
+        items.push({ type: 'signal', tone: 'signal', providerId, provider: providerName, label: stateLabel, summary: String(provider.summary || stateLabel || 'Verified degraded signal'), href: String(provider.url || ''), started: '', updated, sort: Date.parse(updated) || 0 });
       }
-      return hours + 'h ' + rem + 'm ago';
+    });
+    const seen = new Map();
+    items.sort((a, b) => b.sort - a.sort || a.provider.localeCompare(b.provider));
+    items.forEach((item) => { if (!seen.has(keyFor(item))) seen.set(keyFor(item), item); });
+    return Array.from(seen.values()).slice(0, 5);
+  }
+
+  function setText(root, selector, text) { const el = root.querySelector(selector); if (el) el.textContent = text; }
+
+  function render(container, payload, config) {
+    const items = currentItems(payload);
+    const meta = payload && payload.meta ? payload.meta : {};
+    const refreshed = meta.fetchedAt || payload.fetched_at || meta.generatedAt || '';
+    container.classList.toggle('lo-home-teaser--active', items.length > 0);
+    container.classList.toggle('lo-home-teaser--clear', items.length === 0);
+    container.classList.remove('lo-home-teaser--delayed');
+    const light = container.querySelector('.lo-home-status-light');
+    if (light) {
+      light.classList.toggle('lo-home-status-light--alert', items.length > 0);
+      light.classList.toggle('lo-home-status-light--clear', items.length === 0);
+      setText(light, '.screen-reader-text', items.length > 0 ? 'Active provider incidents or degraded signals' : 'No active provider incidents');
     }
-    const days = Math.floor(hours / 24);
-    return days + ' day' + (days === 1 ? '' : 's') + ' ago';
+    const screen = container.querySelector('.lo-home-teaser__screen');
+    if (!screen) return;
+    while (screen.firstChild) screen.removeChild(screen.firstChild);
+    if (items.length === 0) {
+      const empty = document.createElement('div'); empty.className = 'lo-home-empty';
+      const p1 = document.createElement('p'); p1.textContent = 'all quiet. suspicious, but fine.';
+      const p2 = document.createElement('p'); p2.textContent = 'last checked: ' + (formatTime(refreshed) || 'recently');
+      empty.append(p1, p2); screen.append(empty); return;
+    }
+    const band = document.createElement('div'); band.className = 'lo-home-live-band'; band.setAttribute('role', 'status'); band.setAttribute('aria-live', 'polite');
+    const dot = document.createElement('span'); dot.className = 'lo-home-live-band__dot'; dot.setAttribute('aria-hidden', 'true');
+    const copy = document.createElement('div');
+    const label = document.createElement('p'); label.className = 'lo-home-live-band__label'; label.textContent = items.some((i) => i.type === 'outage') ? 'LIVE OUTAGE SIGNAL' : 'VERIFIED DEGRADED SIGNAL';
+    const count = document.createElement('p'); count.className = 'lo-home-live-band__count'; count.textContent = items.length + ' current ' + (items.length === 1 ? 'signal' : 'signals');
+    const providers = document.createElement('p'); providers.className = 'lo-home-live-band__providers'; providers.textContent = Array.from(new Set(items.map((i) => i.provider))).slice(0, 3).join(' + ');
+    copy.append(label, count, providers); band.append(dot, copy); screen.append(band);
+    const list = document.createElement('ul'); list.className = 'lo-home-alert-list';
+    items.forEach((item) => {
+      const li = document.createElement('li'); li.className = 'lo-home-alert lo-home-alert--' + item.tone;
+      const metaEl = document.createElement('div'); metaEl.className = 'lo-home-alert__meta';
+      const strong = document.createElement('strong'); strong.className = 'lo-home-alert__provider'; strong.textContent = item.provider;
+      const status = document.createElement('span'); status.className = 'lo-home-alert__status'; status.textContent = item.type === 'signal' ? 'Degraded signal' : item.label;
+      metaEl.append(strong, status);
+      const body = document.createElement('p'); body.className = 'lo-home-alert__body'; body.textContent = item.summary;
+      const times = document.createElement('div'); times.className = 'lo-home-alert__times';
+      if (item.started) { const t = document.createElement('time'); t.className = 'lo-home-alert__time'; t.dateTime = item.started; t.textContent = 'Started ' + formatTime(item.started); times.append(t); }
+      if (item.updated) { const t = document.createElement('time'); t.className = 'lo-home-alert__time'; t.dateTime = item.updated; t.textContent = 'Updated ' + formatTime(item.updated); times.append(t); }
+      const a = document.createElement('a'); a.className = 'lo-home-alert__details'; a.href = item.href || config.dashboardUrl + (item.providerId ? '#provider-' + encodeURIComponent(item.providerId) : ''); a.textContent = 'Details';
+      li.append(metaEl, body, times, a); list.append(li);
+    });
+    screen.append(list);
   }
 
-  const startDate = new Date(iso);
-  if (isNaN(startDate.getTime())) return;
-
-  function update() {
-    summaryEl.setAttribute('data-relative', formatRelative(startDate));
+  function markDelayed(container) {
+    container.classList.add('lo-home-teaser--delayed');
+    const screen = container.querySelector('.lo-home-teaser__screen');
+    if (screen && !screen.querySelector('.lo-home-delayed')) { const p = document.createElement('p'); p.className = 'lo-home-delayed'; p.setAttribute('role', 'status'); p.textContent = 'Live verification delayed; showing the last saved homepage snapshot.'; screen.append(p); }
   }
 
-  update();
-  setInterval(update, 60000);
-})();
+  function init(container) {
+    const config = parseConfig(container);
+    if (!config.endpoint || container.dataset.loTeaserReady === '1') return;
+    container.dataset.loTeaserReady = '1';
+    const refresh = () => {
+      if (inFlight || document.hidden) return;
+      inFlight = true;
+      const url = new URL(config.endpoint, window.location.href); url.searchParams.set('_lo_cache_bust', Date.now().toString());
+      fetch(url.toString(), { cache: 'no-store', credentials: 'same-origin' }).then((r) => { if (!r.ok) throw new Error('status fetch failed'); return r.json(); }).then((payload) => render(container, payload, config)).catch(() => markDelayed(container)).finally(() => { inFlight = false; });
+    };
+    refresh();
+    timer = window.setInterval(refresh, config.interval);
+    document.addEventListener('visibilitychange', () => { if (!document.hidden) refresh(); });
+  }
+
+  window.LousyOutagesTeaser = { currentItems, render, markDelayed, init };
+  document.addEventListener('DOMContentLoaded', () => { const c = document.getElementById('lousy-outages-teaser'); if (c) init(c); });
+}());

--- a/functions.php
+++ b/functions.php
@@ -86,6 +86,26 @@ function retro_game_music_theme_scripts() {
                 filemtime( $teaser_css )
             );
         }
+
+        $teaser_js = get_template_directory() . '/assets/js/lousy-outages-teaser.js';
+        if ( file_exists( $teaser_js ) ) {
+            wp_enqueue_script(
+                'lousy-outages-home-teaser',
+                get_template_directory_uri() . '/assets/js/lousy-outages-teaser.js',
+                array(),
+                filemtime( $teaser_js ),
+                true
+            );
+            wp_localize_script(
+                'lousy-outages-home-teaser',
+                'lousyOutagesTeaser',
+                array(
+                    'endpoint'        => esc_url_raw( rest_url( 'lousy-outages/v1/status' ) ),
+                    'dashboardUrl'    => esc_url_raw( home_url( '/lousy-outages/' ) ),
+                    'refreshInterval' => 5 * MINUTE_IN_SECONDS * 1000,
+                )
+            );
+        }
     }
 
     if ( is_page_template( 'page-pacific-power-play.php' ) || is_page( 'pacific-power-play' ) ) {
@@ -554,7 +574,7 @@ function get_lousy_outages_home_teaser_data(): array {
         'stale'    => false,
     ];
 
-    if ( ! class_exists( '\\SuzyEaston\\LousyOutages\\Summary' ) || ! method_exists( '\\SuzyEaston\\LousyOutages\\Summary', 'ordered_recent_incidents' ) ) {
+    if ( ! class_exists( '\\SuzyEaston\\LousyOutages\\Summary' ) || ! method_exists( '\\SuzyEaston\\LousyOutages\\Summary', 'ordered_current_incidents' ) ) {
         error_log( 'Lousy Outages homepage teaser unavailable: shared Summary incident loader missing.' );
         return $default;
     }
@@ -562,10 +582,6 @@ function get_lousy_outages_home_teaser_data(): array {
     $incidents = method_exists( '\SuzyEaston\LousyOutages\Summary', 'ordered_current_incidents' )
         ? \SuzyEaston\LousyOutages\Summary::ordered_current_incidents( 5 )
         : [];
-
-    if ( empty( $incidents ) ) {
-        $incidents = \SuzyEaston\LousyOutages\Summary::ordered_recent_incidents( 30, true, 5 );
-    }
 
     if ( ! is_array( $incidents ) ) {
         error_log( 'Lousy Outages homepage teaser unavailable: shared Summary incident loader returned invalid data.' );

--- a/lousy-outages/includes/Summary.php
+++ b/lousy-outages/includes/Summary.php
@@ -106,8 +106,7 @@ class Summary {
             $tileKind = strtolower((string) ($provider['tile_kind'] ?? $provider['tileKind'] ?? ''));
 
             if (!$incidents) {
-                $hasCurrentSignal = in_array($tileKind, ['outage', 'signal'], true)
-                    || !in_array($providerStatus, ['', 'operational', 'ok', 'none', 'unknown'], true);
+                $hasCurrentSignal = in_array($tileKind, ['outage', 'signal'], true);
                 if (!$hasCurrentSignal) {
                     continue;
                 }
@@ -119,7 +118,7 @@ class Summary {
                     'provider' => $providerName,
                     'status' => $providerStatus ?: 'incident',
                     'status_label' => Fetcher::status_label($providerStatus ?: 'incident'),
-                    'severity' => in_array($providerStatus, ['outage', 'major', 'critical'], true) ? 'outage' : 'degraded',
+                    'severity' => 'outage' === $tileKind ? 'outage' : 'degraded',
                     'important' => true,
                     'summary' => (string) ($provider['summary'] ?? $provider['message'] ?? Fetcher::status_label($providerStatus ?: 'incident')),
                     'started_at' => self::format_incident_time($updated),
@@ -136,7 +135,7 @@ class Summary {
             });
 
             foreach ($incidents as $incident) {
-                if (!is_array($incident)) {
+                if (!is_array($incident) || !self::is_unresolved_incident($incident)) {
                     continue;
                 }
 
@@ -161,7 +160,8 @@ class Summary {
             }
         }
 
-        return $limit > 0 ? array_slice($records, 0, $limit) : $records;
+        $deduped = self::dedupe_ordered_incidents($records);
+        return $limit > 0 ? array_slice($deduped, 0, $limit) : $deduped;
     }
 
     /**

--- a/parts/lousy-outages-teaser.php
+++ b/parts/lousy-outages-teaser.php
@@ -13,6 +13,8 @@ $teaser_data  = function_exists( 'get_lousy_outages_home_teaser_data' )
         'last_checked' => '',
     ];
 $teaser_href = $teaser_data['href'] ?? home_url( '/lousy-outages/' );
+$teaser_endpoint = rest_url( 'lousy-outages/v1/status' );
+$teaser_interval = 5 * MINUTE_IN_SECONDS * 1000;
 $rows = isset( $teaser_data['rows'] ) && is_array( $teaser_data['rows'] ) ? array_slice( $teaser_data['rows'], 0, 5 ) : [];
 $last_checked = $teaser_data['last_checked'] ?? '';
 $active_count = count( $rows );
@@ -28,7 +30,7 @@ if ( count( $provider_names ) > 3 ) {
     $provider_summary .= ' +' . ( count( $provider_names ) - 3 ) . ' more';
 }
 ?>
-<section id="lousy-outages-teaser" class="lo-home-teaser<?php echo esc_attr( empty( $rows ) ? ' lo-home-teaser--clear' : ' lo-home-teaser--active' ); ?>" aria-labelledby="lo-home-heading">
+<section id="lousy-outages-teaser" class="lo-home-teaser<?php echo esc_attr( empty( $rows ) ? ' lo-home-teaser--clear' : ' lo-home-teaser--active' ); ?>" aria-labelledby="lo-home-heading" data-lo-endpoint="<?php echo esc_url( $teaser_endpoint ); ?>" data-lo-dashboard-url="<?php echo esc_url( $teaser_href ); ?>" data-lo-refresh-interval="<?php echo esc_attr( (string) $teaser_interval ); ?>">
     <div class="lo-home-teaser__titlebar">
         <div class="lo-home-title-copy">
             <p class="lo-home-kicker"><?php echo esc_html( 'arcade system monitor' ); ?></p>

--- a/scripts/build-lousy-outages-plugin.sh
+++ b/scripts/build-lousy-outages-plugin.sh
@@ -3,10 +3,10 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DIST="$ROOT/dist"
 OUT="$DIST/lousy-outages.zip"
-SRC="$ROOT/plugins/lousy-outages"
+SRC="$ROOT/lousy-outages"
 mkdir -p "$DIST"
 rm -f "$OUT"
-cd "$ROOT/plugins"
+cd "$ROOT"
 zip -r "$OUT" lousy-outages \
   -x '*/.git/*' '*/tests/*' '*/node_modules/*' '*/.env' '*/.env.*' '*/secrets/*' '*/wp-config.php' '*.bak' '*.backup' '*.tmp' '*/.DS_Store'
 

--- a/scripts/check-lousy-outages-tree-drift.sh
+++ b/scripts/check-lousy-outages-tree-drift.sh
@@ -3,8 +3,18 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 CANON="$ROOT/lousy-outages"
 ALT="$ROOT/plugins/lousy-outages"
-if [[ ! -d "$CANON" || ! -d "$ALT" ]]; then
-  echo "OK: one plugin tree present or alternate missing"; exit 0
+BUILD="$ROOT/scripts/build-lousy-outages-plugin.sh"
+if ! rg -n 'SRC="\$ROOT/lousy-outages"|cd "\$ROOT"' "$BUILD" >/dev/null; then
+  echo "ERROR: build script is not using canonical top-level lousy-outages/." >&2
+  exit 1
+fi
+if [[ ! -d "$CANON" ]]; then
+  echo "ERROR: canonical plugin tree missing: $CANON" >&2
+  exit 1
+fi
+if [[ ! -d "$ALT" ]]; then
+  echo "OK: canonical plugin tree present and no deprecated alternate tree found"
+  exit 0
 fi
 KEYS=(
   "includes/Api.php"
@@ -15,11 +25,15 @@ KEYS=(
   "includes/Sources/HackerNewsChatterSource.php"
   "lousy-outages.php"
 )
-status=0
+drift=0
 for f in "${KEYS[@]}"; do
-  if ! cmp -s "$CANON/$f" "$ALT/$f"; then echo "DRIFT: $f differs between canonical and deprecated tree"; status=1; fi
+  if ! cmp -s "$CANON/$f" "$ALT/$f"; then
+    echo "WARNING: deprecated plugins/lousy-outages/$f differs from canonical lousy-outages/$f and is ignored by deployment."
+    drift=1
+  fi
 done
-if [[ $status -ne 0 ]]; then
-  echo "Canonical deploy path is top-level lousy-outages/. Do not deploy plugins/lousy-outages/." >&2
+if [[ $drift -ne 0 ]]; then
+  echo "OK: canonical deploy path is top-level lousy-outages/; deprecated plugins/lousy-outages/ is excluded from the ZIP workflow."
+else
+  echo "OK: plugin trees match and deployment uses canonical top-level lousy-outages/."
 fi
-exit $status

--- a/tests/LousyOutagesHomeTeaserTest.php
+++ b/tests/LousyOutagesHomeTeaserTest.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+namespace {
+if (!defined('DAY_IN_SECONDS')) define('DAY_IN_SECONDS', 86400);
+if (!defined('HOUR_IN_SECONDS')) define('HOUR_IN_SECONDS', 3600);
+function sanitize_key($key){ return preg_replace('/[^a-z0-9_\-]/','', strtolower((string)$key)); }
+function sanitize_title($title){ return trim(preg_replace('/[^a-z0-9]+/','-', strtolower((string)$title)),'-'); }
+function home_url($path=''){ return 'https://example.test'.$path; }
+$GLOBALS['lo_test_snapshot'] = ['providers'=>[]];
+function lousy_outages_get_snapshot(bool $force_refresh=false): array { return $GLOBALS['lo_test_snapshot']; }
+}
+namespace SuzyEaston\LousyOutages {
+class Fetcher { public static function status_label($s){ return ucwords(str_replace('_',' ', (string)$s)); } }
+class Store { public function get_all(){ return []; } }
+}
+namespace {
+require_once __DIR__ . '/../lousy-outages/includes/Summary.php';
+function assert_true($cond, $msg){ if(!$cond){ fwrite(STDERR, "FAIL: $msg\n"); exit(1);} }
+function set_snapshot(array $providers): void { $GLOBALS['lo_test_snapshot'] = ['providers'=>$providers]; }
+$base = '2026-07-19T10:00:00Z';
+set_snapshot([
+ ['id'=>'github','name'=>'GitHub','stateCode'=>'degraded','tile_kind'=>'outage','sort_key'=>0,'updatedAt'=>$base,'incidents'=>[['id'=>'i1','title'=>'Actions down','status'=>'investigating','startedAt'=>'2026-07-19T09:00:00Z','updatedAt'=>'2026-07-19T09:30:00Z','url'=>'https://status.example/i1']]],
+]);
+$rows = \SuzyEaston\LousyOutages\Summary::ordered_current_incidents(5);
+assert_true(count($rows)===1 && $rows[0]['provider']==='GitHub' && $rows[0]['summary']==='Actions down', 'unresolved incident appears');
+set_snapshot(array_map(fn($i)=>['id'=>'p'.$i,'name'=>'P'.$i,'stateCode'=>'degraded','tile_kind'=>'outage','sort_key'=>$i,'updatedAt'=>$base,'incidents'=>[['title'=>'I'.$i,'status'=>'investigating','startedAt'=>'2026-07-19T0'.$i.':00:00Z','updatedAt'=>'2026-07-19T0'.$i.':30:00Z']]], range(1,6)));
+$rows = \SuzyEaston\LousyOutages\Summary::ordered_current_incidents(5);
+assert_true(count($rows)===5 && $rows[0]['provider']==='P1' && $rows[4]['provider']==='P5', 'ordered and limited to five');
+set_snapshot([['id'=>'ok','name'=>'OK','stateCode'=>'operational','tile_kind'=>'operational','updatedAt'=>$base,'incidents'=>[]]]);
+assert_true(\SuzyEaston\LousyOutages\Summary::ordered_current_incidents(5)===[], 'operational clear');
+set_snapshot([['id'=>'slow','name'=>'Slow','stateCode'=>'degraded','tile_kind'=>'signal','updatedAt'=>$base,'summary'=>'Latency verified','incidents'=>[]]]);
+$rows = \SuzyEaston\LousyOutages\Summary::ordered_current_incidents(5);
+assert_true(count($rows)===1 && $rows[0]['severity']==='degraded', 'degraded provider is signal');
+set_snapshot([['id'=>'unk','name'=>'Unknown','stateCode'=>'unknown','tile_kind'=>'unknown','updatedAt'=>$base,'incidents'=>[],'error'=>'fetch failed']]);
+assert_true(\SuzyEaston\LousyOutages\Summary::ordered_current_incidents(5)===[], 'unknown does not become outage');
+set_snapshot([['id'=>'old','name'=>'Old','stateCode'=>'operational','tile_kind'=>'operational','updatedAt'=>$base,'incidents'=>[['title'=>'Resolved','status'=>'resolved','startedAt'=>'2026-07-18T09:00:00Z','updatedAt'=>'2026-07-18T10:00:00Z']]]]);
+assert_true(\SuzyEaston\LousyOutages\Summary::ordered_current_incidents(5)===[], 'resolved incidents hidden');
+set_snapshot([['id'=>'dup','name'=>'Dup','stateCode'=>'degraded','tile_kind'=>'outage','sort_key'=>0,'updatedAt'=>$base,'incidents'=>[
+ ['title'=>'Same outage details','status'=>'investigating','startedAt'=>'2026-07-19T09:00:00Z','updatedAt'=>'2026-07-19T09:10:00Z'],
+ ['title'=>'Same outage','status'=>'identified','startedAt'=>'2026-07-19T09:00:10Z','updatedAt'=>'2026-07-19T09:20:00Z']
+]]]);
+assert_true(count(\SuzyEaston\LousyOutages\Summary::ordered_current_incidents(5))===1, 'duplicates deduped');
+echo "OK\n";
+}


### PR DESCRIPTION
### Motivation
- The homepage teaser sometimes showed historical or resolved incidents because it fell back to stored recent history instead of the dashboard’s canonical current snapshot. 
- The goal is for the homepage to reflect the same live provider state and incident rules as the full `/lousy-outages/` dashboard and to hydrate from the canonical REST endpoint after load.
- The change also resolves a deployment drift by making the top-level `lousy-outages/` tree the canonical build source.

### Description
- Stop using historical fallback: the homepage PHP now only uses `Summary::ordered_current_incidents()` and no longer falls back to `ordered_recent_incidents()`, so resolved/historical events cannot be promoted to live. (changed `functions.php`, `parts/lousy-outages-teaser.php`) 
- Hardened current-incident normalization and dedupe: `Summary::ordered_current_incidents()` now requires unresolved incidents for incident rows, interprets `tile_kind` consistently, deduplicates records, and applies the same ordering used by the dashboard. (changed `lousy-outages/includes/Summary.php`) 
- Add a small client hydrator: a new `assets/js/lousy-outages-teaser.js` module fetches `/wp-json/lousy-outages/v1/status` with cache-safe (`no-store`) behavior, cache-busting query param, request de-duping, five-minute default polling, visibility-aware refreshes, safe DOM updates using `textContent`, and a graceful delayed/unverified UI when fetch fails. (added/changed `assets/js/lousy-outages-teaser.js`) 
- Enqueue + localize script and pass endpoint via `data-*`: the theme now enqueues the teaser script only on the front/home template and localizes the REST endpoint, dashboard URL, and refresh interval; the teaser markup exposes these via `data-lo-*` attributes. (changed `functions.php`, `parts/lousy-outages-teaser.php`) 
- UX/CSS tweak for delayed state: added small styling for a clear “delayed/unverified” look while preserving existing design and semantics. (changed `assets/css/lousy-outages-teaser.css`) 
- Fix deployment packaging and drift check: `scripts/build-lousy-outages-plugin.sh` now packages the canonical top-level `lousy-outages/` tree, and `scripts/check-lousy-outages-tree-drift.sh` enforces/validates that deployment path while warning about an ignored deprecated `plugins/lousy-outages/` tree. (changed `scripts/build-lousy-outages-plugin.sh`, `scripts/check-lousy-outages-tree-drift.sh`) 
- Add focused regression tests: PHP unit test `tests/LousyOutagesHomeTeaserTest.php` and JS selector tests `__tests__/lousy-outages-teaser.test.js` exercise the required cases (unresolved incidents, ordering/limit, clear state, degraded signals, unknown/fetch failures, resolved suppression, dedupe). (added `tests/LousyOutagesHomeTeaserTest.php`, `__tests__/lousy-outages-teaser.test.js`) 
- Files changed in this PR: `functions.php`, `parts/lousy-outages-teaser.php`, `lousy-outages/includes/Summary.php`, `assets/js/lousy-outages-teaser.js`, `assets/css/lousy-outages-teaser.css`, `scripts/build-lousy-outages-plugin.sh`, `scripts/check-lousy-outages-tree-drift.sh`, `tests/LousyOutagesHomeTeaserTest.php`, and `__tests__/lousy-outages-teaser.test.js`.

### Testing
- PHP linting: `php -l functions.php && php -l parts/lousy-outages-teaser.php && php -l lousy-outages/includes/Summary.php` — passed. 
- Focused PHP tests: `php tests/LousyOutagesHomeTeaserTest.php` — passed (validates unresolved incidents, ordering/limit, clear, degraded, unknown/fetch-failed suppression, resolved suppression, and dedupe). 
- JavaScript unit tests: `node --test __tests__/lousy-outages-teaser.test.js` — passed (validates selector logic, limiting, dedupe, clear/degraded/unknown/resolved distinctions). 
- Integration / packaging checks: `bash scripts/check-lousy-outages-tree-drift.sh` — passed with warnings that the deprecated `plugins/lousy-outages/` tree differs and is intentionally ignored by the canonical deployment; `bash scripts/build-lousy-outages-plugin.sh` — produced `dist/lousy-outages.zip` built from `lousy-outages/` and validated to contain required files. 
- Verified deploy artifact: inspected `dist/lousy-outages.zip` and confirmed it contains the canonical plugin files (`lousy-outages/lousy-outages.php`, `lousy-outages/includes/Summary.php`, `lousy-outages/includes/Api.php`, `lousy-outages/public/shortcode.php`, `lousy-outages/assets/lousy-outages.js`). 
- Noted unrelated pre-existing failures: `php tests/NewFeaturesTest.php` and some `php tests/FetcherTest.php` expectations continue to fail in the repository test harness due to unrelated test-harness stubs/constants and existing Statuspage fallback expectations; these were not changed by this PR. 

If you want, I can open a follow-up to add an e2e smoke check that compares live homepage output, the dashboard page, and the `/wp-json/lousy-outages/v1/status` payload in a single test run, or adjust polling interval defaults."}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c947d4cac8331a29bf69c58916d4a)