### PR TITLE
Restore Lousy Outages provider refresh core

### DIFF
--- a/.github/workflows/release-lousy-outages.yml
+++ b/.github/workflows/release-lousy-outages.yml
@@ -19,12 +19,21 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.3'
+          extensions: simplexml, xml
       - name: PHP lint plugin
         run: find lousy-outages -path 'lousy-outages/tests' -prune -o -name '*.php' -print0 | xargs -0 -n1 php -l
-      - name: Run focused tests
+      - name: Run repository architecture test
+        run: php tests/lousy-outages/repository-architecture-test.php
+      - name: Run RSS and AWS lifecycle regressions
         run: |
-          php tests/lousy-outages/repository-architecture-test.php
-          php lousy-outages/tests/history-store-test.php
+          php tests/lousy-outages/rss-long-running-regression.php
+          php tests/lousy-outages/aws-snapshot-pipeline-regression.php
+      - name: Run history migration tests
+        run: php lousy-outages/tests/history-store-test.php
+      - name: Run count-parity/current-state tests
+        run: php tests/lousy-outages/current-state-contract-test.php
+      - name: Run homepage teaser JavaScript/PHP tests
+        run: php tests/LousyOutagesHomeTeaserTest.php
       - name: Build release ZIP
         run: scripts/build-lousy-outages-release.sh
       - name: Validate release ZIP
@@ -34,6 +43,10 @@ jobs:
           test -f dist/release-manifest.json
           sha256sum -c dist/lousy-outages.zip.sha256
           php tests/lousy-outages/wp-install-upgrade-architecture-test.php
+      - name: Real WordPress clean-install test
+        run: tests/lousy-outages/wp-real-install-test.sh clean
+      - name: Real WordPress upgrade test
+        run: tests/lousy-outages/wp-real-install-test.sh upgrade
       - name: Upload workflow artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The current flagship prototype. A first-person Vancouver corridor build focused 
 - `/api/outages` provides live provider pulls with `Cache-Control: no-store`
 - `/wp-json/lousy-outages/v1/status` remains available for legacy consumers
 - Polling cadence can be tuned with `OUTAGES_POLL_MS` or the `lousy_outages_interval` option
-- Background refresh can be warmed manually with `wp cron event run lousy_outages_poll`
+- Background refresh can be warmed manually with `wp cron event run lousy_outages_refresh_official_providers`
 
 It is intentionally practical but still fun: command-line vibes, alert hooks, and very online reliability energy.
 

--- a/docs/lousy-outages-runtime-audit.md
+++ b/docs/lousy-outages-runtime-audit.md
@@ -1,0 +1,35 @@
+# Lousy Outages runtime audit for 0.3.2
+
+This audit was written before the 0.3.2 runtime repair. The current plugin contains several overlapping paths that can fetch, normalize, cache, schedule, and alert on provider data.
+
+## Existing network and persistence paths
+
+| Path | Fetches provider status/incidents? | Writes provider state? | Writes canonical snapshot? | Persists history? | Sends alerts? | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| `lousy_outages_poll` -> `lousy_outages_run_poll()` | Yes, through `lousy_outages_collect_statuses(true)` and `Fetcher::fetch()` for all enabled providers. | Yes, `Store::update()` for each provider. | Yes, `lousy_outages_refresh_snapshot()`. | Indirectly through detector/notification side effects, not HistoryStore v2 canonical lifecycle. | Yes, via `Detector`, `SMS`, and `Email`. | Duplicate full provider-fetch pipeline. |
+| `lousy_outages_cron_refresh` -> `lousy_outages_refresh_data()` | Yes, through `lousy_outages_collect_statuses()`. | Yes, `Store::update()` for each provider. | Yes, `lousy_outages_refresh_snapshot()`. | Not reliably for current official incidents before this repair. | No direct alert sending. | Best existing basis for canonical official provider refresh because it already has a lock and last-known-good merge. |
+| `lousy_outages_refresh` -> `IncidentAlerts::run()` | Yes before 0.3.2: `collect_incidents()` included registered sources and legacy feeds in addition to snapshot. | No provider-state write. | No. | Yes, `IncidentStore::persistIncidents()` then HistoryStore migration. | Yes. | Alert path independently refetched sources; must become snapshot/history consumer only. |
+| `lo_check_statuses` -> `IncidentAlerts::run()` | Same as `lousy_outages_refresh`. | No provider-state write. | No. | Yes. | Yes. | Duplicate alert schedule and duplicate provider-fetch risk. |
+| `lo_refresh_snapshot` -> `lo_run_snapshot_refresh()` -> `lo_snapshot_refresh(true)` | Yes via legacy snapshot runtime when available. | Legacy snapshot store only. | Writes `lo_snapshot_payload_v1`, not the canonical `lousy_outages_snapshot`. | No. | No. | Duplicate snapshot refresh schedule. |
+| `lo_send_daily_digest` -> `IncidentAlerts::send_daily_digest()` | No provider fetch required; consumes persisted incidents. | No. | No. | Prunes stale stored incident records. | Sends digest email. | May remain scheduled separately. |
+| Manual admin poll (`admin_post_lousy_outages_poll_now`) | Queues/executes `lousy_outages_poll`. | Yes via poll hook. | Yes. | Legacy side effects. | Potentially yes. | Must be replaced by authenticated POST refresh using canonical lock. |
+| REST refresh (`/lousy-outages/v1/refresh`) | Yes via `lousy_outages_refresh_data(true)`. | Yes. | Yes. | No before repair. | No. | Previously allowed anonymous GET/POST. Must be authenticated nonce-protected POST only. |
+| Homepage teaser / shortcode render | Should consume snapshot, but `lousy_outages_get_snapshot(true)` fallback could fetch on page render when no snapshot existed. | Possible through forced snapshot refresh. | Possible through forced snapshot refresh. | No. | No. | Page views must not initiate provider collection. |
+| Dashboard / summary REST / history REST | Summary reads snapshot but could force refresh; history consumes HistoryStore v2. | Possible via forced summary fallback. | Possible via forced summary fallback. | History migration is read-time and idempotent. | No. | Summary must expose the normalized current-state lanes. |
+
+## Hooks traced
+
+- `lousy_outages_poll`: independently performs provider network requests and writes provider state/snapshot.
+- `lousy_outages_cron_refresh`: independently performs provider network requests and writes provider state/snapshot.
+- `lousy_outages_refresh`: before repair, independently fetched incidents through alert collectors; after repair, must consume saved snapshot only.
+- `lo_check_statuses`: before repair, same duplicate alert collector as above; after repair, obsolete for scheduling.
+- `lo_refresh_snapshot`: independently refreshes a legacy snapshot and can perform provider collection through the old snapshot runtime.
+- `lo_send_daily_digest`: consumes persisted incident/digest data and does not need provider network requests.
+
+## Proposed canonical provider-refresh pipeline
+
+Use exactly one scheduled provider-fetch hook: `lousy_outages_refresh_official_providers`.
+
+The hook calls `lousy_outages_refresh_official_providers()`, an alias around the canonical refresh service. That service fetches all enabled official providers, merges bounded last-known-good data, normalizes the current-state schema (`outages`, `signals`, `unverified`, `operational`, `meta`), writes `lousy_outages_snapshot`, updates provider state, appends current official incident lifecycle records to HistoryStore v2 through `IncidentStore`, and returns a structured result. Alerting, homepage, dashboard, RSS, summary REST, and history REST must consume the saved snapshot/history rather than refetching providers.
+
+Upgrade to 0.3.2 must unschedule `lousy_outages_poll`, `lousy_outages_cron_refresh`, `lousy_outages_refresh`, `lo_check_statuses`, and `lo_refresh_snapshot`; preserve `lo_send_daily_digest` and subscriber cleanup; and schedule `lousy_outages_refresh_official_providers` exactly once.

--- a/lousy-outages/README.md
+++ b/lousy-outages/README.md
@@ -77,7 +77,7 @@ Place `[lousy_outages]` in any page or post to render the status table. A page t
 
 ## Development
 
-Polling runs via WP-Cron (`lousy_outages_poll`). A separate background refresh (`lousy_outages_cron_refresh`) updates the snapshot and "Last fetched" timestamp every 15 minutes; on low-traffic sites, point a system cron at `wp-cron.php` to keep it firing. Results are stored in an option and also exposed at `/wp-json/lousy-outages/v1/status`.
+Official-provider refresh runs via WP-Cron (`lousy_outages_refresh_official_providers`) and updates the saved snapshot and "Last fetched" timestamp every 15 minutes; on low-traffic sites, point a system cron at `wp-cron.php` to keep it firing. Results are stored in an option and also exposed at `/wp-json/lousy-outages/v1/status`.
 
 ## How to subscribe to RSS
 

--- a/lousy-outages/includes/AdminCleanup.php
+++ b/lousy-outages/includes/AdminCleanup.php
@@ -59,6 +59,8 @@ class AdminCleanup {
         $pluginsDir = defined('WP_PLUGIN_DIR') ? WP_PLUGIN_DIR : dirname((string)(defined('LOUSY_OUTAGES_PATH') ? LOUSY_OUTAGES_PATH : __DIR__), 2);
         $active = (array) get_option('active_plugins', []);
         $routes = function_exists('rest_get_server') ? rest_get_server()->get_routes() : [];
+        $summaryCheck = self::check_rest_route('/lousy-outages/v1/summary');
+        $historyCheck = self::check_rest_route('/lousy-outages/v1/history');
         $history = class_exists('SuzyEaston\\LousyOutages\\Storage\\HistoryStore') ? (new \SuzyEaston\LousyOutages\Storage\HistoryStore())->all(30) : [];
         $dirs = [];
         foreach (glob(rtrim($pluginsDir, '/').'/lousy-outages*', GLOB_ONLYDIR) ?: [] as $dir) { $dirs[] = basename($dir); }
@@ -73,6 +75,8 @@ class AdminCleanup {
             'temporary_helper_plugins' => $helpers,
             'summary_endpoint_registered' => isset($routes['/lousy-outages/v1/summary']),
             'history_endpoint_registered' => isset($routes['/lousy-outages/v1/history']),
+            'summary_endpoint_check' => $summaryCheck,
+            'history_endpoint_check' => $historyCheck,
             'historical_events_visible' => is_array($history),
             'canonical_history_options_exist' => ['lo_event_log_v2'=>false !== get_option('lo_event_log_v2', false), 'lo_history_migration_v2_marker'=>false !== get_option('lo_history_migration_v2_marker', false)],
             'dry_run_only' => true,
@@ -82,30 +86,45 @@ class AdminCleanup {
     public static function cleanup(): array {
         $report = self::inspect();
         if (!is_file((string)$report['canonical_filesystem_path'])) { return ['removed'=>[], 'message'=>'Canonical plugin file is missing; cleanup aborted.']; }
-        if (!version_compare((string)$report['canonical_version'], '0.3.1', '>=')) { return ['removed'=>[], 'message'=>'Canonical plugin version is below 0.3.1; cleanup aborted.']; }
-        if (empty($report['canonical_active']) || empty($report['summary_endpoint_registered']) || empty($report['historical_events_visible'])) { return ['removed'=>[], 'message'=>'Safety checks failed; cleanup aborted.']; }
-        if (function_exists('deactivate_plugins')) { deactivate_plugins(self::HELPERS, true); }
+        if (!version_compare((string)$report['canonical_version'], '0.3.2', '>=')) { return ['removed'=>[], 'message'=>'Canonical plugin version is below 0.3.1; cleanup aborted.']; }
+        if (empty($report['canonical_active']) || empty($report['summary_endpoint_registered']) || empty($report['history_endpoint_registered']) || empty($report['summary_endpoint_check']['ok']) || empty($report['history_endpoint_check']['ok']) || empty($report['historical_events_visible'])) { return ['removed'=>[], 'message'=>'Safety checks failed; cleanup aborted.']; }
+        if (function_exists('deactivate_plugins')) { deactivate_plugins(array_values(array_filter(self::HELPERS, static fn($h) => is_file(rtrim((defined('WP_PLUGIN_DIR') ? WP_PLUGIN_DIR : dirname((string)LOUSY_OUTAGES_PATH)), '/').'/'.$h))), true); }
         $pluginsDir = defined('WP_PLUGIN_DIR') ? WP_PLUGIN_DIR : dirname((string)LOUSY_OUTAGES_PATH);
         $removed = [];
         foreach (self::REMOVABLE_DIRS as $dir) {
             $path = rtrim($pluginsDir, '/').'/'.$dir;
             if (is_dir($path) && self::remove_dir($path)) { $removed[] = $dir; }
         }
-        self::write_report($report, $removed);
-        return ['removed'=>$removed, 'message'=>'Cleanup completed.'];
+        $path = self::write_report($report, $removed);
+        return ['removed'=>$removed, 'message'=>'Cleanup completed. Report: '.$path];
     }
 
     private static function remove_dir(string $dir): bool {
         $base = basename($dir);
         if (!in_array($base, self::REMOVABLE_DIRS, true)) { return false; }
+        $realBase = realpath(dirname($dir));
+        $realDir = realpath($dir);
+        if (!$realBase || !$realDir || strncmp($realDir, $realBase, strlen($realBase)) !== 0 || is_link($dir)) { return false; }
         $it = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS), \RecursiveIteratorIterator::CHILD_FIRST);
-        foreach ($it as $f) { $f->isDir() ? rmdir($f->getPathname()) : unlink($f->getPathname()); }
+        foreach ($it as $f) { if ($f->isLink()) { return false; } $f->isDir() ? rmdir($f->getPathname()) : unlink($f->getPathname()); }
         return rmdir($dir);
     }
 
-    private static function write_report(array $report, array $removed): void {
+    private static function write_report(array $report, array $removed): string {
         $uploads = wp_upload_dir();
         $dir = trailingslashit($uploads['basedir'] ?? sys_get_temp_dir());
-        file_put_contents($dir.'lousy-outages-cleanup-'.gmdate('Ymd-His').'.txt', wp_json_encode(['report'=>$report,'removed'=>$removed,'created_at'=>gmdate('c')], JSON_PRETTY_PRINT));
+        $path = $dir.'lousy-outages-cleanup-'.gmdate('Ymd-His').'.txt';
+        file_put_contents($path, wp_json_encode(['report'=>$report,'removed'=>$removed,'created_at'=>gmdate('c')], JSON_PRETTY_PRINT));
+        return $path;
+    }
+
+    private static function check_rest_route(string $route): array {
+        if (!function_exists('rest_do_request') || !class_exists('WP_REST_Request')) { return ['ok'=>false,'status'=>0,'message'=>'REST unavailable']; }
+        $request = new \WP_REST_Request('GET', $route);
+        $response = rest_do_request($request);
+        $status = method_exists($response, 'get_status') ? (int)$response->get_status() : 0;
+        $data = method_exists($response, 'get_data') ? $response->get_data() : null;
+        $validHistory = $route !== '/lousy-outages/v1/history' || (is_array($data) && isset($data['providers']) && is_array($data['providers']));
+        return ['ok'=>$status === 200 && is_array($data) && $validHistory,'status'=>$status,'empty_history_valid'=>$route === '/lousy-outages/v1/history' ? $validHistory : null];
     }
 }

--- a/lousy-outages/includes/Api.php
+++ b/lousy-outages/includes/Api.php
@@ -60,8 +60,8 @@ class Api {
             'lousy-outages/v1',
             '/refresh',
             [
-                'methods'             => ['POST', 'GET'],
-                'permission_callback' => '__return_true',
+                'methods'             => 'POST',
+                'permission_callback' => [self::class, 'verify_nonce'],
                 'callback'            => [self::class, 'handle_refresh'],
             ]
         );
@@ -317,7 +317,12 @@ class Api {
      * Trigger a manual refresh of provider statuses.
      */
     public static function handle_refresh(WP_REST_Request $request): WP_REST_Response {
-        $result = \lousy_outages_refresh_data(true);
+        $rateKey = 'lo_manual_refresh_' . get_current_user_id();
+        if (get_transient($rateKey)) {
+            return new WP_REST_Response(['ok'=>false,'message'=>'Manual refresh rate limit exceeded.'], 429);
+        }
+        set_transient($rateKey, 1, 2 * MINUTE_IN_SECONDS);
+        $result = \lousy_outages_refresh_official_providers(true);
         $skipped = !empty($result['skipped']);
         $ok      = !empty($result['ok']);
 
@@ -401,9 +406,6 @@ class Api {
         $filters       = self::sanitize_provider_list(is_string($providerParam) ? $providerParam : null);
 
         $snapshot = \lousy_outages_get_snapshot(false);
-        if (empty($snapshot['providers'])) {
-            $snapshot = \lousy_outages_get_snapshot(true);
-        }
 
         $providers = isset($snapshot['providers']) && is_array($snapshot['providers']) ? array_values($snapshot['providers']) : [];
         $providers = array_map(static function ($provider) {
@@ -440,7 +442,8 @@ class Api {
                 'trending' => !empty($trending['trending']),
             ];
         } else {
-            $meta = self::build_summary_meta($providers);
+            $current_state = isset($snapshot['current_state']) && is_array($snapshot['current_state']) ? $snapshot['current_state'] : (function_exists('lousy_outages_current_state_from_snapshot') ? \lousy_outages_current_state_from_snapshot($snapshot) : []);
+            $meta = isset($current_state['meta']) && is_array($current_state['meta']) ? $current_state['meta'] : self::build_summary_meta($providers);
             $currentOfficialIds = array_fill_keys((array) ($meta['current_official_provider_ids'] ?? []), true);
             $filterOfficialCorroboration = static function (array $items) use ($currentOfficialIds): array {
                 return array_values(array_filter($items, static function ($item) use ($currentOfficialIds): bool {
@@ -455,6 +458,7 @@ class Api {
                 'trending'   => $trending,
                 'source'     => $source,
                 'meta'       => $meta,
+                'current_state' => $current_state,
             ];
             if (!empty($errors)) {
                 $payload['errors'] = $errors;
@@ -534,8 +538,8 @@ class Api {
 
         $last_refresh_local = $last_refresh_epoch > 0 ? wp_date('c', $last_refresh_epoch) : null;
 
-        $next_refresh      = wp_next_scheduled('lousy_outages_cron_refresh');
-        $next_alert_run    = wp_next_scheduled('lousy_outages_refresh');
+        $next_refresh      = wp_next_scheduled('lousy_outages_refresh_official_providers');
+        $next_alert_run    = null;
         $next_daily_digest = wp_next_scheduled('lo_send_daily_digest');
 
         $payload = [

--- a/lousy-outages/includes/Cron.php
+++ b/lousy-outages/includes/Cron.php
@@ -13,15 +13,14 @@ if (! function_exists('lo_cron_bootstrap')) {
     function lo_cron_bootstrap(): void
     {
         add_filter('cron_schedules', 'lo_register_snapshot_schedule');
-        add_action('init', 'lo_ensure_snapshot_schedule');
-        add_action('lo_refresh_snapshot', 'lo_run_snapshot_refresh');
+        // 0.3.2: legacy snapshot cron is intentionally not scheduled; canonical provider refresh writes both snapshots.
     }
 }
 
 if (! function_exists('lo_cron_activate')) {
     function lo_cron_activate(): void
     {
-        lo_ensure_snapshot_schedule();
+        wp_clear_scheduled_hook('lo_refresh_snapshot');
     }
 }
 
@@ -64,9 +63,7 @@ if (! function_exists('lo_snapshot_interval_seconds')) {
 if (! function_exists('lo_ensure_snapshot_schedule')) {
     function lo_ensure_snapshot_schedule(): void
     {
-        if (! wp_next_scheduled('lo_refresh_snapshot')) {
-            wp_schedule_event(time() + 30, 'lo_snapshot_interval', 'lo_refresh_snapshot');
-        }
+        wp_clear_scheduled_hook('lo_refresh_snapshot');
     }
 }
 

--- a/lousy-outages/includes/Cron/Refresh.php
+++ b/lousy-outages/includes/Cron/Refresh.php
@@ -11,8 +11,7 @@ class Refresh
     {
         add_filter('cron_schedules', [self::class, 'registerSchedule']);
         add_action('init', [self::class, 'ensureScheduled']);
-        add_action('lousy_outages_cron_refresh', '\\lousy_outages_refresh_data');
-        add_action('lousy_outages_refresh', [IncidentAlerts::class, 'run']);
+        add_action('lousy_outages_refresh_official_providers', '\\lousy_outages_refresh_official_providers');
         add_action('lo_send_daily_digest', [IncidentAlerts::class, 'send_daily_digest']);
     }
 
@@ -45,12 +44,11 @@ class Refresh
 
     public static function ensureScheduled(): void
     {
-        if (! wp_next_scheduled('lousy_outages_cron_refresh')) {
-            wp_schedule_event(time() + MINUTE_IN_SECONDS, 'lousy_outages_15min', 'lousy_outages_cron_refresh');
+        foreach (['lousy_outages_poll','lousy_outages_cron_refresh','lousy_outages_refresh','lo_check_statuses','lo_refresh_snapshot'] as $hook) {
+            wp_clear_scheduled_hook($hook);
         }
-
-        if (! wp_next_scheduled('lousy_outages_refresh')) {
-            wp_schedule_event(time() + MINUTE_IN_SECONDS, 'five_minutes', 'lousy_outages_refresh');
+        if (! wp_next_scheduled('lousy_outages_refresh_official_providers')) {
+            wp_schedule_event(time() + MINUTE_IN_SECONDS, 'lousy_outages_15min', 'lousy_outages_refresh_official_providers');
         }
 
         $target = self::nextDigestTimestamp();

--- a/lousy-outages/includes/IncidentAlerts.php
+++ b/lousy-outages/includes/IncidentAlerts.php
@@ -64,10 +64,7 @@ class IncidentAlerts {
     }
 
     public static function ensure_schedule(): void {
-        if (!wp_next_scheduled('lo_check_statuses')) {
-            wp_schedule_event(time() + 60, 'lo_five_minutes', 'lo_check_statuses');
-            do_action('lousy_outages_log', 'cron_scheduled', ['hook' => 'lo_check_statuses']);
-        }
+        wp_clear_scheduled_hook('lo_check_statuses');
     }
 
     public static function maybe_trigger_fallback(): void {
@@ -91,8 +88,7 @@ class IncidentAlerts {
             return;
         }
 
-        wp_schedule_single_event(time() + 60, 'lo_check_statuses');
-        do_action('lousy_outages_log', 'cron_fallback_scheduled', ['hook' => 'lo_check_statuses']);
+        // Alerts consume the canonical snapshot and are no longer scheduled as a provider-fetch fallback.
     }
 
     public static function register_routes(): void {
@@ -534,21 +530,7 @@ class IncidentAlerts {
     public static function collect_incidents(): array {
         $combined = [];
 
-        foreach (self::collect_from_registered_sources() as $incident) {
-            $normalized = self::normalize_incident($incident);
-            if ($normalized instanceof Incident) {
-                $combined[$normalized->provider . '|' . $normalized->id] = $normalized;
-            }
-        }
-
         foreach (self::collect_from_snapshot() as $incident) {
-            $normalized = self::normalize_incident($incident);
-            if ($normalized instanceof Incident) {
-                $combined[$normalized->provider . '|' . $normalized->id] = $normalized;
-            }
-        }
-
-        foreach (self::collect_from_legacy_feeds() as $incident) {
             $normalized = self::normalize_incident($incident);
             if ($normalized instanceof Incident) {
                 $combined[$normalized->provider . '|' . $normalized->id] = $normalized;

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -3,7 +3,7 @@ declare( strict_types=1 );
 /**
  * Plugin Name: Lousy Outages
  * Description: WordPress-native outage intelligence, community reporting, and early-warning signals for third-party service dependencies.
- * Version: 0.3.1
+ * Version: 0.3.2
  * Author: Suzy Easton
  * Text Domain: lousy-outages
  */
@@ -24,10 +24,10 @@ if ( defined( 'LOUSY_OUTAGES_DISABLE' ) && LOUSY_OUTAGES_DISABLE ) {
 }
 
 if ( ! defined( 'LOUSY_OUTAGES_VERSION' ) ) {
-    define( 'LOUSY_OUTAGES_VERSION', '0.3.1' );
+    define( 'LOUSY_OUTAGES_VERSION', '0.3.2' );
 }
 if ( ! defined( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION' ) ) {
-    define( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION', 3 );
+    define( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION', 4 );
 }
 if ( ! defined( 'LOUSY_OUTAGES_FILE' ) ) {
     define( 'LOUSY_OUTAGES_FILE', __FILE__ );
@@ -149,19 +149,8 @@ add_action(
  * Schedule polling event on activation and create page.
  */
 function lousy_outages_activate() {
-    if ( ! wp_next_scheduled( 'lousy_outages_poll' ) ) {
-        $interval = (int) get_option( 'lousy_outages_interval', 300 );
-        wp_schedule_event( time() + 60, 'lousy_outages_interval', 'lousy_outages_poll' );
-    }
-    if ( ! wp_next_scheduled( 'lousy_outages_cron_refresh' ) ) {
-        wp_schedule_event( time() + MINUTE_IN_SECONDS, 'lousy_outages_15min', 'lousy_outages_cron_refresh' );
-    }
-    if ( ! wp_next_scheduled( 'lo_check_statuses' ) ) {
-        wp_schedule_event( time() + 60, 'lo_five_minutes', 'lo_check_statuses' );
-    }
-    if ( function_exists( 'lo_cron_activate' ) ) {
-        lo_cron_activate();
-    }
+    lousy_outages_upgrade_032_runtime();
+    lousy_outages_schedule_canonical_refresh();
     lousy_outages_create_page();
     lousy_outages_maybe_install_schema( true );
     ( new \SuzyEaston\LousyOutages\Storage\HistoryStore() )->migrate();
@@ -176,6 +165,34 @@ function lousy_outages_activate() {
     }
 }
 register_activation_hook( __FILE__, 'lousy_outages_activate' );
+
+function lousy_outages_schedule_canonical_refresh(): void {
+    if ( ! wp_next_scheduled( 'lousy_outages_refresh_official_providers' ) ) {
+        wp_schedule_event( time() + MINUTE_IN_SECONDS, 'lousy_outages_15min', 'lousy_outages_refresh_official_providers' );
+    }
+}
+
+function lousy_outages_upgrade_032_runtime(): void {
+    foreach ( [ 'lousy_outages_poll', 'lousy_outages_cron_refresh', 'lousy_outages_refresh', 'lo_check_statuses', 'lo_refresh_snapshot' ] as $hook ) {
+        wp_clear_scheduled_hook( $hook );
+    }
+    foreach ( [ 'lo_diag_public_chatter', 'lo_diag_hacker_news_chatter', 'lousy_outages_last_external_collection', 'lousy_outages_signal_engine_last_fused', 'lo_diag_cloudflare_radar', 'lo_diag_synthetic_canary', 'lo_diag_canadian_infrastructure_watch' ] as $key ) {
+        delete_option( $key );
+        delete_transient( $key );
+    }
+    update_option( 'lousy_outages_runtime_version', LOUSY_OUTAGES_VERSION, false );
+    lousy_outages_schedule_canonical_refresh();
+}
+add_action( 'init', static function (): void {
+    if ( version_compare( (string) get_option( 'lousy_outages_runtime_version', '0.0.0' ), '0.3.2', '<' ) ) {
+        lousy_outages_upgrade_032_runtime();
+    }
+}, 3 );
+add_action( 'lousy_outages_refresh_official_providers', 'lousy_outages_refresh_official_providers' );
+function lousy_outages_refresh_official_providers( bool $bypass_cache = true ): array {
+    return lousy_outages_refresh_data( $bypass_cache );
+}
+
 
 function lousy_outages_maybe_install_schema( bool $force = false ): void {
     $schema_version = ExternalSignals::SCHEMA_VERSION;
@@ -217,13 +234,13 @@ add_action( 'init', static function (): void {
  * Clear cron on deactivation.
  */
 function lousy_outages_deactivate() {
+    wp_clear_scheduled_hook( 'lousy_outages_refresh_official_providers' );
     wp_clear_scheduled_hook( 'lousy_outages_poll' );
     wp_clear_scheduled_hook( 'lousy_outages_cron_refresh' );
+    wp_clear_scheduled_hook( 'lousy_outages_refresh' );
     wp_clear_scheduled_hook( 'lo_check_statuses' );
     Subscriptions::clear_schedule();
-    if ( function_exists( 'lo_cron_deactivate' ) ) {
-        lo_cron_deactivate();
-    }
+    wp_clear_scheduled_hook( 'lo_refresh_snapshot' );
     if ( function_exists( 'flush_rewrite_rules' ) ) {
         flush_rewrite_rules( false );
     }
@@ -527,6 +544,10 @@ function lousy_outages_refresh_data( bool $bypass_cache = true ): array {
         }
 
         $snapshot  = lousy_outages_refresh_snapshot( $states, $timestamp_iso, 'live' );
+        if ( class_exists( '\\SuzyEaston\\LousyOutages\\IncidentAlerts' ) && method_exists( '\\SuzyEaston\\LousyOutages\\IncidentAlerts', 'collect_from_snapshot' ) ) {
+            $incidents_for_history = \SuzyEaston\LousyOutages\IncidentAlerts::collect_from_snapshot();
+            ( new \SuzyEaston\LousyOutages\Storage\IncidentStore() )->persistIncidents( $incidents_for_history );
+        }
         $providers = isset( $snapshot['providers'] ) && is_array( $snapshot['providers'] ) ? $snapshot['providers'] : [];
         $trending  = isset( $snapshot['trending'] ) && is_array( $snapshot['trending'] ) ? $snapshot['trending'] : [ 'trending' => false, 'signals' => [] ];
 
@@ -552,6 +573,7 @@ function lousy_outages_refresh_data( bool $bypass_cache = true ): array {
             'errors'       => $errors,
             'trending'     => $trending,
             'quality'      => $quality,
+            'current_state'=> isset( $snapshot['current_state'] ) && is_array( $snapshot['current_state'] ) ? $snapshot['current_state'] : lousy_outages_current_state_from_snapshot( $snapshot ),
             'source'       => ! empty( $quality['ok'] ) ? 'live' : 'last_good_with_errors',
             'refreshedAt'  => $timestamp_iso,
             'refreshed_at' => $timestamp_epoch,
@@ -650,6 +672,7 @@ function lousy_outages_filter_snapshot( array $snapshot ): array {
 
     $allowed = array_fill_keys( array_keys( $enabled ), true );
 
+    $original_provider_count = count( $providers );
     $snapshot['providers'] = array_values(
         array_filter(
             $providers,
@@ -669,7 +692,9 @@ function lousy_outages_filter_snapshot( array $snapshot ): array {
         )
     );
 
-    $snapshot['trending'] = ( new \SuzyEaston\LousyOutages\Trending() )->evaluate( $snapshot['providers'] );
+    if ( count( $snapshot['providers'] ) !== $original_provider_count || ! isset( $snapshot['trending'] ) ) {
+        $snapshot['trending'] = ( new \SuzyEaston\LousyOutages\Trending() )->evaluate( $snapshot['providers'] );
+    }
 
     return $snapshot;
 }
@@ -733,17 +758,104 @@ function lousy_outages_update_aws_snapshot_diagnostic( array $snapshot ): void {
     }
 }
 
+
+function lousy_outages_signal_freshness_seconds(): int {
+    return (int) apply_filters( 'lousy_outages_signal_freshness_seconds', 45 * MINUTE_IN_SECONDS );
+}
+
+function lousy_outages_provider_timestamp( array $provider ): int {
+    foreach ( [ 'checked_at', 'checkedAt', 'fetched_at', 'updated_at', 'updatedAt', 'last_successful_at' ] as $field ) {
+        if ( ! empty( $provider[ $field ] ) ) {
+            $ts = strtotime( (string) $provider[ $field ] );
+            if ( $ts ) { return (int) $ts; }
+        }
+    }
+    return 0;
+}
+
+function lousy_outages_current_state_from_snapshot( array $snapshot ): array {
+    $providers = isset( $snapshot['providers'] ) && is_array( $snapshot['providers'] ) ? array_values( $snapshot['providers'] ) : [];
+    $now = time();
+    $fresh_window = lousy_outages_signal_freshness_seconds();
+    $outages = [];
+    $signals = [];
+    $unverified = [];
+    $operational = [];
+    $current_provider_ids = [];
+    foreach ( $providers as $provider ) {
+        if ( ! is_array( $provider ) ) { continue; }
+        $provider_id = sanitize_key( (string) ( $provider['id'] ?? $provider['provider'] ?? $provider['name'] ?? '' ) );
+        $provider['provider_id'] = $provider_id;
+        $verification = strtolower( (string) ( $provider['verification_status'] ?? '' ) );
+        $is_stale = ! empty( $provider['is_stale'] );
+        $status = strtolower( (string) ( $provider['stateCode'] ?? $provider['status'] ?? 'unknown' ) );
+        if ( in_array( $verification, [ 'failed', 'unknown' ], true ) || ( 'unknown' === $status && ! $is_stale ) ) {
+            $provider['lane'] = 'unverified';
+            $provider['stale_label'] = $is_stale ? 'Delayed provider data' : 'Could not verify provider status';
+            $unverified[] = $provider;
+            continue;
+        }
+        if ( $is_stale ) {
+            $provider['lane'] = 'unverified';
+            $provider['stale_label'] = 'Delayed provider data; showing bounded last-known-good context.';
+            $unverified[] = $provider;
+            continue;
+        }
+        $current_incidents = class_exists( '\\SuzyEaston\\LousyOutages\\Summary' ) ? \SuzyEaston\LousyOutages\Summary::current_incidents_for_provider( $provider ) : (array) ( $provider['incidents'] ?? [] );
+        foreach ( $current_incidents as $incident ) {
+            if ( ! is_array( $incident ) ) { continue; }
+            $record = $incident;
+            $record['provider_id'] = $provider_id;
+            $record['provider'] = (string) ( $provider['name'] ?? $provider['provider'] ?? $provider_id );
+            $record['provider_url'] = (string) ( $provider['url'] ?? $provider['link'] ?? '' );
+            $outages[] = $record;
+            if ( '' !== $provider_id ) { $current_provider_ids[] = $provider_id; }
+        }
+        if ( $current_incidents ) { continue; }
+        $tile_kind = strtolower( (string) ( $provider['tile_kind'] ?? $provider['tileKind'] ?? '' ) );
+        $ts = lousy_outages_provider_timestamp( $provider );
+        $fresh = $ts > 0 && ( $now - $ts ) <= $fresh_window;
+        if ( 'signal' === $tile_kind && $fresh ) {
+            $provider['lane'] = 'signals';
+            $provider['fresh_until'] = gmdate( 'c', $ts + $fresh_window );
+            $signals[] = $provider;
+        } else {
+            $provider['lane'] = 'operational';
+            $operational[] = $provider;
+        }
+    }
+    return [
+        'outages' => array_values( $outages ),
+        'signals' => array_values( $signals ),
+        'unverified' => array_values( $unverified ),
+        'operational' => array_values( $operational ),
+        'meta' => [
+            'active_outage_count' => count( $outages ),
+            'signal_count' => count( $signals ),
+            'unverified_count' => count( $unverified ),
+            'operational_count' => count( $operational ),
+            'generated_at' => gmdate( 'c' ),
+            'freshness_window_seconds' => $fresh_window,
+            'current_official_provider_ids' => array_values( array_unique( $current_provider_ids ) ),
+        ],
+    ];
+}
+
 function lousy_outages_store_snapshot( array $snapshot ): void {
     $cache_key = lousy_outages_snapshot_cache_key();
     $ttl       = (int) apply_filters( 'lousy_outages_snapshot_ttl', 5 * MINUTE_IN_SECONDS );
+    $snapshot['current_state'] = lousy_outages_current_state_from_snapshot( $snapshot );
     set_transient( $cache_key, $snapshot, max( 60, $ttl ) );
     update_option( 'lousy_outages_snapshot', $snapshot, false );
+    update_option( 'lousy_outages_current_state', $snapshot['current_state'], false );
     lousy_outages_update_aws_snapshot_diagnostic( $snapshot );
 }
 
 function lousy_outages_refresh_snapshot( array $states, string $timestamp, string $source = 'snapshot' ): array {
     $snapshot = lousy_outages_build_snapshot( $states, $timestamp, $source );
     lousy_outages_store_snapshot( $snapshot );
+    $stored_snapshot = get_option( 'lousy_outages_snapshot', $snapshot );
+    if ( is_array( $stored_snapshot ) ) { $snapshot = $stored_snapshot; }
 
     if ( function_exists( 'lo_snapshot_store' ) && function_exists( 'lo_snapshot_normalize_service' ) ) {
         $services = [];
@@ -861,8 +973,8 @@ function lousy_outages_get_snapshot( bool $force_refresh = false ): array {
 
     $store  = new Store();
     $states = $store->get_all();
-    if ( empty( $states ) ) {
-        $states = lousy_outages_collect_statuses( $force_refresh );
+    if ( ! $force_refresh && empty( $states ) ) {
+        return is_array( $stored ) ? lousy_outages_filter_snapshot( $stored ) : [];
     }
 
     $timestamp = get_option( 'lousy_outages_last_poll' );

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -389,21 +389,9 @@ function render_shortcode(): string {
     $config['initial']['source']    = $source;
     $config['initial']['errors']    = $snapshot_errors;
 
-    $build_meta_counts = static function (array $providers): array {
-        $current = \SuzyEaston\LousyOutages\Summary::current_provider_tiles($providers);
-        $counts = ['active_outage_count'=>0,'signal_count'=>0,'unverified_count'=>0,'generated_at'=>gmdate('c'),'current_official_provider_ids'=>[]];
-        foreach ($current as $provider) {
-            if (!is_array($provider)) { continue; }
-            $tile_kind = strtolower((string) ($provider['tile_kind'] ?? $provider['tileKind'] ?? ''));
-            $provider_id = sanitize_key((string) ($provider['id'] ?? $provider['provider'] ?? $provider['name'] ?? ''));
-            if ('outage' === $tile_kind && !empty($provider['incidents'])) { $counts['active_outage_count'] += 1; if ($provider_id !== '') { $counts['current_official_provider_ids'][] = $provider_id; } }
-            elseif ('signal' === $tile_kind) { $counts['signal_count'] += 1; }
-        }
-        $counts['current_official_provider_ids'] = array_values(array_unique($counts['current_official_provider_ids']));
-        return $counts;
-    };
-
-    $meta_counts = $build_meta_counts($config['initial']['providers']);
+    $current_state = function_exists('lousy_outages_current_state_from_snapshot') ? \lousy_outages_current_state_from_snapshot(['providers' => $config['initial']['providers']]) : [];
+    $meta_counts = isset($current_state['meta']) && is_array($current_state['meta']) ? $current_state['meta'] : ['active_outage_count'=>0,'signal_count'=>0,'unverified_count'=>0,'generated_at'=>gmdate('c')];
+    $config['initial']['current_state'] = $current_state;
     $config['meta'] = $meta_counts;
     $config['initial']['meta'] = $meta_counts;
 
@@ -721,7 +709,7 @@ function render_shortcode(): string {
                 <div class="lo-grid lo-grid--section" data-lo-section-grid="unverified" hidden></div>
             </section>
         </div>
-        <section class="lo-corroboration-radar lo-chatter-scanner" data-lo-chatter-scanner>
+        <?php if (false) : ?><section class="lo-corroboration-radar lo-chatter-scanner" data-lo-chatter-scanner>
             <div class="lo-corroboration-radar__head">
                 <div>
                     <h3 class="lo-block-title">CORROBORATION RADAR</h3>
@@ -840,6 +828,7 @@ function render_shortcode(): string {
             <?php endif; ?>
             <footer class="lo-corroboration-radar__footer">Scanner idle. Official radar remains primary.</footer>
         </section>
+        <?php endif; ?>
         <?php if (LO_SHOW_WIDESPREAD) : ?>
         <div class="lo-trending" data-lo-trending<?php echo $trending_active ? '' : ' hidden'; ?> data-lo-trending-generated="<?php echo esc_attr($trending_generated); ?>" aria-live="assertive">
             <span class="lo-trending__icon" aria-hidden="true">⚡</span>
@@ -852,9 +841,9 @@ function render_shortcode(): string {
         <div class="lo-hero" data-lo-hero hidden>
             <article class="lo-card lo-card--hero">
                 <div class="lo-head">
-                    <h3 class="lo-title">No official active incidents</h3>
+                    <h3 class="lo-title">No confirmed incidents in the saved provider snapshot</h3>
                 </div>
-                <p class="lo-summary">Public signals are being watched.</p>
+                <p class="lo-summary">Official provider feeds are checked by the scheduled refresh; emerging signals and verification delays appear above when present.</p>
                 <p class="lo-card-meta">Last checked: <span data-lo-hero-time>—</span></p>
             </article>
         </div>

--- a/scripts/build-lousy-outages-release.sh
+++ b/scripts/build-lousy-outages-release.sh
@@ -4,7 +4,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SRC="$ROOT/lousy-outages"
 DIST="$ROOT/dist"
 ZIP="$DIST/lousy-outages.zip"
-VERSION="0.3.1"
+VERSION="0.3.2"
 PLUGIN_HEADER="Plugin Name: Lousy"$' '"Outages"
 rm -rf "$DIST/.lousy-outages-build" "$ZIP" "$ZIP.sha256" "$DIST/release-manifest.json"
 mkdir -p "$DIST/.lousy-outages-build/lousy-outages" "$DIST"
@@ -17,13 +17,13 @@ rsync -a --delete \
 mapfile -t entries < <(zipinfo -1 "$ZIP")
 printf '%s\n' "${entries[@]}" | grep -qx 'lousy-outages/lousy-outages.php'
 ! printf '%s\n' "${entries[@]}" | grep -qx 'lousy-outages/lousy-outages/lousy-outages.php'
-! printf '%s\n' "${entries[@]}" | grep -q '^lousy-outages-0\.3\.1/'
+! printf '%s\n' "${entries[@]}" | grep -q '^lousy-outages-0\.3\.2/'
 count=0; tmp="$DIST/.lousy-outages-build/check"; rm -rf "$tmp"; mkdir -p "$tmp"; unzip -q "$ZIP" -d "$tmp"
 while IFS= read -r -d '' f; do grep -q "$PLUGIN_HEADER" "$f" && count=$((count+1)) || true; done < <(find "$tmp" -type f -print0)
 [ "$count" -eq 1 ]
 for bad in '.ea-php-cli.cache' 'tests/' 'recovery' 'diagnostic' '\\'; do ! printf '%s\n' "${entries[@]}" | grep -qiF "$bad"; done
-grep -Eq '^ \* Version: 0\.3\.1$' "$tmp/lousy-outages/lousy-outages.php"
-grep -Eq "define\( 'LOUSY_OUTAGES_VERSION', '0\.3\.1' \);" "$tmp/lousy-outages/lousy-outages.php"
+grep -Eq '^ \* Version: 0\.3\.2$' "$tmp/lousy-outages/lousy-outages.php"
+grep -Eq "define\( 'LOUSY_OUTAGES_VERSION', '0\.3\.2' \);" "$tmp/lousy-outages/lousy-outages.php"
 sha256sum "$ZIP" | awk '{print $1"  lousy-outages.zip"}' > "$ZIP.sha256"
 sha=$(awk '{print $1}' "$ZIP.sha256")
 commit=$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || echo unknown)

--- a/tests/lousy-outages/current-state-contract-test.php
+++ b/tests/lousy-outages/current-state-contract-test.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+if (!defined('ABSPATH')) define('ABSPATH', __DIR__ . '/../../');
+if (!defined('MINUTE_IN_SECONDS')) define('MINUTE_IN_SECONDS', 60);
+if (!defined('HOUR_IN_SECONDS')) define('HOUR_IN_SECONDS', 3600);
+if (!defined('DAY_IN_SECONDS')) define('DAY_IN_SECONDS', 86400);
+foreach (['add_action','add_filter','register_activation_hook','register_deactivation_hook','add_shortcode'] as $fn) { if (!function_exists($fn)) { eval('function '.$fn.'(...$a){}'); } }
+if (!function_exists('apply_filters')) { function apply_filters($tag,$value){ return $value; } }
+if (!function_exists('plugin_dir_path')) { function plugin_dir_path($f){ return dirname($f).'/'; } }
+if (!function_exists('plugin_dir_url')) { function plugin_dir_url($f){ return 'https://example.test/'; } }
+if (!function_exists('wp_next_scheduled')) { function wp_next_scheduled(){ return false; } }
+if (!function_exists('wp_schedule_event')) { function wp_schedule_event(){ return true; } }
+if (!function_exists('wp_clear_scheduled_hook')) { function wp_clear_scheduled_hook(){} }
+if (!function_exists('wp_date')) { function wp_date($f,$t=null){ return gmdate($f,$t?:time()); } }
+if (!function_exists('sanitize_key')) { function sanitize_key($v){ return preg_replace('/[^a-z0-9_\-]/','',strtolower((string)$v)) ?: ''; } }
+if (!function_exists('wp_json_encode')) { function wp_json_encode($v){ return json_encode($v); } }
+if (!function_exists('get_option')) { function get_option($k,$d=null){ return $GLOBALS['lo_options'][$k] ?? $d; } }
+if (!function_exists('update_option')) { function update_option($k,$v,$a=null){ $GLOBALS['lo_options'][$k]=$v; return true; } }
+if (!function_exists('get_transient')) { function get_transient($k){ return $GLOBALS['lo_transients'][$k] ?? false; } }
+if (!function_exists('set_transient')) { function set_transient($k,$v,$ttl=0){ $GLOBALS['lo_transients'][$k]=$v; return true; } }
+if (!function_exists('delete_transient')) { function delete_transient($k){ unset($GLOBALS['lo_transients'][$k]); } }
+if (!function_exists('__')) { function __($v){ return $v; } }
+if (!function_exists('esc_html__')) { function esc_html__($v){ return $v; } }
+require __DIR__ . '/../../lousy-outages/lousy-outages.php';
+function assert_true($c,$m){ if(!$c){ fwrite(STDERR,"FAIL: $m\n"); exit(1);} }
+$now = gmdate('c'); $old = gmdate('c', time() - 2 * HOUR_IN_SECONDS);
+$snapshot = ['providers'=>[
+ ['id'=>'one','name'=>'One','stateCode'=>'degraded','tile_kind'=>'outage','verification_status'=>'verified','checked_at'=>$now,'incidents'=>[
+  ['id'=>'i1','title'=>'First','status'=>'investigating','updatedAt'=>$now],
+  ['id'=>'i2','title'=>'Second','status'=>'identified','updatedAt'=>$now],
+  ['id'=>'i3','title'=>'Resolved','status'=>'resolved','updatedAt'=>$now],
+ ]],
+ ['id'=>'sig','name'=>'Signal','stateCode'=>'degraded','tile_kind'=>'signal','verification_status'=>'verified','checked_at'=>$now,'incidents'=>[]],
+ ['id'=>'fail','name'=>'Fail','stateCode'=>'unknown','verification_status'=>'failed','error'=>'timeout','checked_at'=>$now,'incidents'=>[]],
+ ['id'=>'stale','name'=>'Stale','stateCode'=>'degraded','tile_kind'=>'signal','verification_status'=>'verified','checked_at'=>$old,'incidents'=>[]],
+ ['id'=>'ok','name'=>'Okay','stateCode'=>'operational','verification_status'=>'verified','checked_at'=>$now,'incidents'=>[]],
+]];
+$state = lousy_outages_current_state_from_snapshot($snapshot);
+assert_true(count($state['outages'])===2, 'one provider with two active incidents yields two outage records');
+assert_true(count($state['signals'])===1, 'fresh provider signal counted once');
+assert_true(count($state['unverified'])===1, 'failed provider is unverified');
+assert_true($state['meta']['active_outage_count']===2 && $state['meta']['signal_count']===1 && $state['meta']['unverified_count']===1, 'meta counts match lanes');
+assert_true(count($state['outages']) + count($state['signals']) === $state['meta']['active_outage_count'] + $state['meta']['signal_count'], 'homepage count parity');
+echo "OK\n";

--- a/tests/lousy-outages/wp-install-upgrade-architecture-test.php
+++ b/tests/lousy-outages/wp-install-upgrade-architecture-test.php
@@ -7,23 +7,23 @@ $fail = static function(string $m): void { fwrite(STDERR, "FAIL: $m\n"); exit(1)
 $entryList = explode("\n", trim(shell_exec('zipinfo -1 '.escapeshellarg($zip)) ?: ''));
 if (!in_array('lousy-outages/lousy-outages.php', $entryList, true)) $fail('main file missing');
 if (in_array('lousy-outages/lousy-outages/lousy-outages.php', $entryList, true)) $fail('nested main file present');
-foreach ($entryList as $e) { if (preg_match('/(^|\/)lousy-outages-0\.3\.1\//', $e)) $fail('versioned dir present'); }
+foreach ($entryList as $e) { if (preg_match('/(^|\/)lousy-outages-0\.3\.2\//', $e)) $fail('versioned dir present'); }
 $tmp = sys_get_temp_dir().'/lo-wp-'.bin2hex(random_bytes(4));
 mkdir($tmp.'/wp-content/plugins', 0777, true);
 copy($zip, $tmp.'/plugin.zip');
 $install = static function($zip, $plugins) { $cmd='unzip -oq '.escapeshellarg($zip).' -d '.escapeshellarg($plugins); system($cmd, $code); return $code; };
 if ($install($zip, $tmp.'/wp-content/plugins') !== 0) $fail('clean unzip failed');
 if (!is_file($tmp.'/wp-content/plugins/lousy-outages/lousy-outages.php')) $fail('clean install path wrong');
-if (is_dir($tmp.'/wp-content/plugins/lousy-outages-0.3.1')) $fail('created versioned clean install dir');
+if (is_dir($tmp.'/wp-content/plugins/lousy-outages-0.3.2')) $fail('created versioned clean install dir');
 $main = file_get_contents($tmp.'/wp-content/plugins/lousy-outages/lousy-outages.php');
-if (!preg_match('/Version:\s*0\.3\.1/', $main)) $fail('header version not 0.3.1');
+if (!preg_match('/Version:\s*0\.3\.2/', $main)) $fail('header version not 0.3.2');
 $plugins = $tmp.'/upgrade/wp-content/plugins'; mkdir($plugins.'/lousy-outages', 0777, true);
 file_put_contents($plugins.'/lousy-outages/lousy-outages.php', "<?php\n/*\nPlugin Name: ' . 'Lousy Outages\nVersion: 0.3.0\n*/\n");
 foreach (['lousy-outages-0.3.0','lousy-outages-recovery-updater-v2','lousy-outages-activation-diagnostics'] as $d) mkdir($plugins.'/'.$d, 0777, true);
 if ($install($zip, $plugins) !== 0) $fail('upgrade unzip failed');
 if (!is_file($plugins.'/lousy-outages/lousy-outages.php')) $fail('upgrade path wrong');
 if (is_file($plugins.'/lousy-outages/lousy-outages/lousy-outages.php')) $fail('nested upgrade path introduced');
-if (is_dir($plugins.'/lousy-outages-0.3.1')) $fail('created versioned upgrade dir');
+if (is_dir($plugins.'/lousy-outages-0.3.2')) $fail('created versioned upgrade dir');
 $historyOptions = ['lo_event_log','lo_event_log_compacted_v1','lousy_outages_history','lousy_outages_log','lousy_outages_states','lo_event_log_v2','lo_history_migration_backup_v2','lo_history_migration_v2_marker'];
 if (count($historyOptions) !== 8) $fail('history fixture incomplete');
 echo json_encode(['ok'=>true,'active_plugin'=>'lousy-outages/lousy-outages.php','shortcodes_expected'=>['lousy_outages','lousy_outages_teaser'],'rest_routes_expected'=>['/lousy-outages/v1/summary','/lousy-outages/v1/history']], JSON_PRETTY_PRINT), "\n";

--- a/tests/lousy-outages/wp-real-install-test.sh
+++ b/tests/lousy-outages/wp-real-install-test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+mode="${1:-clean}"
+if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1; then
+  echo "Docker Compose is required for the real WordPress $mode test." >&2
+  exit 2
+fi
+scripts/build-lousy-outages-release.sh >/tmp/lo-build.log
+work="$(mktemp -d)"
+trap 'cd /workspace/suzyeastonca 2>/dev/null || true; docker compose -f "$work/compose.yml" down -v >/dev/null 2>&1 || true; rm -rf "$work"' EXIT
+cat > "$work/compose.yml" <<YML
+services:
+  db:
+    image: mariadb:11
+    environment:
+      MARIADB_DATABASE: wordpress
+      MARIADB_USER: wordpress
+      MARIADB_PASSWORD: wordpress
+      MARIADB_ROOT_PASSWORD: root
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+  wp:
+    image: wordpress:cli-php8.3
+    depends_on:
+      db:
+        condition: service_healthy
+    user: "33:33"
+    volumes:
+      - wp:/var/www/html
+      - ${PWD}:/repo
+    working_dir: /var/www/html
+    entrypoint: ["sh", "-c", "sleep infinity"]
+volumes:
+  wp:
+YML
+docker compose -f "$work/compose.yml" up -d --quiet-pull
+wp() { docker compose -f "$work/compose.yml" exec -T wp wp --allow-root "$@"; }
+wp core download --force
+wp config create --dbname=wordpress --dbuser=wordpress --dbpass=wordpress --dbhost=db --skip-check
+wp core install --url=http://example.test --title=LO --admin_user=admin --admin_password=password --admin_email=admin@example.test
+if [[ "$mode" == "upgrade" ]]; then
+  mkdir -p "$work/fixture/lousy-outages"
+  { printf '%s\n' '<?php'; printf '%s\n' '/* Plugin Name: Lousy Out'"ages"; printf '%s\n' 'Version: 0.3.0 */'; } > "$work/fixture/lousy-outages/lousy-outages.php"
+  docker compose -f "$work/compose.yml" cp "$work/fixture/lousy-outages" wp:/var/www/html/wp-content/plugins/lousy-outages
+  for opt in lo_event_log lo_event_log_compacted_v1 lousy_outages_history lousy_outages_log lousy_outages_states lo_event_log_v2 lo_history_migration_backup_v2 lo_history_migration_v2_marker; do wp option update "$opt" '{"seed":"preserve"}' --format=json; done
+  for hook in lousy_outages_poll lousy_outages_cron_refresh lousy_outages_refresh lo_check_statuses lo_refresh_snapshot; do wp cron event schedule "$hook" now hourly; done
+fi
+wp plugin install /repo/dist/lousy-outages.zip --force
+wp plugin activate lousy-outages
+wp plugin status lousy-outages | tee "$work/status.txt"
+wp eval 'if (plugin_basename(LOUSY_OUTAGES_FILE)!=="lousy-outages/lousy-outages.php") { exit(1); } if (LOUSY_OUTAGES_VERSION!=="0.3.2") { exit(2); } echo "version-ok\n";'
+wp eval 'do_action("init"); global $shortcode_tags; foreach (["lousy_outages","lousy_outages_teaser"] as $s) { if (empty($shortcode_tags[$s])) exit(3); } echo "shortcodes-ok\n";'
+wp eval 'do_action("rest_api_init"); $r=rest_get_server()->get_routes(); foreach (["/lousy-outages/v1/summary","/lousy-outages/v1/history"] as $route) { if (empty($r[$route])) exit(4); } echo "routes-ok\n";'
+wp eval '$s=rest_do_request(new WP_REST_Request("GET","/lousy-outages/v1/summary")); $h=rest_do_request(new WP_REST_Request("GET","/lousy-outages/v1/history")); if($s->get_status()!==200||$h->get_status()!==200) exit(5); echo "rest-ok\n";'
+wp eval '$events=_get_cron_array(); $count=0; foreach($events as $ts=>$hooks){ if(isset($hooks["lousy_outages_refresh_official_providers"])) $count += count($hooks["lousy_outages_refresh_official_providers"]); foreach(["lousy_outages_poll","lousy_outages_cron_refresh","lousy_outages_refresh","lo_check_statuses","lo_refresh_snapshot"] as $old){ if(isset($hooks[$old])) exit(6); } } if($count!==1) exit(7); echo "cron-ok\n";'
+if [[ "$mode" == "upgrade" ]]; then
+  wp eval 'foreach(["lo_event_log","lo_event_log_compacted_v1","lousy_outages_history","lousy_outages_log","lousy_outages_states","lo_event_log_v2","lo_history_migration_backup_v2","lo_history_migration_v2_marker"] as $o){ if(get_option($o)===false) exit(8); } echo "history-preserved\n";'
+  wp eval 'if (is_dir(WP_PLUGIN_DIR."/lousy-outages-0.3.2") || is_dir(WP_PLUGIN_DIR."/lousy-outages/lousy-outages")) exit(9); echo "layout-ok\n";'
+fi


### PR DESCRIPTION
### Motivation

- Multiple scheduled and ad-hoc paths were independently fetching provider feeds, writing state, and driving alerts which produced duplicated network requests, inconsistent snapshot/state, and anonymous refresh surfaces. 
- Alerting and UI sometimes refetched sources instead of consuming a single canonical snapshot, causing count and rendering divergence between homepage, dashboard and REST APIs. 
- The upgrade to 0.3.2 must preserve history and subscribers while consolidating refresh scheduling and preventing page views or anonymous GETs from initiating provider collection.

### Description

- Add a runtime audit (`docs/lousy-outages-runtime-audit.md`) and introduce one canonical provider-refresh hook `lousy_outages_refresh_official_providers` that delegates to the existing refresh service and is scheduled once via WP-Cron. 
- Consolidate refresh behavior: unschedule duplicate provider-fetch/snapshot hooks (`lousy_outages_poll`, `lousy_outages_cron_refresh`, `lousy_outages_refresh`, `lo_check_statuses`, `lo_refresh_snapshot`), persist a canonical `lousy_outages_snapshot` and compute a normalized `current_state` with lanes `outages`, `signals`, `unverified`, `operational`, and `meta`. 
- Make alerting and UI consume the saved snapshot/history only by updating `IncidentAlerts::collect_incidents()` to use snapshot data, wrapping the Corroboration Radar UI in a safe-off default, and stop allowing page render fallbacks to force provider collection. 
- Lock down manual refresh to an authenticated, nonce-protected `POST` (rate-limited) on `/lousy-outages/v1/refresh`, add an activation/upgrade routine to clear obsolete diagnostics/transients while preserving HistoryStore v2 options, bump the plugin to `0.3.2` and snapshot schema to version `4`, and harden the cleanup screen to validate REST summary/history before destructive removal. 
- Add tests and CI changes: a `current-state` contract test, a real WordPress disposable `wp-real-install-test.sh` (Docker-based) for clean install/upgrade validation, and CI workflow updates to run RSS/AWS/history/count-parity/homepage tests and require XML/SimpleXML in CI.

### Testing

- Ran repository and plugin validation: `php tests/lousy-outages/repository-architecture-test.php` (OK) and PHP lint across plugin files (OK). 
- Ran functional regressions: `php tests/lousy-outages/rss-long-running-regression.php` (OK), `php tests/lousy-outages/aws-snapshot-pipeline-regression.php` (OK), `php lousy-outages/tests/history-store-test.php` (OK), `php tests/lousy-outages/current-state-contract-test.php` (OK), and `php tests/LousyOutagesHomeTeaserTest.php` (OK). 
- Built and validated ZIP with `scripts/build-lousy-outages-release.sh` and `php tests/lousy-outages/wp-install-upgrade-architecture-test.php` (OK). 
- Added real WordPress clean/upgrade script `tests/lousy-outages/wp-real-install-test.sh` that requires Docker Compose; this script could not run in the current execution environment because Docker Compose was not available (test script present and wired into CI).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ecd3d79148331a6bfb0c8e9e04633)