### PR TITLE
Fix live parity and dashboard: canonical current-state, plugin assets, bounded history (0.3.6)

### DIFF
--- a/docs/lousy-outages-live-parity-diagnosis.md
+++ b/docs/lousy-outages-live-parity-diagnosis.md
@@ -1,0 +1,67 @@
+# Lousy Outages live parity diagnosis
+
+## Disposable environment
+
+Repository inspection started from `2106215e700a9378436121929431777aa455dc32` on branch `fix/lousy-outages-live-parity-and-dashboard`. The local disposable test harness stubs WordPress functions for contract tests; no production deployment, tag, release, or ZIP artifact was created.
+
+## Reproduction findings
+
+Production evidence reported a 0.3.4 split-brain state: the homepage rendered **5 Current Issues** while the full dashboard rendered zero incidents/signals/unverified providers, displayed **Auto-refresh degraded**, failed to display history, and still exposed an obsolete public-chatter panel. That divergence is reproducible from repository behavior before this repair because public surfaces did not all consume one read-only canonical current-state accessor.
+
+## Recorded diagnostics checklist
+
+- Plugin version: production evidence `0.3.4`; repository baseline `0.3.5`; target `0.3.6`.
+- Plugin filesystem path: expected `wp-content/plugins/lousy-outages/lousy-outages.php`.
+- Snapshot schema version: baseline `4`; target `5`.
+- Scheduled cron hooks: canonical `lousy_outages_refresh_official_providers`; legacy hooks are cleared.
+- Dashboard assets before repair: could resolve from `/wp-content/themes/.../lousy-outages/assets/` because shortcode asset discovery checked theme paths first.
+- Dashboard assets after repair: always `/wp-content/plugins/lousy-outages/assets/` via `LOUSY_OUTAGES_URL . 'assets/'`.
+- Homepage rendered issue count: production evidence `5`.
+- REST summary counts: must equal `current_state.meta` and the lengths of `outages`, `signals`, and `unverified`.
+- Dashboard rendered lane counts: must equal the same `current_state` arrays.
+- Saved snapshot counts: authoritative after validation.
+- Store/provider-state counts: no longer used by public reads to invent a fallback current state.
+- Browser console errors / failed REST requests: production evidence indicates history REST failure and degraded hydration badge.
+- History response status: required HTTP 200 for `GET /wp-json/lousy-outages/v1/history?days=30&page=1&per_page=20`.
+- LiteSpeed/page-cache evidence: summary/history routes now send no-store/no-cache headers plus a scoped LiteSpeed no-cache header.
+
+## Endpoint contract to inspect
+
+### `GET /wp-json/lousy-outages/v1/summary`
+
+Expected after repair:
+
+- HTTP status: `200`.
+- Content type: JSON from WordPress REST.
+- Response size: bounded to canonical providers/current lanes; no public-chatter diagnostics.
+- `fetched_at`: copied from saved canonical snapshot.
+- `source`: copied from saved canonical snapshot or explicit delayed source.
+- `meta`: counts exactly match lane array lengths.
+- `current_state`: includes `outages`, `signals`, `unverified`, `operational`, `providers`, `meta`, `fetched_at`, `source`, `errors`, `plugin_version`, `snapshot_schema_version`.
+- Errors: explicit if the saved snapshot is missing/invalid.
+
+### `GET /wp-json/lousy-outages/v1/history?days=30&page=1&per_page=20`
+
+Expected after repair:
+
+- HTTP status: `200`.
+- Content type: JSON from WordPress REST.
+- Response size: at most 20 returned records on page 1.
+- `fetched_at`: endpoint `generated_at` and `meta.fetchedAt`.
+- Source: dedicated retained history table when available.
+- Counts: `meta.returned_count <= per_page`; `meta.total_matching` from bounded table count.
+- Errors: endpoint should not fatal from loading a giant option first.
+
+## Root cause summary
+
+Before the repair, the homepage, dashboard SSR, REST summary, and JavaScript hydration could combine different inputs: saved snapshot, transient snapshot, Store/provider state fallback, history-derived incidents, and stale theme-copied assets. The dashboard could therefore hydrate with JavaScript that did not match the plugin PHP, while public REST reads could rebuild or fallback rather than only reading the canonical saved snapshot.
+
+## Safe production replacement sequence
+
+1. Back up the database and current `wp-content/plugins/lousy-outages` directory.
+2. Replace only the standalone plugin directory with the 0.3.6 build; do not deploy a theme copy.
+3. In WP Admin, confirm Lousy Outages Diagnostics reports plugin path under `wp-content/plugins/lousy-outages/`, version `0.3.6`, schema `5`, and plugin asset URLs.
+4. Run the canonical provider refresh once from an authenticated/admin path or WP-Cron.
+5. Purge only LiteSpeed entries for the Lousy Outages page and REST route URLs: `/lousy-outages/`, `/wp-json/lousy-outages/v1/summary`, and `/wp-json/lousy-outages/v1/history*`.
+6. Do not purge unrelated site caches automatically.
+7. Run production smoke tests for summary, history, homepage/dashboard parity, console errors, and plugin asset URL paths.

--- a/lousy-outages/assets/lousy-outages.css
+++ b/lousy-outages/assets/lousy-outages.css
@@ -2681,8 +2681,75 @@
   }
 }
 
-/* 0.3.5 layout hierarchy repair */
+/* 0.3.6 layout hierarchy repair */
 .lo-history__retry { margin-left: .5rem; }
 .lo-subscribe, .lo-report, .lo-settings, .lo-history { min-width: 0; overflow-wrap: anywhere; }
 .lo-subscribe input, .lo-subscribe select, .lo-subscribe textarea, .lo-report input, .lo-report select, .lo-report textarea { max-width: 100%; min-height: 44px; }
 @media (max-width: 720px) { .lo-history__heading, .lo-history__controls { display: grid; grid-template-columns: 1fr; gap: .75rem; } .lo-subscribe form, .lo-report form { display: grid; grid-template-columns: 1fr; } }
+
+/* 0.3.6 operations-console hierarchy */
+.lousy-outages {
+  max-width: 1180px;
+  margin-inline: auto;
+}
+.lo-hero,
+.lo-current,
+.lo-history,
+.lo-providers {
+  border: 1px solid rgba(44, 255, 199, 0.32);
+  background: linear-gradient(135deg, rgba(4, 15, 28, 0.96), rgba(7, 24, 33, 0.92));
+  box-shadow: 0 0 0 1px rgba(127, 255, 0, 0.08), 0 18px 45px rgba(0, 0, 0, 0.35);
+}
+.lo-hero {
+  display: grid;
+  gap: 1rem;
+  padding: clamp(1rem, 3vw, 1.7rem);
+}
+.lo-hero__metrics,
+.lo-current__lanes,
+.lo-provider-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: clamp(.75rem, 2vw, 1rem);
+}
+.lo-current [data-lo-lane="outages"] { border-color: rgba(255, 77, 166, .46); }
+.lo-current [data-lo-lane="signals"] { border-color: rgba(255, 224, 138, .46); }
+.lo-current [data-lo-lane="unverified"] { border-color: rgba(84, 209, 255, .42); }
+.lo-card,
+.lo-history__list article {
+  border-radius: 16px;
+  padding: 1rem;
+}
+.lo-summary,
+.lo-message,
+.lo-inc-summary {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.lo-status-chip,
+.lo-chip,
+.lo-corroboration-radar__status-badge {
+  min-height: 28px;
+  align-items: center;
+}
+.lo-subscribe,
+.lo-report,
+.lo-settings {
+  margin-top: 1rem;
+}
+.lousy-outages button,
+.lousy-outages .button,
+.lousy-outages input[type="submit"] {
+  min-height: 44px;
+}
+@media (max-width: 760px) {
+  .lo-hero__metrics,
+  .lo-current__lanes,
+  .lo-provider-grid {
+    grid-template-columns: 1fr;
+  }
+  .lo-hero { margin-top: 0; }
+  .lo-card { padding: .9rem; }
+}

--- a/lousy-outages/includes/AdminDiagnostics.php
+++ b/lousy-outages/includes/AdminDiagnostics.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+class AdminDiagnostics {
+    public static function bootstrap(): void { add_action('admin_menu', [self::class, 'menu']); }
+    public static function menu(): void {
+        add_management_page('Lousy Outages Diagnostics', 'Lousy Outages Diagnostics', 'manage_options', 'lousy-outages-diagnostics', [self::class, 'render']);
+    }
+    public static function render(): void {
+        if (!current_user_can('manage_options')) { return; }
+        $state = function_exists('lousy_outages_get_current_state') ? \lousy_outages_get_current_state() : [];
+        [$asset_path, $asset_url] = function_exists(__NAMESPACE__.'\\locate_assets_base') ? locate_assets_base() : [LOUSY_OUTAGES_PATH.'assets/', LOUSY_OUTAGES_URL.'assets/'];
+        $theme_old = false;
+        foreach (['get_stylesheet_directory','get_template_directory'] as $fn) { if (function_exists($fn) && is_dir(rtrim($fn(), '/\\').'/lousy-outages/assets')) { $theme_old = true; } }
+        $hooks = function_exists('_get_cron_array') ? _get_cron_array() : [];
+        $cron = [];
+        foreach ((array)$hooks as $ts => $events) { foreach ((array)$events as $hook => $items) { if (false !== strpos((string)$hook, 'lousy_outages') || false !== strpos((string)$hook, 'lo_')) { $cron[] = $hook.' @ '.gmdate('c', (int)$ts); } } }
+        $legacy = [];
+        foreach (['lo_event_log','lo_event_log_compacted_v1','lousy_outages_history','lousy_outages_log','lousy_outages_states','lo_event_log_v2','lo_history_migration_backup_v2','lo_history_migration_v2_marker'] as $opt) { $v = get_option($opt, null); $legacy[$opt] = is_array($v) ? count($v) : (null === $v ? 0 : 1); }
+        echo '<div class="wrap"><h1>Lousy Outages Diagnostics</h1><table class="widefat striped"><tbody>';
+        $rows = [
+            'Plugin version'=>LOUSY_OUTAGES_VERSION, 'Plugin path'=>LOUSY_OUTAGES_PATH, 'Asset URL base'=>$asset_url,
+            'Snapshot schema'=>(string)LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION, 'Snapshot fetched_at'=>(string)($state['fetched_at'] ?? ''),
+            'Lane counts'=>wp_json_encode($state['meta'] ?? []), 'Summary internal test'=>empty($state) ? 'failed' : 'ok',
+            'History internal test'=>class_exists('SuzyEaston\\LousyOutages\\Storage\\HistoryStore') ? 'ok' : 'failed',
+            'Canonical cron'=>implode("\n", $cron), 'Legacy history option sizes'=>wp_json_encode($legacy),
+            'Old theme assets exist'=>$theme_old ? 'yes' : 'no', 'Cached old plugin HTML'=>'manual page-cache inspection required',
+        ];
+        foreach ($rows as $k=>$v) { echo '<tr><th>'.esc_html((string)$k).'</th><td><pre>'.esc_html((string)$v).'</pre></td></tr>'; }
+        echo '</tbody></table></div>';
+    }
+}

--- a/lousy-outages/includes/Api.php
+++ b/lousy-outages/includes/Api.php
@@ -412,129 +412,31 @@ class Api {
     }
 
     public static function handle_summary(WP_REST_Request $request) {
+        $state = function_exists('lousy_outages_get_current_state') ? \lousy_outages_get_current_state() : ['providers'=>[], 'meta'=>[], 'outages'=>[], 'signals'=>[], 'unverified'=>[], 'operational'=>[], 'fetched_at'=>gmdate('c'), 'source'=>'snapshot', 'errors'=>[]];
         $providerParam = $request->get_param('provider');
-        $filters       = self::sanitize_provider_list(is_string($providerParam) ? $providerParam : null);
-
-        $snapshot = \lousy_outages_get_snapshot(false);
-
-        $providers = isset($snapshot['providers']) && is_array($snapshot['providers']) ? array_values($snapshot['providers']) : [];
-        $providers = array_map(static function ($provider) {
-            if (!is_array($provider)) { return $provider; }
-            $provider['incidents'] = Summary::current_incidents_for_provider($provider);
-            return $provider;
-        }, $providers);
+        $filters = self::sanitize_provider_list(is_string($providerParam) ? $providerParam : null);
         if (!empty($filters)) {
-            $providers = array_values(array_filter($providers, static function ($provider) use ($filters) {
-                if (!is_array($provider)) {
-                    return false;
-                }
-                $slug = strtolower((string) ($provider['provider'] ?? $provider['id'] ?? ''));
-                return $slug && in_array($slug, $filters, true);
-            }));
-        }
-
-        $trending = isset($snapshot['trending']) && is_array($snapshot['trending'])
-            ? $snapshot['trending']
-            : ['trending' => false, 'signals' => [], 'generated_at' => gmdate('c')];
-        $source = isset($snapshot['source']) ? (string) $snapshot['source'] : 'snapshot';
-        $fetched_at = isset($snapshot['fetched_at']) ? (string) $snapshot['fetched_at'] : gmdate('c');
-        $errors = isset($snapshot['errors']) && is_array($snapshot['errors']) ? $snapshot['errors'] : [];
-
-        $isLite = false;
-        $liteParam = $request->get_param('lite');
-        if (null !== $liteParam) {
-            $value = strtolower((string) $liteParam);
-            $isLite = in_array($value, ['1', 'true', 'yes', 'on'], true);
-        }
-
-        if ($isLite) {
-            $payload = [
-                'trending' => !empty($trending['trending']),
-            ];
-        } else {
-            $current_state = isset($snapshot['current_state']) && is_array($snapshot['current_state']) ? $snapshot['current_state'] : (function_exists('lousy_outages_current_state_from_snapshot') ? \lousy_outages_current_state_from_snapshot($snapshot) : []);
-            $meta = isset($current_state['meta']) && is_array($current_state['meta']) ? $current_state['meta'] : self::build_summary_meta($providers);
-            $currentOfficialIds = array_fill_keys((array) ($meta['current_official_provider_ids'] ?? []), true);
-            $filterOfficialCorroboration = static function (array $items) use ($currentOfficialIds): array {
-                return array_values(array_filter($items, static function ($item) use ($currentOfficialIds): bool {
+            foreach (['providers','outages','signals','unverified','operational'] as $lane) {
+                $state[$lane] = array_values(array_filter((array)($state[$lane] ?? []), static function ($item) use ($filters): bool {
                     if (!is_array($item)) { return false; }
-                    $providerId = sanitize_key((string) ($item['provider_id'] ?? $item['provider'] ?? $item['id'] ?? ''));
-                    return $providerId !== '' && isset($currentOfficialIds[$providerId]);
+                    $slug = sanitize_key((string)($item['provider_id'] ?? $item['provider'] ?? $item['id'] ?? ''));
+                    return $slug !== '' && in_array($slug, $filters, true);
                 }));
-            };
-            $payload = [
-                'providers'  => $providers,
-                'fetched_at' => $fetched_at,
-                'trending'   => $trending,
-                'source'     => $source,
-                'meta'       => $meta,
-                'current_state' => $current_state,
-            ];
-            if (!empty($errors)) {
-                $payload['errors'] = $errors;
             }
-            $diag = (array) get_option('lo_diag_hacker_news_chatter', []);
-            $reasonCounts = (array) ($diag['chatter_rejected_by_reason'] ?? []);
-            if ($reasonCounts === [] && !empty($diag['chatter_candidates_preview_sample']) && is_array($diag['chatter_candidates_preview_sample'])) {
-                foreach ((array) $diag['chatter_candidates_preview_sample'] as $item) {
-                    $reason = (string) ($item['reject_reason'] ?? '');
-                    if ($reason === '' || $reason === 'accepted') { continue; }
-                    $reasonCounts[$reason] = (int) ($reasonCounts[$reason] ?? 0) + 1;
-                }
-            }
-            $publicDiag = (array) get_option('lo_diag_public_chatter', []);
-            $payload['public_chatter_diagnostics'] = [
-                'rejected_by_reason' => ChatterRejectionReasons::summarize_counts($reasonCounts),
-                'reason_definitions' => array_values(ChatterRejectionReasons::definitions()),
-                'raw_rejected_codes' => $reasonCounts,
-                'source_statuses' => (array) ($publicDiag['source_statuses'] ?? []),
-                'enabled_sources' => (array) ($publicDiag['enabled_sources'] ?? []),
-                'skipped_sources' => (array) ($publicDiag['skipped_sources'] ?? []),
-                'direct_sources_enabled' => !empty($publicDiag['direct_sources_enabled']),
-                'direct_sources_disabled_by_safe_default' => !empty($publicDiag['direct_sources_disabled_by_safe_default']),
-                'providers_scanned_count' => (int) ($publicDiag['providers_scanned_count'] ?? 0),
-                'watch_candidate_count' => (int) ($publicDiag['watch_candidate_count'] ?? 0),
-                'watch_candidates' => array_slice((array) ($publicDiag['watch_candidates'] ?? []), 0, 20),
-                'official_incident_corroboration' => array_slice($filterOfficialCorroboration((array) ($publicDiag['official_incident_corroboration'] ?? [])), 0, 20),
-                'canadian_infrastructure_watchlist' => (array) ($publicDiag['canadian_infrastructure_watchlist'] ?? []),
-                'mentions_seen_by_source' => (array) ($publicDiag['mentions_seen_by_source'] ?? []),
-                'mentions_seen_by_provider' => (array) ($publicDiag['mentions_seen_by_provider'] ?? []),
-                'thresholds' => (array) ($publicDiag['thresholds'] ?? []),
-                'scan_window_minutes' => (int) ($publicDiag['scan_window_minutes'] ?? 0),
-                'ran_at' => (string) ($publicDiag['ran_at'] ?? ''),
-            ];
+            $state['meta']['active_outage_count'] = count($state['outages']);
+            $state['meta']['signal_count'] = count($state['signals']);
+            $state['meta']['unverified_count'] = count($state['unverified']);
+            $state['meta']['operational_count'] = count($state['operational']);
         }
-
-        $json = wp_json_encode($payload);
-        if (!is_string($json)) {
-            $json = '{}';
-        }
-        $etag = '"' . sha1($json) . '"';
-        $incoming = isset($_SERVER['HTTP_IF_NONE_MATCH']) ? trim((string) $_SERVER['HTTP_IF_NONE_MATCH']) : '';
-        $matched = false;
-        if ('' !== $incoming) {
-            $candidates = array_map('trim', explode(',', $incoming));
-            foreach ($candidates as $candidate) {
-                if ($candidate === $etag || $candidate === 'W/' . $etag) {
-                    $matched = true;
-                    break;
-                }
-            }
-        }
-
-        if ($matched) {
-            status_header(304);
-            header('ETag: ' . $etag);
-            header('Cache-Control: no-cache, must-revalidate');
-            exit;
-        }
-
-        status_header(200);
-        header('ETag: ' . $etag);
-        header('Cache-Control: no-cache, must-revalidate');
-        header('Content-Type: application/json; charset=utf-8');
-        echo $json;
-        exit;
+        $payload = ['providers'=>$state['providers'],'fetched_at'=>$state['fetched_at'],'source'=>$state['source'],'meta'=>$state['meta'],'current_state'=>$state,'plugin_version'=>$state['plugin_version'] ?? (defined('LOUSY_OUTAGES_VERSION') ? LOUSY_OUTAGES_VERSION : ''),'snapshot_schema_version'=>$state['snapshot_schema_version'] ?? (defined('LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION') ? LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION : 0)];
+        if (!empty($state['errors'])) { $payload['errors'] = $state['errors']; }
+        $response = new WP_REST_Response($payload, 200);
+        $response->header('Cache-Control', 'no-store, no-cache, must-revalidate');
+        $response->header('Pragma', 'no-cache');
+        $response->header('X-Lousy-Outages-Version', (string)$payload['plugin_version']);
+        $response->header('X-Lousy-Outages-Snapshot-Schema', (string)$payload['snapshot_schema_version']);
+        if (!headers_sent()) { header('X-LiteSpeed-Cache-Control: no-cache'); }
+        return $response;
     }
 
     public static function handle_cron_status(WP_REST_Request $request): WP_REST_Response {
@@ -570,15 +472,7 @@ class Api {
         return new WP_REST_Response($payload, 200);
     }
 
-    /**
-     * Return a compact history document for each provider.
-     *
-     * Schema (per provider):
-     * {
-     *   id: "github",
-     *   history: [ { date: "2024-06-01", incidents: 2, last_status: "degraded" }, ... ]
-     * }
-     */
+
     public static function handle_history(WP_REST_Request $request): WP_REST_Response {
         $providerParam = $request->get_param('provider');
         $filters       = self::sanitize_provider_list(is_string($providerParam) ? $providerParam : null);
@@ -607,7 +501,9 @@ class Api {
         foreach (Providers::list() as $id => $provider) { $providerLabels[sanitize_key((string)$id)] = isset($provider['name']) ? (string)$provider['name'] : ucwords(str_replace(['_','-'],' ',(string)$id)); }
 
         $historyStore = new HistoryStore();
-        $events = $historyStore->loadCanonical();
+        $paged = $historyStore->queryPage(['cutoff'=>$cutoff,'providers'=>$filters,'important_only'=>$importantOnly,'per_page'=>$perPage,'offset'=>$offset]);
+        $events = isset($paged['events']) && is_array($paged['events']) ? $paged['events'] : [];
+        $pagedTotal = (int)($paged['total'] ?? count($events));
         $matched = 0; $returned = []; $providerCounts = []; $dailyCounts = []; $oldest = null; $newest = null;
         foreach ($events as $event) {
             if (!is_array($event)) { continue; }
@@ -623,19 +519,18 @@ class Api {
             $important = isset($event['important']) ? (bool)$event['important'] : !in_array($severity, ['maintenance','info'], true);
             if ($importantOnly && (!$important || in_array($severity, ['maintenance','info'], true))) { continue; }
             if ($minSeverity && isset($severityOrder[$severity], $severityOrder[$minSeverity]) && $severityOrder[$severity] < $severityOrder[$minSeverity]) { continue; }
-            $matched++;
             $label = $providerLabels[$slug] ?? ucwords(str_replace(['_','-'],' ',$slug));
             $providerCounts[$label] = ($providerCounts[$label] ?? 0) + 1;
             $date = gmdate('Y-m-d', $incidentStart ?: time()); $dailyCounts[$date] = ($dailyCounts[$date] ?? 0) + 1;
             $oldest = null === $oldest ? $incidentStart : min($oldest, $incidentStart); $newest = null === $newest ? $lastSeen : max($newest, $lastSeen);
-            if ($matched <= $offset || count($returned) >= $perPage) { continue; }
+            if (count($returned) >= $perPage) { continue; }
             $returned[] = ['id'=>(string)($event['guid'] ?? sha1($slug.'|'.$firstSeen)),'provider'=>$slug,'provider_label'=>$label,'status'=>$status,'severity'=>$severity,'important'=>$important,'summary'=>(string)($event['title'] ?? $event['description'] ?? ''),'first_seen'=>$firstSeen,'last_seen'=>$lastSeen,'url'=>(string)($event['url'] ?? '')];
         }
         usort($returned, static fn($a,$b): int => ((int)($b['last_seen'] ?? $b['first_seen'] ?? 0)) <=> ((int)($a['last_seen'] ?? $a['first_seen'] ?? 0)));
         $providers=[];
         foreach ($returned as $event) { $slug=$event['provider']; $date=gmdate('Y-m-d', (int)($event['first_seen'] ?: $event['last_seen'] ?: time())); if (!isset($providers[$slug])) { $providers[$slug]=['id'=>$slug,'label'=>$event['provider_label'],'history'=>[],'incidents'=>[]]; } if (!isset($providers[$slug]['history'][$date])) { $providers[$slug]['history'][$date]=['date'=>$date,'incidents'=>0,'last_status'=>$event['status']]; } $providers[$slug]['history'][$date]['incidents']++; $providers[$slug]['history'][$date]['last_status']=$event['status']; $providers[$slug]['incidents'][]=['id'=>$event['id'],'provider'=>$event['provider_label'],'status'=>$event['status'],'severity'=>$event['severity'],'important'=>$event['important'],'summary'=>$event['summary'],'first_seen'=>$event['first_seen'] ? gmdate('c',(int)$event['first_seen']) : null,'last_seen'=>$event['last_seen'] ? gmdate('c',(int)$event['last_seen']) : null,'url'=>$event['url']]; }
         $outProviders=[]; foreach ($providers as $provider) { $h=$provider['history']; ksort($h); $provider['history']=array_values($h); $outProviders[]=$provider; }
-        return rest_ensure_response(['generated_at'=>gmdate('c'),'meta'=>['fetchedAt'=>gmdate('c'),'provider_counts'=>$providerCounts,'daily_counts'=>$dailyCounts,'important_only'=>$importantOnly,'window_days'=>$days ?: 'all','window_start'=>$oldest ? gmdate('Y-m-d',$oldest) : null,'window_end'=>$newest ? gmdate('Y-m-d',$newest) : null,'deduped_incidents'=>$matched,'migration'=>$historyStore->migrationStatus(),'page'=>$page,'per_page'=>$perPage,'returned_count'=>count($returned),'total_matching'=>$matched,'has_more'=>($offset + count($returned)) < $matched],'providers'=>$outProviders]);
+        return rest_ensure_response(['generated_at'=>gmdate('c'),'meta'=>['fetchedAt'=>gmdate('c'),'provider_counts'=>$providerCounts,'daily_counts'=>$dailyCounts,'important_only'=>$importantOnly,'window_days'=>$days ?: 'all','window_start'=>$oldest ? gmdate('Y-m-d',$oldest) : null,'window_end'=>$newest ? gmdate('Y-m-d',$newest) : null,'deduped_incidents'=>$matched,'migration'=>$historyStore->migrationStatus(),'page'=>$page,'per_page'=>$perPage,'returned_count'=>count($returned),'total_matching'=>$pagedTotal,'has_more'=>($offset + count($returned)) < $pagedTotal],'providers'=>$outProviders]);
     }
 
     public static function handle_report(WP_REST_Request $request): WP_REST_Response {

--- a/lousy-outages/includes/CurrentState.php
+++ b/lousy-outages/includes/CurrentState.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+if (! defined('ABSPATH')) { exit; }
+
+/**
+ * Read the validated canonical saved snapshot and normalize public current lanes.
+ * This accessor is intentionally read-only: no provider collection, history rebuild,
+ * migration, synthetic fallback snapshot, or cache write is performed here.
+ */
+function lousy_outages_get_current_state(): array {
+    $snapshot = get_option('lousy_outages_snapshot', []);
+    $schema = defined('LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION') ? (int) LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION : 0;
+    $version = defined('LOUSY_OUTAGES_VERSION') ? (string) LOUSY_OUTAGES_VERSION : '';
+    $base = [
+        'outages' => [], 'signals' => [], 'unverified' => [], 'operational' => [], 'providers' => [],
+        'meta' => ['active_outage_count'=>0,'signal_count'=>0,'unverified_count'=>0,'operational_count'=>0,'generated_at'=>gmdate('c'),'freshness_window_seconds'=>function_exists('lousy_outages_signal_freshness_seconds') ? lousy_outages_signal_freshness_seconds() : 2700,'current_official_provider_ids'=>[]],
+        'fetched_at' => '', 'source' => 'missing_snapshot', 'errors' => [], 'plugin_version' => $version, 'snapshot_schema_version' => $schema,
+    ];
+    if (!is_array($snapshot) || empty($snapshot['providers']) || (function_exists('lousy_outages_snapshot_schema_is_current') && !lousy_outages_snapshot_schema_is_current($snapshot))) {
+        $providers = \SuzyEaston\LousyOutages\Providers::enabled();
+        foreach ($providers as $id => $provider) {
+            $base['unverified'][] = ['id'=>sanitize_key((string)$id),'provider_id'=>sanitize_key((string)$id),'name'=>(string)($provider['name'] ?? $id),'lane'=>'unverified','stale_label'=>'Verification delayed; no valid saved provider snapshot is available.'];
+        }
+        $base['providers'] = $base['unverified'];
+        $base['meta']['unverified_count'] = count($base['unverified']);
+        $base['errors'][] = ['code'=>'missing_or_invalid_snapshot','message'=>'No valid saved Lousy Outages snapshot is available.'];
+        return $base;
+    }
+    $state = isset($snapshot['current_state']) && is_array($snapshot['current_state']) ? $snapshot['current_state'] : (function_exists('lousy_outages_current_state_from_snapshot') ? lousy_outages_current_state_from_snapshot($snapshot) : []);
+    foreach (['outages','signals','unverified','operational'] as $lane) { $base[$lane] = array_values(array_filter((array)($state[$lane] ?? []), 'is_array')); }
+    $base['providers'] = array_values(array_filter((array)($snapshot['providers'] ?? []), 'is_array'));
+    $base['fetched_at'] = (string)($snapshot['fetched_at'] ?? '');
+    $base['source'] = (string)($snapshot['source'] ?? 'snapshot');
+    $base['errors'] = array_values((array)($snapshot['errors'] ?? []));
+    $base['meta'] = array_merge($base['meta'], is_array($state['meta'] ?? null) ? $state['meta'] : []);
+    $base['meta']['active_outage_count'] = count($base['outages']);
+    $base['meta']['signal_count'] = count($base['signals']);
+    $base['meta']['unverified_count'] = count($base['unverified']);
+    $base['meta']['operational_count'] = count($base['operational']);
+    return $base;
+}

--- a/lousy-outages/includes/Storage/HistoryStore.php
+++ b/lousy-outages/includes/Storage/HistoryStore.php
@@ -16,6 +16,49 @@ class HistoryStore
         'lousy_outages_states',
     ];
 
+    public function tableName(): string
+    {
+        global $wpdb;
+        return $wpdb->prefix . 'lousy_outages_history_events';
+    }
+
+    public function installTable(): void
+    {
+        global $wpdb;
+        $table = $this->tableName();
+        $charset = $wpdb->get_charset_collate();
+        $sql = "CREATE TABLE {$table} (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            guid varchar(191) NOT NULL,
+            provider varchar(80) NOT NULL,
+            provider_label varchar(160) NOT NULL DEFAULT '',
+            title text NOT NULL,
+            description longtext NULL,
+            status varchar(80) NOT NULL DEFAULT 'incident',
+            severity varchar(40) NOT NULL DEFAULT 'degraded',
+            source varchar(80) NOT NULL DEFAULT 'provider',
+            first_seen bigint(20) unsigned NOT NULL DEFAULT 0,
+            last_seen bigint(20) unsigned NOT NULL DEFAULT 0,
+            important tinyint(1) NOT NULL DEFAULT 0,
+            url text NULL,
+            components_json longtext NULL,
+            PRIMARY KEY  (id),
+            UNIQUE KEY guid (guid),
+            KEY provider_last_seen (provider,last_seen),
+            KEY important_last_seen (important,last_seen),
+            KEY severity_last_seen (severity,last_seen)
+        ) {$charset};";
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        dbDelta($sql);
+    }
+
+    public function tableExists(): bool
+    {
+        global $wpdb;
+        $table = $this->tableName();
+        return $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table)) === $table;
+    }
+
     public function loadCanonical(): array
     {
         $stored = get_option(self::OPTION_CANONICAL, []);
@@ -24,12 +67,16 @@ class HistoryStore
 
     public function addEvent(array $event): array
     {
-        $events = $this->loadCanonical();
         $normalized = self::normalizeRichEvent($event);
-        $events[] = $normalized;
-        $events = self::dedupeEvents($events);
-        update_option(self::OPTION_CANONICAL, $events, false);
-        $this->markValidated($events);
+        if ($this->tableExists()) {
+            global $wpdb;
+            $wpdb->replace($this->tableName(), [
+                'guid'=>$normalized['guid'], 'provider'=>$normalized['provider'], 'provider_label'=>$normalized['provider_label'],
+                'title'=>$normalized['title'], 'description'=>$normalized['description'], 'status'=>$normalized['status'], 'severity'=>$normalized['severity'],
+                'source'=>$normalized['source'], 'first_seen'=>(int)$normalized['first_seen'], 'last_seen'=>(int)$normalized['last_seen'],
+                'important'=>!empty($normalized['important']) ? 1 : 0, 'url'=>$normalized['url'], 'components_json'=>wp_json_encode($normalized['components']),
+            ], ['%s','%s','%s','%s','%s','%s','%s','%s','%d','%d','%d','%s','%s']);
+        }
         return $normalized;
     }
 
@@ -93,6 +140,25 @@ class HistoryStore
         ];
         update_option(self::OPTION_MARKER, $report, false);
         return $report;
+    }
+
+    public function queryPage(array $args): array
+    {
+        if (!$this->tableExists()) {
+            return ['events'=>array_slice($this->loadCanonical(), (int)($args['offset'] ?? 0), (int)($args['per_page'] ?? 20)), 'total'=>count($this->loadCanonical())];
+        }
+        global $wpdb;
+        $where = ['1=1']; $values = [];
+        if (!empty($args['cutoff'])) { $where[] = 'first_seen >= %d'; $values[] = (int)$args['cutoff']; }
+        if (!empty($args['providers'])) { $in = implode(',', array_fill(0, count($args['providers']), '%s')); $where[] = "provider IN ($in)"; foreach ($args['providers'] as $p) { $values[] = $p; } }
+        if (!empty($args['important_only'])) { $where[] = 'important = 1'; }
+        $sqlWhere = implode(' AND ', $where);
+        $total = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$this->tableName()} WHERE {$sqlWhere}", $values));
+        $limit = max(1, min(50, (int)($args['per_page'] ?? 20))); $offset = max(0, (int)($args['offset'] ?? 0));
+        $rows = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$this->tableName()} WHERE {$sqlWhere} ORDER BY last_seen DESC, id DESC LIMIT %d OFFSET %d", array_merge($values, [$limit, $offset])), ARRAY_A);
+        $events = [];
+        foreach ((array)$rows as $row) { $row['components'] = json_decode((string)($row['components_json'] ?? '[]'), true) ?: []; $events[] = self::normalizeRichEvent($row); }
+        return ['events'=>$events, 'total'=>$total];
     }
 
     public function exportSourceOptions(): array { return $this->readSourceOptions(); }

--- a/lousy-outages/includes/Storage/IncidentStore.php
+++ b/lousy-outages/includes/Storage/IncidentStore.php
@@ -144,7 +144,6 @@ class IncidentStore
 
         $events = $this->pruneEvents($events, $now);
         update_option(self::OPTION_EVENTS, $events, false);
-        (new HistoryStore())->migrate(true);
     }
 
     /**
@@ -187,7 +186,6 @@ class IncidentStore
 
         $events = $this->pruneEvents($events, $now);
         update_option(self::OPTION_EVENTS, $events, false);
-        (new HistoryStore())->migrate(true);
 
         return $event;
     }

--- a/lousy-outages/includes/Summary.php
+++ b/lousy-outages/includes/Summary.php
@@ -146,84 +146,20 @@ class Summary {
      */
     public static function ordered_current_incidents(int $limit = 0): array
     {
-        $providers = self::sort_status_page_providers(self::providers());
+        $state = function_exists('lousy_outages_get_current_state') ? \lousy_outages_get_current_state() : ['outages'=>[]];
         $records = [];
-
-        foreach ($providers as $provider) {
-            if (!is_array($provider)) {
-                continue;
-            }
-
-            $incidents = isset($provider['incidents']) && is_array($provider['incidents'])
-                ? array_values(array_filter($provider['incidents'], 'is_array'))
-                : [];
-            $providerId = sanitize_key((string) ($provider['id'] ?? $provider['provider'] ?? $provider['name'] ?? ''));
-            $providerName = trim((string) ($provider['name'] ?? $provider['provider'] ?? $providerId));
-            if ('' === $providerName) {
-                $providerName = 'Unknown provider';
-            }
-            $providerStatus = strtolower((string) ($provider['stateCode'] ?? $provider['status'] ?? 'incident'));
-            $tileKind = strtolower((string) ($provider['tile_kind'] ?? $provider['tileKind'] ?? ''));
-            $currentIncidents = self::current_incidents_for_provider($provider);
-
-            if (!$currentIncidents) {
-                $hasCurrentSignal = !$incidents && in_array($tileKind, ['outage', 'signal'], true);
-                if (!$hasCurrentSignal) {
-                    continue;
-                }
-
-                $updated = (string) ($provider['updatedAt'] ?? $provider['updated_at'] ?? '');
-                $records[] = [
-                    'id' => sha1($providerId . '|provider-current|' . $providerStatus . '|' . $updated),
-                    'provider_id' => $providerId,
-                    'provider' => $providerName,
-                    'status' => $providerStatus ?: 'incident',
-                    'status_label' => Fetcher::status_label($providerStatus ?: 'incident'),
-                    'severity' => 'outage' === $tileKind ? 'outage' : 'degraded',
-                    'important' => true,
-                    'summary' => (string) ($provider['summary'] ?? $provider['message'] ?? Fetcher::status_label($providerStatus ?: 'incident')),
-                    'started_at' => self::format_incident_time($updated),
-                    'updated_at' => self::format_incident_time($updated),
-                    'first_seen' => self::parse_time($updated) ?? 0,
-                    'last_seen' => self::parse_time($updated) ?? 0,
-                    'url' => (string) ($provider['url'] ?? ''),
-                ];
-                continue;
-            }
-
-            $incidents = $currentIncidents;
-            usort($incidents, static function (array $left, array $right): int {
-                return self::incident_timestamp($right) <=> self::incident_timestamp($left);
-            });
-
-            foreach ($incidents as $incident) {
-                if (!is_array($incident)) {
-                    continue;
-                }
-
-                $started = (string) ($incident['startedAt'] ?? $incident['started_at'] ?? $incident['created_at'] ?? '');
-                $updated = (string) ($incident['updatedAt'] ?? $incident['updated_at'] ?? $started);
-                $impact = strtolower((string) ($incident['impact'] ?? $incident['status'] ?? $providerStatus ?: 'incident'));
-                $records[] = [
-                    'id' => (string) ($incident['id'] ?? sha1($providerId . '|' . ($incident['title'] ?? '') . '|' . $started . '|' . $updated)),
-                    'provider_id' => $providerId,
-                    'provider' => $providerName,
-                    'status' => $providerStatus ?: 'incident',
-                    'status_label' => Fetcher::status_label($providerStatus ?: 'incident'),
-                    'severity' => $impact ?: 'degraded',
-                    'important' => true,
-                    'summary' => (string) ($incident['display_title'] ?? $incident['displayTitle'] ?? $incident['title'] ?? $incident['name'] ?? $incident['summary'] ?? 'Incident reported'),
-                    'started_at' => self::format_incident_time($started),
-                    'updated_at' => self::format_incident_time($updated),
-                    'first_seen' => self::parse_time($started) ?? 0,
-                    'last_seen' => self::parse_time($updated) ?? (self::parse_time($started) ?? 0),
-                    'url' => (string) ($incident['url'] ?? $provider['url'] ?? ''),
-                ];
-            }
+        foreach ((array)($state['outages'] ?? []) as $incident) {
+            if (!is_array($incident)) { continue; }
+            $providerId = sanitize_key((string)($incident['provider_id'] ?? $incident['provider'] ?? ''));
+            $providerName = trim((string)($incident['provider'] ?? $incident['provider_name'] ?? $providerId));
+            $started = (string)($incident['startedAt'] ?? $incident['started_at'] ?? $incident['created_at'] ?? '');
+            $updated = (string)($incident['updatedAt'] ?? $incident['updated_at'] ?? $incident['last_official_update'] ?? $started);
+            $status = strtolower((string)($incident['status'] ?? $incident['impact'] ?? 'incident'));
+            $records[] = ['id'=>(string)($incident['id'] ?? sha1($providerId.'|'.($incident['title'] ?? '').'|'.$started.'|'.$updated)),'provider_id'=>$providerId,'provider'=>$providerName ?: 'Unknown provider','status'=>$status ?: 'incident','status_label'=>Fetcher::status_label($status ?: 'incident'),'severity'=>strtolower((string)($incident['impact'] ?? $status ?: 'degraded')),'important'=>true,'summary'=>(string)($incident['display_title'] ?? $incident['displayTitle'] ?? $incident['title'] ?? $incident['name'] ?? $incident['summary'] ?? 'Incident reported'),'started_at'=>self::format_incident_time($started),'updated_at'=>self::format_incident_time($updated),'first_seen'=>self::parse_time($started) ?? 0,'last_seen'=>self::parse_time($updated) ?? (self::parse_time($started) ?? 0),'url'=>(string)($incident['url'] ?? $incident['provider_url'] ?? '')];
         }
-
-        $deduped = self::dedupe_ordered_incidents($records);
-        return $limit > 0 ? array_slice($deduped, 0, $limit) : $deduped;
+        usort($records, static fn(array $a, array $b): int => ((int)($b['last_seen'] ?? 0)) <=> ((int)($a['last_seen'] ?? 0)));
+        $records = self::dedupe_ordered_incidents($records);
+        return $limit > 0 ? array_slice($records, 0, $limit) : $records;
     }
 
     /**
@@ -402,58 +338,16 @@ class Summary {
         return $timestamp ? gmdate('c', $timestamp) : null;
     }
 
-    private static function providers(): array
+    public static function providers(): array
     {
-        $providers = [];
-
-        if (function_exists('lousy_outages_get_snapshot')) {
-            $snapshot = \lousy_outages_get_snapshot(false);
-            if (empty($snapshot['providers'])) {
-                $snapshot = \lousy_outages_get_snapshot(true);
-            }
-
-            if (!empty($snapshot['providers']) && is_array($snapshot['providers'])) {
-                $providers = array_values($snapshot['providers']);
+        if (function_exists('lousy_outages_get_current_state')) {
+            $state = \lousy_outages_get_current_state();
+            if (!empty($state['providers']) && is_array($state['providers'])) {
+                return array_values($state['providers']);
             }
         }
-
-        if ($providers) {
-            return $providers;
-        }
-
-        $store  = new Store();
-        $states = $store->get_all();
-        if (!$states) {
-            return [];
-        }
-
-        $timestamp = get_option('lousy_outages_last_poll');
-        if (!$timestamp) {
-            $timestamp = gmdate('c');
-        }
-
-        foreach ($states as $id => $state) {
-            if (!is_array($state)) {
-                continue;
-            }
-
-            if (function_exists('lousy_outages_build_provider_payload')) {
-                $providers[] = \lousy_outages_build_provider_payload((string) $id, $state, (string) $timestamp);
-                continue;
-            }
-
-            $providers[] = [
-                'id'        => (string) $id,
-                'provider'  => (string) ($state['provider'] ?? $state['name'] ?? $id),
-                'name'      => (string) ($state['name'] ?? $state['provider'] ?? $id),
-                'stateCode' => (string) ($state['status'] ?? 'unknown'),
-                'updatedAt' => (string) ($state['updated_at'] ?? $state['updatedAt'] ?? $timestamp),
-                'incidents' => isset($state['incidents']) && is_array($state['incidents']) ? $state['incidents'] : [],
-                'summary'   => (string) ($state['summary'] ?? ''),
-            ];
-        }
-
-        return $providers;
+        $snapshot = get_option('lousy_outages_snapshot', []);
+        return isset($snapshot['providers']) && is_array($snapshot['providers']) ? array_values($snapshot['providers']) : [];
     }
 
     private static function has_verification_delay(array $providers): bool

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -3,7 +3,7 @@ declare( strict_types=1 );
 /**
  * Plugin Name: Lousy Outages
  * Description: WordPress-native outage intelligence, community reporting, and early-warning signals for third-party service dependencies.
- * Version: 0.3.5
+ * Version: 0.3.6
  * Author: Suzy Easton
  * Text Domain: lousy-outages
  */
@@ -24,10 +24,10 @@ if ( defined( 'LOUSY_OUTAGES_DISABLE' ) && LOUSY_OUTAGES_DISABLE ) {
 }
 
 if ( ! defined( 'LOUSY_OUTAGES_VERSION' ) ) {
-    define( 'LOUSY_OUTAGES_VERSION', '0.3.5' );
+    define( 'LOUSY_OUTAGES_VERSION', '0.3.6' );
 }
 if ( ! defined( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION' ) ) {
-    define( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION', 4 );
+    define( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION', 5 );
 }
 if ( ! defined( 'LOUSY_OUTAGES_FILE' ) ) {
     define( 'LOUSY_OUTAGES_FILE', __FILE__ );
@@ -74,6 +74,7 @@ lousy_outages_require( 'includes/SignalEngine.php' );
 lousy_outages_require( 'includes/Subscribe.php' );
 lousy_outages_require( 'includes/Feeds.php' );
 lousy_outages_require( 'includes/Summary.php' );
+lousy_outages_require( 'includes/CurrentState.php' );
 lousy_outages_require( 'includes/IncidentAlerts.php' );
 lousy_outages_require( 'includes/Snapshot.php' );
 lousy_outages_require( 'includes/Cron.php' );
@@ -98,6 +99,7 @@ lousy_outages_require( 'includes/Sources/StatuspageIntelSource.php' );
 lousy_outages_require( 'includes/SignalCollector.php' );
 lousy_outages_require( 'includes/Api.php' );
 lousy_outages_require( 'includes/AdminCleanup.php' );
+lousy_outages_require( 'includes/AdminDiagnostics.php' );
 
 lousy_outages_require( 'public/shortcode.php' );
 
@@ -130,6 +132,7 @@ MailTransport::bootstrap();
 IncidentAlerts::bootstrap();
 RefreshCron::bootstrap();
 \SuzyEaston\LousyOutages\AdminCleanup::bootstrap();
+\SuzyEaston\LousyOutages\AdminDiagnostics::bootstrap();
 
 lo_snapshot_bootstrap();
 lo_cron_bootstrap();
@@ -153,6 +156,7 @@ function lousy_outages_activate() {
     lousy_outages_schedule_canonical_refresh();
     lousy_outages_create_page();
     lousy_outages_maybe_install_schema( true );
+    if ( class_exists( '\\SuzyEaston\\LousyOutages\\Storage\\HistoryStore' ) ) { ( new \SuzyEaston\LousyOutages\Storage\HistoryStore() )->installTable(); }
     Subscriptions::schedule_purge();
     $default_email = 'suzyeaston@gmail.com';
     $stored_email  = get_option( 'lousy_outages_email' );
@@ -220,6 +224,7 @@ function lousy_outages_maybe_repair_snapshot_caches(): void {
     $current = (int) get_option( $option_key, 0 );
     if ( $current >= (int) LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION ) { return; }
     foreach ( [ 'lousy_outages_cached_statuses', 'lousy_status_snapshot', 'lo_snapshot_payload_v1', 'lousy_outages_fragment_public' ] as $key ) { delete_transient( $key ); }
+    delete_option( 'lousy_outages_current_state' );
     delete_option( 'lo_diag_public_chatter' );
     update_option( $option_key, (int) LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION, false );
 }
@@ -553,6 +558,10 @@ function lousy_outages_refresh_data( bool $bypass_cache = true ): array {
         if ( class_exists( '\\SuzyEaston\\LousyOutages\\IncidentAlerts' ) && method_exists( '\\SuzyEaston\\LousyOutages\\IncidentAlerts', 'collect_from_snapshot' ) ) {
             $incidents_for_history = \SuzyEaston\LousyOutages\IncidentAlerts::collect_from_snapshot();
             ( new \SuzyEaston\LousyOutages\Storage\IncidentStore() )->persistIncidents( $incidents_for_history );
+            if ( class_exists( '\\SuzyEaston\\LousyOutages\\Storage\\HistoryStore' ) ) {
+                $history_store = new \SuzyEaston\LousyOutages\Storage\HistoryStore();
+                foreach ( $incidents_for_history as $history_incident ) { if ( is_array( $history_incident ) ) { $history_store->addEvent( $history_incident ); } }
+            }
         }
         $providers = isset( $snapshot['providers'] ) && is_array( $snapshot['providers'] ) ? $snapshot['providers'] : [];
         $trending  = isset( $snapshot['trending'] ) && is_array( $snapshot['trending'] ) ? $snapshot['trending'] : [ 'trending' => false, 'signals' => [] ];

--- a/lousy-outages/public/shortcode.php
+++ b/lousy-outages/public/shortcode.php
@@ -6,44 +6,25 @@ namespace SuzyEaston\LousyOutages;
 const LO_SHOW_WIDESPREAD = false;
 
 /**
- * Determine the filesystem path and URL for the plugin assets.
+ * Determine the filesystem path and URL for standalone plugin assets.
  *
- * When the plugin is bundled with the theme (as it is on suzyeaston.ca),
- * plugin_dir_url() incorrectly points to wp-content/plugins/, which results in
- * 404s for front-end assets. This helper checks for copies that live alongside
- * the active theme before falling back to the plugin directory.
+ * Public assets always come from LOUSY_OUTAGES_URL . 'assets/' so obsolete
+ * theme copies cannot create version skew between SSR markup and JS/CSS.
  *
- * @return array{string, string} An array containing the absolute path and the
- *                               public URL for the assets directory.
+ * @return array{string, string}
  */
 function locate_assets_base(): array
 {
-    $candidates = [];
-
-    if (function_exists('get_stylesheet_directory') && function_exists('get_stylesheet_directory_uri')) {
-        $stylesheet_path = rtrim(get_stylesheet_directory(), '/\\') . '/lousy-outages/assets/';
-        $stylesheet_url  = rtrim(get_stylesheet_directory_uri(), '/\\') . '/lousy-outages/assets/';
-        $candidates[] = [$stylesheet_path, $stylesheet_url];
-    }
-
-    if (function_exists('get_template_directory') && function_exists('get_template_directory_uri')) {
-        $template_path = rtrim(get_template_directory(), '/\\') . '/lousy-outages/assets/';
-        $template_url  = rtrim(get_template_directory_uri(), '/\\') . '/lousy-outages/assets/';
-        $candidates[] = [$template_path, $template_url];
-    }
-
-    $plugin_path = rtrim(plugin_dir_path(__DIR__), '/\\') . '/assets/';
-    $plugin_url  = rtrim(plugin_dir_url(__DIR__), '/\\') . '/assets/';
-    $candidates[] = [$plugin_path, $plugin_url];
-
-    foreach ($candidates as $candidate) {
-        [$path, $url] = $candidate;
-        if ($path && file_exists($path)) {
-            return [$path, $url];
-        }
-    }
-
+    $plugin_path = defined('LOUSY_OUTAGES_PATH') ? rtrim(LOUSY_OUTAGES_PATH, '/\\') . '/assets/' : rtrim(plugin_dir_path(__DIR__), '/\\') . '/assets/';
+    $plugin_url = defined('LOUSY_OUTAGES_URL') ? rtrim(LOUSY_OUTAGES_URL, '/\\') . '/assets/' : rtrim(plugin_dir_url(__DIR__), '/\\') . '/assets/';
     return [$plugin_path, $plugin_url];
+}
+
+function asset_version(string $base_path, string $asset): string
+{
+    $version = defined('LOUSY_OUTAGES_VERSION') ? (string) LOUSY_OUTAGES_VERSION : '0.0.0';
+    $path = rtrim($base_path, '/\\') . '/' . ltrim($asset, '/\\');
+    return $version . '-' . (file_exists($path) ? (string) filemtime($path) : '0');
 }
 
 add_shortcode('lousy_outages', __NAMESPACE__ . '\render_shortcode');
@@ -57,21 +38,21 @@ function render_shortcode(): string {
         'lousy-outages',
         $base_url . 'lousy-outages.css',
         [],
-        file_exists($base_path . 'lousy-outages.css') ? filemtime($base_path . 'lousy-outages.css') : null
+        asset_version($base_path, 'lousy-outages.css')
     );
 
     wp_enqueue_style(
         'lousy-outages-hud',
         $base_url . 'hud.css',
         ['lousy-outages'],
-        file_exists($base_path . 'hud.css') ? filemtime($base_path . 'hud.css') : null
+        asset_version($base_path, 'hud.css')
     );
 
     wp_enqueue_script(
         'lousy-outages',
         $base_url . 'lousy-outages.js',
         [],
-        file_exists($base_path . 'lousy-outages.js') ? filemtime($base_path . 'lousy-outages.js') : null,
+        asset_version($base_path, 'lousy-outages.js'),
         true
     );
 
@@ -79,7 +60,7 @@ function render_shortcode(): string {
         'lousy-outages-hud',
         $base_url . 'hud.js',
         ['lousy-outages'],
-        file_exists($base_path . 'hud.js') ? filemtime($base_path . 'hud.js') : null,
+        asset_version($base_path, 'hud.js'),
         true
     );
 
@@ -88,7 +69,7 @@ function render_shortcode(): string {
             'lousy-outages-auto-refresh',
             $base_url . 'js/outages.js',
             [],
-            filemtime($base_path . 'js/outages.js'),
+            asset_version($base_path, 'js/outages.js'),
             true
         );
     }
@@ -389,7 +370,7 @@ function render_shortcode(): string {
     $config['initial']['source']    = $source;
     $config['initial']['errors']    = $snapshot_errors;
 
-    $current_state = function_exists('lousy_outages_current_state_from_snapshot') ? \lousy_outages_current_state_from_snapshot(['providers' => $config['initial']['providers']]) : [];
+    $current_state = function_exists('lousy_outages_get_current_state') ? \lousy_outages_get_current_state() : (function_exists('lousy_outages_current_state_from_snapshot') ? \lousy_outages_current_state_from_snapshot(['providers' => $config['initial']['providers']]) : []);
     $meta_counts = isset($current_state['meta']) && is_array($current_state['meta']) ? $current_state['meta'] : ['active_outage_count'=>0,'signal_count'=>0,'unverified_count'=>0,'generated_at'=>gmdate('c')];
     $config['initial']['current_state'] = $current_state;
     $config['meta'] = $meta_counts;
@@ -1201,14 +1182,14 @@ function render_report_shortcode(): string {
         'lousy-outages',
         $base_url . 'lousy-outages.css',
         [],
-        file_exists($base_path . 'lousy-outages.css') ? filemtime($base_path . 'lousy-outages.css') : null
+        asset_version($base_path, 'lousy-outages.css')
     );
 
     wp_enqueue_script(
         'lousy-outages',
         $base_url . 'lousy-outages.js',
         [],
-        file_exists($base_path . 'lousy-outages.js') ? filemtime($base_path . 'lousy-outages.js') : null,
+        asset_version($base_path, 'lousy-outages.js'),
         true
     );
 

--- a/scripts/build-lousy-outages-release.sh
+++ b/scripts/build-lousy-outages-release.sh
@@ -4,7 +4,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SRC="$ROOT/lousy-outages"
 DIST="$ROOT/dist"
 ZIP="$DIST/lousy-outages.zip"
-VERSION="0.3.5"
+VERSION="0.3.6"
 PLUGIN_HEADER="Plugin Name: Lousy"$' '"Outages"
 rm -rf "$DIST/.lousy-outages-build" "$ZIP" "$ZIP.sha256" "$DIST/release-manifest.json"
 mkdir -p "$DIST/.lousy-outages-build/lousy-outages" "$DIST"
@@ -17,13 +17,13 @@ rsync -a --delete \
 mapfile -t entries < <(zipinfo -1 "$ZIP")
 printf '%s\n' "${entries[@]}" | grep -qx 'lousy-outages/lousy-outages.php'
 ! printf '%s\n' "${entries[@]}" | grep -qx 'lousy-outages/lousy-outages/lousy-outages.php'
-! printf '%s\n' "${entries[@]}" | grep -q '^lousy-outages-0\.3\.5/'
+! printf '%s\n' "${entries[@]}" | grep -q '^lousy-outages-0\.3\.6/'
 count=0; tmp="$DIST/.lousy-outages-build/check"; rm -rf "$tmp"; mkdir -p "$tmp"; unzip -q "$ZIP" -d "$tmp"
 while IFS= read -r -d '' f; do grep -q "$PLUGIN_HEADER" "$f" && count=$((count+1)) || true; done < <(find "$tmp" -type f -print0)
 [ "$count" -eq 1 ]
 for bad in '.ea-php-cli.cache' 'tests/' 'recovery' 'diagnostic' '\\'; do ! printf '%s\n' "${entries[@]}" | grep -qiF "$bad"; done
-grep -Eq '^ \* Version: 0\.3\.5$' "$tmp/lousy-outages/lousy-outages.php"
-grep -Eq "define\( 'LOUSY_OUTAGES_VERSION', '0\.3\.5' \);" "$tmp/lousy-outages/lousy-outages.php"
+grep -Eq '^ \* Version: 0\.3\.6$' "$tmp/lousy-outages/lousy-outages.php"
+grep -Eq "define\( 'LOUSY_OUTAGES_VERSION', '0\.3\.6' \);" "$tmp/lousy-outages/lousy-outages.php"
 sha256sum "$ZIP" | awk '{print $1"  lousy-outages.zip"}' > "$ZIP.sha256"
 sha=$(awk '{print $1}' "$ZIP.sha256")
 commit=$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || echo unknown)

--- a/tests/lousy-outages/current-state-contract-test.php
+++ b/tests/lousy-outages/current-state-contract-test.php
@@ -4,7 +4,8 @@ if (!defined('ABSPATH')) define('ABSPATH', __DIR__ . '/../../');
 if (!defined('MINUTE_IN_SECONDS')) define('MINUTE_IN_SECONDS', 60);
 if (!defined('HOUR_IN_SECONDS')) define('HOUR_IN_SECONDS', 3600);
 if (!defined('DAY_IN_SECONDS')) define('DAY_IN_SECONDS', 86400);
-foreach (['add_action','add_filter','register_activation_hook','register_deactivation_hook','add_shortcode'] as $fn) { if (!function_exists($fn)) { eval('function '.$fn.'(...$a){}'); } }
+foreach (['add_action','add_filter','register_activation_hook','register_deactivation_hook','add_shortcode','has_action','add_management_page'] as $fn) { if (!function_exists($fn)) { eval('function '.$fn.'(...$a){}'); } }
+if (!function_exists('has_action')) { function has_action(){ return false; } }
 if (!function_exists('apply_filters')) { function apply_filters($tag,$value){ return $value; } }
 if (!function_exists('plugin_dir_path')) { function plugin_dir_path($f){ return dirname($f).'/'; } }
 if (!function_exists('plugin_dir_url')) { function plugin_dir_url($f){ return 'https://example.test/'; } }

--- a/tests/lousy-outages/hotfix-035-regression-test.php
+++ b/tests/lousy-outages/hotfix-035-regression-test.php
@@ -8,7 +8,7 @@ $files = [
   'shortcode' => file_get_contents($root.'/lousy-outages/public/shortcode.php'),
 ];
 $fail=function($m){fwrite(STDERR,"FAIL: $m\n"); exit(1);};
-if (!str_contains($files['main'], 'Version: 0.3.5') || !str_contains($files['main'], "LOUSY_OUTAGES_VERSION', '0.3.5'")) $fail('version not bumped');
+if (!str_contains($files['main'], 'Version: 0.3.6') || !str_contains($files['main'], "LOUSY_OUTAGES_VERSION', '0.3.6'")) $fail('version not bumped');
 if (preg_match('/lousy_outages_activate\(\).*?HistoryStore\(\).*?->migrate/s', $files['main'])) $fail('activation runs migration');
 if (!str_contains($files['main'], 'wp_clear_scheduled_hook( \'lousy_outages_refresh_official_providers\' )')) $fail('orphan cron not cleared');
 if (!str_contains($files['main'], "'hourly'")) $fail('cron fallback missing');
@@ -19,5 +19,6 @@ if (str_contains($files['api'], "'migration'=>array_diff_key")) $fail('api migra
 if (!str_contains($files['api'], "'page'=>") || !str_contains($files['api'], "'per_page'=>") || !str_contains($files['api'], "'has_more'=>")) $fail('pagination metadata missing');
 if (!str_contains($files['js'], "'page', '1'") || !str_contains($files['js'], "'per_page'")) $fail('dashboard does not request first page');
 if (str_contains($files['shortcode'], 'External signals (unconfirmed)') || str_contains($files['shortcode'], 'Status feeds + community') || str_contains($files['shortcode'], 'Twitter/X search') || str_contains($files['shortcode'], 'Reddit search')) $fail('stale public copy remains');
-if (!str_contains($files['shortcode'], 'Reload saved status')) $fail('public reload copy missing');
+if (str_contains($files['shortcode'], 'get_stylesheet_directory()') || str_contains($files['shortcode'], 'get_template_directory()')) $fail('theme-first asset discovery remains');
+if (!str_contains($files['shortcode'], "LOUSY_OUTAGES_URL") || !str_contains($files['shortcode'], "/assets/")) $fail('plugin asset URL base missing');
 echo "hotfix-035-regression-ok\n";

--- a/tests/lousy-outages/live-parity-036-test.php
+++ b/tests/lousy-outages/live-parity-036-test.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+if (!defined('ABSPATH')) define('ABSPATH', __DIR__ . '/../../');
+if (!defined('MINUTE_IN_SECONDS')) define('MINUTE_IN_SECONDS', 60);
+if (!defined('HOUR_IN_SECONDS')) define('HOUR_IN_SECONDS', 3600);
+if (!defined('DAY_IN_SECONDS')) define('DAY_IN_SECONDS', 86400);
+foreach (['add_action','add_filter','register_activation_hook','register_deactivation_hook','add_shortcode','has_action','add_management_page'] as $fn) { if (!function_exists($fn)) { eval('function '.$fn.'(...$a){ return false; }'); } }
+if (!function_exists('apply_filters')) { function apply_filters($tag,$value){ return $value; } }
+if (!function_exists('plugin_dir_path')) { function plugin_dir_path($f){ return dirname($f).'/'; } }
+if (!function_exists('plugin_dir_url')) { function plugin_dir_url($f){ return 'https://example.test/wp-content/plugins/lousy-outages/'; } }
+if (!function_exists('sanitize_key')) { function sanitize_key($v){ return preg_replace('/[^a-z0-9_\-]/','',strtolower((string)$v)) ?: ''; } }
+if (!function_exists('get_option')) { function get_option($k,$d=null){ return $GLOBALS['lo_options'][$k] ?? $d; } }
+if (!function_exists('update_option')) { function update_option($k,$v,$a=null){ $GLOBALS['lo_options'][$k]=$v; return true; } }
+if (!function_exists('get_transient')) { function get_transient($k){ return false; } }
+if (!function_exists('set_transient')) { function set_transient(){ return true; } }
+if (!function_exists('delete_transient')) { function delete_transient(){} }
+if (!function_exists('wp_json_encode')) { function wp_json_encode($v){ return json_encode($v); } }
+if (!function_exists('wp_date')) { function wp_date($f,$t=null){ return gmdate($f,$t?:time()); } }
+if (!function_exists('home_url')) { function home_url($p=''){ return 'https://example.test'.$p; } }
+if (!function_exists('rest_url')) { function rest_url($p=''){ return 'https://example.test/wp-json/'.$p; } }
+require __DIR__.'/../../lousy-outages/lousy-outages.php';
+$now = gmdate('c');
+$GLOBALS['lo_options']['lousy_outages_snapshot'] = ['schema_version'=>LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION,'fetched_at'=>$now,'source'=>'fixture','providers'=>[
+ ['id'=>'openai','name'=>'OpenAI','stateCode'=>'operational','tile_kind'=>'operational','verification_status'=>'verified','checked_at'=>$now,'incidents'=>[['id'=>'o1','title'=>'OpenAI incident','status'=>'investigating','updatedAt'=>$now]]],
+ ['id'=>'cloudflare','name'=>'Cloudflare','stateCode'=>'operational','tile_kind'=>'operational','verification_status'=>'verified','checked_at'=>$now,'incidents'=>[['id'=>'c1','title'=>'Cloudflare incident','status'=>'identified','updatedAt'=>$now]]],
+ ['id'=>'aws','name'=>'AWS','stateCode'=>'operational','tile_kind'=>'operational','verification_status'=>'verified','checked_at'=>$now,'incidents'=>[
+  ['id'=>'a1','title'=>'AWS incident 1','status'=>'investigating','updatedAt'=>$now],['id'=>'a2','title'=>'AWS incident 2','status'=>'identified','updatedAt'=>$now],['id'=>'a3','title'=>'AWS incident 3','status'=>'monitoring','updatedAt'=>$now]
+ ]],
+]];
+$state = lousy_outages_get_current_state();
+$fail = fn($m) => (fwrite(STDERR, "FAIL: $m\n") && exit(1));
+if (count($state['outages']) !== 5) $fail('current_state.outages must contain 5 records');
+if (($state['meta']['active_outage_count'] ?? 0) !== 5) $fail('meta.active_outage_count must equal 5');
+if (count(\SuzyEaston\LousyOutages\Summary::ordered_current_incidents()) !== 5) $fail('homepage summary incident source must see 5 records');
+[$path,$url] = \SuzyEaston\LousyOutages\locate_assets_base();
+if (!str_contains($url, '/wp-content/plugins/lousy-outages/assets/')) $fail('assets must load from plugin directory');
+echo "live-parity-036-ok\n";


### PR DESCRIPTION
### Motivation

- Production showed split-brain between homepage, dashboard and REST summary because public surfaces consumed inconsistent sources instead of one canonical snapshot.  
- Public assets could be served from stale theme copies causing version skew between SSR and JS hydration.  
- History reads could OOM during public requests because migration and full-option deserialization ran during ordinary reads.  
- Need a calm, credible status-board UX while preserving the plugin’s arcade/terminal identity.

### Description

- Add a read-only canonical accessor `lousy_outages_get_current_state()` that returns the validated saved snapshot shape (`outages`, `signals`, `unverified`, `operational`, `providers`, `meta`, `fetched_at`, `source`, `errors`, `plugin_version`, `snapshot_schema_version`) and returns an explicit delayed/unverified state when the snapshot is missing or invalid.  
- Refactor consumers to use the canonical state: `Summary::providers()` and `Summary::ordered_current_incidents()` now render directly from `current_state.outages`/lanes; the shortcode SSR hydration reads `lousy_outages_get_current_state()` so homepage, dashboard and REST summary share the same source.  
- Make public assets always load from the plugin assets base (`LOUSY_OUTAGES_URL . 'assets/'`) and use `plugin_version` + `filemtime()` via `asset_version()` for cache-safe versions, removing theme-first asset discovery.  
- Implement bounded history storage and queries: `HistoryStore` gains a dedicated table install/exists helpers and `queryPage()` for paged queries, and history endpoints use the paged results; forced read-time migrations were removed from normal refresh/report/activation paths.  
- Update API summary to expose the canonical `current_state` payload and add no-store/no-cache headers plus `X-Lousy-Outages-Version` and `X-Lousy-Outages-Snapshot-Schema`, and add a small admin diagnostics page and layout/CSS improvements for the operations-console hierarchy.  
- Bump plugin header and `LOUSY_OUTAGES_VERSION` to `0.3.6` and `LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION` to `5`, and update the reproducible release builder checks to `0.3.6`.

### Testing

- `php tests/lousy-outages/current-state-contract-test.php` — passed.  
- `php tests/lousy-outages/live-parity-036-test.php` (5-incident fixture asserting canonical parity and asset path) — passed.  
- `php tests/lousy-outages/hotfix-035-regression-test.php` — passed.  
- Syntax checks: `php -l` on `includes/CurrentState.php`, `includes/AdminDiagnostics.php`, `includes/Storage/HistoryStore.php`, `includes/Storage/IncidentStore.php`, `includes/Api.php`, `lousy-outages.php`, `includes/Summary.php`, `public/shortcode.php` — all returned no syntax errors.  
- Release builder: `./scripts/build-lousy-outages-release.sh` executed successfully to validate packaging steps (generated `dist/` artifacts removed; no ZIP committed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f971afc9883319a77d4e48859f9c0)