### PR TITLE
Refresh README for Suzy’s public lab and consulting work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # Suzy Easton
 
-This is the public creative-technology portfolio and laboratory of Suzy Easton, a Vancouver-based AI strategist, solutions engineer, creative technologist, musician, and product builder. It powers [suzyeaston.ca](https://suzyeaston.ca), documents selected experiments, and shows how practical systems can still have a pulse.
+*Practical AI, strange interfaces, and useful systems built in Vancouver.*
 
-Useful doors in:
+This repository powers [suzyeaston.ca](https://suzyeaston.ca), the public creative-technology home of Suzy Easton.
+
+It is part portfolio, part workshop, and part open notebook. The work moves between AI strategy, cloud operations, automation, civic data, music technology, interactive storytelling, and the occasional interface that looks like it escaped from an arcade cabinet.
+
+Some projects are polished. Some are mid-mutation. All of them have survived contact with reality.
+
+## Doors in
 
 - [Live site](https://suzyeaston.ca)
 - [Lousy Outages](https://suzyeaston.ca/lousy-outages/)
@@ -12,75 +18,147 @@ Useful doors in:
 
 ## What this is
 
-This repository is a public lab, a portfolio, and a build-in-public record. It brings together practical AI, cloud and IT operations, automation, civic data, music technology, interactive storytelling, and experimental interfaces.
+This is a public lab for building useful things in plain sight.
 
-It is also evidence of professional capability: taking ambiguous ideas, turning them into working systems, testing them, improving them, and leaving enough of the process visible that other people can understand the decisions. Some projects are polished. Some are mid-mutation. All of them are real.
+The repository contains selected experiments, production code, prototypes, documentation, and the visible remains of ideas being tested properly rather than discussed forever.
+
+It also shows how Suzy works: start with an unclear problem, find the useful part, build a working system, test it, listen to what breaks, and improve it without sanding off all the personality.
+
+The code is public where that makes sense. Client work, private infrastructure, subscriber data, and future commercial layers live elsewhere.
 
 ## Featured work
 
 ### Lousy Outages
 
-Lousy Outages is independent outage intelligence for AI, cloud, developer, and creative tools. It watches provider status sources, groups incidents into a public dashboard, and translates reliability noise into explanations humans can act on.
+**Lousy Outages** is independent outage intelligence for AI, cloud, developer, and creative tools.
 
-The public work includes source-backed provider monitoring, incident grouping, public status display, RSS/feed foundations, community-signal experiments, and email-alert infrastructure. It is built for the space between a vendor saying “all systems operational” and everyone in the room quietly losing faith in the internet.
+It watches official provider sources, groups related notices into clearer incidents, and turns status-page language into information people can actually use. The public dashboard is built for the awkward space between “all systems operational” and an entire group chat quietly confirming that nothing works.
 
-Future commercial layers may include personalised or premium monitoring, higher-signal alerting, and private operational views. Subscriber details, client systems, and private infrastructure are not part of this public repository.
+Current public work includes:
 
-Useful developer entry point: `GET /wp-json/lousy-outages/v1/status`. More implementation notes live in [`lousy-outages/README.md`](lousy-outages/README.md).
+- source-backed provider monitoring
+- incident grouping and lifecycle tracking
+- public status and history views
+- RSS and notification foundations
+- email-alert infrastructure
+- community-signal experiments
+- provider and incident diagnostics
+
+Future commercial layers may include personalised monitoring, higher-signal alerting, private operational views, and custom provider coverage.
+
+Subscriber information, customer systems, and private infrastructure are not included in this repository.
+
+Developer entry point:
+
+```text
+GET /wp-json/lousy-outages/v1/status
+```
+
+Implementation and deployment notes live in [`lousy-outages/README.md`](lousy-outages/README.md).
 
 ### Gastown First-Person Simulator
 
-Gastown Simulator is an interactive Vancouver corridor experiment built around civic/open-data pipelines, browser-world authoring, route logic, and public-place storytelling. It is less a finished game than a working question: what happens when local data, street atmosphere, and playful interface design share the same map?
+Gastown Simulator is an interactive Vancouver experiment built around civic data, browser-based world building, route logic, atmosphere, and public-place storytelling.
 
-The repository includes the WordPress page template, JavaScript simulator code, generated world data, local texture references, dialog data, and build scripts for refreshing selected City of Vancouver data. Detailed props, NPC, texture, and civic-data authoring notes have moved to [`docs/gastown-authoring.md`](docs/gastown-authoring.md).
+The current world focuses on the corridor around Waterfront Station, Water Street, and the Steam Clock. It combines generated world data, local textures, dialogue, sound, navigation systems, and selected City of Vancouver datasets.
+
+It is not trying to reproduce the city perfectly. It is exploring what happens when maps, memory, public data, and a slightly haunted sense of place share the same browser window.
+
+The repository includes:
+
+- the WordPress page template
+- simulator JavaScript
+- generated world data
+- dialogue and audio systems
+- local texture references
+- civic-data build tooling
+- props and NPC authoring structures
+
+Detailed authoring notes live in [`docs/gastown-authoring.md`](docs/gastown-authoring.md).
 
 ### Track Analyzer
 
-Track Analyzer is a musician-focused AI-assisted feedback tool for uploaded MP3s. The point is fast, practical notes on feel, lyrics, structure, and arrangement, not mystic robot judgement from a chrome-plated oracle.
+Track Analyzer is an AI-assisted feedback tool for musicians working with uploaded MP3s.
 
-It reflects a larger theme in this repo: AI is most useful when it helps a human make the next creative or technical decision with more clarity.
+It offers practical notes on feel, lyrics, structure, arrangement, and creative direction. The goal is not to replace judgement or taste. It is to help a musician hear the next decision more clearly.
+
+That approach runs through much of this repository: AI works best here as a collaborator, checkpoint, research tool, or second set of ears.
 
 ### Other experiments
 
-Not every experiment needs the same size billboard. Selected archive and side projects include Albini Q&A-related recording prompts, ASMR Lab, Loop Lab, riff-generation tools, music pages, audiovisual sketches, Vancouver data pieces, and Suzy’s Retro Arcade styling system.
+Other projects and archives include:
 
-The experiments change often. Software has declined to become a finished medium.
+- Albini Q&A and recording-culture tools
+- ASMR Lab
+- Loop Lab
+- riff and music-generation experiments
+- audiovisual sketches
+- Vancouver civic-data pieces
+- Suzy’s Retro Arcade interface system
+
+Not every experiment needs the same size billboard. Some are active, some are resting, and some are waiting for the right strange afternoon.
 
 ## Consulting and collaboration
 
-Suzy is available for selected consulting and collaboration involving:
+Suzy is available for selected consulting, prototyping, and collaboration involving:
 
 - practical AI strategy and implementation
-- AI workflow and automation design
-- prototypes and internal tools
+- AI workflows and automation
+- internal tools and product prototypes
 - cloud and service-status intelligence
-- creative-technology products
-- music and multimedia systems
-- technical discovery, architecture, and troubleshooting
+- creative-technology systems
+- music and multimedia tools
+- technical discovery and architecture
+- troubleshooting complicated systems that have acquired folklore
 
-This repository demonstrates how she works: find a useful problem, translate ambiguity into a system, build the prototype, test it, improve it in public, and preserve personality and accessibility while doing the serious parts properly.
+The work is especially suited to organisations and creative teams that need to move from a broad idea to something testable, understandable, and genuinely useful.
 
-For consulting, collaboration, or useful strange ideas, start at [Work with Suzy](https://suzyeaston.ca/work-with-suzy/) or email through the contact options on the site.
+This repository shows the process:
+
+- find the real problem
+- reduce the ambiguity
+- design the system
+- build the prototype
+- test the failure paths
+- improve it in public where appropriate
+- keep the result accessible and human
+
+For consulting, collaboration, or useful strange ideas, visit the [Work with Suzy](https://suzyeaston.ca/work-with-suzy/) page or use the contact options on the live site.
 
 ## Technical foundations
 
-The stack is intentionally practical rather than precious. The public site is a custom WordPress theme with PHP templates, JavaScript interfaces, REST APIs, Node tooling, automation scripts, scheduled jobs, cloud/status integrations, open-data pipelines, and responsive, accessible interface work.
+The stack is practical, flexible, and mostly uninterested in technological fashion shows.
 
-There is also Astro tooling in the repository for front-end build and preview workflows. The WordPress theme and the Lousy Outages plugin remain the main production shape.
+Core technologies include:
 
-Built in Vancouver, where the weather provides free resilience testing.
+- WordPress and PHP
+- JavaScript
+- REST APIs
+- Node tooling
+- scheduled jobs and automation
+- cloud and provider-status integrations
+- open-data pipelines
+- responsive interface design
+- accessibility testing
+- Docker-based local QA tooling
+
+There is also Astro tooling for selected front-end build and preview workflows.
+
+The custom WordPress theme and Lousy Outages plugin remain the main production shape of the site.
+
+Built in Vancouver, where the rain provides free resilience testing.
 
 ## Running the project
 
-This is primarily a production WordPress theme and public development repository, with Docker-based local QA support rather than a universal one-command product install.
+This is primarily a production WordPress theme and public development repository. It includes Docker-based local QA support, but it is not packaged as a universal one-command product installation.
 
-Install Node dependencies when needed:
+Install Node dependencies:
 
 ```sh
 npm install
 ```
 
-Run available JavaScript tests:
+Run the JavaScript test suite:
 
 ```sh
 npm test
@@ -111,31 +189,39 @@ Refresh the Gastown civic-data world build:
 npm run build:gastown-world
 ```
 
-The local WordPress setup uses Docker Compose, WordPress, MariaDB, WP-CLI, this theme mounted as `suzyeastonca`, and the `lousy-outages` plugin mounted from this repository.
+The local WordPress environment uses Docker Compose, WordPress, MariaDB, and WP-CLI. The theme and Lousy Outages plugin are mounted directly from this repository for testing.
 
 ## Project documentation
 
-Specialised notes live outside the main README so this page can introduce the work without becoming a basement filing cabinet.
+Specialised notes live outside the main README so this page can remain an introduction rather than becoming a basement filing cabinet.
 
 - [`docs/gastown-authoring.md`](docs/gastown-authoring.md), props, NPCs, textures, and civic-data world builds
-- [`lousy-outages/README.md`](lousy-outages/README.md), provider monitoring, notifications, feeds, QA, and deployment notes
+- [`lousy-outages/README.md`](lousy-outages/README.md), monitoring, notifications, feeds, QA, and deployment
 - [`assets/audio/gastown/README.md`](assets/audio/gastown/README.md), Gastown audio assets
-- [`assets/brand/README.md`](assets/brand/README.md), brand asset notes
+- [`assets/brand/README.md`](assets/brand/README.md), brand assets and usage notes
 
 ## Open source and commercial development
 
-This repository contains selected public experiments and portfolio work. It is a community resource, a professional proof point, and a visible lab for ideas Suzy is willing to develop in public.
+This repository contains selected public experiments and portfolio work.
 
-That does not mean every future layer belongs here. Commercial services, customer implementations, consulting systems, subscriber infrastructure, and proprietary components may live in private repositories. Client work and private infrastructure are not included here.
+It is a community resource, a professional proof point, and a place for ideas that benefit from being developed in the open.
 
-Public code remains governed by its applicable licence. Contributions and issue reports are welcome where they fit the public project, but the public repository should not be read as a promise that all related work will remain open forever.
+That does not mean every future layer belongs here.
+
+Commercial services, consulting systems, customer implementations, subscriber infrastructure, and proprietary components may be developed in private repositories. Client work and private infrastructure are not included here.
+
+Public code remains governed by its applicable licence. Contributions and issue reports are welcome where they fit the public project, but this repository should not be read as a promise that all related work will always remain open.
 
 ## About Suzy
 
-Suzy Easton is a Vancouver-based musician and technologist working across AI strategy, solutions engineering, product prototypes, music systems, civic curiosity, and experimental web interfaces. Her background in recording, performance, production culture, support, QA, operations, and software gives the work its shape: direct, iterative, technical, and allergic to unnecessary gloss.
+Suzy Easton is a Vancouver-based AI strategist, solutions engineer, musician, and creative technologist.
+
+Her background spans music performance and recording, technical support, QA, IT operations, cloud systems, automation, and software development. That mix shapes the work: direct, iterative, technically grounded, and suspicious of unnecessary gloss.
 
 Suzy’s Retro Arcade is still part of the house style. It is not the whole job description.
 
 ## Licence
 
-The public code in this repository is available under the MIT Licence where applicable. See [`LICENSE`](LICENSE) for the licence text.
+Public code in this repository is available under the MIT Licence where applicable.
+
+See [`LICENSE`](LICENSE) for the full licence text.


### PR DESCRIPTION
### Motivation

- Refresh the repository README to present the project as a public lab and consulting/home page with clearer featured-work and consulting copy. 
- Surface the primary project entry points (“Doors in”) using the repository/site slugs that already exist. 
- Preserve Canadian spelling, avoid changes to application code, and keep documentation links accurate and local where possible.

### Description

- Replaced `README.md` with the supplied refreshed copy that restructures the intro, featured projects, consulting notes, technical foundations, running instructions, and documentation links. 
- Updated the “Doors in” list to use the existing site slugs (`/lousy-outages/`, `/gastown-sim/`, `/suzys-track-analyzer/`, `/work-with-suzy/`) rather than inventing routes. 
- Converted referenced documentation mentions into local Markdown links where files exist (for example `lousy-outages/README.md`, `docs/gastown-authoring.md`, `assets/audio/gastown/README.md`, `assets/brand/README.md`, and `LICENSE`). 
- Did not modify application code or runtime assets; only `README.md` was changed.

### Testing

- Verified README npm commands against `package.json` scripts with a local parser, and found all referenced commands present (OK). 
- Verified that referenced local documentation files exist using a link-target check script (OK). 
- Ran a local Markdown structure/link validator (fenced-code balance, heading spacing, trailing-whitespace, local link targets) and it passed; installation of `markdownlint-cli` via `npm` failed due to registry `403` in this environment, so full `markdownlint` could not be executed (installation blocked). 
- Ran the repository test suite with `npm test`; the run reported 78 tests total with 60 passing and 18 failing, which are existing application tests unrelated to the README-only change. Confirmed only `README.md` was staged and committed as part of this update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61893111388331a2c7fdc22111980f)