### PR TITLE
Fix AWS outage snapshot metadata

### DIFF
--- a/__tests__/lousy-outages-teaser.test.js
+++ b/__tests__/lousy-outages-teaser.test.js
@@ -22,7 +22,7 @@ test('long-running AWS regional incident appears as current issue with official 
   const providers=[
     {id:'teamviewer',name:'TeamViewer',tile_kind:'outage',incidents:[{title:'Connectivity issues',status:'investigating',updated_at:'2026-07-19T07:00:00Z'}]},
     {id:'cloudflare',name:'Cloudflare',tile_kind:'outage',incidents:[{title:'Dashboard errors',status:'identified',updated_at:'2026-07-19T06:00:00Z'}]},
-    {id:'aws',name:'AWS',tile_kind:'outage',checked_at:'2026-07-19T10:00:00Z',incidents:[{title:'Service disruption in UAE (ME-CENTRAL-1)',summary:'Official source says recovery is expected to take months due to physical infrastructure damage.',status:'outage',impact:'outage',scope:'regional',region_name:'UAE',region_code:'ME-CENTRAL-1',is_long_running:true,last_official_update:'2026-04-30T12:00:00Z',updated_at:'2026-04-30T12:00:00Z'}]},
+    {id:'aws',name:'AWS',tile_kind:'outage',checked_at:'2026-07-19T10:00:00Z',incidents:[{display_title:'Multiple AWS services disrupted in UAE (ME-CENTRAL-1)',source_title:'Operational issue - Multiple services (UAE)',title:'Operational issue - Multiple services (UAE)',summary:'Official source says recovery is expected to take months due to physical infrastructure damage.',status:'outage',impact:'outage',scope:'regional',region_name:'UAE',region_code:'ME-CENTRAL-1',is_long_running:true,last_official_update:'2026-04-30T12:00:00Z',updated_at:'2026-04-30T12:00:00Z'}]},
     {id:'openai',name:'OpenAI',tile_kind:'operational',incidents:[],recent_incidents:[{title:'Resolved',status:'operational'}]}
   ];
   const items=teaser.currentItems(payload(providers));
@@ -32,7 +32,7 @@ test('long-running AWS regional incident appears as current issue with official 
   assert.equal(aws.type,'outage');
   assert.equal(aws.label,'Ongoing regional disruption');
   assert.equal(aws.region,'UAE · ME-CENTRAL-1');
-  assert.equal(aws.summary,'Service disruption in UAE (ME-CENTRAL-1)');
+  assert.equal(aws.summary,'Multiple AWS services disrupted in UAE (ME-CENTRAL-1)');
   assert.match(aws.details,/recovery is expected to take months/);
   assert.equal(aws.lastOfficialUpdate,'2026-04-30T12:00:00Z');
   assert.equal(aws.checkedAt,'2026-07-19T10:00:00Z');

--- a/assets/js/lousy-outages-teaser.js
+++ b/assets/js/lousy-outages-teaser.js
@@ -57,7 +57,7 @@
         const updated = incident.updatedAt || incident.updated_at || started || provider.updatedAt || provider.updated_at || '';
         items.push({
           type: 'outage', tone: 'outage', providerId, provider: providerName, label: incident.scope === 'regional' ? 'Ongoing regional disruption' : 'Active incident',
-          summary: String(incident.title || incident.summary || provider.summary || 'Incident reported'),
+          summary: String(incident.display_title || incident.displayTitle || incident.title || incident.summary || provider.summary || 'Incident reported'),
           details: String(incident.summary || ''),
           region: [incident.region_name, incident.region_code].filter(Boolean).join(' · '),
           lastOfficialUpdate: incident.last_official_update || incident.lastOfficialUpdate || updated,

--- a/lousy-outages/assets/lousy-outages.js
+++ b/lousy-outages/assets/lousy-outages.js
@@ -1499,7 +1499,7 @@
           li.className = 'lo-inc-item';
           var title = state.doc.createElement('p');
           title.className = 'lo-inc-title';
-          var condensedName = condenseIncidentTitle(providerSlug, incident.name || incident.title || incident.summary || 'Incident', 118);
+          var condensedName = condenseIncidentTitle(providerSlug, incident.display_title || incident.displayTitle || incident.name || incident.title || incident.summary || provider.summary || 'Incident', 118);
           title.textContent = condensedName.text || 'Incident';
           if (condensedName.title && condensedName.title !== condensedName.text) {
             title.setAttribute('title', condensedName.title);

--- a/lousy-outages/includes/Fetcher.php
+++ b/lousy-outages/includes/Fetcher.php
@@ -433,6 +433,12 @@ class Fetcher {
         }
         $result['updated_at'] = $updated ?: $defaults['updated_at'];
         $result['checked_at'] = $defaults['checked_at'] ?? gmdate('c');
+        foreach ($result['incidents'] as &$incident) {
+            if (is_array($incident)) {
+                $incident['checked_at'] = $result['checked_at'];
+            }
+        }
+        unset($incident);
         if (! empty($incidents) && ! empty($incidents[0]['last_official_update'])) {
             $result['last_official_update'] = $incidents[0]['last_official_update'];
         }
@@ -709,6 +715,7 @@ class Fetcher {
             $entry = [
                 'id'         => (string) ($incident['id'] ?? md5(wp_json_encode($incident))),
                 'title'      => $title ?: 'Incident',
+                'source_title' => $title ?: 'Incident',
                 'summary'    => $summary,
                 'started_at' => $started,
                 'updated_at' => $updated,
@@ -720,6 +727,7 @@ class Fetcher {
                 'url'        => $url,
             ];
             $entry = array_merge($entry, $metadata);
+            $entry['display_title'] = $this->display_title($provider, $entry);
 
             if ($isResolved) {
                 $recent[] = $entry;
@@ -763,7 +771,35 @@ class Fetcher {
         if (preg_match('/\b(months?|long-running|extended|ongoing)\b/i', $lower)) {
             $metadata['is_long_running'] = true;
         }
+        if (preg_match('/multiple services/i', $text)) {
+            $metadata['service_name'] = 'Multiple services';
+        }
         return $metadata;
+    }
+
+    private function display_title(array $provider, array $incident): string {
+        $providerId = strtolower((string) ($provider['id'] ?? ''));
+        $providerName = (string) ($provider['name'] ?? $providerId);
+        $source = trim((string) ($incident['source_title'] ?? $incident['title'] ?? ''));
+        $service = trim((string) ($incident['service_name'] ?? ''));
+        $regionName = trim((string) ($incident['region_name'] ?? ''));
+        $regionCode = trim((string) ($incident['region_code'] ?? ''));
+        $status = strtolower((string) ($incident['status'] ?? $incident['impact'] ?? ''));
+        $generic = preg_match('/^(increased error rates|operational issue\s*-\s*multiple services(?:\s*\([^)]*\))?|multiple services|service disruption|major outage reported\.?|service degradation reported\.?)$/i', $source) === 1;
+        if ($generic && ($regionName || $regionCode || $service || 'aws' === $providerId)) {
+            $serviceLabel = $service ?: (false !== stripos($source, 'multiple services') ? 'Multiple services' : $providerName . ' services');
+            if ('aws' === $providerId && false === stripos($serviceLabel, 'aws')) {
+                $serviceLabel = str_ireplace('Multiple services', 'Multiple AWS services', $serviceLabel);
+                if (false === stripos($serviceLabel, 'AWS')) {
+                    $serviceLabel = $providerName . ' ' . lcfirst($serviceLabel);
+                }
+            }
+            $verb = in_array($status, ['outage', 'major', 'critical', 'disrupted'], true) ? 'disrupted' : 'degraded';
+            $where = $regionName ? ' in ' . $regionName : '';
+            if ($regionCode) { $where .= ' (' . $regionCode . ')'; }
+            return trim($serviceLabel . ' ' . $verb . $where);
+        }
+        return $source ?: (string) ($incident['summary'] ?? 'Incident');
     }
 
     private function maybe_retry_ipv4(array $response, string $endpoint, array $headers): array {

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -26,6 +26,9 @@ if ( defined( 'LOUSY_OUTAGES_DISABLE' ) && LOUSY_OUTAGES_DISABLE ) {
 if ( ! defined( 'LOUSY_OUTAGES_VERSION' ) ) {
     define( 'LOUSY_OUTAGES_VERSION', '0.2.0' );
 }
+if ( ! defined( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION' ) ) {
+    define( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION', 2 );
+}
 if ( ! defined( 'LOUSY_OUTAGES_FILE' ) ) {
     define( 'LOUSY_OUTAGES_FILE', __FILE__ );
 }
@@ -640,6 +643,7 @@ function lousy_outages_build_snapshot( array $states, string $timestamp, string 
     $trending  = ( new \SuzyEaston\LousyOutages\Trending() )->evaluate( $providers );
 
     return lousy_outages_filter_snapshot( [
+        'schema_version' => LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION,
         'providers'  => $providers,
         'fetched_at' => $timestamp,
         'trending'   => $trending,
@@ -648,11 +652,35 @@ function lousy_outages_build_snapshot( array $states, string $timestamp, string 
     ] );
 }
 
+
+function lousy_outages_update_aws_snapshot_diagnostic( array $snapshot ): void {
+    $providers = isset( $snapshot['providers'] ) && is_array( $snapshot['providers'] ) ? $snapshot['providers'] : [];
+    foreach ( $providers as $provider ) {
+        if ( ! is_array( $provider ) || 'aws' !== strtolower( (string) ( $provider['id'] ?? '' ) ) ) { continue; }
+        $incidents = isset( $provider['incidents'] ) && is_array( $provider['incidents'] ) ? $provider['incidents'] : [];
+        $recent = isset( $provider['recentIncidents'] ) && is_array( $provider['recentIncidents'] ) ? $provider['recentIncidents'] : [];
+        $first = $incidents[0] ?? ( $recent[0] ?? [] );
+        update_option( 'lousy_outages_aws_snapshot_diagnostic', [
+            'parsed_rss_item_count' => (int) ( $provider['parsed_rss_item_count'] ?? $provider['rss_item_count'] ?? count( $incidents ) + count( $recent ) ),
+            'active_incident_count' => count( $incidents ),
+            'recent_incident_count' => count( $recent ),
+            'tile_kind' => (string) ( $provider['tile_kind'] ?? '' ),
+            'source_title' => is_array( $first ) ? (string) ( $first['source_title'] ?? $first['title'] ?? '' ) : '',
+            'display_title' => is_array( $first ) ? (string) ( $first['display_title'] ?? $first['displayTitle'] ?? '' ) : '',
+            'official_update_timestamp' => is_array( $first ) ? (string) ( $first['last_official_update'] ?? $first['lastOfficialUpdate'] ?? '' ) : '',
+            'checked_timestamp' => (string) ( $provider['checked_at'] ?? $provider['checkedAt'] ?? $snapshot['fetched_at'] ?? '' ),
+            'snapshot_schema_version' => (int) ( $snapshot['schema_version'] ?? 0 ),
+        ], false );
+        return;
+    }
+}
+
 function lousy_outages_store_snapshot( array $snapshot ): void {
     $cache_key = lousy_outages_snapshot_cache_key();
     $ttl       = (int) apply_filters( 'lousy_outages_snapshot_ttl', 5 * MINUTE_IN_SECONDS );
     set_transient( $cache_key, $snapshot, max( 60, $ttl ) );
     update_option( 'lousy_outages_snapshot', $snapshot, false );
+    lousy_outages_update_aws_snapshot_diagnostic( $snapshot );
 }
 
 function lousy_outages_refresh_snapshot( array $states, string $timestamp, string $source = 'snapshot' ): array {
@@ -681,17 +709,93 @@ function lousy_outages_refresh_snapshot( array $states, string $timestamp, strin
     return $snapshot;
 }
 
+
+function lousy_outages_snapshot_schema_is_current( array $snapshot ): bool {
+    if ( (int) ( $snapshot['schema_version'] ?? 0 ) !== (int) LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION ) {
+        return false;
+    }
+    $providers = isset( $snapshot['providers'] ) && is_array( $snapshot['providers'] ) ? $snapshot['providers'] : [];
+    foreach ( $providers as $provider ) {
+        if ( ! is_array( $provider ) ) { return false; }
+        $incidents = isset( $provider['incidents'] ) && is_array( $provider['incidents'] ) ? $provider['incidents'] : [];
+        foreach ( $incidents as $incident ) {
+            if ( ! is_array( $incident ) ) { return false; }
+            $needs = ! empty( $incident['region_name'] ) || ! empty( $incident['region_code'] ) || ! empty( $incident['is_long_running'] ) || ( isset( $incident['scope'] ) && 'regional' === strtolower( (string) $incident['scope'] ) );
+            if ( $needs ) {
+                foreach ( [ 'status', 'scope', 'last_official_update', 'checked_at', 'display_title', 'source_title' ] as $field ) {
+                    if ( ! array_key_exists( $field, $incident ) ) { return false; }
+                }
+            }
+        }
+    }
+    return true;
+}
+
+function lousy_outages_incident_value( array $incident, string $snake, string $camel = '' ) {
+    if ( array_key_exists( $snake, $incident ) ) { return $incident[ $snake ]; }
+    if ( $camel && array_key_exists( $camel, $incident ) ) { return $incident[ $camel ]; }
+    return null;
+}
+
+function lousy_outages_display_title_for_incident( string $id, array $state, array $incident ): string {
+    $provider = (string) ( $state['name'] ?? $state['provider'] ?? $id );
+    $source = trim( (string) ( lousy_outages_incident_value( $incident, 'source_title' ) ?? lousy_outages_incident_value( $incident, 'title' ) ?? '' ) );
+    $service = trim( (string) ( lousy_outages_incident_value( $incident, 'service_name' ) ?? lousy_outages_incident_value( $incident, 'service' ) ?? '' ) );
+    $region_name = trim( (string) ( lousy_outages_incident_value( $incident, 'region_name', 'regionName' ) ?? '' ) );
+    $region_code = trim( (string) ( lousy_outages_incident_value( $incident, 'region_code', 'regionCode' ) ?? '' ) );
+    $status = strtolower( (string) ( lousy_outages_incident_value( $incident, 'status' ) ?? lousy_outages_incident_value( $incident, 'impact' ) ?? $state['status'] ?? '' ) );
+    $generic = preg_match( '/^(increased error rates|operational issue\s*-\s*multiple services(?:\s*\([^)]*\))?|multiple services|service disruption|major outage reported\.?|service degradation reported\.?)$/i', $source ) === 1;
+    if ( $generic && ( $region_name || $region_code || $service || 'aws' === strtolower( $id ) ) ) {
+        $service_label = $service ?: ( false !== stripos( $source, 'multiple services' ) ? 'Multiple services' : $provider . ' services' );
+        if ( 'aws' === strtolower( $id ) && false === stripos( $service_label, 'aws' ) ) {
+            $service_label = str_ireplace( 'Multiple services', 'Multiple AWS services', $service_label );
+            if ( false === stripos( $service_label, 'AWS' ) ) { $service_label = $provider . ' ' . lcfirst( $service_label ); }
+        }
+        $verb = in_array( $status, [ 'outage', 'major', 'critical', 'disrupted' ], true ) ? 'disrupted' : 'degraded';
+        $where = $region_name ? ' in ' . $region_name : '';
+        if ( $region_code ) { $where .= ' (' . $region_code . ')'; }
+        return trim( $service_label . ' ' . $verb . $where );
+    }
+    return $source ?: (string) ( $incident['summary'] ?? $state['summary'] ?? 'Incident' );
+}
+
+function lousy_outages_map_incident_payload( string $id, array $state, array $incident, string $fetched_at ): array {
+    $source_title = (string) ( lousy_outages_incident_value( $incident, 'source_title', 'sourceTitle' ) ?? lousy_outages_incident_value( $incident, 'title' ) ?? 'Incident' );
+    $display_title = (string) ( lousy_outages_incident_value( $incident, 'display_title', 'displayTitle' ) ?? lousy_outages_display_title_for_incident( $id, $state, array_merge( $incident, [ 'source_title' => $source_title ] ) ) );
+    return [
+        'id'        => (string) ( $incident['id'] ?? md5( $id . wp_json_encode( $incident ) ) ),
+        'title'     => $source_title,
+        'display_title' => $display_title,
+        'displayTitle' => $display_title,
+        'source_title' => $source_title,
+        'sourceTitle' => $source_title,
+        'summary'   => $incident['summary'] ?? '',
+        'startedAt' => lousy_outages_incident_value( $incident, 'started_at', 'startedAt' ) ?? '',
+        'updatedAt' => lousy_outages_incident_value( $incident, 'updated_at', 'updatedAt' ) ?? '',
+        'impact'    => lousy_outages_incident_value( $incident, 'impact' ) ?? 'minor',
+        'status'    => lousy_outages_incident_value( $incident, 'status' ) ?? lousy_outages_incident_value( $incident, 'impact' ) ?? 'minor',
+        'scope'     => lousy_outages_incident_value( $incident, 'scope' ) ?? '',
+        'region_name' => lousy_outages_incident_value( $incident, 'region_name', 'regionName' ) ?? '',
+        'region_code' => lousy_outages_incident_value( $incident, 'region_code', 'regionCode' ) ?? '',
+        'is_long_running' => (bool) ( lousy_outages_incident_value( $incident, 'is_long_running', 'isLongRunning' ) ?? false ),
+        'last_official_update' => lousy_outages_incident_value( $incident, 'last_official_update', 'lastOfficialUpdate' ) ?? lousy_outages_incident_value( $incident, 'updated_at', 'updatedAt' ) ?? '',
+        'checked_at' => lousy_outages_incident_value( $incident, 'checked_at', 'checkedAt' ) ?? ( $state['checked_at'] ?? $fetched_at ),
+        'eta'       => $incident['eta'] ?? 'investigating',
+        'url'       => $incident['url'] ?? ( $state['url'] ?? '' ),
+    ];
+}
+
 function lousy_outages_get_snapshot( bool $force_refresh = false ): array {
     $cache_key = lousy_outages_snapshot_cache_key();
     if ( ! $force_refresh ) {
         $cached = get_transient( $cache_key );
-        if ( is_array( $cached ) && ! empty( $cached['providers'] ) ) {
+        if ( is_array( $cached ) && ! empty( $cached['providers'] ) && lousy_outages_snapshot_schema_is_current( $cached ) ) {
             return lousy_outages_filter_snapshot( $cached );
         }
     }
 
     $stored = get_option( 'lousy_outages_snapshot', [] );
-    if ( ! $force_refresh && is_array( $stored ) && ! empty( $stored['providers'] ) ) {
+    if ( ! $force_refresh && is_array( $stored ) && ! empty( $stored['providers'] ) && lousy_outages_snapshot_schema_is_current( $stored ) ) {
         $filtered = lousy_outages_filter_snapshot( $stored );
         lousy_outages_store_snapshot( $filtered );
         return $filtered;
@@ -1487,16 +1591,7 @@ function lousy_outages_build_provider_payload( string $id, array $state, string 
             if ( ! is_array( $incident ) ) {
                 continue;
             }
-            $incidents[] = [
-                'id'        => (string) ( $incident['id'] ?? md5( $id . wp_json_encode( $incident ) ) ),
-                'title'     => $incident['title'] ?? 'Incident',
-                'summary'   => $incident['summary'] ?? '',
-                'startedAt' => $incident['started_at'] ?? '',
-                'updatedAt' => $incident['updated_at'] ?? '',
-                'impact'    => $incident['impact'] ?? 'minor',
-                'eta'       => $incident['eta'] ?? 'investigating',
-                'url'       => $incident['url'] ?? ( $state['url'] ?? '' ),
-            ];
+            $incidents[] = lousy_outages_map_incident_payload( $id, $state, $incident, $fetched_at );
         }
     }
     if ( ! empty( $state['recent_incidents'] ) && is_array( $state['recent_incidents'] ) ) {
@@ -1504,16 +1599,7 @@ function lousy_outages_build_provider_payload( string $id, array $state, string 
             if ( ! is_array( $incident ) ) {
                 continue;
             }
-            $recent_incidents[] = [
-                'id'        => (string) ( $incident['id'] ?? md5( $id . wp_json_encode( $incident ) ) ),
-                'title'     => $incident['title'] ?? 'Incident',
-                'summary'   => $incident['summary'] ?? '',
-                'startedAt' => $incident['started_at'] ?? '',
-                'updatedAt' => $incident['updated_at'] ?? '',
-                'impact'    => $incident['impact'] ?? 'minor',
-                'eta'       => $incident['eta'] ?? 'investigating',
-                'url'       => $incident['url'] ?? ( $state['url'] ?? '' ),
-            ];
+            $recent_incidents[] = lousy_outages_map_incident_payload( $id, $state, $incident, $fetched_at );
         }
     }
 
@@ -1532,6 +1618,10 @@ function lousy_outages_build_provider_payload( string $id, array $state, string 
         'sort_key'   => $state['sort_key'] ?? null,
         'confidence'=> $state['confidence'] ?? null,
         'summary'    => $state['summary'] ?? $label,
+        'checked_at' => $state['checked_at'] ?? $fetched_at,
+        'checkedAt'  => $state['checked_at'] ?? $fetched_at,
+        'last_official_update' => $state['last_official_update'] ?? '',
+        'lastOfficialUpdate' => $state['last_official_update'] ?? '',
         'updatedAt'  => $updated_at,
         'url'        => $url,
         'snark'      => $state['snark'] ?? '',

--- a/plugins/lousy-outages/assets/lousy-outages.js
+++ b/plugins/lousy-outages/assets/lousy-outages.js
@@ -1499,7 +1499,7 @@
           li.className = 'lo-inc-item';
           var title = state.doc.createElement('p');
           title.className = 'lo-inc-title';
-          var condensedName = condenseIncidentTitle(providerSlug, incident.name || incident.title || incident.summary || 'Incident', 118);
+          var condensedName = condenseIncidentTitle(providerSlug, incident.display_title || incident.displayTitle || incident.name || incident.title || incident.summary || provider.summary || 'Incident', 118);
           title.textContent = condensedName.text || 'Incident';
           if (condensedName.title && condensedName.title !== condensedName.text) {
             title.setAttribute('title', condensedName.title);

--- a/plugins/lousy-outages/includes/Fetcher.php
+++ b/plugins/lousy-outages/includes/Fetcher.php
@@ -433,6 +433,12 @@ class Fetcher {
         }
         $result['updated_at'] = $updated ?: $defaults['updated_at'];
         $result['checked_at'] = $defaults['checked_at'] ?? gmdate('c');
+        foreach ($result['incidents'] as &$incident) {
+            if (is_array($incident)) {
+                $incident['checked_at'] = $result['checked_at'];
+            }
+        }
+        unset($incident);
         if (! empty($incidents) && ! empty($incidents[0]['last_official_update'])) {
             $result['last_official_update'] = $incidents[0]['last_official_update'];
         }
@@ -709,6 +715,7 @@ class Fetcher {
             $entry = [
                 'id'         => (string) ($incident['id'] ?? md5(wp_json_encode($incident))),
                 'title'      => $title ?: 'Incident',
+                'source_title' => $title ?: 'Incident',
                 'summary'    => $summary,
                 'started_at' => $started,
                 'updated_at' => $updated,
@@ -720,6 +727,7 @@ class Fetcher {
                 'url'        => $url,
             ];
             $entry = array_merge($entry, $metadata);
+            $entry['display_title'] = $this->display_title($provider, $entry);
 
             if ($isResolved) {
                 $recent[] = $entry;
@@ -763,7 +771,35 @@ class Fetcher {
         if (preg_match('/\b(months?|long-running|extended|ongoing)\b/i', $lower)) {
             $metadata['is_long_running'] = true;
         }
+        if (preg_match('/multiple services/i', $text)) {
+            $metadata['service_name'] = 'Multiple services';
+        }
         return $metadata;
+    }
+
+    private function display_title(array $provider, array $incident): string {
+        $providerId = strtolower((string) ($provider['id'] ?? ''));
+        $providerName = (string) ($provider['name'] ?? $providerId);
+        $source = trim((string) ($incident['source_title'] ?? $incident['title'] ?? ''));
+        $service = trim((string) ($incident['service_name'] ?? ''));
+        $regionName = trim((string) ($incident['region_name'] ?? ''));
+        $regionCode = trim((string) ($incident['region_code'] ?? ''));
+        $status = strtolower((string) ($incident['status'] ?? $incident['impact'] ?? ''));
+        $generic = preg_match('/^(increased error rates|operational issue\s*-\s*multiple services(?:\s*\([^)]*\))?|multiple services|service disruption|major outage reported\.?|service degradation reported\.?)$/i', $source) === 1;
+        if ($generic && ($regionName || $regionCode || $service || 'aws' === $providerId)) {
+            $serviceLabel = $service ?: (false !== stripos($source, 'multiple services') ? 'Multiple services' : $providerName . ' services');
+            if ('aws' === $providerId && false === stripos($serviceLabel, 'aws')) {
+                $serviceLabel = str_ireplace('Multiple services', 'Multiple AWS services', $serviceLabel);
+                if (false === stripos($serviceLabel, 'AWS')) {
+                    $serviceLabel = $providerName . ' ' . lcfirst($serviceLabel);
+                }
+            }
+            $verb = in_array($status, ['outage', 'major', 'critical', 'disrupted'], true) ? 'disrupted' : 'degraded';
+            $where = $regionName ? ' in ' . $regionName : '';
+            if ($regionCode) { $where .= ' (' . $regionCode . ')'; }
+            return trim($serviceLabel . ' ' . $verb . $where);
+        }
+        return $source ?: (string) ($incident['summary'] ?? 'Incident');
     }
 
     private function maybe_retry_ipv4(array $response, string $endpoint, array $headers): array {

--- a/plugins/lousy-outages/lousy-outages.php
+++ b/plugins/lousy-outages/lousy-outages.php
@@ -26,6 +26,9 @@ if ( defined( 'LOUSY_OUTAGES_DISABLE' ) && LOUSY_OUTAGES_DISABLE ) {
 if ( ! defined( 'LOUSY_OUTAGES_VERSION' ) ) {
     define( 'LOUSY_OUTAGES_VERSION', '0.2.0' );
 }
+if ( ! defined( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION' ) ) {
+    define( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION', 2 );
+}
 if ( ! defined( 'LOUSY_OUTAGES_FILE' ) ) {
     define( 'LOUSY_OUTAGES_FILE', __FILE__ );
 }
@@ -640,6 +643,7 @@ function lousy_outages_build_snapshot( array $states, string $timestamp, string 
     $trending  = ( new \SuzyEaston\LousyOutages\Trending() )->evaluate( $providers );
 
     return lousy_outages_filter_snapshot( [
+        'schema_version' => LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION,
         'providers'  => $providers,
         'fetched_at' => $timestamp,
         'trending'   => $trending,
@@ -648,11 +652,35 @@ function lousy_outages_build_snapshot( array $states, string $timestamp, string 
     ] );
 }
 
+
+function lousy_outages_update_aws_snapshot_diagnostic( array $snapshot ): void {
+    $providers = isset( $snapshot['providers'] ) && is_array( $snapshot['providers'] ) ? $snapshot['providers'] : [];
+    foreach ( $providers as $provider ) {
+        if ( ! is_array( $provider ) || 'aws' !== strtolower( (string) ( $provider['id'] ?? '' ) ) ) { continue; }
+        $incidents = isset( $provider['incidents'] ) && is_array( $provider['incidents'] ) ? $provider['incidents'] : [];
+        $recent = isset( $provider['recentIncidents'] ) && is_array( $provider['recentIncidents'] ) ? $provider['recentIncidents'] : [];
+        $first = $incidents[0] ?? ( $recent[0] ?? [] );
+        update_option( 'lousy_outages_aws_snapshot_diagnostic', [
+            'parsed_rss_item_count' => (int) ( $provider['parsed_rss_item_count'] ?? $provider['rss_item_count'] ?? count( $incidents ) + count( $recent ) ),
+            'active_incident_count' => count( $incidents ),
+            'recent_incident_count' => count( $recent ),
+            'tile_kind' => (string) ( $provider['tile_kind'] ?? '' ),
+            'source_title' => is_array( $first ) ? (string) ( $first['source_title'] ?? $first['title'] ?? '' ) : '',
+            'display_title' => is_array( $first ) ? (string) ( $first['display_title'] ?? $first['displayTitle'] ?? '' ) : '',
+            'official_update_timestamp' => is_array( $first ) ? (string) ( $first['last_official_update'] ?? $first['lastOfficialUpdate'] ?? '' ) : '',
+            'checked_timestamp' => (string) ( $provider['checked_at'] ?? $provider['checkedAt'] ?? $snapshot['fetched_at'] ?? '' ),
+            'snapshot_schema_version' => (int) ( $snapshot['schema_version'] ?? 0 ),
+        ], false );
+        return;
+    }
+}
+
 function lousy_outages_store_snapshot( array $snapshot ): void {
     $cache_key = lousy_outages_snapshot_cache_key();
     $ttl       = (int) apply_filters( 'lousy_outages_snapshot_ttl', 5 * MINUTE_IN_SECONDS );
     set_transient( $cache_key, $snapshot, max( 60, $ttl ) );
     update_option( 'lousy_outages_snapshot', $snapshot, false );
+    lousy_outages_update_aws_snapshot_diagnostic( $snapshot );
 }
 
 function lousy_outages_refresh_snapshot( array $states, string $timestamp, string $source = 'snapshot' ): array {
@@ -681,17 +709,93 @@ function lousy_outages_refresh_snapshot( array $states, string $timestamp, strin
     return $snapshot;
 }
 
+
+function lousy_outages_snapshot_schema_is_current( array $snapshot ): bool {
+    if ( (int) ( $snapshot['schema_version'] ?? 0 ) !== (int) LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION ) {
+        return false;
+    }
+    $providers = isset( $snapshot['providers'] ) && is_array( $snapshot['providers'] ) ? $snapshot['providers'] : [];
+    foreach ( $providers as $provider ) {
+        if ( ! is_array( $provider ) ) { return false; }
+        $incidents = isset( $provider['incidents'] ) && is_array( $provider['incidents'] ) ? $provider['incidents'] : [];
+        foreach ( $incidents as $incident ) {
+            if ( ! is_array( $incident ) ) { return false; }
+            $needs = ! empty( $incident['region_name'] ) || ! empty( $incident['region_code'] ) || ! empty( $incident['is_long_running'] ) || ( isset( $incident['scope'] ) && 'regional' === strtolower( (string) $incident['scope'] ) );
+            if ( $needs ) {
+                foreach ( [ 'status', 'scope', 'last_official_update', 'checked_at', 'display_title', 'source_title' ] as $field ) {
+                    if ( ! array_key_exists( $field, $incident ) ) { return false; }
+                }
+            }
+        }
+    }
+    return true;
+}
+
+function lousy_outages_incident_value( array $incident, string $snake, string $camel = '' ) {
+    if ( array_key_exists( $snake, $incident ) ) { return $incident[ $snake ]; }
+    if ( $camel && array_key_exists( $camel, $incident ) ) { return $incident[ $camel ]; }
+    return null;
+}
+
+function lousy_outages_display_title_for_incident( string $id, array $state, array $incident ): string {
+    $provider = (string) ( $state['name'] ?? $state['provider'] ?? $id );
+    $source = trim( (string) ( lousy_outages_incident_value( $incident, 'source_title' ) ?? lousy_outages_incident_value( $incident, 'title' ) ?? '' ) );
+    $service = trim( (string) ( lousy_outages_incident_value( $incident, 'service_name' ) ?? lousy_outages_incident_value( $incident, 'service' ) ?? '' ) );
+    $region_name = trim( (string) ( lousy_outages_incident_value( $incident, 'region_name', 'regionName' ) ?? '' ) );
+    $region_code = trim( (string) ( lousy_outages_incident_value( $incident, 'region_code', 'regionCode' ) ?? '' ) );
+    $status = strtolower( (string) ( lousy_outages_incident_value( $incident, 'status' ) ?? lousy_outages_incident_value( $incident, 'impact' ) ?? $state['status'] ?? '' ) );
+    $generic = preg_match( '/^(increased error rates|operational issue\s*-\s*multiple services(?:\s*\([^)]*\))?|multiple services|service disruption|major outage reported\.?|service degradation reported\.?)$/i', $source ) === 1;
+    if ( $generic && ( $region_name || $region_code || $service || 'aws' === strtolower( $id ) ) ) {
+        $service_label = $service ?: ( false !== stripos( $source, 'multiple services' ) ? 'Multiple services' : $provider . ' services' );
+        if ( 'aws' === strtolower( $id ) && false === stripos( $service_label, 'aws' ) ) {
+            $service_label = str_ireplace( 'Multiple services', 'Multiple AWS services', $service_label );
+            if ( false === stripos( $service_label, 'AWS' ) ) { $service_label = $provider . ' ' . lcfirst( $service_label ); }
+        }
+        $verb = in_array( $status, [ 'outage', 'major', 'critical', 'disrupted' ], true ) ? 'disrupted' : 'degraded';
+        $where = $region_name ? ' in ' . $region_name : '';
+        if ( $region_code ) { $where .= ' (' . $region_code . ')'; }
+        return trim( $service_label . ' ' . $verb . $where );
+    }
+    return $source ?: (string) ( $incident['summary'] ?? $state['summary'] ?? 'Incident' );
+}
+
+function lousy_outages_map_incident_payload( string $id, array $state, array $incident, string $fetched_at ): array {
+    $source_title = (string) ( lousy_outages_incident_value( $incident, 'source_title', 'sourceTitle' ) ?? lousy_outages_incident_value( $incident, 'title' ) ?? 'Incident' );
+    $display_title = (string) ( lousy_outages_incident_value( $incident, 'display_title', 'displayTitle' ) ?? lousy_outages_display_title_for_incident( $id, $state, array_merge( $incident, [ 'source_title' => $source_title ] ) ) );
+    return [
+        'id'        => (string) ( $incident['id'] ?? md5( $id . wp_json_encode( $incident ) ) ),
+        'title'     => $source_title,
+        'display_title' => $display_title,
+        'displayTitle' => $display_title,
+        'source_title' => $source_title,
+        'sourceTitle' => $source_title,
+        'summary'   => $incident['summary'] ?? '',
+        'startedAt' => lousy_outages_incident_value( $incident, 'started_at', 'startedAt' ) ?? '',
+        'updatedAt' => lousy_outages_incident_value( $incident, 'updated_at', 'updatedAt' ) ?? '',
+        'impact'    => lousy_outages_incident_value( $incident, 'impact' ) ?? 'minor',
+        'status'    => lousy_outages_incident_value( $incident, 'status' ) ?? lousy_outages_incident_value( $incident, 'impact' ) ?? 'minor',
+        'scope'     => lousy_outages_incident_value( $incident, 'scope' ) ?? '',
+        'region_name' => lousy_outages_incident_value( $incident, 'region_name', 'regionName' ) ?? '',
+        'region_code' => lousy_outages_incident_value( $incident, 'region_code', 'regionCode' ) ?? '',
+        'is_long_running' => (bool) ( lousy_outages_incident_value( $incident, 'is_long_running', 'isLongRunning' ) ?? false ),
+        'last_official_update' => lousy_outages_incident_value( $incident, 'last_official_update', 'lastOfficialUpdate' ) ?? lousy_outages_incident_value( $incident, 'updated_at', 'updatedAt' ) ?? '',
+        'checked_at' => lousy_outages_incident_value( $incident, 'checked_at', 'checkedAt' ) ?? ( $state['checked_at'] ?? $fetched_at ),
+        'eta'       => $incident['eta'] ?? 'investigating',
+        'url'       => $incident['url'] ?? ( $state['url'] ?? '' ),
+    ];
+}
+
 function lousy_outages_get_snapshot( bool $force_refresh = false ): array {
     $cache_key = lousy_outages_snapshot_cache_key();
     if ( ! $force_refresh ) {
         $cached = get_transient( $cache_key );
-        if ( is_array( $cached ) && ! empty( $cached['providers'] ) ) {
+        if ( is_array( $cached ) && ! empty( $cached['providers'] ) && lousy_outages_snapshot_schema_is_current( $cached ) ) {
             return lousy_outages_filter_snapshot( $cached );
         }
     }
 
     $stored = get_option( 'lousy_outages_snapshot', [] );
-    if ( ! $force_refresh && is_array( $stored ) && ! empty( $stored['providers'] ) ) {
+    if ( ! $force_refresh && is_array( $stored ) && ! empty( $stored['providers'] ) && lousy_outages_snapshot_schema_is_current( $stored ) ) {
         $filtered = lousy_outages_filter_snapshot( $stored );
         lousy_outages_store_snapshot( $filtered );
         return $filtered;
@@ -1487,16 +1591,7 @@ function lousy_outages_build_provider_payload( string $id, array $state, string 
             if ( ! is_array( $incident ) ) {
                 continue;
             }
-            $incidents[] = [
-                'id'        => (string) ( $incident['id'] ?? md5( $id . wp_json_encode( $incident ) ) ),
-                'title'     => $incident['title'] ?? 'Incident',
-                'summary'   => $incident['summary'] ?? '',
-                'startedAt' => $incident['started_at'] ?? '',
-                'updatedAt' => $incident['updated_at'] ?? '',
-                'impact'    => $incident['impact'] ?? 'minor',
-                'eta'       => $incident['eta'] ?? 'investigating',
-                'url'       => $incident['url'] ?? ( $state['url'] ?? '' ),
-            ];
+            $incidents[] = lousy_outages_map_incident_payload( $id, $state, $incident, $fetched_at );
         }
     }
     if ( ! empty( $state['recent_incidents'] ) && is_array( $state['recent_incidents'] ) ) {
@@ -1504,16 +1599,7 @@ function lousy_outages_build_provider_payload( string $id, array $state, string 
             if ( ! is_array( $incident ) ) {
                 continue;
             }
-            $recent_incidents[] = [
-                'id'        => (string) ( $incident['id'] ?? md5( $id . wp_json_encode( $incident ) ) ),
-                'title'     => $incident['title'] ?? 'Incident',
-                'summary'   => $incident['summary'] ?? '',
-                'startedAt' => $incident['started_at'] ?? '',
-                'updatedAt' => $incident['updated_at'] ?? '',
-                'impact'    => $incident['impact'] ?? 'minor',
-                'eta'       => $incident['eta'] ?? 'investigating',
-                'url'       => $incident['url'] ?? ( $state['url'] ?? '' ),
-            ];
+            $recent_incidents[] = lousy_outages_map_incident_payload( $id, $state, $incident, $fetched_at );
         }
     }
 
@@ -1532,6 +1618,10 @@ function lousy_outages_build_provider_payload( string $id, array $state, string 
         'sort_key'   => $state['sort_key'] ?? null,
         'confidence'=> $state['confidence'] ?? null,
         'summary'    => $state['summary'] ?? $label,
+        'checked_at' => $state['checked_at'] ?? $fetched_at,
+        'checkedAt'  => $state['checked_at'] ?? $fetched_at,
+        'last_official_update' => $state['last_official_update'] ?? '',
+        'lastOfficialUpdate' => $state['last_official_update'] ?? '',
         'updatedAt'  => $updated_at,
         'url'        => $url,
         'snark'      => $state['snark'] ?? '',

--- a/tests/lousy-outages/aws-snapshot-pipeline-regression.php
+++ b/tests/lousy-outages/aws-snapshot-pipeline-regression.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) define('ABSPATH', __DIR__ . '/../../');
+if (!defined('DAY_IN_SECONDS')) define('DAY_IN_SECONDS', 86400);
+if (!defined('MINUTE_IN_SECONDS')) define('MINUTE_IN_SECONDS', 60);
+if (!defined('HOUR_IN_SECONDS')) define('HOUR_IN_SECONDS', 3600);
+if (!defined('YEAR_IN_SECONDS')) define('YEAR_IN_SECONDS', 31536000);
+if (!function_exists('plugin_dir_path')) { function plugin_dir_path($f){ return dirname($f) . '/'; } }
+if (!function_exists('plugin_dir_url')) { function plugin_dir_url($f){ return 'https://example.com/wp-content/plugins/lousy-outages/'; } }
+if (!function_exists('add_action')) { function add_action(...$args){} }
+if (!function_exists('add_filter')) { function add_filter(...$args){} }
+if (!function_exists('apply_filters')) { function apply_filters($tag,$value){ return $value; } }
+if (!function_exists('add_shortcode')) { function add_shortcode(...$args){} }
+if (!function_exists('register_activation_hook')) { function register_activation_hook(...$args){} }
+if (!function_exists('register_deactivation_hook')) { function register_deactivation_hook(...$args){} }
+if (!function_exists('wp_next_scheduled')) { function wp_next_scheduled(){ return false; } }
+if (!function_exists('wp_schedule_event')) { function wp_schedule_event(){ return true; } }
+if (!function_exists('wp_clear_scheduled_hook')) { function wp_clear_scheduled_hook(){} }
+if (!function_exists('wp_date')) { function wp_date($format,$timestamp=null){ return gmdate($format, $timestamp ? (int)$timestamp : time()); } }
+if (!function_exists('wp_parse_url')) { function wp_parse_url($url,$component=-1){ return parse_url((string)$url, $component); } }
+if (!function_exists('trailingslashit')) { function trailingslashit($v){ return rtrim((string)$v,'/').'/'; } }
+if (!function_exists('wp_json_encode')) { function wp_json_encode($v){ return json_encode($v); } }
+if (!function_exists('wp_strip_all_tags')) { function wp_strip_all_tags($v){ return strip_tags((string)$v); } }
+if (!function_exists('sanitize_text_field')) { function sanitize_text_field($v){ return trim(strip_tags((string)$v)); } }
+if (!function_exists('sanitize_key')) { function sanitize_key($v){ return preg_replace('/[^a-z0-9_]/','',strtolower((string)$v)) ?? ''; } }
+if (!function_exists('esc_html__')) { function esc_html__($v){ return $v; } }
+if (!function_exists('__')) { function __($v){ return $v; } }
+if (!function_exists('get_option')) { function get_option($k,$d=null){ return $GLOBALS['lo_options'][$k] ?? $d; } }
+if (!function_exists('update_option')) { function update_option($k,$v,$autoload=null){ $GLOBALS['lo_options'][$k]=$v; return true; } }
+if (!function_exists('get_transient')) { function get_transient($k){ return $GLOBALS['lo_transients'][$k] ?? false; } }
+if (!function_exists('set_transient')) { function set_transient($k,$v,$ttl=0){ $GLOBALS['lo_transients'][$k]=$v; return true; } }
+
+require __DIR__ . '/../../plugins/lousy-outages/lousy-outages.php';
+
+use SuzyEaston\LousyOutages\Fetcher;
+use function SuzyEaston\LousyOutages\Adapters\from_rss_atom;
+
+function assert_true($cond, $msg) { if (!$cond) { fwrite(STDERR, "FAIL: $msg\n"); exit(1); } }
+function call_private($object, string $method, array $args) { $ref = new ReflectionMethod($object, $method); $ref->setAccessible(true); return $ref->invokeArgs($object, $args); }
+
+$GLOBALS['lo_options'] = ['lousy_outages_last_poll' => '2026-07-19T10:00:00+00:00'];
+$GLOBALS['lo_transients'] = [];
+$xml = '<rss><channel><item><title>Operational issue - Multiple services (UAE)</title><link>https://status.aws.amazon.com/</link><pubDate>Thu, 30 Apr 2026 12:00:00 GMT</pubDate><description><![CDATA[We are experiencing a service disruption affecting multiple services in the UAE region (ME-CENTRAL-1). Full restoration is expected to take several months.]]></description></item></channel></rss>';
+$normalized = from_rss_atom($xml);
+$fetcher = new Fetcher();
+$provider = ['id'=>'aws','name'=>'AWS','provider'=>'AWS','status_url'=>'https://status.aws.amazon.com/','type'=>'rss'];
+$state = call_private($fetcher, 'assemble_result', [[
+  'id'=>'aws','name'=>'AWS','provider'=>'AWS','status'=>'unknown','status_label'=>'Unknown','summary'=>'Waiting','message'=>'Waiting','updated_at'=>'2026-07-19T10:00:00+00:00','checked_at'=>'2026-07-19T10:00:00+00:00','url'=>'https://status.aws.amazon.com/','incidents'=>[],'error'=>null,'source_type'=>'rss'
+], $normalized, $provider]);
+$state = call_private($fetcher, 'apply_tile_metadata', [$state, $provider, false]);
+$snapshot = lousy_outages_build_snapshot(['aws'=>$state], '2026-07-19T10:00:00+00:00', 'test');
+$aws = $snapshot['providers'][0];
+$incident = $aws['incidents'][0] ?? [];
+assert_true($snapshot['schema_version'] === LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION, 'schema version is stored');
+assert_true($aws['tile_kind'] === 'outage', 'AWS is outage tile');
+assert_true(count($aws['incidents']) === 1, 'AWS active incident serialized');
+assert_true($incident['display_title'] === 'Multiple AWS services disrupted in UAE (ME-CENTRAL-1)', 'display title enriched');
+assert_true($incident['source_title'] === 'Operational issue - Multiple services (UAE)', 'source title preserved');
+assert_true($incident['scope'] === 'regional' && $incident['region_name'] === 'UAE' && $incident['region_code'] === 'ME-CENTRAL-1', 'regional metadata preserved');
+assert_true($incident['is_long_running'] === true, 'long-running preserved');
+assert_true(substr($incident['last_official_update'], 0, 10) === '2026-04-30', 'official update remains Apr 30');
+assert_true(substr($incident['checked_at'], 0, 10) === '2026-07-19', 'checked_at is separate check time');
+assert_true($aws['summary'] !== 'Major outage reported.', 'provider summary is not generic');
+
+// Migration: old snapshots are rejected, current snapshots reused from cache.
+$legacy = ['providers'=>[['id'=>'aws','name'=>'AWS','tile_kind'=>'signal','summary'=>'Major outage reported.','incidents'=>[]]], 'fetched_at'=>'2026-07-19T09:00:00+00:00'];
+$GLOBALS['lo_transients'][lousy_outages_snapshot_cache_key()] = $legacy;
+$GLOBALS['lo_options']['lousy_outages_snapshot'] = $legacy;
+$GLOBALS['lo_options']['lousy_outages_states'] = ['aws'=>$state];
+$migrated = lousy_outages_get_snapshot(false);
+assert_true(($migrated['schema_version'] ?? 0) === LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION, 'legacy unversioned snapshot rebuilt');
+assert_true(($migrated['providers'][0]['incidents'][0]['display_title'] ?? '') === 'Multiple AWS services disrupted in UAE (ME-CENTRAL-1)', 'rebuilt summary includes expanded metadata');
+$current = lousy_outages_get_snapshot(false);
+assert_true($current === $migrated, 'current-version transient reused without rebuild churn');
+
+echo json_encode($aws, JSON_PRETTY_PRINT) . "\nOK\n";


### PR DESCRIPTION
### Motivation

- Preserve normalized incident metadata end-to-end so provider snapshots carry status, scope, regional fields, long-running flags, official update times, and checked timestamps instead of being collapsed to a generic signal summary.
- Ensure homepage/dashboard clients prefer a data-driven, provider-aware `display_title` (enriched from official titles) while retaining the original `source_title` for auditability.
- Prevent stale legacy snapshots from hiding active incidents by adding a schema version and forcing safe rebuilds when encountering older or malformed payloads.

### Description

- Map incidents through a new canonical serializer so `lousy_outages_build_provider_payload()` preserves normalized fields (status, scope, region_name, region_code, is_long_running, last_official_update, checked_at, display_title, source_title) and provider-level `checked_at`/`last_official_update` are included in snapshots.
- Add provider-aware display-title normalization that enriches generic AWS titles into headings like “Multiple AWS services disrupted in UAE (ME-CENTRAL-1)” while preserving the official source title, implemented in new mapping/helpers and mirrored into the Fetcher normalization path.
- Introduce snapshot schema versioning (`LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION = 2`), store `schema_version` in snapshots, and add `lousy_outages_snapshot_schema_is_current()` to reject and rebuild legacy/malformed snapshots safely.
- Update clients to prefer `incident.display_title`/`incident.displayTitle` (homepage teaser and dashboard renderer) and add a narrow AWS diagnostic written to `lousy_outages_aws_snapshot_diagnostic` for production inspection without leaking raw RSS bodies.
- Files changed: `plugins/lousy-outages/lousy-outages.php`, `plugins/lousy-outages/includes/Fetcher.php`, `plugins/lousy-outages/assets/lousy-outages.js`, `assets/js/lousy-outages-teaser.js`, mirrored plugin tree under `lousy-outages/`, and added test `tests/lousy-outages/aws-snapshot-pipeline-regression.php` plus small teaser test update `__tests__/lousy-outages-teaser.test.js`.

### Testing

- PHP syntax checks (`php -l`) on modified files succeeded. 
- PHP regression tests `tests/lousy-outages/rss-long-running-regression.php` and the new `tests/lousy-outages/aws-snapshot-pipeline-regression.php` ran and passed, validating RSS→Fetcher→snapshot pipeline and the final serialized provider shape (tile_kind outage, one active incident, enriched `display_title`, preserved `source_title`, regional metadata, distinct `last_official_update` and `checked_at`).
- JS unit tests for the homepage teaser (`node --test __tests__/lousy-outages-teaser.test.js`) passed, confirming the teaser now prefers `display_title` and renders AWS as an outage with the expected badge and dates.
- Plugin build and drift checks (`scripts/check-lousy-outages-tree-drift.sh` and `scripts/build-lousy-outages-plugin.sh`) completed and the built ZIP contains the patched files.
- Broader JS integration/regression suites were exercised but contain pre-existing unrelated failures (not caused by this AWS data-path change), namely three failing tests in the larger integration set: `snarkOutage uses provider-specific quip when available`, `manual refresh falls back to status endpoint when refresh endpoint fails`, and `manual refresh treats skipped lock as success and keeps timestamp aligned`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d5eef3a00833196691d14e753bc02)