### PR TITLE
Fix Lousy Outages active incident lifecycle and RSS lifecycle grouping

### DIFF
--- a/lousy-outages/includes/Adapters.php
+++ b/lousy-outages/includes/Adapters.php
@@ -130,7 +130,7 @@ function from_rss_atom(string $xml): array {
     $items = [];
     $resolve_status = static function (string $title, string $summary): string {
         $text = strtolower($title . ' ' . $summary);
-        if (preg_match('/\bresolved\b|this issue is now resolved|issue is now resolved|issue has been resolved|ended at|fully recovered|closed/i', $text)) {
+        if (preg_match('/\b(resolved|completed|closed|postmortem)\b|\ball systems operational\b|service is operational|this issue is now resolved|issue is now resolved|issue has been resolved|ended at|fully recovered/i', $text)) {
             return 'resolved';
         }
         if (preg_match('/\b(scheduled|planned).{0,40}maintenance\b/i', $text)) {
@@ -158,6 +158,7 @@ function from_rss_atom(string $xml): array {
                 'started_at' => '',
                 'updated_at' => (string) ($item->pubDate ?? ''),
                 'shortlink'  => (string) ($item->link ?? ''),
+                'guid'       => (string) ($item->guid ?? ''),
             ];
         }
     } else {
@@ -171,6 +172,7 @@ function from_rss_atom(string $xml): array {
                 'started_at' => '',
                 'updated_at' => (string) ($item->updated ?? ($item->published ?? '')),
                 'shortlink'  => (string) ($item->link['href'] ?? ($item->link ?? '')),
+                'guid'       => (string) ($item->id ?? ''),
             ];
         }
     }
@@ -191,6 +193,33 @@ function from_rss_atom(string $xml): array {
         },
         $items
     );
+
+
+    $identity = static function (array $item): string {
+        $url = strtolower(trim((string) ($item['shortlink'] ?? '')));
+        $guid = strtolower(trim((string) ($item['guid'] ?? '')));
+        $title = strtolower(trim((string) ($item['name'] ?? '')));
+        $summary = strtolower(trim((string) ($item['summary'] ?? '')));
+        $text = preg_replace('/\b(resolved|completed|closed|postmortem|operational|investigating|identified|monitoring|update|issue|operational issue|service disruption|outage|major|degraded)\b/i', ' ', $title . ' ' . $summary) ?? ($title . ' ' . $summary);
+        $parts = [];
+        if (preg_match('/\b([a-z]{2}-[a-z]+-\d+)\b/i', $text, $m)) { $parts[] = strtolower($m[1]); }
+        if (preg_match('/\b(uae|united arab emirates)\b/i', $text)) { $parts[] = 'uae'; }
+        if (preg_match('/\b(multiple services|[a-z0-9][a-z0-9 +._-]{2,40}(?:service|api|database|compute|storage))\b/i', $text, $m)) { $parts[] = strtolower(trim($m[1])); }
+        $normalized = trim(preg_replace('/[^a-z0-9]+/', ' ', $text) ?? '');
+        $normalized = trim(preg_replace('/\s+/', ' ', $normalized) ?? '');
+        $semantic = implode('|', array_unique(array_filter($parts))) ?: implode(' ', array_slice(explode(' ', $normalized), 0, 8));
+        if ($semantic !== '') { return 'semantic|' . $semantic; }
+        return $url !== '' ? 'url|' . $url : ($guid !== '' ? 'guid|' . $guid : 'title|' . $title);
+    };
+    $grouped = [];
+    foreach ($items as $item) {
+        $key = $identity($item);
+        if (!isset($grouped[$key]) || (int)($item['timestamp'] ?? 0) > (int)($grouped[$key]['timestamp'] ?? 0)) {
+            $item['lifecycle_key'] = $key;
+            $grouped[$key] = $item;
+        }
+    }
+    $items = array_values($grouped);
 
     usort(
         $items,

--- a/lousy-outages/includes/Api.php
+++ b/lousy-outages/includes/Api.php
@@ -21,32 +21,19 @@ class Api {
             'generated_at'        => gmdate('c'),
         ];
 
-        foreach ($providers as $provider) {
-            if (!is_array($provider)) {
-                continue;
-            }
+        $currentProviderIds = [];
+        foreach (Summary::current_provider_tiles($providers) as $provider) {
+            if (!is_array($provider)) { continue; }
+            $providerId = sanitize_key((string) ($provider['id'] ?? $provider['provider'] ?? $provider['name'] ?? ''));
             $tileKind = strtolower((string) ($provider['tile_kind'] ?? $provider['tileKind'] ?? ''));
-            if ('' === $tileKind) {
-                $status = strtolower((string) ($provider['status'] ?? $provider['stateCode'] ?? 'unknown'));
-                if ('operational' === $status) {
-                    $tileKind = 'operational';
-                } elseif ('unknown' === $status) {
-                    $tileKind = 'unknown';
-                } elseif (!empty($provider['incidents'])) {
-                    $tileKind = 'outage';
-                } else {
-                    $tileKind = 'signal';
-                }
-            }
-
-            if ('outage' === $tileKind) {
+            if ('outage' === $tileKind && !empty($provider['incidents'])) {
                 $counts['active_outage_count'] += 1;
+                if ($providerId !== '') { $currentProviderIds[] = $providerId; }
             } elseif ('signal' === $tileKind) {
                 $counts['signal_count'] += 1;
-            } elseif ('unknown' === $tileKind || 'manual' === $tileKind) {
-                $counts['unverified_count'] += 1;
             }
         }
+        $counts['current_official_provider_ids'] = array_values(array_unique($currentProviderIds));
 
         return $counts;
     }
@@ -340,6 +327,20 @@ class Api {
         }
 
         $providers = isset($result['providers']) && is_array($result['providers']) ? $result['providers'] : [];
+        $providers = array_map(static function ($provider) {
+            if (!is_array($provider)) { return $provider; }
+            $provider['incidents'] = Summary::current_incidents_for_provider($provider);
+            return $provider;
+        }, $providers);
+        $refreshMeta = self::build_summary_meta($providers);
+        $refreshCurrentOfficialIds = array_fill_keys((array) ($refreshMeta['current_official_provider_ids'] ?? []), true);
+        $filterOfficialCorroboration = static function (array $items) use ($refreshCurrentOfficialIds): array {
+            return array_values(array_filter($items, static function ($item) use ($refreshCurrentOfficialIds): bool {
+                if (!is_array($item)) { return false; }
+                $providerId = sanitize_key((string) ($item['provider_id'] ?? $item['provider'] ?? $item['id'] ?? ''));
+                return $providerId !== '' && isset($refreshCurrentOfficialIds[$providerId]);
+            }));
+        };
         $errors    = isset($result['errors']) && is_array($result['errors']) ? $result['errors'] : [];
         $trending  = isset($result['trending']) && is_array($result['trending']) ? $result['trending'] : ['trending' => false, 'signals' => []];
         $refreshed_at = isset($result['refreshedAt']) ? (string) $result['refreshedAt'] : gmdate('c');
@@ -364,7 +365,7 @@ class Api {
             'direct_sources_enabled' => !empty($publicDiag['direct_sources_enabled']),
             'direct_sources_disabled_by_safe_default' => !empty($publicDiag['direct_sources_disabled_by_safe_default']),
             'watch_candidate_count' => (int) ($publicDiag['watch_candidate_count'] ?? 0),
-            'official_incident_corroboration' => array_slice((array) ($publicDiag['official_incident_corroboration'] ?? []), 0, 20),
+            'official_incident_corroboration' => array_slice($filterOfficialCorroboration((array) ($publicDiag['official_incident_corroboration'] ?? [])), 0, 20),
             'canadian_infrastructure_watchlist' => (array) ($publicDiag['canadian_infrastructure_watchlist'] ?? []),
             'ran_at' => (string) ($publicDiag['ran_at'] ?? ''),
             'sources_configured' => (array) ($publicDiag['sources_configured'] ?? []),
@@ -404,6 +405,11 @@ class Api {
         }
 
         $providers = isset($snapshot['providers']) && is_array($snapshot['providers']) ? array_values($snapshot['providers']) : [];
+        $providers = array_map(static function ($provider) {
+            if (!is_array($provider)) { return $provider; }
+            $provider['incidents'] = Summary::current_incidents_for_provider($provider);
+            return $provider;
+        }, $providers);
         if (!empty($filters)) {
             $providers = array_values(array_filter($providers, static function ($provider) use ($filters) {
                 if (!is_array($provider)) {
@@ -434,6 +440,14 @@ class Api {
             ];
         } else {
             $meta = self::build_summary_meta($providers);
+            $currentOfficialIds = array_fill_keys((array) ($meta['current_official_provider_ids'] ?? []), true);
+            $filterOfficialCorroboration = static function (array $items) use ($currentOfficialIds): array {
+                return array_values(array_filter($items, static function ($item) use ($currentOfficialIds): bool {
+                    if (!is_array($item)) { return false; }
+                    $providerId = sanitize_key((string) ($item['provider_id'] ?? $item['provider'] ?? $item['id'] ?? ''));
+                    return $providerId !== '' && isset($currentOfficialIds[$providerId]);
+                }));
+            };
             $payload = [
                 'providers'  => $providers,
                 'fetched_at' => $fetched_at,
@@ -466,7 +480,7 @@ class Api {
                 'providers_scanned_count' => (int) ($publicDiag['providers_scanned_count'] ?? 0),
                 'watch_candidate_count' => (int) ($publicDiag['watch_candidate_count'] ?? 0),
                 'watch_candidates' => array_slice((array) ($publicDiag['watch_candidates'] ?? []), 0, 20),
-                'official_incident_corroboration' => array_slice((array) ($publicDiag['official_incident_corroboration'] ?? []), 0, 20),
+                'official_incident_corroboration' => array_slice($filterOfficialCorroboration((array) ($publicDiag['official_incident_corroboration'] ?? [])), 0, 20),
                 'canadian_infrastructure_watchlist' => (array) ($publicDiag['canadian_infrastructure_watchlist'] ?? []),
                 'mentions_seen_by_source' => (array) ($publicDiag['mentions_seen_by_source'] ?? []),
                 'mentions_seen_by_provider' => (array) ($publicDiag['mentions_seen_by_provider'] ?? []),

--- a/lousy-outages/includes/Fetcher.php
+++ b/lousy-outages/includes/Fetcher.php
@@ -660,13 +660,24 @@ class Fetcher {
         $active         = [];
         $recent         = [];
         $historyCutoff  = time() - (35 * DAY_IN_SECONDS);
+        $grouped = [];
         foreach ($incidents as $incident) {
+            if (!is_array($incident)) { continue; }
+            $titleKey = strtolower(trim(preg_replace('/[^a-z0-9]+/', ' ', (string)($incident['title'] ?? $incident['name'] ?? $incident['summary'] ?? '')) ?? ''));
+            $regionKey = '';
+            $blob = (string)($incident['title'] ?? '') . ' ' . (string)($incident['summary'] ?? '');
+            if (preg_match('/\b([a-z]{2}-[a-z]+-\d+)\b/i', $blob, $m)) { $regionKey = strtolower($m[1]); }
+            $key = strtolower((string)($incident['guid'] ?? '')) ?: (strtolower((string)($incident['shortlink'] ?? $incident['url'] ?? '')) ?: $regionKey . '|' . $titleKey);
+            $ts = strtotime((string)($incident['updated_at'] ?? $incident['updatedAt'] ?? $incident['started_at'] ?? $incident['startedAt'] ?? '')) ?: 0;
+            if (!isset($grouped[$key]) || $ts >= (int)($grouped[$key]['_ts'] ?? 0)) { $incident['_ts'] = $ts; $grouped[$key] = $incident; }
+        }
+        foreach (array_values($grouped) as $incident) {
             if (! is_array($incident)) {
                 continue;
             }
 
             $rawStatus = strtolower((string) ($incident['status'] ?? ''));
-            $isResolved = in_array($rawStatus, ['resolved', 'completed', 'postmortem'], true);
+            $isResolved = in_array($rawStatus, ['resolved', 'completed', 'postmortem', 'operational', 'ok', 'closed'], true);
             if (! $isResolved && in_array($rawStatus, ['unknown', ''], true) && empty($incident['impact'])) {
                 continue;
             }
@@ -729,7 +740,14 @@ class Fetcher {
             $entry = array_merge($entry, $metadata);
             $entry['display_title'] = $this->display_title($provider, $entry);
 
+            $ongoingText = strtolower($title . ' ' . $summary . ' ' . $rawStatus);
+            $explicitOngoing = preg_match('/\b(investigating|identified|monitoring|ongoing|continues?|continuing|currently|still experiencing|working to resolve|recovery is expected|unresolved|months?|long-running|extended)\b/i', $ongoingText) === 1;
+            $recentEnough = $effective && $effective >= (time() - (7 * DAY_IN_SECONDS));
             if ($isResolved) {
+                $recent[] = $entry;
+                continue;
+            }
+            if (!$recentEnough && !$explicitOngoing) {
                 $recent[] = $entry;
                 continue;
             }
@@ -767,8 +785,8 @@ class Fetcher {
         }
         $reference = $started ?: $updated;
         $referenceTs = $reference ? strtotime($reference) : 0;
-        $metadata['is_long_running'] = (bool) ($referenceTs && (time() - $referenceTs) >= (35 * DAY_IN_SECONDS));
-        if (preg_match('/\b(months?|long-running|extended|ongoing)\b/i', $lower)) {
+        $metadata['is_long_running'] = false;
+        if (preg_match('/\b(months?|long-running|extended|ongoing|continues?|continuing|still experiencing|recovery is expected)\b/i', $lower)) {
             $metadata['is_long_running'] = true;
         }
         if (preg_match('/multiple services/i', $text)) {

--- a/lousy-outages/includes/Sources/PublicChatterSource.php
+++ b/lousy-outages/includes/Sources/PublicChatterSource.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace SuzyEaston\LousyOutages\Sources;
 
+use SuzyEaston\LousyOutages\Summary;
+
 use SuzyEaston\LousyOutages\Providers;
 use SuzyEaston\LousyOutages\SignalSourceInterface;
 
@@ -334,19 +336,15 @@ class PublicChatterSource implements SignalSourceInterface {
             $snapshot = get_option('lousy_outages_snapshot', []);
         }
         $out = [];
-        foreach ((array)($snapshot['providers'] ?? []) as $tile) {
-            if (!is_array($tile)) { continue; }
+        foreach (Summary::current_provider_tiles((array)($snapshot['providers'] ?? [])) as $tile) {
+            if (!is_array($tile) || empty($tile['incidents'])) { continue; }
             $providerId = sanitize_key((string)($tile['provider'] ?? $tile['id'] ?? ''));
             if ($providerId === '') { continue; }
-            $status = strtolower((string)($tile['status'] ?? $tile['stateCode'] ?? ''));
-            $incidents = (array)($tile['incidents'] ?? []);
-            $active = !in_array($status, ['', 'operational', 'ok', 'unknown'], true) || !empty($incidents);
-            if (!$active) { continue; }
-            $title = (string)($tile['summary'] ?? $tile['status_label'] ?? $tile['state'] ?? 'Active incident');
-            if (!empty($incidents[0]) && is_array($incidents[0])) {
-                $title = (string)($incidents[0]['name'] ?? $incidents[0]['title'] ?? $title);
-                $status = strtolower((string)($incidents[0]['status'] ?? $status));
-            }
+            $incidents = array_values(array_filter((array)($tile['incidents'] ?? []), 'is_array'));
+            if (empty($incidents)) { continue; }
+            $incident = $incidents[0];
+            $status = strtolower((string)($incident['status'] ?? $incident['impact'] ?? $tile['status'] ?? $tile['stateCode'] ?? 'active'));
+            $title = (string)($incident['display_title'] ?? $incident['displayTitle'] ?? $incident['name'] ?? $incident['title'] ?? $incident['summary'] ?? $tile['summary'] ?? 'Active incident');
             $out[$providerId] = [
                 'provider_id' => $providerId,
                 'provider_name' => (string)($tile['name'] ?? $tile['provider_name'] ?? ($providers[$providerId]['name'] ?? $providerId)),

--- a/lousy-outages/includes/Summary.php
+++ b/lousy-outages/includes/Summary.php
@@ -73,6 +73,49 @@ class Summary {
     }
 
 
+
+    public static function current_provider_tiles(array $providers = null): array
+    {
+        $providers = null === $providers ? self::providers() : $providers;
+        $out = [];
+        foreach (self::sort_status_page_providers($providers) as $provider) {
+            if (!is_array($provider)) { continue; }
+            $current = self::current_incidents_for_provider($provider);
+            if (empty($current)) {
+                $tileKind = strtolower((string) ($provider['tile_kind'] ?? $provider['tileKind'] ?? ''));
+                if (!in_array($tileKind, ['outage', 'signal'], true) || !empty($provider['incidents'])) { continue; }
+            }
+            $copy = $provider;
+            $copy['incidents'] = $current;
+            $out[] = $copy;
+        }
+        return $out;
+    }
+
+    public static function current_incidents_for_provider(array $provider): array
+    {
+        $incidents = isset($provider['incidents']) && is_array($provider['incidents']) ? array_values(array_filter($provider['incidents'], 'is_array')) : [];
+        $current = array_values(array_filter($incidents, static function (array $incident): bool {
+            return self::is_current_official_incident($incident);
+        }));
+        usort($current, static function (array $left, array $right): int { return self::incident_timestamp($right) <=> self::incident_timestamp($left); });
+        return $current;
+    }
+
+    public static function is_current_official_incident(array $incident, ?int $now = null): bool
+    {
+        $now = $now ?? time();
+        if (!self::is_unresolved_incident($incident)) { return false; }
+        $status = strtolower((string) ($incident['status'] ?? $incident['impact'] ?? ''));
+        $text = strtolower((string)($incident['title'] ?? '') . ' ' . (string)($incident['name'] ?? '') . ' ' . (string)($incident['summary'] ?? '') . ' ' . (string)($incident['eta'] ?? ''));
+        $ongoing = in_array($status, ['investigating','identified','monitoring','ongoing'], true)
+            || preg_match('/\b(investigating|identified|monitoring|ongoing|continues?|continuing|currently|still experiencing|working to resolve|recovery is expected|unresolved)\b/i', $text);
+        $updated = self::incident_timestamp($incident);
+        $ageWindow = 7 * DAY_IN_SECONDS;
+        if ($updated && ($now - $updated) <= $ageWindow) { return true; }
+        return (bool) $ongoing;
+    }
+
     /**
      * Return the ordered active incident collection used by the public status page.
      *
@@ -104,9 +147,7 @@ class Summary {
             }
             $providerStatus = strtolower((string) ($provider['stateCode'] ?? $provider['status'] ?? 'incident'));
             $tileKind = strtolower((string) ($provider['tile_kind'] ?? $provider['tileKind'] ?? ''));
-            $currentIncidents = array_values(array_filter($incidents, static function (array $incident): bool {
-                return self::is_unresolved_incident($incident);
-            }));
+            $currentIncidents = self::current_incidents_for_provider($provider);
 
             if (!$currentIncidents) {
                 $hasCurrentSignal = !$incidents && in_array($tileKind, ['outage', 'signal'], true);
@@ -154,7 +195,7 @@ class Summary {
                     'status_label' => Fetcher::status_label($providerStatus ?: 'incident'),
                     'severity' => $impact ?: 'degraded',
                     'important' => true,
-                    'summary' => (string) ($incident['title'] ?? $incident['summary'] ?? 'Incident reported'),
+                    'summary' => (string) ($incident['display_title'] ?? $incident['displayTitle'] ?? $incident['title'] ?? $incident['name'] ?? $incident['summary'] ?? 'Incident reported'),
                     'started_at' => self::format_incident_time($started),
                     'updated_at' => self::format_incident_time($updated),
                     'first_seen' => self::parse_time($started) ?? 0,
@@ -417,7 +458,7 @@ class Summary {
                     continue;
                 }
 
-                if (!self::is_unresolved_incident($incident)) {
+                if (!self::is_current_official_incident($incident)) {
                     continue;
                 }
 
@@ -515,7 +556,7 @@ class Summary {
                     continue;
                 }
 
-                if (!self::is_unresolved_incident($incident)) {
+                if (!self::is_current_official_incident($incident)) {
                     continue;
                 }
 

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -380,45 +380,25 @@ function render_shortcode(): string {
         }
     }
 
-    $config['initial']['providers'] = array_values($ordered_tiles);
+    $config['initial']['providers'] = array_map(static function ($provider) {
+        if (!is_array($provider)) { return $provider; }
+        $provider['incidents'] = \SuzyEaston\LousyOutages\Summary::current_incidents_for_provider($provider);
+        return $provider;
+    }, array_values($ordered_tiles));
     $config['initial']['source']    = $source;
     $config['initial']['errors']    = $snapshot_errors;
 
     $build_meta_counts = static function (array $providers): array {
-        $counts = [
-            'active_outage_count' => 0,
-            'signal_count'        => 0,
-            'unverified_count'    => 0,
-            'generated_at'        => gmdate('c'),
-        ];
-
-        foreach ($providers as $provider) {
-            if (!is_array($provider)) {
-                continue;
-            }
+        $current = \SuzyEaston\LousyOutages\Summary::current_provider_tiles($providers);
+        $counts = ['active_outage_count'=>0,'signal_count'=>0,'unverified_count'=>0,'generated_at'=>gmdate('c'),'current_official_provider_ids'=>[]];
+        foreach ($current as $provider) {
+            if (!is_array($provider)) { continue; }
             $tile_kind = strtolower((string) ($provider['tile_kind'] ?? $provider['tileKind'] ?? ''));
-            if ('' === $tile_kind) {
-                $status = strtolower((string) ($provider['status'] ?? $provider['stateCode'] ?? 'unknown'));
-                if ('operational' === $status) {
-                    $tile_kind = 'operational';
-                } elseif ('unknown' === $status) {
-                    $tile_kind = 'unknown';
-                } elseif (!empty($provider['incidents'])) {
-                    $tile_kind = 'outage';
-                } else {
-                    $tile_kind = 'signal';
-                }
-            }
-
-            if ('outage' === $tile_kind) {
-                $counts['active_outage_count'] += 1;
-            } elseif ('signal' === $tile_kind) {
-                $counts['signal_count'] += 1;
-            } elseif ('unknown' === $tile_kind || 'manual' === $tile_kind) {
-                $counts['unverified_count'] += 1;
-            }
+            $provider_id = sanitize_key((string) ($provider['id'] ?? $provider['provider'] ?? $provider['name'] ?? ''));
+            if ('outage' === $tile_kind && !empty($provider['incidents'])) { $counts['active_outage_count'] += 1; if ($provider_id !== '') { $counts['current_official_provider_ids'][] = $provider_id; } }
+            elseif ('signal' === $tile_kind) { $counts['signal_count'] += 1; }
         }
-
+        $counts['current_official_provider_ids'] = array_values(array_unique($counts['current_official_provider_ids']));
         return $counts;
     };
 

--- a/plugins/lousy-outages/includes/Adapters.php
+++ b/plugins/lousy-outages/includes/Adapters.php
@@ -130,7 +130,7 @@ function from_rss_atom(string $xml): array {
     $items = [];
     $resolve_status = static function (string $title, string $summary): string {
         $text = strtolower($title . ' ' . $summary);
-        if (preg_match('/\bresolved\b|this issue is now resolved|issue is now resolved|issue has been resolved|ended at|fully recovered|closed/i', $text)) {
+        if (preg_match('/\b(resolved|completed|closed|postmortem)\b|\ball systems operational\b|service is operational|this issue is now resolved|issue is now resolved|issue has been resolved|ended at|fully recovered/i', $text)) {
             return 'resolved';
         }
         if (preg_match('/\b(scheduled|planned).{0,40}maintenance\b/i', $text)) {
@@ -158,6 +158,7 @@ function from_rss_atom(string $xml): array {
                 'started_at' => '',
                 'updated_at' => (string) ($item->pubDate ?? ''),
                 'shortlink'  => (string) ($item->link ?? ''),
+                'guid'       => (string) ($item->guid ?? ''),
             ];
         }
     } else {
@@ -171,6 +172,7 @@ function from_rss_atom(string $xml): array {
                 'started_at' => '',
                 'updated_at' => (string) ($item->updated ?? ($item->published ?? '')),
                 'shortlink'  => (string) ($item->link['href'] ?? ($item->link ?? '')),
+                'guid'       => (string) ($item->id ?? ''),
             ];
         }
     }
@@ -191,6 +193,33 @@ function from_rss_atom(string $xml): array {
         },
         $items
     );
+
+
+    $identity = static function (array $item): string {
+        $url = strtolower(trim((string) ($item['shortlink'] ?? '')));
+        $guid = strtolower(trim((string) ($item['guid'] ?? '')));
+        $title = strtolower(trim((string) ($item['name'] ?? '')));
+        $summary = strtolower(trim((string) ($item['summary'] ?? '')));
+        $text = preg_replace('/\b(resolved|completed|closed|postmortem|operational|investigating|identified|monitoring|update|issue|operational issue|service disruption|outage|major|degraded)\b/i', ' ', $title . ' ' . $summary) ?? ($title . ' ' . $summary);
+        $parts = [];
+        if (preg_match('/\b([a-z]{2}-[a-z]+-\d+)\b/i', $text, $m)) { $parts[] = strtolower($m[1]); }
+        if (preg_match('/\b(uae|united arab emirates)\b/i', $text)) { $parts[] = 'uae'; }
+        if (preg_match('/\b(multiple services|[a-z0-9][a-z0-9 +._-]{2,40}(?:service|api|database|compute|storage))\b/i', $text, $m)) { $parts[] = strtolower(trim($m[1])); }
+        $normalized = trim(preg_replace('/[^a-z0-9]+/', ' ', $text) ?? '');
+        $normalized = trim(preg_replace('/\s+/', ' ', $normalized) ?? '');
+        $semantic = implode('|', array_unique(array_filter($parts))) ?: implode(' ', array_slice(explode(' ', $normalized), 0, 8));
+        if ($semantic !== '') { return 'semantic|' . $semantic; }
+        return $url !== '' ? 'url|' . $url : ($guid !== '' ? 'guid|' . $guid : 'title|' . $title);
+    };
+    $grouped = [];
+    foreach ($items as $item) {
+        $key = $identity($item);
+        if (!isset($grouped[$key]) || (int)($item['timestamp'] ?? 0) > (int)($grouped[$key]['timestamp'] ?? 0)) {
+            $item['lifecycle_key'] = $key;
+            $grouped[$key] = $item;
+        }
+    }
+    $items = array_values($grouped);
 
     usort(
         $items,

--- a/plugins/lousy-outages/includes/Api.php
+++ b/plugins/lousy-outages/includes/Api.php
@@ -21,32 +21,19 @@ class Api {
             'generated_at'        => gmdate('c'),
         ];
 
-        foreach ($providers as $provider) {
-            if (!is_array($provider)) {
-                continue;
-            }
+        $currentProviderIds = [];
+        foreach (Summary::current_provider_tiles($providers) as $provider) {
+            if (!is_array($provider)) { continue; }
+            $providerId = sanitize_key((string) ($provider['id'] ?? $provider['provider'] ?? $provider['name'] ?? ''));
             $tileKind = strtolower((string) ($provider['tile_kind'] ?? $provider['tileKind'] ?? ''));
-            if ('' === $tileKind) {
-                $status = strtolower((string) ($provider['status'] ?? $provider['stateCode'] ?? 'unknown'));
-                if ('operational' === $status) {
-                    $tileKind = 'operational';
-                } elseif ('unknown' === $status) {
-                    $tileKind = 'unknown';
-                } elseif (!empty($provider['incidents'])) {
-                    $tileKind = 'outage';
-                } else {
-                    $tileKind = 'signal';
-                }
-            }
-
-            if ('outage' === $tileKind) {
+            if ('outage' === $tileKind && !empty($provider['incidents'])) {
                 $counts['active_outage_count'] += 1;
+                if ($providerId !== '') { $currentProviderIds[] = $providerId; }
             } elseif ('signal' === $tileKind) {
                 $counts['signal_count'] += 1;
-            } elseif ('unknown' === $tileKind || 'manual' === $tileKind) {
-                $counts['unverified_count'] += 1;
             }
         }
+        $counts['current_official_provider_ids'] = array_values(array_unique($currentProviderIds));
 
         return $counts;
     }
@@ -340,6 +327,20 @@ class Api {
         }
 
         $providers = isset($result['providers']) && is_array($result['providers']) ? $result['providers'] : [];
+        $providers = array_map(static function ($provider) {
+            if (!is_array($provider)) { return $provider; }
+            $provider['incidents'] = Summary::current_incidents_for_provider($provider);
+            return $provider;
+        }, $providers);
+        $refreshMeta = self::build_summary_meta($providers);
+        $refreshCurrentOfficialIds = array_fill_keys((array) ($refreshMeta['current_official_provider_ids'] ?? []), true);
+        $filterOfficialCorroboration = static function (array $items) use ($refreshCurrentOfficialIds): array {
+            return array_values(array_filter($items, static function ($item) use ($refreshCurrentOfficialIds): bool {
+                if (!is_array($item)) { return false; }
+                $providerId = sanitize_key((string) ($item['provider_id'] ?? $item['provider'] ?? $item['id'] ?? ''));
+                return $providerId !== '' && isset($refreshCurrentOfficialIds[$providerId]);
+            }));
+        };
         $errors    = isset($result['errors']) && is_array($result['errors']) ? $result['errors'] : [];
         $trending  = isset($result['trending']) && is_array($result['trending']) ? $result['trending'] : ['trending' => false, 'signals' => []];
         $refreshed_at = isset($result['refreshedAt']) ? (string) $result['refreshedAt'] : gmdate('c');
@@ -364,7 +365,7 @@ class Api {
             'direct_sources_enabled' => !empty($publicDiag['direct_sources_enabled']),
             'direct_sources_disabled_by_safe_default' => !empty($publicDiag['direct_sources_disabled_by_safe_default']),
             'watch_candidate_count' => (int) ($publicDiag['watch_candidate_count'] ?? 0),
-            'official_incident_corroboration' => array_slice((array) ($publicDiag['official_incident_corroboration'] ?? []), 0, 20),
+            'official_incident_corroboration' => array_slice($filterOfficialCorroboration((array) ($publicDiag['official_incident_corroboration'] ?? [])), 0, 20),
             'canadian_infrastructure_watchlist' => (array) ($publicDiag['canadian_infrastructure_watchlist'] ?? []),
             'ran_at' => (string) ($publicDiag['ran_at'] ?? ''),
             'sources_configured' => (array) ($publicDiag['sources_configured'] ?? []),
@@ -404,6 +405,11 @@ class Api {
         }
 
         $providers = isset($snapshot['providers']) && is_array($snapshot['providers']) ? array_values($snapshot['providers']) : [];
+        $providers = array_map(static function ($provider) {
+            if (!is_array($provider)) { return $provider; }
+            $provider['incidents'] = Summary::current_incidents_for_provider($provider);
+            return $provider;
+        }, $providers);
         if (!empty($filters)) {
             $providers = array_values(array_filter($providers, static function ($provider) use ($filters) {
                 if (!is_array($provider)) {
@@ -434,6 +440,14 @@ class Api {
             ];
         } else {
             $meta = self::build_summary_meta($providers);
+            $currentOfficialIds = array_fill_keys((array) ($meta['current_official_provider_ids'] ?? []), true);
+            $filterOfficialCorroboration = static function (array $items) use ($currentOfficialIds): array {
+                return array_values(array_filter($items, static function ($item) use ($currentOfficialIds): bool {
+                    if (!is_array($item)) { return false; }
+                    $providerId = sanitize_key((string) ($item['provider_id'] ?? $item['provider'] ?? $item['id'] ?? ''));
+                    return $providerId !== '' && isset($currentOfficialIds[$providerId]);
+                }));
+            };
             $payload = [
                 'providers'  => $providers,
                 'fetched_at' => $fetched_at,
@@ -466,7 +480,7 @@ class Api {
                 'providers_scanned_count' => (int) ($publicDiag['providers_scanned_count'] ?? 0),
                 'watch_candidate_count' => (int) ($publicDiag['watch_candidate_count'] ?? 0),
                 'watch_candidates' => array_slice((array) ($publicDiag['watch_candidates'] ?? []), 0, 20),
-                'official_incident_corroboration' => array_slice((array) ($publicDiag['official_incident_corroboration'] ?? []), 0, 20),
+                'official_incident_corroboration' => array_slice($filterOfficialCorroboration((array) ($publicDiag['official_incident_corroboration'] ?? [])), 0, 20),
                 'canadian_infrastructure_watchlist' => (array) ($publicDiag['canadian_infrastructure_watchlist'] ?? []),
                 'mentions_seen_by_source' => (array) ($publicDiag['mentions_seen_by_source'] ?? []),
                 'mentions_seen_by_provider' => (array) ($publicDiag['mentions_seen_by_provider'] ?? []),

--- a/plugins/lousy-outages/includes/Fetcher.php
+++ b/plugins/lousy-outages/includes/Fetcher.php
@@ -660,13 +660,24 @@ class Fetcher {
         $active         = [];
         $recent         = [];
         $historyCutoff  = time() - (35 * DAY_IN_SECONDS);
+        $grouped = [];
         foreach ($incidents as $incident) {
+            if (!is_array($incident)) { continue; }
+            $titleKey = strtolower(trim(preg_replace('/[^a-z0-9]+/', ' ', (string)($incident['title'] ?? $incident['name'] ?? $incident['summary'] ?? '')) ?? ''));
+            $regionKey = '';
+            $blob = (string)($incident['title'] ?? '') . ' ' . (string)($incident['summary'] ?? '');
+            if (preg_match('/\b([a-z]{2}-[a-z]+-\d+)\b/i', $blob, $m)) { $regionKey = strtolower($m[1]); }
+            $key = strtolower((string)($incident['guid'] ?? '')) ?: (strtolower((string)($incident['shortlink'] ?? $incident['url'] ?? '')) ?: $regionKey . '|' . $titleKey);
+            $ts = strtotime((string)($incident['updated_at'] ?? $incident['updatedAt'] ?? $incident['started_at'] ?? $incident['startedAt'] ?? '')) ?: 0;
+            if (!isset($grouped[$key]) || $ts >= (int)($grouped[$key]['_ts'] ?? 0)) { $incident['_ts'] = $ts; $grouped[$key] = $incident; }
+        }
+        foreach (array_values($grouped) as $incident) {
             if (! is_array($incident)) {
                 continue;
             }
 
             $rawStatus = strtolower((string) ($incident['status'] ?? ''));
-            $isResolved = in_array($rawStatus, ['resolved', 'completed', 'postmortem'], true);
+            $isResolved = in_array($rawStatus, ['resolved', 'completed', 'postmortem', 'operational', 'ok', 'closed'], true);
             if (! $isResolved && in_array($rawStatus, ['unknown', ''], true) && empty($incident['impact'])) {
                 continue;
             }
@@ -729,7 +740,14 @@ class Fetcher {
             $entry = array_merge($entry, $metadata);
             $entry['display_title'] = $this->display_title($provider, $entry);
 
+            $ongoingText = strtolower($title . ' ' . $summary . ' ' . $rawStatus);
+            $explicitOngoing = preg_match('/\b(investigating|identified|monitoring|ongoing|continues?|continuing|currently|still experiencing|working to resolve|recovery is expected|unresolved|months?|long-running|extended)\b/i', $ongoingText) === 1;
+            $recentEnough = $effective && $effective >= (time() - (7 * DAY_IN_SECONDS));
             if ($isResolved) {
+                $recent[] = $entry;
+                continue;
+            }
+            if (!$recentEnough && !$explicitOngoing) {
                 $recent[] = $entry;
                 continue;
             }
@@ -767,8 +785,8 @@ class Fetcher {
         }
         $reference = $started ?: $updated;
         $referenceTs = $reference ? strtotime($reference) : 0;
-        $metadata['is_long_running'] = (bool) ($referenceTs && (time() - $referenceTs) >= (35 * DAY_IN_SECONDS));
-        if (preg_match('/\b(months?|long-running|extended|ongoing)\b/i', $lower)) {
+        $metadata['is_long_running'] = false;
+        if (preg_match('/\b(months?|long-running|extended|ongoing|continues?|continuing|still experiencing|recovery is expected)\b/i', $lower)) {
             $metadata['is_long_running'] = true;
         }
         if (preg_match('/multiple services/i', $text)) {

--- a/plugins/lousy-outages/includes/Sources/PublicChatterSource.php
+++ b/plugins/lousy-outages/includes/Sources/PublicChatterSource.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace SuzyEaston\LousyOutages\Sources;
 
+use SuzyEaston\LousyOutages\Summary;
+
 use SuzyEaston\LousyOutages\Providers;
 use SuzyEaston\LousyOutages\SignalSourceInterface;
 
@@ -334,19 +336,15 @@ class PublicChatterSource implements SignalSourceInterface {
             $snapshot = get_option('lousy_outages_snapshot', []);
         }
         $out = [];
-        foreach ((array)($snapshot['providers'] ?? []) as $tile) {
-            if (!is_array($tile)) { continue; }
+        foreach (Summary::current_provider_tiles((array)($snapshot['providers'] ?? [])) as $tile) {
+            if (!is_array($tile) || empty($tile['incidents'])) { continue; }
             $providerId = sanitize_key((string)($tile['provider'] ?? $tile['id'] ?? ''));
             if ($providerId === '') { continue; }
-            $status = strtolower((string)($tile['status'] ?? $tile['stateCode'] ?? ''));
-            $incidents = (array)($tile['incidents'] ?? []);
-            $active = !in_array($status, ['', 'operational', 'ok', 'unknown'], true) || !empty($incidents);
-            if (!$active) { continue; }
-            $title = (string)($tile['summary'] ?? $tile['status_label'] ?? $tile['state'] ?? 'Active incident');
-            if (!empty($incidents[0]) && is_array($incidents[0])) {
-                $title = (string)($incidents[0]['name'] ?? $incidents[0]['title'] ?? $title);
-                $status = strtolower((string)($incidents[0]['status'] ?? $status));
-            }
+            $incidents = array_values(array_filter((array)($tile['incidents'] ?? []), 'is_array'));
+            if (empty($incidents)) { continue; }
+            $incident = $incidents[0];
+            $status = strtolower((string)($incident['status'] ?? $incident['impact'] ?? $tile['status'] ?? $tile['stateCode'] ?? 'active'));
+            $title = (string)($incident['display_title'] ?? $incident['displayTitle'] ?? $incident['name'] ?? $incident['title'] ?? $incident['summary'] ?? $tile['summary'] ?? 'Active incident');
             $out[$providerId] = [
                 'provider_id' => $providerId,
                 'provider_name' => (string)($tile['name'] ?? $tile['provider_name'] ?? ($providers[$providerId]['name'] ?? $providerId)),

--- a/plugins/lousy-outages/includes/Summary.php
+++ b/plugins/lousy-outages/includes/Summary.php
@@ -73,6 +73,49 @@ class Summary {
     }
 
 
+
+    public static function current_provider_tiles(array $providers = null): array
+    {
+        $providers = null === $providers ? self::providers() : $providers;
+        $out = [];
+        foreach (self::sort_status_page_providers($providers) as $provider) {
+            if (!is_array($provider)) { continue; }
+            $current = self::current_incidents_for_provider($provider);
+            if (empty($current)) {
+                $tileKind = strtolower((string) ($provider['tile_kind'] ?? $provider['tileKind'] ?? ''));
+                if (!in_array($tileKind, ['outage', 'signal'], true) || !empty($provider['incidents'])) { continue; }
+            }
+            $copy = $provider;
+            $copy['incidents'] = $current;
+            $out[] = $copy;
+        }
+        return $out;
+    }
+
+    public static function current_incidents_for_provider(array $provider): array
+    {
+        $incidents = isset($provider['incidents']) && is_array($provider['incidents']) ? array_values(array_filter($provider['incidents'], 'is_array')) : [];
+        $current = array_values(array_filter($incidents, static function (array $incident): bool {
+            return self::is_current_official_incident($incident);
+        }));
+        usort($current, static function (array $left, array $right): int { return self::incident_timestamp($right) <=> self::incident_timestamp($left); });
+        return $current;
+    }
+
+    public static function is_current_official_incident(array $incident, ?int $now = null): bool
+    {
+        $now = $now ?? time();
+        if (!self::is_unresolved_incident($incident)) { return false; }
+        $status = strtolower((string) ($incident['status'] ?? $incident['impact'] ?? ''));
+        $text = strtolower((string)($incident['title'] ?? '') . ' ' . (string)($incident['name'] ?? '') . ' ' . (string)($incident['summary'] ?? '') . ' ' . (string)($incident['eta'] ?? ''));
+        $ongoing = in_array($status, ['investigating','identified','monitoring','ongoing'], true)
+            || preg_match('/\b(investigating|identified|monitoring|ongoing|continues?|continuing|currently|still experiencing|working to resolve|recovery is expected|unresolved)\b/i', $text);
+        $updated = self::incident_timestamp($incident);
+        $ageWindow = 7 * DAY_IN_SECONDS;
+        if ($updated && ($now - $updated) <= $ageWindow) { return true; }
+        return (bool) $ongoing;
+    }
+
     /**
      * Return the ordered active incident collection used by the public status page.
      *
@@ -104,9 +147,7 @@ class Summary {
             }
             $providerStatus = strtolower((string) ($provider['stateCode'] ?? $provider['status'] ?? 'incident'));
             $tileKind = strtolower((string) ($provider['tile_kind'] ?? $provider['tileKind'] ?? ''));
-            $currentIncidents = array_values(array_filter($incidents, static function (array $incident): bool {
-                return self::is_unresolved_incident($incident);
-            }));
+            $currentIncidents = self::current_incidents_for_provider($provider);
 
             if (!$currentIncidents) {
                 $hasCurrentSignal = !$incidents && in_array($tileKind, ['outage', 'signal'], true);
@@ -154,7 +195,7 @@ class Summary {
                     'status_label' => Fetcher::status_label($providerStatus ?: 'incident'),
                     'severity' => $impact ?: 'degraded',
                     'important' => true,
-                    'summary' => (string) ($incident['title'] ?? $incident['summary'] ?? 'Incident reported'),
+                    'summary' => (string) ($incident['display_title'] ?? $incident['displayTitle'] ?? $incident['title'] ?? $incident['name'] ?? $incident['summary'] ?? 'Incident reported'),
                     'started_at' => self::format_incident_time($started),
                     'updated_at' => self::format_incident_time($updated),
                     'first_seen' => self::parse_time($started) ?? 0,
@@ -417,7 +458,7 @@ class Summary {
                     continue;
                 }
 
-                if (!self::is_unresolved_incident($incident)) {
+                if (!self::is_current_official_incident($incident)) {
                     continue;
                 }
 
@@ -515,7 +556,7 @@ class Summary {
                     continue;
                 }
 
-                if (!self::is_unresolved_incident($incident)) {
+                if (!self::is_current_official_incident($incident)) {
                     continue;
                 }
 

--- a/plugins/lousy-outages/public/shortcode.php
+++ b/plugins/lousy-outages/public/shortcode.php
@@ -380,45 +380,25 @@ function render_shortcode(): string {
         }
     }
 
-    $config['initial']['providers'] = array_values($ordered_tiles);
+    $config['initial']['providers'] = array_map(static function ($provider) {
+        if (!is_array($provider)) { return $provider; }
+        $provider['incidents'] = \SuzyEaston\LousyOutages\Summary::current_incidents_for_provider($provider);
+        return $provider;
+    }, array_values($ordered_tiles));
     $config['initial']['source']    = $source;
     $config['initial']['errors']    = $snapshot_errors;
 
     $build_meta_counts = static function (array $providers): array {
-        $counts = [
-            'active_outage_count' => 0,
-            'signal_count'        => 0,
-            'unverified_count'    => 0,
-            'generated_at'        => gmdate('c'),
-        ];
-
-        foreach ($providers as $provider) {
-            if (!is_array($provider)) {
-                continue;
-            }
+        $current = \SuzyEaston\LousyOutages\Summary::current_provider_tiles($providers);
+        $counts = ['active_outage_count'=>0,'signal_count'=>0,'unverified_count'=>0,'generated_at'=>gmdate('c'),'current_official_provider_ids'=>[]];
+        foreach ($current as $provider) {
+            if (!is_array($provider)) { continue; }
             $tile_kind = strtolower((string) ($provider['tile_kind'] ?? $provider['tileKind'] ?? ''));
-            if ('' === $tile_kind) {
-                $status = strtolower((string) ($provider['status'] ?? $provider['stateCode'] ?? 'unknown'));
-                if ('operational' === $status) {
-                    $tile_kind = 'operational';
-                } elseif ('unknown' === $status) {
-                    $tile_kind = 'unknown';
-                } elseif (!empty($provider['incidents'])) {
-                    $tile_kind = 'outage';
-                } else {
-                    $tile_kind = 'signal';
-                }
-            }
-
-            if ('outage' === $tile_kind) {
-                $counts['active_outage_count'] += 1;
-            } elseif ('signal' === $tile_kind) {
-                $counts['signal_count'] += 1;
-            } elseif ('unknown' === $tile_kind || 'manual' === $tile_kind) {
-                $counts['unverified_count'] += 1;
-            }
+            $provider_id = sanitize_key((string) ($provider['id'] ?? $provider['provider'] ?? $provider['name'] ?? ''));
+            if ('outage' === $tile_kind && !empty($provider['incidents'])) { $counts['active_outage_count'] += 1; if ($provider_id !== '') { $counts['current_official_provider_ids'][] = $provider_id; } }
+            elseif ('signal' === $tile_kind) { $counts['signal_count'] += 1; }
         }
-
+        $counts['current_official_provider_ids'] = array_values(array_unique($counts['current_official_provider_ids']));
         return $counts;
     };
 

--- a/tests/LousyOutagesHomeTeaserTest.php
+++ b/tests/LousyOutagesHomeTeaserTest.php
@@ -32,6 +32,14 @@ set_snapshot([['id'=>'slow','name'=>'Slow','stateCode'=>'degraded','tile_kind'=>
 $rows = \SuzyEaston\LousyOutages\Summary::ordered_current_incidents(5); assert_true(count($rows)===1 && $rows[0]['severity']==='degraded', 'signal tile becomes degraded row');
 set_snapshot([['id'=>'unk','name'=>'Unknown','stateCode'=>'degraded','tile_kind'=>'unknown','updatedAt'=>$base,'incidents'=>[]],['id'=>'man','name'=>'Manual','stateCode'=>'degraded','tile_kind'=>'manual','updatedAt'=>$base,'incidents'=>[]]]);
 assert_true(\SuzyEaston\LousyOutages\Summary::ordered_current_incidents(5)===[], 'unknown/manual tiles not active');
+
+set_snapshot([['id'=>'aws','name'=>'AWS','stateCode'=>'degraded','tile_kind'=>'outage','updatedAt'=>$base,'incidents'=>[['display_title'=>'Multiple AWS services disrupted in UAE (ME-CENTRAL-1)','title'=>'Operational issue - Multiple services (UAE)','summary'=>'Recovery is expected to take months in ME-CENTRAL-1.','status'=>'major','impact'=>'major','updatedAt'=>'2026-04-30T12:00:00Z']]]]);
+$rows = \SuzyEaston\LousyOutages\Summary::ordered_current_incidents(5);
+assert_true(count($rows)===1 && $rows[0]['provider_id']==='aws' && $rows[0]['summary']==='Multiple AWS services disrupted in UAE (ME-CENTRAL-1)', 'explicit long-running AWS remains current with display title');
+set_snapshot([['id'=>'aws','name'=>'AWS','stateCode'=>'degraded','tile_kind'=>'outage','updatedAt'=>$base,'incidents'=>[['title'=>'Major outage reported.','summary'=>'Service disruption reported.','status'=>'major','impact'=>'major','updatedAt'=>'2026-04-30T12:00:00Z']]]]);
+assert_true(\SuzyEaston\LousyOutages\Summary::ordered_current_incidents(5)===[], 'old ambiguous AWS entry is not current');
+set_snapshot([['id'=>'aws','name'=>'AWS','stateCode'=>'operational','tile_kind'=>'outage','updatedAt'=>$base,'incidents'=>[['title'=>'Operational issue - Multiple services (UAE)','summary'=>'This issue is now resolved.','status'=>'resolved','impact'=>'operational','updatedAt'=>$base],['title'=>'Operational issue - Multiple services (UAE)','summary'=>'Service disruption in ME-CENTRAL-1.','status'=>'major','impact'=>'major','updatedAt'=>'2026-04-30T12:00:00Z']]]]);
+assert_true(\SuzyEaston\LousyOutages\Summary::ordered_current_incidents(5)===[], 'new resolution suppresses older outage in current selector');
 $summary = file_get_contents(__DIR__ . '/../plugins/lousy-outages/includes/Summary.php');
 assert_true(str_contains($summary, "'eta'") && strpos($summary, "incident['impact'] ?? incident['status']") === false, 'WordPress-loaded plugin tree contains repaired Summary implementation');
 $functions = file_get_contents(__DIR__ . '/../functions.php'); $part = file_get_contents(__DIR__ . '/../parts/lousy-outages-teaser.php'); $js = file_get_contents(__DIR__ . '/../assets/js/lousy-outages-teaser.js');

--- a/tests/lousy-outages/rss-long-running-regression.php
+++ b/tests/lousy-outages/rss-long-running-regression.php
@@ -50,4 +50,14 @@ $recentResolved['updated_at'] = gmdate('r', time() - 2 * DAY_IN_SECONDS);
 $recentBuckets = call_private($fetcher, 'normalize_incident_buckets', [[$recentResolved], $provider, 'operational']);
 assert_true(count($recentBuckets['active']) === 0 && count($recentBuckets['recent']) === 1, 'Recent resolved entries remain history only');
 
+
+$resolvedXml = '<rss><channel><item><title>Operational issue - Multiple services (UAE)</title><link>https://status.aws.amazon.com/</link><pubDate>Fri, 01 May 2026 12:00:00 GMT</pubDate><description>This issue is now resolved for the UAE region (ME-CENTRAL-1).</description></item><item><title>Operational issue - Multiple services (UAE)</title><link>https://status.aws.amazon.com/</link><pubDate>Thu, 30 Apr 2026 12:00:00 GMT</pubDate><description>We are experiencing a service disruption affecting multiple services in the UAE region (ME-CENTRAL-1).</description></item></channel></rss>';
+$resolvedNormalized = from_rss_atom($resolvedXml);
+assert_true($resolvedNormalized['state'] === 'operational', 'newer AWS resolved lifecycle update wins');
+assert_true(count($resolvedNormalized['incidents']) === 1 && $resolvedNormalized['incidents'][0]['status'] === 'resolved', 'lifecycle grouping keeps only latest update');
+$ambiguous = $raw;
+$ambiguous['summary'] = 'Service disruption reported.';
+$ambiguous['status'] = 'major';
+$ambiguousBuckets = call_private($fetcher, 'normalize_incident_buckets', [[$ambiguous], $provider, 'outage']);
+assert_true(count($ambiguousBuckets['active']) === 0 && count($ambiguousBuckets['recent']) === 1, 'old ambiguous RSS item moves to history');
 echo "ok\n";


### PR DESCRIPTION
### Motivation
- Homepage teaser, REST/full-page summary, public-chatter corroboration and shortcode were using inconsistent "active" tests and different presentation fields, allowing stale RSS entries to be treated as active while the official active-incident list was empty. 
- Root cause: RSS/Atom entries were normalized as independent events and various consumers reimplemented slightly different active-incident filters, producing divergent sources of truth and stale corroboration from `lo_diag_public_chatter`.
- The change unifies lifecycle handling so a single canonical definition of a current official incident is used everywhere and lifecycle updates (including resolutions) are grouped so the newest authoritative update wins.

### Description
- Introduce a shared canonical selector and helpers in `Summary`: `current_provider_tiles()`, `current_incidents_for_provider()`, and `is_current_official_incident()` and switch all consumers to use them for consistent active/incidents selection. (files changed: `plugins/lousy-outages/includes/Summary.php`, `lousy-outages/includes/Summary.php`)
- Normalize RSS/Atom lifecycle updates and add stable lifecycle identity grouping in the adapters by capturing GUID/URL/title/service/region cues and keeping only the newest grouped update as authoritative. (files changed: `plugins/lousy-outages/includes/Adapters.php`, `lousy-outages/includes/Adapters.php`)
- Harden incident bucketing in `Fetcher` to group lifecycle updates, treat explicit resolved updates appropriately, move old ambiguous items to `recent`/history unless explicitly ongoing, and make `is_long_running` depend on explicit language rather than age alone; also prefer `display_title` for presentation. (files changed: `plugins/lousy-outages/includes/Fetcher.php`, `lousy-outages/includes/Fetcher.php`)
- Make REST/summary, shortcode initial payload, and public-chatter seed provider generation derive counts and provider lists from the canonical selector and filter stale corroboration entries to only canonical current official providers. (files changed: `plugins/lousy-outages/includes/Api.php`, `lousy-outages/includes/Api.php`, `plugins/lousy-outages/public/shortcode.php`, `lousy-outages/public/shortcode.php`, `plugins/lousy-outages/includes/Sources/PublicChatterSource.php`, `lousy-outages/includes/Sources/PublicChatterSource.php`)
- Mirror deploy-critical changes into the top-level `lousy-outages/` tree so plugin deployment source matches runtime code. (multiple mirrored files under `lousy-outages/`)
- Tests: add regression assertions and fixtures for explicit long-running AWS incident, ambiguous old AWS RSS item, newer resolved update suppressing older outage, lifecycle grouping, and homepage/full-page parity. (files changed: `tests/LousyOutagesHomeTeaserTest.php`, `tests/lousy-outages/rss-long-running-regression.php`)

### Testing
- Ran `php tests/LousyOutagesHomeTeaserTest.php` and it passed (OK). 
- Ran the JS teaser tests with `node --test __tests__/lousy-outages-teaser.test.js` and they passed (all Lousy Outages teaser assertions passed). 
- Ran `php tests/lousy-outages/rss-long-running-regression.php` and `php tests/lousy-outages/aws-snapshot-pipeline-regression.php` and both passed, validating RSS grouping, resolution wins, history behavior, long-running metadata, and display title preservation. 
- Ran PHP lint on all modified PHP files and `./scripts/check-lousy-outages-tree-drift.sh` to confirm plugin trees match; both checks succeeded. 
- Ran repository `npm test`; overall suite contains unrelated failures in other domains (Gastown/sync/snark/refresh tests), but all Lousy Outages-related JS tests within the suite passed. 

Deployment notes: no schema migration required; recommend deploying the code and triggering a Lousy Outages refresh or clearing the Lousy Outages snapshot/transient caches so stored snapshots rebuild and stale cached corroboration is removed promptly.

Files changed (high level):
- plugins/lousy-outages/includes/{Summary.php,Adapters.php,Fetcher.php,Api.php,Sources/PublicChatterSource.php,public/shortcode.php}
- lousy-outages/includes/{Summary.php,Adapters.php,Fetcher.php,Api.php,Sources/PublicChatterSource.php,public/shortcode.php}
- tests/{LousyOutagesHomeTeaserTest.php, lousy-outages/rss-long-running-regression.php}

If you want, I can open a follow-up to add a small admin task that invalidates the `lo_diag_public_chatter` snapshot on deploy to accelerate cache clearing in production.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e7e61ae88833187964a78529ab7aa)