### PR TITLE
Repair Lousy Outages snapshot consistency

### DIFF
--- a/assets/js/lousy-outages-teaser.js
+++ b/assets/js/lousy-outages-teaser.js
@@ -98,9 +98,10 @@
     const screen = container.querySelector('.lo-home-teaser__screen');
     if (!screen) return;
     while (screen.firstChild) screen.removeChild(screen.firstChild);
+    const hasVerificationDelay = (payload && Array.isArray(payload.providers) && payload.providers.some((p) => p && (p.is_stale || p.verification_status === 'failed' || p.verification_status === 'stale' || p.stateCode === 'unknown'))) || (meta && Number(meta.unknown || 0) > 0);
     if (items.length === 0) {
       const empty = document.createElement('div'); empty.className = 'lo-home-empty';
-      const p1 = document.createElement('p'); p1.textContent = 'all quiet. suspicious, but fine.';
+      const p1 = document.createElement('p'); p1.textContent = hasVerificationDelay ? 'verification delayed; latest provider checks are unavailable.' : 'all quiet. suspicious, but fine.';
       const p2 = document.createElement('p'); p2.textContent = 'last checked: ' + (formatTime(refreshed) || 'recently');
       empty.append(p1, p2); screen.append(empty); return;
     }

--- a/functions.php
+++ b/functions.php
@@ -611,8 +611,10 @@ function get_lousy_outages_home_teaser_data(): array {
     }
 
     if ( empty( $rows ) ) {
-        $default['headline'] = 'all quiet. suspicious, but fine.';
-        $default['status'] = 'clear';
+        $current = method_exists( '\SuzyEaston\LousyOutages\Summary', 'current' ) ? \SuzyEaston\LousyOutages\Summary::current() : [];
+        $delayed = is_array( $current ) && 'delayed' === (string) ( $current['kind'] ?? '' );
+        $default['headline'] = $delayed ? 'verification delayed; latest provider checks are unavailable.' : 'all quiet. suspicious, but fine.';
+        $default['status'] = $delayed ? 'delayed' : 'clear';
         $default['last_checked'] = $last_checked;
         $default['footnote'] = $last_checked
             ? sprintf( 'Last checked: %s. <a href="%s">%s</a>', esc_html( $last_checked ), esc_url( $dashboard_url ), esc_html__( 'View the dashboard', 'suzyeastonca' ) )

--- a/lousy-outages/includes/Summary.php
+++ b/lousy-outages/includes/Summary.php
@@ -56,6 +56,23 @@ class Summary {
             ];
         }
 
+        if (self::has_verification_delay($providers)) {
+            return [
+                'kind'        => 'delayed',
+                'hasIncident' => false,
+                'hasSignal'   => false,
+                'providerId'  => '',
+                'provider'    => '',
+                'title'       => 'Verification delayed; latest provider checks are unavailable.',
+                'status'      => 'Verification delayed',
+                'relative'    => '',
+                'started_at'  => '',
+                'href'        => home_url('/lousy-outages/'),
+                'outageCount' => $outageCount,
+                'signalCount' => $signalCount,
+            ];
+        }
+
         return [
             'kind'        => 'clear',
             'hasIncident' => false,
@@ -437,6 +454,19 @@ class Summary {
         }
 
         return $providers;
+    }
+
+    private static function has_verification_delay(array $providers): bool
+    {
+        foreach ($providers as $provider) {
+            if (!is_array($provider)) { continue; }
+            $verification = strtolower((string) ($provider['verification_status'] ?? ''));
+            $status = strtolower((string) ($provider['stateCode'] ?? $provider['status'] ?? ''));
+            if (!empty($provider['is_stale']) || in_array($verification, ['failed', 'stale', 'unknown'], true) || 'unknown' === $status) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static function latest_incident(array $providers): ?array

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -27,7 +27,7 @@ if ( ! defined( 'LOUSY_OUTAGES_VERSION' ) ) {
     define( 'LOUSY_OUTAGES_VERSION', '0.2.0' );
 }
 if ( ! defined( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION' ) ) {
-    define( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION', 2 );
+    define( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION', 3 );
 }
 if ( ! defined( 'LOUSY_OUTAGES_FILE' ) ) {
     define( 'LOUSY_OUTAGES_FILE', __FILE__ );
@@ -203,7 +203,17 @@ function lousy_outages_maybe_install_schema( bool $force = false ): void {
     update_option( 'lousy_outages_external_schema_diagnostic', ExternalSignals::schema_diagnostics(), false );
     update_option( $option_key, $schema_version, false );
 }
+
+function lousy_outages_maybe_repair_snapshot_caches(): void {
+    $option_key = 'lousy_outages_snapshot_schema_version';
+    $current = (int) get_option( $option_key, 0 );
+    if ( $current >= (int) LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION ) { return; }
+    foreach ( [ 'lousy_outages_cached_statuses', 'lousy_status_snapshot', 'lo_snapshot_payload_v1', 'lousy_outages_fragment_public' ] as $key ) { delete_transient( $key ); }
+    delete_option( 'lo_diag_public_chatter' );
+    update_option( $option_key, (int) LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION, false );
+}
 add_action( 'admin_init', 'lousy_outages_maybe_install_schema' );
+add_action( 'init', 'lousy_outages_maybe_repair_snapshot_caches', 4 );
 add_action( 'init', static function (): void {
     if ( is_admin() ) {
         return;
@@ -508,7 +518,10 @@ function lousy_outages_refresh_data( bool $bypass_cache = true ): array {
         $timestamp_iso   = wp_date( 'c', $timestamp_epoch );
         $timestamp_gmt   = gmdate( 'c', $timestamp_epoch );
         $store        = new Store();
-        $states       = lousy_outages_collect_statuses( $bypass_cache );
+        $previous_states = $store->get_all();
+        $raw_states   = lousy_outages_collect_statuses( $bypass_cache );
+        $quality      = lousy_outages_snapshot_quality( $raw_states, $previous_states );
+        $states       = lousy_outages_merge_verified_states( $raw_states, $previous_states, $timestamp_gmt );
         $errors       = [];
 
         foreach ( $states as $id => $state ) {
@@ -531,19 +544,24 @@ function lousy_outages_refresh_data( bool $bypass_cache = true ): array {
         }
 
         update_option( 'lousy_outages_last_poll', $timestamp_iso, false );
-        update_option( 'lousy_outages_last_fetched', $timestamp_epoch, false );
-        update_option( 'lousy_outages_last_fetched_iso', $timestamp_gmt, false );
+        update_option( 'lousy_outages_last_attempted', $timestamp_epoch, false );
+        update_option( 'lousy_outages_last_attempted_iso', $timestamp_gmt, false );
+        if ( ! empty( $quality['ok'] ) ) {
+            update_option( 'lousy_outages_last_fetched', $timestamp_epoch, false );
+            update_option( 'lousy_outages_last_fetched_iso', $timestamp_gmt, false );
+        }
         do_action( 'lousy_outages_log', 'refresh_complete', [
             'count' => count( $states ),
             'ts'    => $timestamp_iso,
         ] );
 
         $response = [
-            'ok'           => true,
+            'ok'           => ! empty( $quality['ok'] ),
             'providers'    => $providers,
             'errors'       => $errors,
             'trending'     => $trending,
-            'source'       => 'live',
+            'quality'      => $quality,
+            'source'       => ! empty( $quality['ok'] ) ? 'live' : 'last_good_with_errors',
             'refreshedAt'  => $timestamp_iso,
             'refreshed_at' => $timestamp_epoch,
         ];
@@ -555,6 +573,55 @@ function lousy_outages_refresh_data( bool $bypass_cache = true ): array {
     }
 
     return $response;
+}
+
+
+function lousy_outages_provider_fetch_failed( array $state ): bool {
+    $status = strtolower( (string) ( $state['status'] ?? '' ) );
+    return ( '' === $status || 'unknown' === $status || ! empty( $state['error'] ) ) && empty( $state['incidents'] );
+}
+
+function lousy_outages_stale_grace_seconds(): int {
+    return (int) apply_filters( 'lousy_outages_stale_grace_seconds', 6 * HOUR_IN_SECONDS );
+}
+
+function lousy_outages_merge_verified_states( array $new_states, array $previous_states, string $attempted_at ): array {
+    $merged = [];
+    foreach ( $new_states as $id => $state ) {
+        if ( ! is_array( $state ) ) { continue; }
+        $failed = lousy_outages_provider_fetch_failed( $state );
+        $prior  = isset( $previous_states[ $id ] ) && is_array( $previous_states[ $id ] ) ? $previous_states[ $id ] : [];
+        if ( $failed && $prior ) {
+            $last_success = (string) ( $prior['last_successful_at'] ?? $prior['checked_at'] ?? $prior['updated_at'] ?? '' );
+            $last_ts = $last_success ? ( strtotime( $last_success ) ?: 0 ) : 0;
+            if ( $last_ts && ( time() - $last_ts ) <= lousy_outages_stale_grace_seconds() ) {
+                $kept = $prior;
+                $kept['verification_status'] = 'stale';
+                $kept['is_stale'] = true;
+                $kept['fetch_error'] = (string) ( $state['error'] ?? $state['message'] ?? 'Fetch failed' );
+                $kept['error'] = $kept['fetch_error'];
+                $kept['last_attempted_at'] = $attempted_at;
+                $kept['last_successful_at'] = $last_success;
+                $merged[ $id ] = $kept;
+                continue;
+            }
+        }
+        $state['verification_status'] = $failed ? 'failed' : 'verified';
+        $state['is_stale'] = false;
+        $state['fetch_error'] = $failed ? (string) ( $state['error'] ?? $state['message'] ?? 'Fetch failed' ) : '';
+        $state['last_attempted_at'] = $attempted_at;
+        if ( ! $failed ) { $state['last_successful_at'] = $attempted_at; }
+        elseif ( ! empty( $prior['last_successful_at'] ) ) { $state['last_successful_at'] = $prior['last_successful_at']; }
+        $merged[ $id ] = $state;
+    }
+    return $merged;
+}
+
+function lousy_outages_snapshot_quality( array $states, array $previous_states = [] ): array {
+    $total = count( $states ); $failed = 0; $verified = 0;
+    foreach ( $states as $state ) { if ( is_array( $state ) && lousy_outages_provider_fetch_failed( $state ) ) { $failed++; } else { $verified++; } }
+    $ok = $total > 0 && $verified > 0 && ( $verified / max( 1, $total ) ) >= (float) apply_filters( 'lousy_outages_quality_min_success_ratio', 0.25 );
+    return [ 'ok' => $ok, 'total' => $total, 'verified' => $verified, 'failed' => $failed, 'success_ratio' => $total ? $verified / $total : 0 ];
 }
 
 function lousy_outages_filter_states_to_enabled( array $states ): array {
@@ -1618,6 +1685,12 @@ function lousy_outages_build_provider_payload( string $id, array $state, string 
         'sort_key'   => $state['sort_key'] ?? null,
         'confidence'=> $state['confidence'] ?? null,
         'summary'    => $state['summary'] ?? $label,
+        'verification_status' => $state['verification_status'] ?? ( ! empty( $state['error'] ) ? 'failed' : 'verified' ),
+        'last_attempted_at' => $state['last_attempted_at'] ?? $state['checked_at'] ?? $fetched_at,
+        'last_successful_at' => $state['last_successful_at'] ?? ( empty( $state['error'] ) ? ( $state['checked_at'] ?? $fetched_at ) : '' ),
+        'data_observed_at' => $updated_at,
+        'is_stale' => ! empty( $state['is_stale'] ),
+        'fetch_error' => $state['fetch_error'] ?? $state['error'] ?? '',
         'checked_at' => $state['checked_at'] ?? $fetched_at,
         'checkedAt'  => $state['checked_at'] ?? $fetched_at,
         'last_official_update' => $state['last_official_update'] ?? '',

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -93,7 +93,8 @@ function render_shortcode(): string {
         );
     }
 
-    $cache_key = is_user_logged_in() ? null : 'lousy_outages_fragment_public';
+    // Dynamic provider data is hydrated from the canonical summary; ignore legacy unversioned fragments.
+    $cache_key = null;
     $cached    = ($cache_key) ? get_transient($cache_key) : null;
     $snapshot_endpoint = esc_url_raw(rest_url('lousy/v1/snapshot'));
 
@@ -643,6 +644,20 @@ function render_shortcode(): string {
             if (in_array($statusValue, ['disabled', 'blocked_by_safe_default', 'not_configured', 'cooldown', 'rate_limited', 'budget_skipped'], true)) { $sourcesBlockedCount++; }
         }
         $officialCorroborationRows = isset($publicDiag['official_incident_corroboration']) && is_array($publicDiag['official_incident_corroboration']) ? $publicDiag['official_incident_corroboration'] : [];
+        $canonicalIncidentProviders = [];
+        foreach ((array) $tiles as $tile) {
+            if (!is_array($tile)) { continue; }
+            $pid = sanitize_key((string) ($tile['id'] ?? $tile['provider'] ?? ''));
+            $active = class_exists('\SuzyEaston\LousyOutages\Summary') && method_exists('\SuzyEaston\LousyOutages\Summary', 'current_incidents_for_provider')
+                ? \SuzyEaston\LousyOutages\Summary::current_incidents_for_provider($tile)
+                : ((isset($tile['incidents']) && is_array($tile['incidents'])) ? $tile['incidents'] : []);
+            if ($pid !== '' && !empty($active)) { $canonicalIncidentProviders[$pid] = true; }
+        }
+        $officialCorroborationRows = array_values(array_filter($officialCorroborationRows, static function ($row) use ($canonicalIncidentProviders): bool {
+            if (!is_array($row)) { return false; }
+            $pid = sanitize_key((string) ($row['provider_id'] ?? $row['provider'] ?? ''));
+            return $pid !== '' && isset($canonicalIncidentProviders[$pid]);
+        }));
         $canadianWatchRows = isset($publicDiag['canadian_infrastructure_watchlist']) && is_array($publicDiag['canadian_infrastructure_watchlist']) ? $publicDiag['canadian_infrastructure_watchlist'] : [];
         $statusLabel = static function($status): string {
             $status = (string) $status;

--- a/parts/lousy-outages-teaser.php
+++ b/parts/lousy-outages-teaser.php
@@ -18,6 +18,7 @@ $teaser_interval = 5 * MINUTE_IN_SECONDS * 1000;
 $rows = isset( $teaser_data['rows'] ) && is_array( $teaser_data['rows'] ) ? array_slice( $teaser_data['rows'], 0, 5 ) : [];
 $last_checked = $teaser_data['last_checked'] ?? '';
 $active_count = count( $rows );
+$is_delayed = empty( $rows ) && 'delayed' === (string) ( $teaser_data['status'] ?? '' );
 $provider_names = [];
 foreach ( $rows as $row ) {
     $provider = trim( (string) ( $row['provider'] ?? '' ) );
@@ -44,7 +45,7 @@ if ( count( $provider_names ) > 3 ) {
     <div class="lo-home-teaser__screen">
         <?php if ( empty( $rows ) ) : ?>
             <div class="lo-home-empty">
-                <p><?php echo esc_html( 'all quiet. suspicious, but fine.' ); ?></p>
+                <p><?php echo esc_html( $is_delayed ? 'verification delayed; latest provider checks are unavailable.' : 'all quiet. suspicious, but fine.' ); ?></p>
                 <p><?php echo esc_html( $last_checked ? 'last checked: ' . $last_checked : 'last checked: recently' ); ?></p>
             </div>
         <?php else : ?>

--- a/plugins/lousy-outages/includes/Summary.php
+++ b/plugins/lousy-outages/includes/Summary.php
@@ -56,6 +56,23 @@ class Summary {
             ];
         }
 
+        if (self::has_verification_delay($providers)) {
+            return [
+                'kind'        => 'delayed',
+                'hasIncident' => false,
+                'hasSignal'   => false,
+                'providerId'  => '',
+                'provider'    => '',
+                'title'       => 'Verification delayed; latest provider checks are unavailable.',
+                'status'      => 'Verification delayed',
+                'relative'    => '',
+                'started_at'  => '',
+                'href'        => home_url('/lousy-outages/'),
+                'outageCount' => $outageCount,
+                'signalCount' => $signalCount,
+            ];
+        }
+
         return [
             'kind'        => 'clear',
             'hasIncident' => false,
@@ -437,6 +454,19 @@ class Summary {
         }
 
         return $providers;
+    }
+
+    private static function has_verification_delay(array $providers): bool
+    {
+        foreach ($providers as $provider) {
+            if (!is_array($provider)) { continue; }
+            $verification = strtolower((string) ($provider['verification_status'] ?? ''));
+            $status = strtolower((string) ($provider['stateCode'] ?? $provider['status'] ?? ''));
+            if (!empty($provider['is_stale']) || in_array($verification, ['failed', 'stale', 'unknown'], true) || 'unknown' === $status) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static function latest_incident(array $providers): ?array

--- a/plugins/lousy-outages/lousy-outages.php
+++ b/plugins/lousy-outages/lousy-outages.php
@@ -27,7 +27,7 @@ if ( ! defined( 'LOUSY_OUTAGES_VERSION' ) ) {
     define( 'LOUSY_OUTAGES_VERSION', '0.2.0' );
 }
 if ( ! defined( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION' ) ) {
-    define( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION', 2 );
+    define( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION', 3 );
 }
 if ( ! defined( 'LOUSY_OUTAGES_FILE' ) ) {
     define( 'LOUSY_OUTAGES_FILE', __FILE__ );
@@ -203,7 +203,17 @@ function lousy_outages_maybe_install_schema( bool $force = false ): void {
     update_option( 'lousy_outages_external_schema_diagnostic', ExternalSignals::schema_diagnostics(), false );
     update_option( $option_key, $schema_version, false );
 }
+
+function lousy_outages_maybe_repair_snapshot_caches(): void {
+    $option_key = 'lousy_outages_snapshot_schema_version';
+    $current = (int) get_option( $option_key, 0 );
+    if ( $current >= (int) LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION ) { return; }
+    foreach ( [ 'lousy_outages_cached_statuses', 'lousy_status_snapshot', 'lo_snapshot_payload_v1', 'lousy_outages_fragment_public' ] as $key ) { delete_transient( $key ); }
+    delete_option( 'lo_diag_public_chatter' );
+    update_option( $option_key, (int) LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION, false );
+}
 add_action( 'admin_init', 'lousy_outages_maybe_install_schema' );
+add_action( 'init', 'lousy_outages_maybe_repair_snapshot_caches', 4 );
 add_action( 'init', static function (): void {
     if ( is_admin() ) {
         return;
@@ -508,7 +518,10 @@ function lousy_outages_refresh_data( bool $bypass_cache = true ): array {
         $timestamp_iso   = wp_date( 'c', $timestamp_epoch );
         $timestamp_gmt   = gmdate( 'c', $timestamp_epoch );
         $store        = new Store();
-        $states       = lousy_outages_collect_statuses( $bypass_cache );
+        $previous_states = $store->get_all();
+        $raw_states   = lousy_outages_collect_statuses( $bypass_cache );
+        $quality      = lousy_outages_snapshot_quality( $raw_states, $previous_states );
+        $states       = lousy_outages_merge_verified_states( $raw_states, $previous_states, $timestamp_gmt );
         $errors       = [];
 
         foreach ( $states as $id => $state ) {
@@ -531,19 +544,24 @@ function lousy_outages_refresh_data( bool $bypass_cache = true ): array {
         }
 
         update_option( 'lousy_outages_last_poll', $timestamp_iso, false );
-        update_option( 'lousy_outages_last_fetched', $timestamp_epoch, false );
-        update_option( 'lousy_outages_last_fetched_iso', $timestamp_gmt, false );
+        update_option( 'lousy_outages_last_attempted', $timestamp_epoch, false );
+        update_option( 'lousy_outages_last_attempted_iso', $timestamp_gmt, false );
+        if ( ! empty( $quality['ok'] ) ) {
+            update_option( 'lousy_outages_last_fetched', $timestamp_epoch, false );
+            update_option( 'lousy_outages_last_fetched_iso', $timestamp_gmt, false );
+        }
         do_action( 'lousy_outages_log', 'refresh_complete', [
             'count' => count( $states ),
             'ts'    => $timestamp_iso,
         ] );
 
         $response = [
-            'ok'           => true,
+            'ok'           => ! empty( $quality['ok'] ),
             'providers'    => $providers,
             'errors'       => $errors,
             'trending'     => $trending,
-            'source'       => 'live',
+            'quality'      => $quality,
+            'source'       => ! empty( $quality['ok'] ) ? 'live' : 'last_good_with_errors',
             'refreshedAt'  => $timestamp_iso,
             'refreshed_at' => $timestamp_epoch,
         ];
@@ -555,6 +573,55 @@ function lousy_outages_refresh_data( bool $bypass_cache = true ): array {
     }
 
     return $response;
+}
+
+
+function lousy_outages_provider_fetch_failed( array $state ): bool {
+    $status = strtolower( (string) ( $state['status'] ?? '' ) );
+    return ( '' === $status || 'unknown' === $status || ! empty( $state['error'] ) ) && empty( $state['incidents'] );
+}
+
+function lousy_outages_stale_grace_seconds(): int {
+    return (int) apply_filters( 'lousy_outages_stale_grace_seconds', 6 * HOUR_IN_SECONDS );
+}
+
+function lousy_outages_merge_verified_states( array $new_states, array $previous_states, string $attempted_at ): array {
+    $merged = [];
+    foreach ( $new_states as $id => $state ) {
+        if ( ! is_array( $state ) ) { continue; }
+        $failed = lousy_outages_provider_fetch_failed( $state );
+        $prior  = isset( $previous_states[ $id ] ) && is_array( $previous_states[ $id ] ) ? $previous_states[ $id ] : [];
+        if ( $failed && $prior ) {
+            $last_success = (string) ( $prior['last_successful_at'] ?? $prior['checked_at'] ?? $prior['updated_at'] ?? '' );
+            $last_ts = $last_success ? ( strtotime( $last_success ) ?: 0 ) : 0;
+            if ( $last_ts && ( time() - $last_ts ) <= lousy_outages_stale_grace_seconds() ) {
+                $kept = $prior;
+                $kept['verification_status'] = 'stale';
+                $kept['is_stale'] = true;
+                $kept['fetch_error'] = (string) ( $state['error'] ?? $state['message'] ?? 'Fetch failed' );
+                $kept['error'] = $kept['fetch_error'];
+                $kept['last_attempted_at'] = $attempted_at;
+                $kept['last_successful_at'] = $last_success;
+                $merged[ $id ] = $kept;
+                continue;
+            }
+        }
+        $state['verification_status'] = $failed ? 'failed' : 'verified';
+        $state['is_stale'] = false;
+        $state['fetch_error'] = $failed ? (string) ( $state['error'] ?? $state['message'] ?? 'Fetch failed' ) : '';
+        $state['last_attempted_at'] = $attempted_at;
+        if ( ! $failed ) { $state['last_successful_at'] = $attempted_at; }
+        elseif ( ! empty( $prior['last_successful_at'] ) ) { $state['last_successful_at'] = $prior['last_successful_at']; }
+        $merged[ $id ] = $state;
+    }
+    return $merged;
+}
+
+function lousy_outages_snapshot_quality( array $states, array $previous_states = [] ): array {
+    $total = count( $states ); $failed = 0; $verified = 0;
+    foreach ( $states as $state ) { if ( is_array( $state ) && lousy_outages_provider_fetch_failed( $state ) ) { $failed++; } else { $verified++; } }
+    $ok = $total > 0 && $verified > 0 && ( $verified / max( 1, $total ) ) >= (float) apply_filters( 'lousy_outages_quality_min_success_ratio', 0.25 );
+    return [ 'ok' => $ok, 'total' => $total, 'verified' => $verified, 'failed' => $failed, 'success_ratio' => $total ? $verified / $total : 0 ];
 }
 
 function lousy_outages_filter_states_to_enabled( array $states ): array {
@@ -1618,6 +1685,12 @@ function lousy_outages_build_provider_payload( string $id, array $state, string 
         'sort_key'   => $state['sort_key'] ?? null,
         'confidence'=> $state['confidence'] ?? null,
         'summary'    => $state['summary'] ?? $label,
+        'verification_status' => $state['verification_status'] ?? ( ! empty( $state['error'] ) ? 'failed' : 'verified' ),
+        'last_attempted_at' => $state['last_attempted_at'] ?? $state['checked_at'] ?? $fetched_at,
+        'last_successful_at' => $state['last_successful_at'] ?? ( empty( $state['error'] ) ? ( $state['checked_at'] ?? $fetched_at ) : '' ),
+        'data_observed_at' => $updated_at,
+        'is_stale' => ! empty( $state['is_stale'] ),
+        'fetch_error' => $state['fetch_error'] ?? $state['error'] ?? '',
         'checked_at' => $state['checked_at'] ?? $fetched_at,
         'checkedAt'  => $state['checked_at'] ?? $fetched_at,
         'last_official_update' => $state['last_official_update'] ?? '',

--- a/plugins/lousy-outages/public/shortcode.php
+++ b/plugins/lousy-outages/public/shortcode.php
@@ -93,7 +93,8 @@ function render_shortcode(): string {
         );
     }
 
-    $cache_key = is_user_logged_in() ? null : 'lousy_outages_fragment_public';
+    // Dynamic provider data is hydrated from the canonical summary; ignore legacy unversioned fragments.
+    $cache_key = null;
     $cached    = ($cache_key) ? get_transient($cache_key) : null;
     $snapshot_endpoint = esc_url_raw(rest_url('lousy/v1/snapshot'));
 
@@ -643,6 +644,20 @@ function render_shortcode(): string {
             if (in_array($statusValue, ['disabled', 'blocked_by_safe_default', 'not_configured', 'cooldown', 'rate_limited', 'budget_skipped'], true)) { $sourcesBlockedCount++; }
         }
         $officialCorroborationRows = isset($publicDiag['official_incident_corroboration']) && is_array($publicDiag['official_incident_corroboration']) ? $publicDiag['official_incident_corroboration'] : [];
+        $canonicalIncidentProviders = [];
+        foreach ((array) $tiles as $tile) {
+            if (!is_array($tile)) { continue; }
+            $pid = sanitize_key((string) ($tile['id'] ?? $tile['provider'] ?? ''));
+            $active = class_exists('\SuzyEaston\LousyOutages\Summary') && method_exists('\SuzyEaston\LousyOutages\Summary', 'current_incidents_for_provider')
+                ? \SuzyEaston\LousyOutages\Summary::current_incidents_for_provider($tile)
+                : ((isset($tile['incidents']) && is_array($tile['incidents'])) ? $tile['incidents'] : []);
+            if ($pid !== '' && !empty($active)) { $canonicalIncidentProviders[$pid] = true; }
+        }
+        $officialCorroborationRows = array_values(array_filter($officialCorroborationRows, static function ($row) use ($canonicalIncidentProviders): bool {
+            if (!is_array($row)) { return false; }
+            $pid = sanitize_key((string) ($row['provider_id'] ?? $row['provider'] ?? ''));
+            return $pid !== '' && isset($canonicalIncidentProviders[$pid]);
+        }));
         $canadianWatchRows = isset($publicDiag['canadian_infrastructure_watchlist']) && is_array($publicDiag['canadian_infrastructure_watchlist']) ? $publicDiag['canadian_infrastructure_watchlist'] : [];
         $statusLabel = static function($status): string {
             $status = (string) $status;

--- a/tests/LousyOutagesHomeTeaserTest.php
+++ b/tests/LousyOutagesHomeTeaserTest.php
@@ -45,5 +45,11 @@ assert_true(str_contains($summary, "'eta'") && strpos($summary, "incident['impac
 $functions = file_get_contents(__DIR__ . '/../functions.php'); $part = file_get_contents(__DIR__ . '/../parts/lousy-outages-teaser.php'); $js = file_get_contents(__DIR__ . '/../assets/js/lousy-outages-teaser.js');
 assert_true(str_contains($functions, 'lousy-outages/v1/summary') && str_contains($part, 'lousy-outages/v1/summary'), 'homepage endpoint configuration is summary');
 assert_true(!str_contains($functions.$part.$js, 'lousy-outages/v1/status'), 'no homepage code references status endpoint');
+set_snapshot([['id'=>'tv','name'=>'TeamViewer','stateCode'=>'degraded','tile_kind'=>'outage','updatedAt'=>$base,'verification_status'=>'stale','is_stale'=>true,'incidents'=>[['id'=>'tv1','title'=>'DEX PLATFORM. Inventory Software pages not loading','status'=>'monitoring','impact'=>'degraded','startedAt'=>'2026-07-20T10:00:00Z','updatedAt'=>'2026-07-20T10:30:00Z']]]]);
+$rows = \SuzyEaston\LousyOutages\Summary::ordered_current_incidents(5);
+assert_true(count($rows)===1 && $rows[0]['provider_id']==='tv', 'stale failed provider remains visible during grace via canonical snapshot');
+set_snapshot([['id'=>'tv','name'=>'TeamViewer','stateCode'=>'unknown','tile_kind'=>'unknown','updatedAt'=>$base,'verification_status'=>'failed','is_stale'=>false,'incidents'=>[]]]);
+$current = \SuzyEaston\LousyOutages\Summary::current();
+assert_true($current['kind']==='delayed' && stripos($current['title'], 'verification delayed') !== false, 'fetch failure is verification delayed, not all quiet');
 echo "OK\n";
 }

--- a/tests/e2e/lousy-outages-production-smoke.spec.js
+++ b/tests/e2e/lousy-outages-production-smoke.spec.js
@@ -1,0 +1,33 @@
+const { test, expect } = require('@playwright/test');
+const base = process.env.LOUSY_PROD_BASE_URL || 'https://www.suzyeaston.ca';
+const runProd = process.env.LOUSY_PROD_SMOKE === '1';
+test.describe('production Lousy Outages contract', () => {
+  test.skip(!runProd, 'Set LOUSY_PROD_SMOKE=1 to run read-only production smoke checks.');
+  test('homepage and dashboard agree on canonical status surfaces', async ({ browser }) => {
+    const context = await browser.newContext({ serviceWorkers: 'block' });
+    await context.route('**/*', r => r.continue());
+    const errors = [];
+    const failed = [];
+    const page = await context.newPage();
+    page.on('console', msg => { if (msg.type() === 'error') errors.push(msg.text()); });
+    page.on('requestfailed', req => failed.push(req.url()));
+    const summary = await (await page.request.get(`${base}/wp-json/lousy-outages/v1/summary`)).json();
+    const history = await (await page.request.get(`${base}/wp-json/lousy-outages/v1/history`)).json();
+    expect(Array.isArray(summary.providers)).toBeTruthy();
+    expect(history).toBeTruthy();
+    await page.goto(`${base}/?qa_timestamp=${Date.now()}`, { waitUntil: 'networkidle' });
+    const homeText = await page.locator('#lousy-outages-teaser').innerText();
+    await page.goto(`${base}/lousy-outages/?qa_timestamp=${Date.now()}`, { waitUntil: 'networkidle' });
+    const dashText = await page.locator('body').innerText();
+    const activeCards = await page.locator('[data-lo-section-grid="incidents"] article').count();
+    const saysNone = /No active incidents/i.test(dashText);
+    const officialRows = await page.locator('.lo-corroboration-radar__incident').count();
+    if (saysNone) expect(officialRows).toBe(0);
+    const allUnknown = summary.providers.length > 0 && summary.providers.every(p => p.stateCode === 'unknown' || p.verification_status === 'failed');
+    if (allUnknown) expect(homeText).not.toMatch(/all quiet/i);
+    expect(activeCards).toBeGreaterThanOrEqual(0);
+    expect(errors).toEqual([]);
+    expect(failed.filter(u => /wp-json\/lousy/.test(u))).toEqual([]);
+    await context.close();
+  });
+});


### PR DESCRIPTION
### Motivation

- Prevent failed provider fetches from overwriting the canonical snapshot and erasing previously verified incidents.
- Make the UI and REST surfaces consistently reflect verified vs stale vs failed provider data and avoid showing “all quiet” when verification is unavailable.
- Provide an explicit, bounded stale/verification model and a refresh quality gate so partial failures don’t appear as fresh successful snapshots.

### Description

- Add per-provider verification metadata to the canonical payload: `verification_status`, `last_attempted_at`, `last_successful_at`, `data_observed_at`, `is_stale`, and `fetch_error`, and expose these in `lousy_outages_build_provider_payload()` and the snapshot path. 
- Introduce merge/quality logic for refreshes: `lousy_outages_provider_fetch_failed()`, `lousy_outages_merge_verified_states()`, and `lousy_outages_snapshot_quality()` to retain recent verified state for a bounded grace window and to compute a `quality` result for each refresh. 
- Separate refresh timestamps: `last_attempted` (always advances) versus `last_fetched` (only updated when the quality gate passes), and surface `quality` and `source` (`live` vs `last_good_with_errors`) in refresh responses. 
- Add a snapshot/schema bump and cache repair: bump `LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION` and provide `lousy_outages_maybe_repair_snapshot_caches()` to invalidate legacy/unversioned transients and diagnostics on upgrade. 
- Align public surfaces to the canonical snapshot: stop using legacy `lousy_outages_fragment_public` for dynamic provider data, filter official corroboration rows to only reference canonical current incidents, and add `has_verification_delay()` + `delayed` state so the homepage/teaser show “verification delayed” instead of “all quiet” when providers are unknown/stale/failed. 
- Add tests and smoke checks: extend `tests/LousyOutagesHomeTeaserTest.php` with stale/failure regression assertions and add a read-only Playwright smoke test `tests/e2e/lousy-outages-production-smoke.spec.js` (gated with `LOUSY_PROD_SMOKE=1`) that verifies homepage/dashboard parity and canonical snapshot structural expectations.

### Testing

- Ran `php tests/LousyOutagesHomeTeaserTest.php` and it passed (`OK`).
- Linted and syntax-checked modified PHP files with `php -l` and JS files with `node --check`, and ran `./scripts/check-lousy-outages-tree-drift.sh`; all changed files passed checks.
- Ran regression scripts for snapshot/RSS pipeline (`tests/lousy-outages/aws-snapshot-pipeline-regression.php` and `tests/lousy-outages/rss-long-running-regression.php`) and they passed for the updated pipeline.
- Observed unrelated test failures in the environment-wide JS test suite (`npm test`) and `tests/FetcherTest.php` exposed pre-existing fetch/fallback expectations; these failures are not introduced by the snapshot/verification changes and are noted in validation output.
- Production browser capture/smoke could not be executed from this runner because Playwright browser install and outbound HTTPS requests were blocked by the environment (Playwright download / `npx playwright install` returned `403`, and direct `curl` CONNECT requests to production returned `403`); the read-only Playwright smoke test is included and should be executed from a network/browser-capable environment with `LOUSY_PROD_SMOKE=1` after deployment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e845ff9dc833194d75bafe8118a37)