### PR TITLE
Optional PublicChatter, recipient preview & delivery diagnostics, and safer mail transport (v0.4.5)

### DIFF
--- a/__tests__/lousy-outages-email-static.test.js
+++ b/__tests__/lousy-outages-email-static.test.js
@@ -1,0 +1,50 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const alerts = fs.readFileSync('lousy-outages/includes/IncidentAlerts.php','utf8');
+const subs = fs.readFileSync('lousy-outages/includes/Subscriptions.php','utf8');
+const transport = fs.readFileSync('lousy-outages/includes/MailTransport.php','utf8');
+const plugin = fs.readFileSync('lousy-outages/lousy-outages.php','utf8');
+
+test('settings page renders with missing PublicChatterSource diagnostic', () => {
+  assert.match(plugin, /includes\/Sources\/PublicChatterSource\.php', false/);
+  assert.match(plugin, /\$lo_public_chatter_source && method_exists/);
+  assert.match(plugin, /Optional source class PublicChatterSource is unavailable/);
+});
+
+test('subscriber selection is canonical, confirmed, realtime, provider-filtered and deduped', () => {
+  assert.match(alerts, /SELECT email,status,providers,realtime_alerts FROM \{\$table\}/);
+  assert.match(alerts, /STATUS_SUBSCRIBED, 'confirmed'/);
+  assert.match(alerts, /no_realtime_opt_in/);
+  assert.match(alerts, /provider_preference_mismatch/);
+  assert.match(alerts, /OPTION_SUBSCRIBERS/);
+  assert.match(alerts, /array_unique\(\$recipients\)/);
+});
+
+test('statistics count confirmed rows for alert/digest totals and preserve confirmation on preference update', () => {
+  assert.match(subs, /status IN \('subscribed','confirmed'\) AND COALESCE\(realtime_alerts/);
+  assert.match(subs, /status IN \('subscribed','confirmed'\) AND COALESCE\(daily_digest/);
+  assert.match(subs, /unset\(\$data\['status'\]\)/);
+});
+
+test('mail transport defaults to WordPress and does not force localhost SMTP/sendmail', () => {
+  assert.match(transport, /get_option\('lousy_outages_mail_transport_mode', 'wordpress'\)/);
+  assert.match(transport, /wordpress_.*\$phpmailer->Mailer/s);
+  assert.doesNotMatch(transport, /Host = '127\.0\.0\.1'/);
+  assert.doesNotMatch(transport, /Port = 25/);
+});
+
+test('batch sending records masked per-recipient accepted-for-sending diagnostics without stopping on failure', () => {
+  assert.match(alerts, /foreach \(\$subscribers as \$email\)/);
+  assert.match(alerts, /accepted_for_sending/);
+  assert.match(alerts, /immediate_failures/);
+  assert.match(alerts, /mask_email/);
+  assert.doesNotMatch(alerts, /return \['ok'=>false,'recipients'=>\$subscribers,'error'=>'mail send failed/);
+});
+
+test('admin test alert is capability and nonce protected', () => {
+  assert.match(plugin, /admin_post_lousy_outages_send_test_alert/);
+  assert.match(plugin, /current_user_can\( 'manage_options' \)/);
+  assert.match(plugin, /check_admin_referer\( 'lousy_outages_send_test_alert' \)/);
+  assert.match(plugin, /sanitize_email\( wp_unslash/);
+});

--- a/lousy-outages/README.md
+++ b/lousy-outages/README.md
@@ -1,5 +1,13 @@
 # Lousy Outages
 
+## 0.4.5
+
+- Settings page now treats public chatter sources as optional and shows an admin diagnostic when `PublicChatterSource` is unavailable.
+- Realtime alert recipients are selected from the subscriptions table first, with legacy `lo_subscribers` compatibility and duplicate removal.
+- Email alert batches attempt each recipient independently and store admin-only diagnostics for attempted, accepted-for-sending, immediate failures, transport, masked recipient results, and last error.
+- Mail transport no longer forces local sendmail or unauthenticated localhost SMTP by default; WordPress, the host, or SMTP plugins remain in control unless `LOUSY_OUTAGES_MAIL_TRANSPORT`, `lousy_outages_mail_transport_mode`, or the matching filter opts into `local_mail` or `local_sendmail`.
+
+
 Monitor third‑party service status and get SMS and email alerts when things break.
 
 ## Providers

--- a/lousy-outages/includes/IncidentAlerts.php
+++ b/lousy-outages/includes/IncidentAlerts.php
@@ -1436,13 +1436,56 @@ class IncidentAlerts {
     }
 
     public static function get_subscribers(): array {
-        $subscribers = get_option(self::OPTION_SUBSCRIBERS, []);
-        if (!is_array($subscribers)) {
-            return [];
-        }
-
-        return array_values(array_filter(array_map('sanitize_email', $subscribers)));
+        $preview = self::recipient_preview('');
+        return array_values(array_map('strval', (array) ($preview['subscriber_recipients'] ?? [])));
     }
+
+    public static function mask_email(string $email): string {
+        $email = strtolower(sanitize_email($email));
+        if (!$email || false === strpos($email, '@')) { return ''; }
+        [$local, $domain] = explode('@', $email, 2);
+        $localMask = substr($local, 0, 1) . str_repeat('*', max(2, min(6, strlen($local) - 1)));
+        return $localMask . '@' . $domain;
+    }
+
+    public static function recipient_preview(string $providerId = ''): array {
+        $providerId = sanitize_key($providerId);
+        $excluded = ['pending'=>0,'no_realtime_opt_in'=>0,'provider_preference_mismatch'=>0,'invalid_email'=>0,'already_sent_deduped'=>0];
+        $recipients = [];
+        global $wpdb;
+        $table = class_exists(__NAMESPACE__ . '\Subscriptions') ? Subscriptions::table_name() : '';
+        if ($table && isset($wpdb) && is_object($wpdb) && method_exists($wpdb, 'get_results') && method_exists($wpdb, 'prepare')) {
+            $rows = $wpdb->get_results("SELECT email,status,providers,realtime_alerts FROM {$table}", ARRAY_A);
+            foreach ((array) $rows as $row) {
+                $email = strtolower(sanitize_email((string) ($row['email'] ?? '')));
+                if (!$email || !is_email($email)) { $excluded['invalid_email']++; continue; }
+                if (!in_array((string) ($row['status'] ?? ''), [Subscriptions::STATUS_SUBSCRIBED, 'confirmed'], true)) { $excluded['pending']++; continue; }
+                if (isset($row['realtime_alerts']) && (int) $row['realtime_alerts'] !== 1) { $excluded['no_realtime_opt_in']++; continue; }
+                $prefs = [];
+                $decoded = json_decode((string) ($row['providers'] ?? ''), true);
+                if (is_array($decoded)) { $prefs = Subscriptions::normalize_provider_ids($decoded); }
+                if ($providerId && $prefs && !in_array($providerId, $prefs, true)) { $excluded['provider_preference_mismatch']++; continue; }
+                $recipients[] = $email;
+            }
+        }
+        $legacy = get_option(self::OPTION_SUBSCRIBERS, []);
+        if (is_array($legacy)) {
+            foreach ($legacy as $raw) {
+                $email = strtolower(sanitize_email((string) $raw));
+                if (!$email || !is_email($email)) { $excluded['invalid_email']++; continue; }
+                if (class_exists(__NAMESPACE__ . '\Subscriptions') && method_exists(__NAMESPACE__ . '\Subscriptions', 'is_confirmed') && !Subscriptions::is_confirmed($email)) { $excluded['pending']++; continue; }
+                if ($providerId && class_exists(__NAMESPACE__ . '\Subscriptions') && !Subscriptions::subscriber_wants_provider($email, $providerId)) { $excluded['provider_preference_mismatch']++; continue; }
+                if (class_exists(__NAMESPACE__ . '\Subscriptions') && !Subscriptions::subscriber_wants_realtime($email)) { $excluded['no_realtime_opt_in']++; continue; }
+                $recipients[] = $email;
+            }
+        }
+        $before = count($recipients);
+        $recipients = array_values(array_unique($recipients));
+        $excluded['already_sent_deduped'] += max(0, $before - count($recipients));
+        return ['subscriber_recipients'=>$recipients,'subscriber_recipients_count'=>count($recipients),'total_recipients_count'=>count($recipients),'excluded'=>$excluded,'masked_recipients'=>array_map([self::class,'mask_email'],$recipients),'timestamp'=>gmdate('c')];
+    }
+
+    public static function latest_delivery_attempt(): array { return (array) get_option(self::OPTION_LAST_ALERT_DELIVERY_RESULT, []); }
 
     private static function normalize_unsubscribe_email(string $email): string {
         $normalized = strtolower(trim((string) sanitize_email($email)));
@@ -1551,92 +1594,46 @@ class IncidentAlerts {
         );
     }
 
+    public static function send_test_alert_to(string $email): array {
+        $email = sanitize_email($email);
+        if (!$email || !is_email($email)) { return ['ok'=>false,'error'=>'invalid_email','recipients'=>[]]; }
+        $incident = self::make_synthetic_incident(['provider'=>'lousy-outages','title'=>'Lousy Outages realistic test alert','status'=>'degraded']);
+        return self::send_incident_alert_email($incident, ['explicit_recipients'=>[$email], 'mode'=>'admin_test']);
+    }
+
     private static function send_incident_alert_email(Incident $incident, array $options = []): array {
         $providerId = sanitize_key((string) $incident->provider);
-        $excluded = ['pending'=>0,'no_realtime_opt_in'=>0,'provider_preference_mismatch'=>0,'invalid_email'=>0,'already_sent_deduped'=>0];
-        $subscribers = [];
-        foreach (self::get_subscribers() as $email) {
-            $clean = sanitize_email((string) $email);
-            if (!$clean || !is_email($clean)) { $excluded['invalid_email']++; continue; }
-            if (!Subscriptions::is_confirmed($clean)) { $excluded['pending']++; continue; }
-            if (!Subscriptions::subscriber_wants_realtime($clean)) { $excluded['no_realtime_opt_in']++; continue; }
-            if (!Subscriptions::subscriber_wants_provider($clean, $providerId)) { $excluded['provider_preference_mismatch']++; continue; }
-            $subscribers[] = $clean;
+        if (!empty($options['explicit_recipients']) && is_array($options['explicit_recipients'])) {
+            $preview = ['subscriber_recipients'=>array_values(array_filter(array_map('sanitize_email', $options['explicit_recipients']))),'excluded'=>[]];
+            $subscribers = $preview['subscriber_recipients'];
+        } else {
+            $preview = self::recipient_preview($providerId);
+            $subscribers = (array) ($preview['subscriber_recipients'] ?? []);
         }
         $notificationEmail = sanitize_email((string) get_option('lousy_outages_email', get_option('admin_email')));
-        $notificationOnly = !empty($options['notification_only']);
-        if ($notificationOnly) {
-            $subscribers = [];
-        }
-        if ($notificationEmail && is_email($notificationEmail)) {
-            $subscribers[] = $notificationEmail;
-        }
+        if (!empty($options['notification_only'])) { $subscribers = []; }
+        if (empty($options['explicit_recipients']) && $notificationEmail && is_email($notificationEmail)) { $subscribers[] = $notificationEmail; }
         $beforeDedup = count($subscribers);
         $subscribers = array_values(array_unique(array_filter(array_map('sanitize_email', $subscribers))));
-        $excluded['already_sent_deduped'] += max(0, $beforeDedup - count($subscribers));
-        update_option(self::OPTION_LAST_ALERT_RECIPIENT_DIAGNOSTICS, [
-            'incident_id' => (string) $incident->id,
-            'provider_id' => $providerId,
-            'provider_name' => (string) $incident->provider,
-            'mode' => (string) ($options['mode'] ?? 'real'),
-            'notification_recipients' => ($notificationEmail && is_email($notificationEmail)) ? [$notificationEmail] : [],
-            'subscriber_recipients_count' => (int) count(array_diff($subscribers, [$notificationEmail])),
-            'total_recipients_count' => (int) count($subscribers),
-            'excluded' => $excluded,
-            'timestamp' => gmdate('c'),
-        ], false);
-        if (empty($subscribers)) {
-            return ['ok'=>false,'recipients'=>[],'error'=>'no_recipients'];
-        }
-        if (!empty($options['dry_run'])) {
-            return ['ok'=>true,'recipients'=>$subscribers,'error'=>''];
-        }
+        $excluded = (array) ($preview['excluded'] ?? []);
+        $excluded['already_sent_deduped'] = (int)($excluded['already_sent_deduped'] ?? 0) + max(0, $beforeDedup - count($subscribers));
+        update_option(self::OPTION_LAST_ALERT_RECIPIENT_DIAGNOSTICS, ['incident_id'=>(string)$incident->id,'provider_id'=>$providerId,'provider_name'=>(string)$incident->provider,'mode'=>(string)($options['mode'] ?? 'real'),'notification_recipients'=>($notificationEmail&&is_email($notificationEmail))?[self::mask_email($notificationEmail)]:[],'subscriber_recipients_count'=>max(0,count(array_diff($subscribers,[$notificationEmail]))),'total_recipients_count'=>count($subscribers),'excluded'=>$excluded,'timestamp'=>gmdate('c')], false);
+        if (empty($subscribers)) { return ['ok'=>false,'recipients'=>[],'error'=>'no_recipients']; }
+        if (!empty($options['dry_run'])) { return ['ok'=>true,'recipients'=>$subscribers,'error'=>'']; }
 
-        $provider      = $incident->provider;
-        $statusLabel   = self::status_label($incident->status);
-        $impact        = $incident->impact ?? self::impact_from_status($incident->status);
-        $timestamp     = gmdate('c', $incident->detected_at);
-        $components    = $incident->component ? array_map('trim', explode(',', $incident->component)) : [];
-        $componentLine = $incident->component ?: 'All monitored components';
-        $url           = $incident->url ?: self::provider_url(sanitize_key($provider));
-        $summary       = $incident->title;
-        if (!empty($options['manual_replay'])) {
-            $summary = '[Lousy Outages replay] ' . preg_replace('/^\[Lousy Outages replay\]\s*/', '', $summary);
-        }
-
+        $provider=$incident->provider; $impact=$incident->impact ?? self::impact_from_status($incident->status); $timestamp=gmdate('c',$incident->detected_at); $components=$incident->component?array_map('trim',explode(',',$incident->component)):[]; $componentLine=$incident->component ?: 'All monitored components'; $url=$incident->url ?: self::provider_url(sanitize_key($provider)); $summary=$incident->title;
+        $accepted=0; $failed=0; $results=[]; $lastError='';
         foreach ($subscribers as $email) {
-            $token = self::build_unsubscribe_token($email);
-            $unsubscribe = add_query_arg(
-                [
-                    'lo_unsub' => 1,
-                    'email'    => rawurlencode($email),
-                    'token'    => $token,
-                ],
-                home_url('/lousy-outages/')
-            );
-
-            $incident_payload = [
-                'service'         => $provider,
-                'status'          => $incident->status,
-                'impact'          => $impact,
-                'summary'         => $summary,
-                'notes'           => !empty($options['manual_replay']) ? 'Administrator-requested replay of a real stored incident. Public subscribers were not notified.' : '',
-                'timestamp'       => $timestamp,
-                'components'      => $componentLine,
-                'components_list' => $components,
-                'url'             => $url,
-                'unsubscribe_url' => $unsubscribe,
-            ];
-
-            $sent = send_lo_outage_alert_email($email, $incident_payload);
-
-            if (! $sent) {
-                self::log_error($provider, 'mail send failed for ' . $email);
-                return ['ok'=>false,'recipients'=>$subscribers,'error'=>'mail send failed for ' . $email];
-            }
+            $token=self::build_unsubscribe_token($email);
+            $unsubscribe=add_query_arg(['lo_unsub'=>1,'email'=>rawurlencode($email),'token'=>$token], home_url('/lousy-outages/'));
+            $payload=['service'=>$provider,'status'=>$incident->status,'impact'=>$impact,'summary'=>$summary,'notes'=>!empty($options['manual_replay'])?'Administrator-requested replay of a real stored incident. Public subscribers were not notified.':'','timestamp'=>$timestamp,'components'=>$componentLine,'components_list'=>$components,'url'=>$url,'unsubscribe_url'=>$unsubscribe];
+            $sent=send_lo_outage_alert_email($email,$payload);
+            if ($sent) { $accepted++; $results[]=['recipient'=>self::mask_email($email),'accepted_for_sending'=>true]; }
+            else { $failed++; $lastError='wp_mail returned false for '.self::mask_email($email); $results[]=['recipient'=>self::mask_email($email),'accepted_for_sending'=>false,'error'=>$lastError]; self::log_error($provider,$lastError); }
         }
-
-        return ['ok'=>true,'recipients'=>$subscribers,'error'=>''];
+        $attempt=['timestamp'=>gmdate('c'),'attempted'=>count($subscribers),'accepted_for_sending'=>$accepted,'immediate_failures'=>$failed,'transport'=>class_exists(__NAMESPACE__.'\MailTransport')?MailTransport::currentTransport():'wordpress','results'=>$results,'last_error'=>$lastError];
+        update_option(self::OPTION_LAST_ALERT_DELIVERY_RESULT, $attempt, false);
+        return ['ok'=>$accepted>0,'recipients'=>$subscribers,'error'=>$failed?($lastError ?: 'one_or_more_failed'):'','attempt'=>$attempt];
     }
 
     /**
@@ -1649,7 +1646,7 @@ class IncidentAlerts {
 
     private static function record_alert_delivery(bool $ok, Incident $incident, array $recipients, string $reason, bool $markSentCalled, array $options = []): void
     {
-        $payload = ['timestamp'=>gmdate('c'),'recipient_count'=>count($recipients),'recipients'=>$recipients,'provider'=>$incident->provider,'incident_id'=>$incident->id,'title'=>$incident->title,'status'=>$incident->status,'mark_sent_called'=>$markSentCalled,'synthetic'=>!empty($options['synthetic']),'mode'=>(string)($options['mode'] ?? 'real'),'reason'=>$reason];
+        $payload = ['timestamp'=>gmdate('c'),'recipient_count'=>count($recipients),'recipients'=>array_map([self::class,'mask_email'],$recipients),'provider'=>$incident->provider,'incident_id'=>$incident->id,'title'=>$incident->title,'status'=>$incident->status,'mark_sent_called'=>$markSentCalled,'synthetic'=>!empty($options['synthetic']),'mode'=>(string)($options['mode'] ?? 'real'),'reason'=>$reason];
         update_option(self::OPTION_LAST_ALERT_DELIVERY_RESULT, $payload, false);
         if ($ok) {
             update_option(self::OPTION_LAST_ALERT_SUCCESS, $payload, false);

--- a/lousy-outages/includes/MailTransport.php
+++ b/lousy-outages/includes/MailTransport.php
@@ -21,6 +21,7 @@ class MailTransport
     {
         add_action('phpmailer_init', [self::class, 'configure']);
         add_action('wp_mail_failed', [self::class, 'handleFailure']);
+        add_action('wp_mail_succeeded', [self::class, 'handleSuccess']);
         add_filter('wp_mail_from', [self::class, 'fromAddress']);
         add_filter('wp_mail_from_name', [self::class, 'fromName']);
     }
@@ -64,31 +65,28 @@ class MailTransport
 
         $phpmailer->Sender = $envelopeSender;
 
-        if (self::$forceMail) {
+        $mode = self::compatMode();
+        if ('local_mail' === $mode || self::$forceMail) {
             $phpmailer->isMail();
             $phpmailer->Mailer = 'mail';
-            self::$transport = 'mail';
+            self::$transport = 'local_mail';
             self::$forceMail = false;
             self::addDebugHeaders($phpmailer, $envelopeSender, $fromAddress);
             return;
         }
 
-        $sendmailPath = self::SENDMAIL_PATH;
-        if (is_string($sendmailPath) && is_executable($sendmailPath)) {
-            $phpmailer->isSendmail();
-            $phpmailer->Sendmail = $sendmailPath . ' -t -i -f ' . escapeshellarg($envelopeSender);
-            self::$transport = 'sendmail';
-            self::addDebugHeaders($phpmailer, $envelopeSender, $fromAddress);
-            return;
+        if ('local_sendmail' === $mode) {
+            $sendmailPath = self::SENDMAIL_PATH;
+            if (is_string($sendmailPath) && is_executable($sendmailPath)) {
+                $phpmailer->isSendmail();
+                $phpmailer->Sendmail = $sendmailPath . ' -t -i -f ' . escapeshellarg($envelopeSender);
+                self::$transport = 'local_sendmail';
+                self::addDebugHeaders($phpmailer, $envelopeSender, $fromAddress);
+                return;
+            }
         }
 
-        $phpmailer->isSMTP();
-        $phpmailer->Host = '127.0.0.1';
-        $phpmailer->Port = 25;
-        $phpmailer->SMTPAuth = false;
-        $phpmailer->SMTPAutoTLS = false;
-        $phpmailer->SMTPKeepAlive = false;
-        self::$transport = 'smtp';
+        self::$transport = 'wordpress_' . (string) $phpmailer->Mailer;
         self::addDebugHeaders($phpmailer, $envelopeSender, $fromAddress);
     }
 
@@ -126,6 +124,12 @@ class MailTransport
         return $desired ?: $name;
     }
 
+    public static function handleSuccess($mailData): void
+    {
+        if (! self::isActive()) { return; }
+        update_option('lousy_outages_last_wp_mail_succeeded', ['timestamp'=>gmdate('c'), 'transport'=>self::$transport], false);
+    }
+
     public static function handleFailure(WP_Error $error): void
     {
         if (! self::isActive()) {
@@ -134,7 +138,7 @@ class MailTransport
 
         self::logFailure($error);
 
-        if ('smtp' !== self::$transport || self::$fallbackAttempted) {
+        if (false === strpos(self::$transport, 'smtp') || self::$fallbackAttempted || 'wordpress_smtp' === self::$transport) {
             return;
         }
 
@@ -176,6 +180,15 @@ class MailTransport
 
         $target = trailingslashit(WP_CONTENT_DIR) . 'uploads/lo-mail.log';
         error_log($logMessage, 3, $target);
+    }
+
+    public static function currentTransport(): string { return self::$transport; }
+
+    private static function compatMode(): string
+    {
+        $mode = defined('LOUSY_OUTAGES_MAIL_TRANSPORT') ? (string) LOUSY_OUTAGES_MAIL_TRANSPORT : (string) get_option('lousy_outages_mail_transport_mode', 'wordpress');
+        $mode = sanitize_key((string) apply_filters('lousy_outages_mail_transport_mode', $mode));
+        return in_array($mode, ['wordpress','local_mail','local_sendmail'], true) ? $mode : 'wordpress';
     }
 
     private static function resolveFromAddress(): string

--- a/lousy-outages/includes/Subscriptions.php
+++ b/lousy-outages/includes/Subscriptions.php
@@ -69,9 +69,9 @@ class Subscriptions {
         $total = (int) $wpdb->get_var("SELECT COUNT(*) FROM {$table}");
         $confirmed = (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$table} WHERE status IN (%s,%s)", self::STATUS_SUBSCRIBED, 'confirmed'));
         $pending = (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$table} WHERE status = %s", self::STATUS_PENDING));
-        $realtime = (int) $wpdb->get_var("SELECT COUNT(*) FROM {$table} WHERE COALESCE(realtime_alerts, 0) <> 0");
-        $digest = (int) $wpdb->get_var("SELECT COUNT(*) FROM {$table} WHERE COALESCE(daily_digest, 0) <> 0");
-        $newsletter = (int) $wpdb->get_var("SELECT COUNT(*) FROM {$table} WHERE COALESCE(newsletter, 0) <> 0");
+        $realtime = (int) $wpdb->get_var("SELECT COUNT(*) FROM {$table} WHERE status IN ('subscribed','confirmed') AND COALESCE(realtime_alerts, 0) <> 0");
+        $digest = (int) $wpdb->get_var("SELECT COUNT(*) FROM {$table} WHERE status IN ('subscribed','confirmed') AND COALESCE(daily_digest, 0) <> 0");
+        $newsletter = (int) $wpdb->get_var("SELECT COUNT(*) FROM {$table} WHERE status IN ('subscribed','confirmed') AND COALESCE(newsletter, 0) <> 0");
 
         $provider_all = (int) $wpdb->get_var("SELECT COUNT(*) FROM {$table} WHERE status IN ('subscribed','confirmed') AND (providers = '' OR providers IS NULL)");
         $provider_specific = max(0, $confirmed - $provider_all);
@@ -222,8 +222,12 @@ class Subscriptions {
             'consent_version' => '2026-05',
         ];
 
-        $existing = $wpdb->get_row($wpdb->prepare("SELECT id FROM {$table} WHERE email = %s", $email));
+        $existing = $wpdb->get_row($wpdb->prepare("SELECT id,status,confirmed_at FROM {$table} WHERE email = %s", $email));
         if ($existing) {
+            if (in_array((string) $existing->status, [self::STATUS_SUBSCRIBED, 'confirmed'], true)) {
+                unset($data['status']);
+                if (!empty($existing->confirmed_at)) { unset($data['confirmed_at']); }
+            }
             $wpdb->update($table, $data, ['id' => (int) $existing->id]);
             return;
         }

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -3,7 +3,7 @@ declare( strict_types=1 );
 /**
  * Plugin Name: Lousy Outages
  * Description: WordPress-native outage intelligence, community reporting, and early-warning signals for third-party service dependencies.
- * Version: 0.4.4
+ * Version: 0.4.5
  * Author: Suzy Easton
  * Text Domain: lousy-outages
  */
@@ -24,7 +24,7 @@ if ( defined( 'LOUSY_OUTAGES_DISABLE' ) && LOUSY_OUTAGES_DISABLE ) {
 }
 
 if ( ! defined( 'LOUSY_OUTAGES_VERSION' ) ) {
-    define( 'LOUSY_OUTAGES_VERSION', '0.4.4' );
+    define( 'LOUSY_OUTAGES_VERSION', '0.4.5' );
 }
 if ( ! defined( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION' ) ) {
     define( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION', 5 );
@@ -46,10 +46,15 @@ if ( ! function_exists( 'lousy_outages_require' ) ) {
             require_once $path;
             return;
         }
-        error_log( '[LO] missing include: ' . $relative );
-        if ( $required ) {
-            return;
+        $severity = $required ? 'required' : 'optional';
+        error_log( '[LO] missing ' . $severity . ' include: ' . $relative );
+        if ( function_exists( 'do_action' ) ) {
+            do_action( 'lousy_outages_missing_include', $relative, $required, $path );
         }
+        $missing = (array) get_option( 'lousy_outages_missing_includes', [] );
+        $missing[ $relative ] = [ 'required' => $required, 'path' => $path, 'last_seen' => gmdate( 'c' ) ];
+        update_option( 'lousy_outages_missing_includes', $missing, false );
+        return;
     }
 }
 
@@ -98,6 +103,12 @@ lousy_outages_require( 'includes/Sources/ProviderFeedSource.php' );
 lousy_outages_require( 'includes/Sources/SourceBudgetManager.php' );
 lousy_outages_require( 'includes/Sources/ChatterRejectionReasons.php' );
 lousy_outages_require( 'includes/Sources/StatuspageIntelSource.php' );
+lousy_outages_require( 'includes/Sources/PublicChatterSource.php', false );
+lousy_outages_require( 'includes/Sources/CloudflareRadarSource.php', false );
+lousy_outages_require( 'includes/Sources/CommunityReportIntelSource.php', false );
+lousy_outages_require( 'includes/Sources/HackerNewsChatterSource.php', false );
+lousy_outages_require( 'includes/Sources/RedditFieldReportsSource.php', false );
+lousy_outages_require( 'includes/Sources/SyntheticCanarySource.php', false );
 lousy_outages_require( 'includes/SignalCollector.php' );
 lousy_outages_require( 'includes/Api.php' );
 lousy_outages_require( 'includes/AdminCleanup.php' );
@@ -1428,9 +1439,11 @@ function lousy_outages_settings_page() {
                 </tr>
                 
                 <?php
-                $lo_public_chatter_source = class_exists('\\SuzyEaston\\LousyOutages\\Sources\\PublicChatterSource') ? new \SuzyEaston\LousyOutages\Sources\PublicChatterSource() : null;
+                $lo_public_chatter_class = '\\SuzyEaston\\LousyOutages\\Sources\\PublicChatterSource';
+                $lo_public_chatter_source = class_exists( $lo_public_chatter_class ) ? new \SuzyEaston\LousyOutages\Sources\PublicChatterSource() : null;
                 $lo_public_chatter_master_enabled = ! empty( get_option( 'lousy_outages_public_chatter_enabled', '1' ) );
-                $lo_public_chatter_direct_enabled = $lo_public_chatter_source->direct_sources_enabled();
+                $lo_public_chatter_direct_enabled = $lo_public_chatter_source && method_exists( $lo_public_chatter_source, 'direct_sources_enabled' ) ? (bool) $lo_public_chatter_source->direct_sources_enabled() : false;
+                $lo_public_chatter_missing = ! $lo_public_chatter_source;
                 $lo_public_chatter_source_statuses = [
                     'Bluesky' => ! empty( get_option( 'lousy_outages_public_chatter_bluesky_enabled', '1' ) ),
                     'Mastodon' => ! empty( get_option( 'lousy_outages_public_chatter_mastodon_enabled', '1' ) ),
@@ -1451,7 +1464,9 @@ function lousy_outages_settings_page() {
                     <p><strong>Open web:</strong> GDELT is open-web/news corroboration with budget/cooldown protection. <strong>Internet health:</strong> Cloudflare Radar and CAIDA IODA are telemetry and do not prove SaaS application outages. <strong>Community:</strong> first-party reports remain unconfirmed.</p>
                     <p class="description">Enabled sources affect dashboard diagnostics/watch candidates only. Email alerts remain thresholded; community reports remains unconfirmed and raw social post text is not shown publicly.</p>
                     <p><strong>Master Public Chatter Radar:</strong> <?php echo esc_html( $lo_public_chatter_master_enabled ? 'Enabled' : 'Disabled' ); ?> | <strong>Direct public source gate:</strong> <?php echo esc_html( $lo_public_chatter_direct_enabled ? 'Enabled' : 'Disabled' ); ?></p>
-                    <?php if ( ! $lo_public_chatter_direct_enabled ) : ?>
+                    <?php if ( $lo_public_chatter_missing ) : ?>
+                        <div class="notice notice-warning inline"><p><?php echo esc_html__( 'Optional source class PublicChatterSource is unavailable; public chatter controls are shown disabled instead of interrupting wp-admin.', 'lousy-outages' ); ?></p></div>
+                    <?php elseif ( ! $lo_public_chatter_direct_enabled ) : ?>
                         <div class="notice notice-warning inline"><p><?php echo esc_html__( 'Direct community reports source gate is disabled. Saved source checkboxes will be visible but collection is blocked until the gate is enabled.', 'lousy-outages' ); ?></p></div>
                     <?php endif; ?>
                     <?php if ( $lo_gdelt_limited ) : ?>
@@ -1506,6 +1521,18 @@ function lousy_outages_settings_page() {
             <?php submit_button( 'Send Synthetic Incident Alert', 'secondary', 'submit', false ); ?>
         </form>
         <p class="description">Synthetic incident verifies the modern template and notification pipeline.</p>
+
+        <h2>Email Delivery Diagnostics</h2>
+        <?php $lo_preview = IncidentAlerts::recipient_preview( '' ); $lo_latest = IncidentAlerts::latest_delivery_attempt(); ?>
+        <p><strong>Recipient preview:</strong> <?php echo esc_html( (string) ( $lo_preview['total_recipients_count'] ?? 0 ) ); ?> recipients would receive a realtime alert. Exclusions: <?php echo esc_html( wp_json_encode( $lo_preview['excluded'] ?? [] ) ); ?></p>
+        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="margin-top: 0.5rem;">
+            <?php wp_nonce_field( 'lousy_outages_send_test_alert' ); ?>
+            <input type="hidden" name="action" value="lousy_outages_send_test_alert">
+            <label for="lo_test_alert_email">Send test alert to</label>
+            <input id="lo_test_alert_email" type="email" name="test_email" value="<?php echo esc_attr( get_option( 'admin_email' ) ); ?>" class="regular-text" required>
+            <?php submit_button( 'Send Test Alert', 'secondary', 'submit', false ); ?>
+        </form>
+        <p><strong>Latest delivery attempt:</strong> <?php echo esc_html( wp_json_encode( $lo_latest ) ); ?></p>
 
         <?php $lo_replay_candidate = IncidentAlerts::latest_replay_candidate(); ?>
         <h2>Alert Health</h2>
@@ -1625,6 +1652,25 @@ add_action( 'admin_post_lousy_outages_test_email', function () {
 
     $redirect = add_query_arg( 'page', 'lousy-outages', admin_url( 'options-general.php' ) );
     wp_safe_redirect( $redirect );
+    exit;
+} );
+
+
+add_action( 'admin_post_lousy_outages_send_test_alert', function () {
+    if ( ! current_user_can( 'manage_options' ) ) {
+        wp_die( esc_html__( 'Sorry, you are not allowed to access this page.', 'lousy-outages' ) );
+    }
+    if ( 'POST' !== strtoupper( (string) ( $_SERVER['REQUEST_METHOD'] ?? '' ) ) ) {
+        wp_die( esc_html__( 'Test alert must be submitted with POST.', 'lousy-outages' ) );
+    }
+    check_admin_referer( 'lousy_outages_send_test_alert' );
+    $to = sanitize_email( wp_unslash( (string) ( $_POST['test_email'] ?? '' ) ) );
+    if ( ! $to || ! is_email( $to ) ) {
+        wp_die( esc_html__( 'Enter a valid test email address.', 'lousy-outages' ), 400 );
+    }
+    $result = IncidentAlerts::send_test_alert_to( $to );
+    set_transient( 'lousy_outages_notice', [ 'message' => ! empty( $result['ok'] ) ? 'Test alert accepted for sending by wp_mail().' : 'Test alert failed immediately: ' . (string) ( $result['error'] ?? 'unknown' ), 'type' => ! empty( $result['ok'] ) ? 'success' : 'error' ], 30 );
+    wp_safe_redirect( add_query_arg( 'page', 'lousy-outages', admin_url( 'options-general.php' ) ) );
     exit;
 } );
 


### PR DESCRIPTION
### Motivation
- Treat optional public chatter source classes as non-fatal to the admin UI and record missing includes as diagnostics instead of breaking wp-admin.
- Improve realtime alert recipient selection to prefer the `subscriptions` table, preserve confirmation state, filter by realtime/provider opt-ins, and deduplicate recipients.
- Make batched email sending resilient by attempting each recipient independently, recording masked per-recipient diagnostics, and avoiding a hard failure on the first send error.
- Stop forcing unauthenticated localhost SMTP/sendmail by default so WordPress and SMTP plugins control transport unless explicitly opted into local modes.

### Description
- Added `IncidentAlerts::recipient_preview`, `mask_email`, `latest_delivery_attempt`, and `send_test_alert_to` to build canonical recipient lists, mask emails for admin diagnostics, and provide a test-alert helper. 
- Reworked `send_incident_alert_email` to use the preview, support `explicit_recipients`, independently attempt each recipient, collect per-recipient `accepted_for_sending`/`immediate_failures` results, persist `OPTION_LAST_ALERT_DELIVERY_RESULT`, and return a detailed `attempt` payload.
- Updated subscribers path: `get_subscribers` now sources from `recipient_preview`, and `record_alert_delivery` masks recipients in stored payloads.
- Subscriptions improvements: `Subscriptions::stats` now counts only confirmed/subscribed rows for delivery stats, and `create_table` preserves existing confirmed status/`confirmed_at` when updating preferences.
- Mail transport changes in `MailTransport`: added `compatMode`, `currentTransport`, and `handleSuccess`, avoid forcing `127.0.0.1:25` or sendmail unless `lousy_outages_mail_transport_mode`/`LOUSY_OUTAGES_MAIL_TRANSPORT` or filter-elected modes (`local_mail`/`local_sendmail`) are selected, and expose transport info via `X-Lousy-Outages-Transport` header.
- Settings/UI changes in `lousy-outages.php`: bump version to `0.4.5`, require several public/source includes as optional, add admin diagnostics and a settings panel section showing recipient preview and latest delivery attempt, and add an admin-post handler `admin_post_lousy_outages_send_test_alert` with capability/nonce checks that leverages `IncidentAlerts::send_test_alert_to`.
- README updated with a `0.4.5` changelog summarizing the behavior changes.

### Testing
- Added a Node-based static test suite file `__tests__/lousy-outages-email-static.test.js` that asserts presence of key strings and behaviors across the PHP files intended for CI validation. 
- No automated tests were executed as part of this PR run; the new `node:test` checks are included for CI and should be run in the pipeline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a624fdf6e148331b4bcbca0f726b259)