### PR TITLE
Add Lousy Outages freemium billing foundation

### DIFF
--- a/__tests__/lousy-outages-monitored-services.test.js
+++ b/__tests__/lousy-outages-monitored-services.test.js
@@ -34,12 +34,12 @@ test('operational services use a four-column semantic table and one filtering pa
   assert.match(js, /Show ' \+ visibleOperational/);
 });
 
-test('0.4.9 release metadata is canonical', () => {
+test('0.5.0 release metadata is canonical', () => {
   const plugin = fs.readFileSync('lousy-outages/lousy-outages.php', 'utf8');
   const readme = fs.readFileSync('lousy-outages/README.md', 'utf8');
   const build = fs.readFileSync('scripts/build-lousy-outages-release.sh', 'utf8');
-  assert.match(plugin, /Version: 0\.4\.9/);
-  assert.match(plugin, /LOUSY_OUTAGES_VERSION', '0\.4\.9'/);
+  assert.match(plugin, /Version: 0\.5\.0/);
+  assert.match(plugin, /LOUSY_OUTAGES_VERSION', '0\.5\.0'/);
   assert.match(readme, /## 0\.4\.8/);
   assert.match(build, /VERSION="0\.4\.9"/);
 });

--- a/assets/css/lousy-outages-page.css
+++ b/assets/css/lousy-outages-page.css
@@ -108,3 +108,7 @@
         padding-inline: 6px;
     }
 }
+/* Paid controls use the same status-console language without touching the public board. */
+.lo-upgrade-callout,.lo-product{margin:2rem 0;padding:clamp(1.25rem,4vw,2.5rem);border:1px solid rgba(94,234,212,.45);background:linear-gradient(135deg,rgba(5,20,29,.96),rgba(21,33,46,.96));box-shadow:8px 8px 0 rgba(0,0,0,.3);color:#e8fbff}
+.lo-product__kicker{color:#5eead4;text-transform:uppercase;letter-spacing:.16em;font-weight:800}.lo-product h1,.lo-product h2,.lo-upgrade-callout h2{color:#fff}.lo-price-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:1rem;margin:2rem 0}.lo-price-card{display:flex;flex-direction:column;gap:.8rem;padding:1.3rem;border:1px solid rgba(255,255,255,.18);background:rgba(0,0,0,.23)}.lo-price-card p{flex:1}.lo-product-button{display:inline-block;width:max-content;max-width:100%;padding:.75rem 1rem;border:1px solid #5eead4;background:#102c36;color:#fff;text-decoration:none;font:inherit;font-weight:800;cursor:pointer}.lo-product-button:hover,.lo-product-button:focus{background:#5eead4;color:#07131a}.lo-comparison{overflow-x:auto}.lo-comparison table{width:100%;border-collapse:collapse;min-width:560px}.lo-comparison th,.lo-comparison td{padding:.8rem;border-bottom:1px solid rgba(255,255,255,.15);text-align:left}.lo-account{max-width:760px;margin-inline:auto}.lo-account input{display:block;width:100%;max-width:420px;margin:.5rem 0 1rem;padding:.75rem}.lo-home-upgrade{text-align:right}
+@media(max-width:720px){.lo-price-grid{grid-template-columns:1fr}}

--- a/docs/lousy-outages-freemium-rollout.md
+++ b/docs/lousy-outages-freemium-rollout.md
@@ -1,0 +1,65 @@
+# Lousy Outages freemium rollout
+
+## Assumptions and decisions
+
+- WordPress users are the account identity. Email magic links create a subscriber-level user only after a valid email request; the response never reveals whether the address exists.
+- Stripe-hosted Checkout and Customer Portal own payment details. The plugin uses WordPress HTTP rather than shipping the Stripe PHP SDK.
+- Pro and Team prices are recurring Stripe Price IDs configured per environment. Taxes, coupons, trials, refunds, and seat metering stay in Stripe for the first release.
+- Existing dashboard, history, RSS, reporting, and basic double-opt-in email paths are unchanged. Paid storage is additive.
+- A Team private board is an access-controlled entitlement and storage scaffold in this release, not a claim that the full board UI is finished.
+
+## Implementation plan and file map
+
+1. `Entitlements.php` defines the fail-closed plan matrix and destination limits. `CommerceStore.php` owns additive tables and customer-plan lookup.
+2. `StripeBilling.php` creates hosted Checkout/Portal sessions and consumes signed, replay-resistant, idempotent Stripe webhooks without a vendor SDK.
+3. `Product.php` provides magic-link accounts, pricing/account shortcodes, watchlist/destination/token endpoints, server-side gates, and analytics hooks.
+4. `CommerceAdmin.php` adds Stripe keys, webhook secret, recurring Price IDs, and rollout flags below the existing Lousy Outages admin menu.
+5. The pricing/account templates and status/home CTAs keep the current theme vocabulary. The existing dashboard remains the primary free experience.
+6. PHP tests cover the complete entitlement boundary and webhook signature/replay boundary. Existing public-dashboard regression tests remain release gates.
+
+## Database and option schema
+
+All tables use the active WordPress prefix. Activation or an admin request runs `dbDelta`; no existing table is altered.
+
+- `lo_customers`: WordPress user to Stripe customer/subscription, effective plan, status, period end, optional team.
+- `lo_watchlists`: owner/team, provider JSON, filter JSON, digest JSON, and sharing flag.
+- `lo_alert_destinations`: owner/team, Slack or webhook type, encrypted endpoint, label and enabled state.
+- `lo_api_tokens`: prefix plus one-way password hash; the plaintext is returned only at creation.
+- `lo_stripe_events`: Stripe event IDs for idempotent webhook processing.
+- `lousy_outages_commerce_schema_version`: migration checkpoint.
+- `lousy_outages_stripe_publishable_key`, `lousy_outages_stripe_secret_key`, `lousy_outages_stripe_webhook_secret`, `lousy_outages_stripe_price_pro`, `lousy_outages_stripe_price_team`: environment billing configuration.
+- `lousy_outages_feature_commerce`, `lousy_outages_feature_webhooks`, `lousy_outages_feature_private_boards`: staged rollout switches.
+
+## Tracking contract
+
+Server integrations attach to `lousy_outages_product_event`. Browser analytics listen for `lousy-outages:event` or consume `dataLayer` events prefixed with `lo_`. Event names are `plan_page_view`, `checkout_start`, `checkout_complete`, `upgrade_click`, `subscription_start`, `subscription_confirm`, `watchlist_saved`, `export_csv`, and `export_pdf`. Payloads must not include raw email addresses, webhook URLs, API tokens, or Stripe secrets.
+
+## Migration notes
+
+1. Back up the database and plugin/theme directories.
+2. Deploy the plugin and theme together. Activation creates the additive tables and the pricing/account child pages. On an already-active install, visit wp-admin once to run the versioned table migration; create the two pages with the supplied templates if activation is not cycled.
+3. Create recurring Pro and Team products/prices in Stripe. Save live/test keys and Price IDs in the matching environment.
+4. Register the displayed webhook URL for `checkout.session.completed`, `customer.subscription.created`, `customer.subscription.updated`, and `customer.subscription.deleted`.
+5. Existing subscribers are not converted. Every existing user resolves to Free until an active/trialing Stripe subscription event is stored.
+
+## Rollout checklist
+
+- [ ] Take database and file backups; verify the rollback artifact.
+- [ ] Deploy to staging with Stripe test keys and commerce disabled.
+- [ ] Run PHP, JavaScript, syntax, public-dashboard, RSS, and email subscription regression suites.
+- [ ] Confirm tables and nested `/lousy-outages/pricing/` and `/account/` pages exist; flush permalinks once if required.
+- [ ] Send signed Stripe test events twice; confirm the second is an idempotent no-op.
+- [ ] Complete Pro and Team test checkouts, open the portal, cancel, and verify access falls back to Free.
+- [ ] Verify Free dashboard/history/RSS/email while logged out and while signed into a Free account.
+- [ ] Verify Pro destination limit, Team token creation, and unknown-plan fail-closed behavior.
+- [ ] Connect analytics to the documented action/browser event and verify it contains no secrets or email.
+- [ ] Add production keys and webhook endpoint, enable commerce for a small cohort, then monitor Stripe event failures and WordPress logs.
+
+## Rollback checklist
+
+- [ ] Disable `lousy_outages_feature_commerce`; do not delete Stripe subscriptions.
+- [ ] Restore the previous plugin/theme artifact and purge page/object caches.
+- [ ] Leave additive `lo_*` commerce tables in place so customer state is recoverable; they are ignored by the previous release.
+- [ ] Disable the Stripe webhook endpoint only after the old code is live. Export missed Stripe events before disabling it.
+- [ ] Confirm the public dashboard, history, RSS, basic email confirmation, cron refresh, and admin dashboard.
+- [ ] If rolling forward again, redeploy and replay unprocessed Stripe events from Stripe before re-enabling checkout.

--- a/functions.php
+++ b/functions.php
@@ -159,7 +159,7 @@ function se_enqueue_hero_wordmark_styles() {
 add_action('wp_enqueue_scripts', 'se_enqueue_hero_wordmark_styles');
 
 function se_enqueue_lousy_outages_page_styles() {
-    if ( is_page_template( 'page-lousy-outages.php' ) || is_page( 'lousy-outages' ) ) {
+    if ( is_page_template( 'page-lousy-outages.php' ) || is_page_template( 'page-lousy-outages-pricing.php' ) || is_page_template( 'page-lousy-outages-account.php' ) || is_page( 'lousy-outages' ) ) {
         $dir = get_stylesheet_directory();
         $uri = get_stylesheet_directory_uri();
         $path = '/assets/css/lousy-outages-page.css';

--- a/lousy-outages/README.md
+++ b/lousy-outages/README.md
@@ -1,5 +1,11 @@
 # Lousy Outages
 
+## 0.5.0
+
+- Adds Free, Pro, and Team entitlements with server-side gates for watchlists, alert destinations, shared/private-board scaffolding, and API tokens.
+- Adds Stripe-hosted recurring Checkout, Customer Portal sessions, signed idempotent webhooks, and low-friction magic-link accounts without bundling a payment SDK.
+- Adds pricing/account pages, upgrade prompts, product analytics hooks, additive commerce storage, admin rollout settings, and migration/runbook documentation while leaving the public dashboard, history, RSS, and basic email path intact.
+
 ## 0.4.9
 
 - Publishes the RSS cache inside every canonical refresh, including refreshes started directly by the dashboard, REST API, or admin tools.

--- a/lousy-outages/assets/lousy-outages.js
+++ b/lousy-outages/assets/lousy-outages.js
@@ -474,6 +474,7 @@
   }
 
   function downloadCSV() {
+    if (root && typeof root.dispatchEvent === 'function' && typeof root.CustomEvent === 'function') root.dispatchEvent(new root.CustomEvent('lousy-outages:event', { detail: { event: 'export_csv' } }));
     var incidents = Array.isArray(state.historyIncidents) ? state.historyIncidents : [];
     if (!incidents.length) {
       if (state.root && state.root.alert) {
@@ -523,6 +524,7 @@
   }
 
   function exportPDF() {
+    if (root && typeof root.dispatchEvent === 'function' && typeof root.CustomEvent === 'function') root.dispatchEvent(new root.CustomEvent('lousy-outages:event', { detail: { event: 'export_pdf' } }));
     if (!state.root || !state.historyCharts) {
       return;
     }

--- a/lousy-outages/includes/CommerceAdmin.php
+++ b/lousy-outages/includes/CommerceAdmin.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+namespace SuzyEaston\LousyOutages;
+
+final class CommerceAdmin {
+    private const OPTIONS=['lousy_outages_stripe_publishable_key','lousy_outages_stripe_secret_key','lousy_outages_stripe_webhook_secret','lousy_outages_stripe_price_pro','lousy_outages_stripe_price_team','lousy_outages_feature_commerce','lousy_outages_feature_webhooks','lousy_outages_feature_private_boards'];
+    public static function bootstrap(): void { add_action('admin_menu',[self::class,'menu']); add_action('admin_init',[self::class,'settings']); }
+    public static function menu(): void { add_submenu_page('lousy-outages','Plans & Billing','Plans & Billing','manage_options','lousy-outages-billing',[self::class,'page']); }
+    public static function settings(): void { foreach(self::OPTIONS as $option) register_setting('lousy_outages_billing',$option,['sanitize_callback'=>str_contains($option,'feature_')?'absint':'sanitize_text_field']); }
+    public static function page(): void { if(!current_user_can('manage_options'))return; ?><div class="wrap"><h1>Plans &amp; Billing</h1><p>Stripe keys can also be supplied through deployment tooling. Secret values are stored as WordPress options and should never be committed.</p><form action="options.php" method="post"><?php settings_fields('lousy_outages_billing'); ?><table class="form-table"><?php foreach(self::OPTIONS as $option): $secret=str_contains($option,'secret'); $flag=str_contains($option,'feature_'); ?><tr><th><label for="<?php echo esc_attr($option); ?>"><?php echo esc_html(ucwords(str_replace(['lousy_outages_','_'],' ', $option))); ?></label></th><td><input id="<?php echo esc_attr($option); ?>" name="<?php echo esc_attr($option); ?>" type="<?php echo $flag?'checkbox':($secret?'password':'text'); ?>" <?php if($flag) checked((int)get_option($option,0),1); ?> value="<?php echo $flag?'1':esc_attr((string)get_option($option,'')); ?>" class="<?php echo $flag?'':'regular-text'; ?>" autocomplete="off"></td></tr><?php endforeach; ?></table><?php submit_button(); ?></form><p><strong>Webhook URL:</strong> <code><?php echo esc_html(rest_url('lousy-outages/v1/stripe/webhook')); ?></code></p></div><?php }
+}

--- a/lousy-outages/includes/CommerceStore.php
+++ b/lousy-outages/includes/CommerceStore.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+final class CommerceStore {
+    public const SCHEMA_VERSION = '1.0.0';
+
+    public static function install(): void {
+        global $wpdb;
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        $charset = $wpdb->get_charset_collate();
+        $p = $wpdb->prefix . 'lo_';
+        dbDelta("CREATE TABLE {$p}customers (
+          user_id bigint(20) unsigned NOT NULL, stripe_customer_id varchar(64) NULL, stripe_subscription_id varchar(64) NULL,
+          plan varchar(16) NOT NULL DEFAULT 'free', subscription_status varchar(32) NOT NULL DEFAULT 'none', current_period_end datetime NULL,
+          team_id bigint(20) unsigned NULL, updated_at datetime NOT NULL, PRIMARY KEY (user_id), UNIQUE KEY stripe_customer_id (stripe_customer_id)
+        ) {$charset};");
+        dbDelta("CREATE TABLE {$p}watchlists (
+          id bigint(20) unsigned NOT NULL AUTO_INCREMENT, owner_user_id bigint(20) unsigned NOT NULL, team_id bigint(20) unsigned NULL,
+          name varchar(190) NOT NULL, providers longtext NOT NULL, filters longtext NULL, digest_preferences longtext NULL, is_shared tinyint(1) NOT NULL DEFAULT 0,
+          created_at datetime NOT NULL, updated_at datetime NOT NULL, PRIMARY KEY (id), KEY owner (owner_user_id), KEY team (team_id)
+        ) {$charset};");
+        dbDelta("CREATE TABLE {$p}alert_destinations (
+          id bigint(20) unsigned NOT NULL AUTO_INCREMENT, owner_user_id bigint(20) unsigned NOT NULL, team_id bigint(20) unsigned NULL,
+          type varchar(20) NOT NULL, label varchar(190) NOT NULL, endpoint_encrypted longtext NOT NULL, enabled tinyint(1) NOT NULL DEFAULT 1, created_at datetime NOT NULL,
+          PRIMARY KEY (id), KEY owner (owner_user_id), KEY team (team_id)
+        ) {$charset};");
+        dbDelta("CREATE TABLE {$p}api_tokens (
+          id bigint(20) unsigned NOT NULL AUTO_INCREMENT, owner_user_id bigint(20) unsigned NOT NULL, team_id bigint(20) unsigned NULL,
+          name varchar(190) NOT NULL, token_prefix varchar(16) NOT NULL, token_hash varchar(255) NOT NULL, last_used_at datetime NULL, created_at datetime NOT NULL, revoked_at datetime NULL,
+          PRIMARY KEY (id), KEY token_prefix (token_prefix), KEY owner (owner_user_id)
+        ) {$charset};");
+        dbDelta("CREATE TABLE {$p}stripe_events (
+          event_id varchar(255) NOT NULL, event_type varchar(100) NOT NULL, processed_at datetime NOT NULL, PRIMARY KEY (event_id)
+        ) {$charset};");
+        update_option('lousy_outages_commerce_schema_version', self::SCHEMA_VERSION, false);
+    }
+
+    public static function customer(int $user_id): array {
+        global $wpdb;
+        $row = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}lo_customers WHERE user_id=%d", $user_id), ARRAY_A);
+        return is_array($row) ? $row : ['user_id' => $user_id, 'plan' => 'free', 'subscription_status' => 'none'];
+    }
+
+    public static function plan(int $user_id): string {
+        $customer = self::customer($user_id);
+        return in_array((string)($customer['subscription_status'] ?? ''), ['active', 'trialing'], true)
+            ? Entitlements::normalize_plan((string)($customer['plan'] ?? 'free')) : 'free';
+    }
+
+    public static function upsert_customer(int $user_id, array $values): void {
+        global $wpdb;
+        $old = self::customer($user_id);
+        $data = array_merge($old, array_intersect_key($values, array_flip(['stripe_customer_id','stripe_subscription_id','plan','subscription_status','current_period_end','team_id'])));
+        $data['user_id'] = $user_id;
+        $data['updated_at'] = current_time('mysql', true);
+        $wpdb->replace($wpdb->prefix . 'lo_customers', $data);
+    }
+
+    public static function event_seen(string $id): bool {
+        global $wpdb;
+        return (bool)$wpdb->get_var($wpdb->prepare("SELECT event_id FROM {$wpdb->prefix}lo_stripe_events WHERE event_id=%s", $id));
+    }
+
+    public static function mark_event(string $id, string $type): void {
+        global $wpdb;
+        $wpdb->insert($wpdb->prefix . 'lo_stripe_events', ['event_id'=>$id, 'event_type'=>$type, 'processed_at'=>current_time('mysql', true)]);
+    }
+}

--- a/lousy-outages/includes/Entitlements.php
+++ b/lousy-outages/includes/Entitlements.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+/** The single server-side source of truth for product access. */
+final class Entitlements {
+    public const PLANS = ['free', 'pro', 'team'];
+
+    private const MATRIX = [
+        'free' => ['public_dashboard', 'recent_history', 'rss', 'email_subscription'],
+        'pro'  => ['public_dashboard', 'recent_history', 'rss', 'email_subscription', 'watchlists', 'advanced_filters', 'digest_preferences', 'alert_destination'],
+        'team' => ['public_dashboard', 'recent_history', 'rss', 'email_subscription', 'watchlists', 'advanced_filters', 'digest_preferences', 'alert_destination', 'shared_boards', 'multiple_destinations', 'api_tokens', 'private_board'],
+    ];
+
+    public static function normalize_plan(string $plan): string {
+        $plan = strtolower(trim($plan));
+        return in_array($plan, self::PLANS, true) ? $plan : 'free';
+    }
+
+    public static function for_plan(string $plan): array {
+        return self::MATRIX[self::normalize_plan($plan)];
+    }
+
+    public static function allows(string $plan, string $feature): bool {
+        return in_array($feature, self::for_plan($plan), true);
+    }
+
+    public static function destination_limit(string $plan): int {
+        return ['free' => 0, 'pro' => 1, 'team' => 20][self::normalize_plan($plan)];
+    }
+}

--- a/lousy-outages/includes/Product.php
+++ b/lousy-outages/includes/Product.php
@@ -1,0 +1,115 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class Product {
+    public static function bootstrap(): void {
+        add_action('rest_api_init',[self::class,'routes']);
+        add_action('template_redirect',[self::class,'consume_magic_link']);
+        add_shortcode('lousy_outages_pricing',[self::class,'pricing']);
+        add_shortcode('lousy_outages_account',[self::class,'account']);
+        add_action('wp_footer',[self::class,'browser_events']);
+    }
+
+    public static function install_pages(): void {
+        $parent=get_page_by_path('lousy-outages');
+        foreach(['pricing'=>['Lousy Outages Pricing','page-lousy-outages-pricing.php'],'account'=>['Lousy Outages Account','page-lousy-outages-account.php']] as $slug=>$config) {
+            if(get_page_by_path('lousy-outages/'.$slug)) continue;
+            $id=wp_insert_post(['post_title'=>$config[0],'post_name'=>$slug,'post_type'=>'page','post_status'=>'publish','post_parent'=>$parent ? (int)$parent->ID : 0]);
+            if(!is_wp_error($id)) update_post_meta((int)$id,'_wp_page_template',$config[1]);
+        }
+    }
+
+    public static function routes(): void {
+        register_rest_route('lousy-outages/v1','/account/magic-link',['methods'=>'POST','permission_callback'=>'__return_true','callback'=>[self::class,'magic_link']]);
+        register_rest_route('lousy-outages/v1','/watchlists',['methods'=>'POST','permission_callback'=>static fn()=>is_user_logged_in(),'callback'=>[self::class,'save_watchlist']]);
+        register_rest_route('lousy-outages/v1','/alert-destinations',['methods'=>'POST','permission_callback'=>static fn()=>is_user_logged_in(),'callback'=>[self::class,'save_destination']]);
+        register_rest_route('lousy-outages/v1','/api-tokens',['methods'=>'POST','permission_callback'=>static fn()=>is_user_logged_in(),'callback'=>[self::class,'create_api_token']]);
+    }
+
+    public static function require_feature(int $user_id,string $feature) {
+        $plan=CommerceStore::plan($user_id);
+        if($feature==='private_board' && !(bool)get_option('lousy_outages_feature_private_boards',false)) return new \WP_Error('feature_disabled','Private boards are not in this rollout yet.',['status'=>503,'feature'=>$feature]);
+        return Entitlements::allows($plan,$feature) ? true : new \WP_Error('upgrade_required','This feature needs a paid plan.',['status'=>403,'plan'=>$plan,'feature'=>$feature]);
+    }
+
+    public static function save_watchlist(WP_REST_Request $request) {
+        $user_id=get_current_user_id(); $allowed=self::require_feature($user_id,'watchlists'); if (is_wp_error($allowed)) return $allowed;
+        global $wpdb; $providers=array_values(array_filter(array_map('sanitize_key',(array)$request->get_param('providers'))));
+        $filters=(array)$request->get_param('filters');
+        if (!Entitlements::allows(CommerceStore::plan($user_id),'advanced_filters')) $filters=[];
+        $wpdb->insert($wpdb->prefix.'lo_watchlists',['owner_user_id'=>$user_id,'name'=>sanitize_text_field((string)$request->get_param('name')),'providers'=>wp_json_encode($providers),'filters'=>wp_json_encode($filters),'digest_preferences'=>wp_json_encode((array)$request->get_param('digest')),'is_shared'=>0,'created_at'=>current_time('mysql',true),'updated_at'=>current_time('mysql',true)]);
+        do_action('lousy_outages_product_event','watchlist_saved',['user_id'=>$user_id,'watchlist_id'=>(int)$wpdb->insert_id]);
+        return new WP_REST_Response(['id'=>(int)$wpdb->insert_id],201);
+    }
+
+    public static function create_api_token(WP_REST_Request $request) {
+        $user_id=get_current_user_id(); $allowed=self::require_feature($user_id,'api_tokens'); if (is_wp_error($allowed)) return $allowed;
+        global $wpdb; $plain='lo_'.bin2hex(random_bytes(24)); $prefix=substr($plain,0,12);
+        $wpdb->insert($wpdb->prefix.'lo_api_tokens',['owner_user_id'=>$user_id,'name'=>sanitize_text_field((string)$request->get_param('name')) ?: 'API token','token_prefix'=>$prefix,'token_hash'=>password_hash($plain,PASSWORD_DEFAULT),'created_at'=>current_time('mysql',true)]);
+        return new WP_REST_Response(['id'=>(int)$wpdb->insert_id,'token'=>$plain,'notice'=>'Copy this token now. It will not be shown again.'],201);
+    }
+
+    public static function save_destination(WP_REST_Request $request) {
+        $user_id=get_current_user_id(); $plan=CommerceStore::plan($user_id); $allowed=self::require_feature($user_id,'alert_destination'); if(is_wp_error($allowed)) return $allowed;
+        $type=sanitize_key((string)$request->get_param('type')); $endpoint=esc_url_raw((string)$request->get_param('endpoint'));
+        if(!in_array($type,['slack','webhook'],true) || !wp_http_validate_url($endpoint)) return new \WP_Error('invalid_destination','Use a valid HTTPS Slack or webhook URL.',['status'=>400]);
+        global $wpdb; $count=(int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$wpdb->prefix}lo_alert_destinations WHERE owner_user_id=%d",$user_id));
+        if($count>=Entitlements::destination_limit($plan)) return new \WP_Error('destination_limit','This plan has reached its destination limit.',['status'=>403]);
+        $encrypted=self::encrypt_secret($endpoint);
+        $wpdb->insert($wpdb->prefix.'lo_alert_destinations',['owner_user_id'=>$user_id,'type'=>$type,'label'=>sanitize_text_field((string)$request->get_param('label')) ?: ucfirst($type),'endpoint_encrypted'=>$encrypted,'enabled'=>1,'created_at'=>current_time('mysql',true)]);
+        return new WP_REST_Response(['id'=>(int)$wpdb->insert_id],201);
+    }
+
+    private static function encrypt_secret(string $value): string {
+        $key=hash('sha256',wp_salt('auth'),true); $iv=random_bytes(12); $tag='';
+        $cipher=openssl_encrypt($value,'aes-256-gcm',$key,OPENSSL_RAW_DATA,$iv,$tag);
+        if($cipher===false) return '';
+        return base64_encode($iv.$tag.$cipher);
+    }
+
+    public static function magic_link(WP_REST_Request $request) {
+        $email=sanitize_email((string)$request->get_param('email'));
+        if (!is_email($email)) return new \WP_Error('invalid_email','Enter a real email address.',['status'=>400]);
+        $user=get_user_by('email',$email);
+        if (!$user) { $id=wp_create_user($email,wp_generate_password(32,true,true),$email); if (!is_wp_error($id)) $user=get_user_by('id',$id); }
+        if ($user) {
+            $token=bin2hex(random_bytes(24)); set_transient('lo_magic_'.hash('sha256',$token),['user_id'=>(int)$user->ID,'redirect'=>home_url('/lousy-outages/account/')],15*MINUTE_IN_SECONDS);
+            wp_mail($email,'Your Lousy Outages sign-in link','One click. No password nonsense.\n\n'.add_query_arg(['lo_magic'=>$token],home_url('/lousy-outages/account/')));
+        }
+        return new WP_REST_Response(['message'=>'If that address can sign in, the link is on its way.']);
+    }
+
+    public static function consume_magic_link(): void {
+        if (empty($_GET['lo_magic'])) return; $token=sanitize_text_field(wp_unslash($_GET['lo_magic'])); $key='lo_magic_'.hash('sha256',$token); $record=get_transient($key);
+        if (!is_array($record) || empty($record['user_id'])) return;
+        delete_transient($key); wp_set_auth_cookie((int)$record['user_id'],true,is_ssl()); wp_safe_redirect((string)$record['redirect']); exit;
+    }
+
+    public static function pricing(): string {
+        do_action('lousy_outages_product_event','plan_page_view',['user_id'=>get_current_user_id()]);
+        $plans=[
+            'Free'=>['$0','Public dashboard, recent history, RSS and basic email. The useful part stays free.'],
+            'Pro'=>['paid monthly','Saved watchlists, component filters, digests and one Slack or webhook destination.'],
+            'Team'=>['paid monthly','Shared boards, more destinations, API tokens and a private-board scaffold.'],
+        ];
+        ob_start(); ?><div class="lo-product"><header><p class="lo-product__kicker">pick your level</p><h1>Outages, with fewer surprises.</h1><p>The public dashboard stays public. Pay when the machine needs to remember things for you.</p></header><div class="lo-price-grid"><?php foreach($plans as $name=>$copy): $slug=strtolower($name); ?><article class="lo-price-card"><h2><?php echo esc_html($name); ?></h2><strong><?php echo esc_html($copy[0]); ?></strong><p><?php echo esc_html($copy[1]); ?></p><?php if($slug==='free'): ?><a class="lo-product-button" href="<?php echo esc_url(home_url('/lousy-outages/')); ?>">Check the dashboard</a><?php else: ?><button class="lo-product-button" data-lo-checkout="<?php echo esc_attr($slug); ?>">Choose <?php echo esc_html($name); ?></button><?php endif; ?></article><?php endforeach; ?></div>
+        <div class="lo-comparison"><table><thead><tr><th>Feature</th><th>Free</th><th>Pro</th><th>Team</th></tr></thead><tbody><?php foreach(['Public dashboard / history / RSS'=>[1,1,1],'Basic email subscription'=>[1,1,1],'Saved watchlists + filters'=>[0,1,1],'Digest preferences'=>[0,1,1],'Alert destinations'=>[0,'1','many'],'Shared boards'=>[0,0,1],'API tokens'=>[0,0,1],'Private board scaffold'=>[0,0,1]] as $feature=>$levels): ?><tr><th><?php echo esc_html($feature); ?></th><?php foreach($levels as $value): ?><td><?php echo esc_html($value===1?'yes':($value===0?'—':$value)); ?></td><?php endforeach; ?></tr><?php endforeach; ?></tbody></table></div></div><?php return (string)ob_get_clean();
+    }
+
+    public static function account(): string {
+        if (!is_user_logged_in()) return '<div class="lo-product lo-account"><h1>Your outage controls.</h1><p>No password maze. We’ll email a one-use sign-in link.</p><form data-lo-magic><label>Email <input type="email" name="email" required></label><button class="lo-product-button">Send the link</button><p data-lo-message></p></form></div>';
+        $plan=CommerceStore::plan(get_current_user_id());
+        return '<div class="lo-product lo-account"><p class="lo-product__kicker">account console</p><h1>'.esc_html(ucfirst($plan)).' plan</h1><p>'.($plan==='free'?'The public signal is yours. Watchlists start on Pro.':'Your paid controls are switched on.').'</p><p><a class="lo-product-button" data-lo-upgrade href="'.esc_url(home_url('/lousy-outages/pricing/')).'">'.($plan==='free'?'See paid plans':'Change plan').'</a> <button class="lo-product-button" data-lo-portal>Manage billing</button></p></div>';
+    }
+
+    public static function browser_events(): void {
+        ?><script>(function(){function event(n,d){window.dispatchEvent(new CustomEvent('lousy-outages:event',{detail:Object.assign({event:n},d||{})}));if(window.dataLayer)window.dataLayer.push(Object.assign({event:'lo_'+n},d||{}));}window.addEventListener('lousy-outages:event',function(e){var d=e.detail||{};if(window.dataLayer&&d.event)window.dataLayer.push(Object.assign({},d,{event:'lo_'+d.event}));});
+        document.addEventListener('click',async function(e){var b=e.target.closest('[data-lo-checkout]');if(b){event('upgrade_click',{plan:b.dataset.loCheckout});if(!<?php echo is_user_logged_in()?'true':'false'; ?>){location.href='<?php echo esc_url_raw(home_url('/lousy-outages/account/')); ?>';return;}b.disabled=true;var r=await fetch('<?php echo esc_url_raw(rest_url('lousy-outages/v1/billing/checkout')); ?>',{method:'POST',headers:{'Content-Type':'application/json','X-WP-Nonce':'<?php echo esc_js(wp_create_nonce('wp_rest')); ?>'},body:JSON.stringify({plan:b.dataset.loCheckout})});var j=await r.json();if(j.url)location.href=j.url;else{b.disabled=false;alert(j.message||'Billing is taking a nap.');}}var p=e.target.closest('[data-lo-portal]');if(p){var r=await fetch('<?php echo esc_url_raw(rest_url('lousy-outages/v1/billing/portal')); ?>',{method:'POST',headers:{'X-WP-Nonce':'<?php echo esc_js(wp_create_nonce('wp_rest')); ?>'}});var j=await r.json();if(j.url)location.href=j.url;}if(e.target.closest('[data-lo-upgrade]'))event('upgrade_click',{placement:'account'});});
+        document.addEventListener('submit',async function(e){var f=e.target.closest('[data-lo-magic]');if(!f)return;e.preventDefault();var r=await fetch('<?php echo esc_url_raw(rest_url('lousy-outages/v1/account/magic-link')); ?>',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:f.email.value})});var j=await r.json();f.querySelector('[data-lo-message]').textContent=j.message||'Check your inbox.';});})();</script><?php
+    }
+}

--- a/lousy-outages/includes/StripeBilling.php
+++ b/lousy-outages/includes/StripeBilling.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages;
+
+use WP_REST_Request;
+use WP_REST_Response;
+
+final class StripeBilling {
+    public static function bootstrap(): void { add_action('rest_api_init', [self::class, 'routes']); }
+
+    public static function routes(): void {
+        register_rest_route('lousy-outages/v1', '/billing/checkout', ['methods'=>'POST','permission_callback'=>static fn()=>is_user_logged_in(),'callback'=>[self::class,'checkout']]);
+        register_rest_route('lousy-outages/v1', '/billing/portal', ['methods'=>'POST','permission_callback'=>static fn()=>is_user_logged_in(),'callback'=>[self::class,'portal']]);
+        register_rest_route('lousy-outages/v1', '/stripe/webhook', ['methods'=>'POST','permission_callback'=>'__return_true','callback'=>[self::class,'webhook']]);
+    }
+
+    private static function request(string $path, array $body) {
+        $key = (string)get_option('lousy_outages_stripe_secret_key', '');
+        if ($key === '') return new \WP_Error('stripe_unconfigured', 'Billing is not configured.', ['status'=>503]);
+        $response = wp_remote_post('https://api.stripe.com/v1/' . ltrim($path, '/'), ['timeout'=>20,'headers'=>['Authorization'=>'Basic '.base64_encode($key.':')],'body'=>$body]);
+        if (is_wp_error($response)) return $response;
+        $decoded = json_decode((string)wp_remote_retrieve_body($response), true);
+        if (wp_remote_retrieve_response_code($response) >= 300) return new \WP_Error('stripe_error', (string)($decoded['error']['message'] ?? 'Stripe request failed.'), ['status'=>502]);
+        return $decoded;
+    }
+
+    public static function checkout(WP_REST_Request $request) {
+        if (!(bool)get_option('lousy_outages_feature_commerce', true)) return new \WP_Error('billing_disabled', 'Billing is temporarily offline.', ['status'=>503]);
+        $plan = Entitlements::normalize_plan((string)$request->get_param('plan'));
+        if (!in_array($plan, ['pro','team'], true)) return new \WP_Error('invalid_plan', 'Choose Pro or Team.', ['status'=>400]);
+        $price = (string)get_option('lousy_outages_stripe_price_'.$plan, '');
+        if ($price === '') return new \WP_Error('price_unconfigured', 'That plan is not ready yet.', ['status'=>503]);
+        $user = wp_get_current_user();
+        $payload = ['mode'=>'subscription','line_items[0][price]'=>$price,'line_items[0][quantity]'=>1,'client_reference_id'=>(string)$user->ID,'customer_email'=>$user->user_email,'success_url'=>home_url('/lousy-outages/account/?checkout=complete&session_id={CHECKOUT_SESSION_ID}'),'cancel_url'=>home_url('/lousy-outages/pricing/?checkout=cancelled'),'metadata[user_id]'=>(string)$user->ID,'metadata[plan]'=>$plan,'subscription_data[metadata][user_id]'=>(string)$user->ID,'subscription_data[metadata][plan]'=>$plan];
+        do_action('lousy_outages_product_event', 'checkout_start', ['user_id'=>$user->ID,'plan'=>$plan]);
+        $session = self::request('checkout/sessions', $payload);
+        return is_wp_error($session) ? $session : new WP_REST_Response(['url'=>$session['url'] ?? ''], 201);
+    }
+
+    public static function portal() {
+        $customer = CommerceStore::customer(get_current_user_id());
+        if (empty($customer['stripe_customer_id'])) return new \WP_Error('no_customer', 'No billing account found.', ['status'=>404]);
+        $session = self::request('billing_portal/sessions', ['customer'=>$customer['stripe_customer_id'],'return_url'=>home_url('/lousy-outages/account/')]);
+        return is_wp_error($session) ? $session : new WP_REST_Response(['url'=>$session['url'] ?? ''], 201);
+    }
+
+    public static function valid_signature(string $payload, string $header, string $secret, ?int $now=null): bool {
+        $parts=[]; foreach (explode(',', $header) as $piece) { [$k,$v]=array_pad(explode('=',trim($piece),2),2,''); $parts[$k][]=$v; }
+        $timestamp=(int)($parts['t'][0] ?? 0); $now=$now ?? time();
+        if (!$timestamp || abs($now-$timestamp)>300 || empty($parts['v1'])) return false;
+        $expected=hash_hmac('sha256', $timestamp.'.'.$payload, $secret);
+        foreach ($parts['v1'] as $signature) if (hash_equals($expected, $signature)) return true;
+        return false;
+    }
+
+    public static function webhook(WP_REST_Request $request) {
+        if (!(bool)get_option('lousy_outages_feature_webhooks', true)) return new \WP_Error('webhooks_disabled','Billing webhooks are disabled.',['status'=>503]);
+        $payload=$request->get_body(); $secret=(string)get_option('lousy_outages_stripe_webhook_secret',''); $signature=(string)$request->get_header('stripe-signature');
+        if ($secret==='' || !self::valid_signature($payload,$signature,$secret)) return new \WP_Error('invalid_signature','Invalid Stripe signature.',['status'=>400]);
+        $event=json_decode($payload,true); $id=(string)($event['id']??''); $type=(string)($event['type']??'');
+        if ($id==='' || CommerceStore::event_seen($id)) return new WP_REST_Response(['received'=>true,'duplicate'=>$id!=='']);
+        self::apply_event($type, (array)($event['data']['object']??[])); CommerceStore::mark_event($id,$type);
+        return new WP_REST_Response(['received'=>true]);
+    }
+
+    public static function apply_event(string $type, array $object): void {
+        $meta=(array)($object['metadata']??[]); $user_id=(int)($meta['user_id']??$object['client_reference_id']??0);
+        if ('checkout.session.completed'===$type && $user_id) {
+            CommerceStore::upsert_customer($user_id,['stripe_customer_id'=>$object['customer']??null,'stripe_subscription_id'=>$object['subscription']??null,'plan'=>$meta['plan']??'free','subscription_status'=>'active']);
+            do_action('lousy_outages_product_event','checkout_complete',['user_id'=>$user_id,'plan'=>$meta['plan']??'free']);
+        } elseif (in_array($type,['customer.subscription.created','customer.subscription.updated','customer.subscription.deleted'],true)) {
+            if (!$user_id && !empty($object['customer'])) { $user_id=self::user_for_customer((string)$object['customer']); }
+            if ($user_id) CommerceStore::upsert_customer($user_id,['stripe_customer_id'=>$object['customer']??null,'stripe_subscription_id'=>$object['id']??null,'plan'=>$meta['plan']??CommerceStore::plan($user_id),'subscription_status'=>$type==='customer.subscription.deleted'?'canceled':($object['status']??'none'),'current_period_end'=>empty($object['current_period_end'])?null:gmdate('Y-m-d H:i:s',(int)$object['current_period_end'])]);
+        }
+    }
+
+    private static function user_for_customer(string $customer): int { global $wpdb; return (int)$wpdb->get_var($wpdb->prepare("SELECT user_id FROM {$wpdb->prefix}lo_customers WHERE stripe_customer_id=%s",$customer)); }
+}

--- a/lousy-outages/includes/Subscribe.php
+++ b/lousy-outages/includes/Subscribe.php
@@ -165,6 +165,8 @@ class Lousy_Outages_Subscribe {
             self::send_welcome_email($email, $token);
         }
 
+        do_action('lousy_outages_product_event', 'subscription_confirm', ['email_hash' => hash('sha256', $email)]);
+
         return self::redirect_with_status('confirmed');
     }
 
@@ -392,6 +394,7 @@ HTML;
 }
 
 function lo_handle_subscribe(\WP_REST_Request $request) {
+    do_action('lousy_outages_product_event', 'subscription_start', []);
     $responseParam  = $request->get_param('challenge_response');
     $noscriptParam  = $request->get_param('lo_noscript_challenge');
     $challengeReply = is_string($responseParam) ? trim((string) $responseParam) : '';

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -3,7 +3,7 @@ declare( strict_types=1 );
 /**
  * Plugin Name: Lousy Outages
  * Description: WordPress-native outage intelligence, community reporting, and early-warning signals for third-party service dependencies.
- * Version: 0.4.9
+ * Version: 0.5.0
  * Author: Suzy Easton
  * Text Domain: lousy-outages
  */
@@ -24,7 +24,7 @@ if ( defined( 'LOUSY_OUTAGES_DISABLE' ) && LOUSY_OUTAGES_DISABLE ) {
 }
 
 if ( ! defined( 'LOUSY_OUTAGES_VERSION' ) ) {
-    define( 'LOUSY_OUTAGES_VERSION', '0.4.9' );
+    define( 'LOUSY_OUTAGES_VERSION', '0.5.0' );
 }
 if ( ! defined( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION' ) ) {
     define( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION', 5 );
@@ -111,6 +111,11 @@ lousy_outages_require( 'includes/Sources/RedditFieldReportsSource.php', false );
 lousy_outages_require( 'includes/Sources/SyntheticCanarySource.php', false );
 lousy_outages_require( 'includes/SignalCollector.php' );
 lousy_outages_require( 'includes/Api.php' );
+lousy_outages_require( 'includes/Entitlements.php' );
+lousy_outages_require( 'includes/CommerceStore.php' );
+lousy_outages_require( 'includes/StripeBilling.php' );
+lousy_outages_require( 'includes/Product.php' );
+lousy_outages_require( 'includes/CommerceAdmin.php' );
 lousy_outages_require( 'includes/AdminCleanup.php' );
 lousy_outages_require( 'includes/AdminDiagnostics.php' );
 lousy_outages_require( 'includes/ProviderPages.php' );
@@ -148,6 +153,9 @@ RefreshCron::bootstrap();
 \SuzyEaston\LousyOutages\AdminCleanup::bootstrap();
 \SuzyEaston\LousyOutages\AdminDiagnostics::bootstrap();
 \SuzyEaston\LousyOutages\ProviderPages::bootstrap();
+\SuzyEaston\LousyOutages\StripeBilling::bootstrap();
+\SuzyEaston\LousyOutages\Product::bootstrap();
+\SuzyEaston\LousyOutages\CommerceAdmin::bootstrap();
 
 lo_snapshot_bootstrap();
 lo_cron_bootstrap();
@@ -171,6 +179,8 @@ function lousy_outages_activate() {
     lousy_outages_schedule_canonical_refresh();
     lousy_outages_create_page();
     lousy_outages_maybe_install_schema( true );
+    \SuzyEaston\LousyOutages\CommerceStore::install();
+    \SuzyEaston\LousyOutages\Product::install_pages();
     if ( class_exists( '\\SuzyEaston\\LousyOutages\\Storage\\HistoryStore' ) ) { ( new \SuzyEaston\LousyOutages\Storage\HistoryStore() )->installTable(); }
     Subscriptions::schedule_purge();
     $default_email = 'suzyeaston@gmail.com';
@@ -253,6 +263,11 @@ function lousy_outages_maybe_repair_snapshot_caches(): void {
     update_option( $option_key, (int) LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION, false );
 }
 add_action( 'admin_init', 'lousy_outages_maybe_install_schema' );
+add_action( 'admin_init', static function (): void {
+    if ( version_compare( (string) get_option( 'lousy_outages_commerce_schema_version', '0' ), \SuzyEaston\LousyOutages\CommerceStore::SCHEMA_VERSION, '<' ) ) {
+        \SuzyEaston\LousyOutages\CommerceStore::install();
+    }
+}, 6 );
 add_action( 'init', 'lousy_outages_maybe_repair_snapshot_caches', 4 );
 add_action( 'init', static function (): void {
     if ( is_admin() ) {

--- a/page-lousy-outages-account.php
+++ b/page-lousy-outages-account.php
@@ -1,0 +1,8 @@
+<?php
+/* Template Name: Lousy Outages Account */
+get_header();
+?>
+<main class="lousy-outages-page lousy-outages-product-page">
+  <div class="lousy-outages-root"><?php echo do_shortcode('[lousy_outages_account]'); ?></div>
+</main>
+<?php get_footer(); ?>

--- a/page-lousy-outages-pricing.php
+++ b/page-lousy-outages-pricing.php
@@ -1,0 +1,8 @@
+<?php
+/* Template Name: Lousy Outages Pricing */
+get_header();
+?>
+<main class="lousy-outages-page lousy-outages-product-page">
+  <div class="lousy-outages-root"><?php echo do_shortcode('[lousy_outages_pricing]'); ?></div>
+</main>
+<?php get_footer(); ?>

--- a/page-lousy-outages.php
+++ b/page-lousy-outages.php
@@ -77,6 +77,12 @@ if ($unsub_success) {
         </div>
       </div>
     </section>
+    <section class="lo-upgrade-callout">
+      <p class="lo-status-board__eyebrow">make the robot remember</p>
+      <h2>Watch the providers that wreck your day.</h2>
+      <p>The dashboard, history, RSS and basic email stay free. Pro adds watchlists, filters and a proper alert destination.</p>
+      <a class="lo-product-button" data-lo-upgrade href="<?php echo esc_url(home_url('/lousy-outages/pricing/')); ?>">See plans</a>
+    </section>
         <?php echo do_shortcode('[lousy_outages_report]'); ?>
     <footer class="lo-support">
       <p class="lo-support__lead">Support the independent status monitor and the infrastructure behind it:</p>

--- a/parts/lousy-outages-teaser.php
+++ b/parts/lousy-outages-teaser.php
@@ -38,4 +38,5 @@ $is_active = $outage_count > 0;
         </div>
         <?php if ( $other_providers ) : ?><p class="lo-home-other">Also watching: <?php foreach ( $other_providers as $i => $provider ) : ?><?php if ( $i ) : ?>, <?php endif; ?><a href="<?php echo esc_url( $provider['href'] ?? $dashboard_url ); ?>"><?php echo esc_html( (string) ( $provider['name'] ?? 'Provider' ) ); ?></a><?php endforeach; ?></p><?php endif; ?>
     </div>
+    <p class="lo-home-upgrade"><a class="lo-home-dashboard-link" data-lo-upgrade href="<?php echo esc_url(home_url('/lousy-outages/pricing/')); ?>">Save your watchlist <span aria-hidden="true">→</span></a></p>
 </section>

--- a/tests/LousyOutagesEntitlementsTest.php
+++ b/tests/LousyOutagesEntitlementsTest.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__.'/bootstrap.php';
+require_once __DIR__.'/../lousy-outages/includes/Entitlements.php';
+use SuzyEaston\LousyOutages\Entitlements;
+
+$assert=static function(bool $condition,string $message): void { if(!$condition) throw new RuntimeException($message); };
+$assert(Entitlements::allows('free','public_dashboard'),'Free must retain the public dashboard');
+$assert(Entitlements::allows('free','rss'),'Free must retain RSS');
+$assert(!Entitlements::allows('free','watchlists'),'Free must not save watchlists');
+$assert(Entitlements::allows('pro','watchlists'),'Pro must save watchlists');
+$assert(Entitlements::destination_limit('pro')===1,'Pro must allow exactly one destination');
+$assert(!Entitlements::allows('pro','api_tokens'),'Pro must not generate API tokens');
+$assert(Entitlements::allows('team','api_tokens'),'Team must generate API tokens');
+$assert(Entitlements::allows('team','private_board'),'Team must expose the private board scaffold');
+$assert(Entitlements::normalize_plan('garbage')==='free','Unknown plans must fail closed');
+echo "ok - entitlement matrix and fail-closed plan normalization\n";

--- a/tests/LousyOutagesStripeWebhookTest.php
+++ b/tests/LousyOutagesStripeWebhookTest.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__.'/bootstrap.php';
+if(!function_exists('get_option')) { function get_option($key,$default=false){ return $default; } }
+require_once __DIR__.'/../lousy-outages/includes/StripeBilling.php';
+use SuzyEaston\LousyOutages\StripeBilling;
+
+$payload='{"id":"evt_123","type":"checkout.session.completed"}'; $secret='whsec_test'; $timestamp=1700000000;
+$valid=hash_hmac('sha256',$timestamp.'.'.$payload,$secret);
+if(!StripeBilling::valid_signature($payload,"t={$timestamp},v1={$valid}",$secret,$timestamp)) throw new RuntimeException('Valid Stripe signature rejected');
+if(StripeBilling::valid_signature($payload,"t={$timestamp},v1=bad",$secret,$timestamp)) throw new RuntimeException('Invalid signature accepted');
+if(StripeBilling::valid_signature($payload,"t={$timestamp},v1={$valid}",$secret,$timestamp+301)) throw new RuntimeException('Replay outside tolerance accepted');
+if(StripeBilling::valid_signature($payload.'x',"t={$timestamp},v1={$valid}",$secret,$timestamp)) throw new RuntimeException('Tampered body accepted');
+echo "ok - Stripe webhook signature, tamper, and replay handling\n";


### PR DESCRIPTION
### Motivation

- Introduce a freemium product model (Free / Pro / Team) with server-side feature gating so paid capabilities can be enforced without removing the current public dashboard experience.
- Add a minimal, safe Stripe Billing integration (hosted Checkout / Customer Portal + signed webhooks) and low-friction account flow (magic-link) to enable recurring revenue while keeping payment details in Stripe.
- Provide additive storage and data models for customers, watchlists, alert destinations, API tokens and idempotent webhook processing so existing free usage remains untouched.

### Description

- Add a central entitlement matrix in `includes/Entitlements.php` that defines feature access per plan and enforces fail-closed behavior for unknown plans.
- Add `includes/CommerceStore.php` to create additive tables (`lo_customers`, `lo_watchlists`, `lo_alert_destinations`, `lo_api_tokens`, `lo_stripe_events`) and provide customer/plan lookup and idempotent event bookkeeping via `dbDelta`.
- Implement `includes/StripeBilling.php` which exposes REST routes for hosted Checkout/Portal, performs HTTP-based Stripe API calls, verifies webhook signatures with replay-protection, and applies subscription lifecycle events to `CommerceStore`.
- Implement `includes/Product.php` to provide magic-link sign-in, server-gated REST endpoints for watchlists/alert destinations/API tokens, shortcodes/pages for `pricing` and `account`, browser event hooks, and page auto-creation on install.
- Add `includes/CommerceAdmin.php` for admin settings (Stripe keys, webhook secret, Price IDs, feature flags) and wire `Product::install_pages()` and `CommerceStore::install()` into plugin activation and admin-init migrations.
- Add small theme/UI changes and CTAs: upgrade callout on the Lousy Outages page, teaser CTA on the homepage, and include pricing/account templates (`page-lousy-outages-pricing.php`, `page-lousy-outages-account.php`) and CSS tweaks to preserve brand styling.
- Add runtime hooks and analytics contract: `do_action('lousy_outages_product_event', ...)` server-side and `lousy-outages:event` browser events (also pushed to `dataLayer` under `lo_` prefix), avoiding any secret leakage in events.
- Secure stored secrets: alert destination endpoints are encrypted at rest, API tokens are hashed and returned once on creation, and webhook events are recorded for idempotency.
- Add developer-facing rollout documentation and runbook in `docs/lousy-outages-freemium-rollout.md` describing migration notes, schema, options, and rollout/rollback checklists.

### Testing

- Ran PHP lint across plugin files with `php -l` and fixed no syntax errors for new/modified files.
- Unit/behavioral checks: `php tests/LousyOutagesEntitlementsTest.php` and `php tests/LousyOutagesStripeWebhookTest.php` both passed, validating entitlement logic and Stripe webhook signature/replay handling.
- Focused Lousy Outages JS/PHP regression: `node --test __tests__/lousy-outages-monitored-services.test.js __tests__/lousy-outages-regression-static.test.js __tests__/lousy-outages-email-static.test.js` produced `17/17` focused Lousy Outages checks passed.
- Repository-wide `npm test` was run and shows pre-existing unrelated failures (74 passed, 23 failed) in other areas of the project (Gastown, simulator, and unrelated front-end tests); the Lousy Outages-specific suites are green.
- Performed `git diff --check` and adjusted plugin version strings and tests to match `0.5.0`; no outstanding check warnings remain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67861023e483318c3ec2fd62d56007)