### PR TITLE
Fix Lousy Outages incident episode lifecycle, RSS publication and cron liveness

### DIFF
--- a/lousy-outages/README.md
+++ b/lousy-outages/README.md
@@ -1,5 +1,11 @@
 # Lousy Outages
 
+## 0.5.1
+
+- Coordinates RSS and realtime email around a bounded, persistent logical incident-episode ledger. Mutable provider prose and polling timestamps no longer republish an ongoing incident; confirmed recovery closes it and permits a later recurrence.
+- Repairs missing or stale canonical refresh scheduling without doing provider I/O during page rendering, records refresh timing/lock/result diagnostics, and clearly identifies installations that require an external cron runner.
+- Tracks successful and failed email recipients per episode so partial batches retry only immediate failures, and removes the provider-wide 90-minute throttle that suppressed distinct incidents.
+
 ## 0.5.0
 
 - Adds Free, Pro, and Team entitlements with server-side gates for watchlists, alert destinations, shared/private-board scaffolding, and API tokens.
@@ -120,7 +126,7 @@ Place `[lousy_outages]` in any page or post to render the status table. A page t
 
 ## Development
 
-Official-provider refresh runs via WP-Cron (`lousy_outages_refresh_official_providers`) and updates the saved snapshot and "Last fetched" timestamp every 15 minutes; on low-traffic sites, point a system cron at `wp-cron.php` to keep it firing. Results are stored in an option and also exposed at `/wp-json/lousy-outages/v1/status`.
+Official-provider refresh runs via WP-Cron (`lousy_outages_refresh_official_providers`) and updates the saved snapshot and "Last fetched" timestamp at the configured interval. Missing or refresh-stale schedules receive one guarded immediate recovery event. When `DISABLE_WP_CRON` is true, an external runner must invoke `wp-cron.php` (or run `wp cron event run lousy_outages_refresh_official_providers`) at least as often as the configured interval. Results are stored in an option and also exposed at `/wp-json/lousy-outages/v1/status`.
 
 ## How to subscribe to RSS
 

--- a/lousy-outages/includes/AdminDiagnostics.php
+++ b/lousy-outages/includes/AdminDiagnostics.php
@@ -21,6 +21,7 @@ class AdminDiagnostics {
         $completed = (array) get_option('lousy_outages_last_refresh_complete', []);
         $provider_health = (array) get_option('lousy_outages_provider_health', []);
         $next = function_exists('wp_next_scheduled') ? wp_next_scheduled('lousy_outages_refresh_official_providers') : false;
+        $alert_health = IncidentAlerts::alert_health();
         $healthy = 0; $failed = 0; $delayed = 0;
         foreach (ProviderRegistry::enabled() as $provider) {
             $id = (string)($provider['id'] ?? '');
@@ -39,6 +40,7 @@ class AdminDiagnostics {
             'Canonical cron hook'=>'lousy_outages_refresh_official_providers',
             'Intended cadence'=>'30 minutes',
             'Next scheduled run'=>$next ? gmdate('c', (int)$next) : 'not scheduled',
+            'Alert / publication health'=>wp_json_encode($alert_health, JSON_PRETTY_PRINT),
             'Last attempted refresh'=>wp_json_encode($attempted),
             'Last successful complete refresh'=>wp_json_encode($completed),
             'Overall refresh health'=>($failed > 0 || $delayed > 0) ? 'attention_needed' : 'healthy',

--- a/lousy-outages/includes/Cron/Refresh.php
+++ b/lousy-outages/includes/Cron/Refresh.php
@@ -11,7 +11,6 @@ class Refresh
     {
         add_filter('cron_schedules', [self::class, 'registerSchedule']);
         add_action('init', [self::class, 'ensureScheduled']);
-        add_action('lousy_outages_refresh_official_providers', '\\lousy_outages_refresh_official_providers');
         add_action('lo_send_daily_digest', [IncidentAlerts::class, 'send_daily_digest']);
     }
 
@@ -47,10 +46,6 @@ class Refresh
         foreach (['lousy_outages_poll','lousy_outages_cron_refresh','lousy_outages_refresh','lo_check_statuses','lo_refresh_snapshot'] as $hook) {
             wp_clear_scheduled_hook($hook);
         }
-        if (! wp_next_scheduled('lousy_outages_refresh_official_providers')) {
-            wp_schedule_event(time() + MINUTE_IN_SECONDS, 'lousy_outages_15min', 'lousy_outages_refresh_official_providers');
-        }
-
         $target = self::nextDigestTimestamp();
         $scheduled = wp_next_scheduled('lo_send_daily_digest');
 

--- a/lousy-outages/includes/Feeds.php
+++ b/lousy-outages/includes/Feeds.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace SuzyEaston\LousyOutages;
 
 use SuzyEaston\LousyOutages\Storage\IncidentStore;
+use SuzyEaston\LousyOutages\Storage\EpisodeStore;
 
 /** Canonical, shared RSS status feed. Feed.php is intentionally not bootstrapped. */
 class Feeds {
@@ -48,15 +49,15 @@ class Feeds {
         $build=['sources_included'=>[],'excluded'=>['quiet_signals'=>0,'duplicate_items'=>0,'expired_signals'=>0,'unknown_excluded'=>0,'operational_excluded'=>0,'old_incidents_excluded'=>0,'provider_states_with_official_incident'=>0,'cross_source_duplicates'=>0],'current_provider_items'=>0,'official_incident_items'=>0,'unconfirmed_signal_items'=>0,'stable_identities_reused'=>0,'new_logical_items'=>0];
         $incidentDays=(int)apply_filters('lo_status_feed_official_incident_days',self::INCIDENT_WINDOW_DAYS); $maxItems=(int)apply_filters('lo_status_feed_max_items',self::INCIDENT_LIMIT); $includeUnknown=(bool)apply_filters('lo_status_feed_include_unknown',false); $cutoff=$now-(max(1,$incidentDays)*DAY_IN_SECONDS);
         $providers=$options['providers']??Providers::list(); $states=$options['states']??(new Store())->get_all(); $lastPoll=(string)($options['last_poll']??get_option('lousy_outages_last_poll',gmdate('c',$now)));
-        $events=$options['incidents']??(new IncidentStore())->getStoredIncidents(self::INCIDENT_LIMIT*3);
+        $events=$options['incidents']??(new EpisodeStore())->publications(self::INCIDENT_LIMIT*3);
         $fused=$options['fused_signals']??SignalEngine::summarize_fused_signals(120); $external=$options['external_signals']??ExternalSignals::get_recent_signals(['windowMinutes'=>120,'limit'=>20]);
         $identity=is_array($options['identity_map']??null)?$options['identity_map']:(array)get_option(self::OPTION_IDENTITIES,[]); $identity+=['official'=>[],'providers'=>[],'signals'=>[]]; $items=[]; $officialProviders=[];
 
         foreach ((array)$events as $event) {
-            if(!is_array($event))continue; $event=(new IncidentStore())->normalizeEvent($event); $published=self::feed_publication_timestamp($event); if($published&&$published<$cutoff){$build['excluded']['old_incidents_excluded']++;continue;}
-            $pid=sanitize_key((string)($event['provider']??'')); $title=trim((string)($event['title']??$event['description']??'Incident')); $severity=strtolower((string)($event['severity']??'info'));
+            if(!is_array($event))continue; if(!isset($event['episode_guid'])){$event=(new IncidentStore())->normalizeEvent($event);} $published=self::feed_publication_timestamp($event); if($published&&$published<$cutoff){$build['excluded']['old_incidents_excluded']++;continue;}
+            $pid=sanitize_key((string)($event['provider_id']??$event['provider']??'')); $title=trim((string)($event['title']??$event['description']??'Incident')); $severity=strtolower((string)($event['severity']??'info'));
             $logical=self::official_incident_identity($event,$pid,$title); $entry=$identity['official'][$logical]??null;
-            if(is_array($entry)){$guid=(string)$entry['guid'];$published=(int)($entry['started_at']??$published);$build['stable_identities_reused']++;}else{$legacy=self::legacy_cached_identity($pid,$title);$guid=(string)($legacy['guid']??sha1('official|'.$logical));$published=(int)($legacy['started_at']??$published);$build['new_logical_items']++;}
+            if(is_array($entry)){$guid=(string)$entry['guid'];$published=(int)($entry['started_at']??$published);$build['stable_identities_reused']++;}else{$legacy=self::legacy_cached_identity($pid,$title);$guid=(string)($event['episode_guid']??$legacy['guid']??sha1('official|'.$logical));$published=(int)($legacy['started_at']??$published);$build['new_logical_items']++;}
             $identity['official'][$logical]=['guid'=>$guid,'started_at'=>$published?:$now,'touched_at'=>$now];$officialProviders[$pid]=true;
             self::put_item($items,['title'=>'['.strtoupper($severity).'] '.($event['provider_label']??ucfirst($pid)).' – '.$title,'link'=>(string)($event['incident_url']??$event['url']??home_url('/lousy-outages/')),'guid'=>$guid,'pubDate'=>self::format_rss_date(gmdate('c',$published?:$now)),'description'=>self::truncate_text((string)($event['description']??$title),200),'timestamp'=>$published?:$now,'categories'=>['official_incident',$severity]],$build);
         }
@@ -85,7 +86,7 @@ class Feeds {
         if($persist)update_option(self::OPTION_IDENTITIES,$identity,false); $build['identity_map_size']=count($identity['official'])+count($identity['providers'])+count($identity['signals']);
         $values=array_values($items);usort($values,static fn($a,$b)=>(int)$b['timestamp']<=>(int)$a['timestamp']);$values=array_slice($values,0,max(1,$maxItems));
         foreach($values as $item){if(in_array('official_incident',$item['categories'],true))$build['official_incident_items']++;if(in_array('current-provider-state',$item['categories'],true))$build['current_provider_items']++;if(in_array('unconfirmed',$item['categories'],true))$build['unconfirmed_signal_items']++;}
-        $build['max_items_applied']=max(1,$maxItems);$build['item_count']=count($values);$newest=$values?(int)$values[0]['timestamp']:$now;$lastUpdated=gmdate('c',$newest);$build['newest_item_date']=$lastUpdated;
+        $build['max_items_applied']=max(1,$maxItems);$build['item_count']=count($values);$build['latest_guid']=$values?(string)$values[0]['guid']:'';$newest=$values?(int)$values[0]['timestamp']:$now;$lastUpdated=gmdate('c',$newest);$build['newest_item_date']=$lastUpdated;
         $public=array_map(static function($item){unset($item['timestamp']);return $item;},$values);$build['feed_content_fingerprint']=self::feed_content_fingerprint($public);update_option(self::OPTION_STATUS_FEED_LAST_BUILD,$lastUpdated,false);return[$public,$lastUpdated,$build];
     }
 
@@ -96,8 +97,8 @@ class Feeds {
     private static function rebuild_cache(bool $save,string $reason): array {[$items,$last,$build]=self::get_status_feed_items();$build['cache_invalidation_reason']=$reason;$payload=['items'=>$items,'last_updated'=>$last,'build'=>$build,'expires_at'=>time()+self::FEED_CACHE_TTL];if($save)update_option(self::OPTION_STATUS_FEED_CACHE,$payload,false);return$payload;}
     private static function valid_cached_payload(bool $checkExpiry=true): ?array {$cached=get_option(self::OPTION_STATUS_FEED_CACHE,[]);if(!is_array($cached)||!isset($cached['items'],$cached['build']))return null;if($checkExpiry&&(int)($cached['expires_at']??0)<=time())return null;return$cached;}
     private static function put_item(array &$items,array $item,array &$build): void {$guid=(string)$item['guid'];if(isset($items[$guid])){$build['excluded']['duplicate_items']++;return;}$items[$guid]=$item;}
-    private static function official_incident_identity(array $event,string $pid,string $title): string {foreach(['guid','incident_id','id'] as $key){if(trim((string)($event[$key]??''))!=='')return $pid.'|id|'.trim((string)$event[$key]);}foreach(['incident_url','shortlink','url'] as $key){$url=trim((string)($event[$key]??''));if($url!==''&&preg_match('#^https?://#i',$url))return $pid.'|url|'.strtolower(rtrim($url,'/'));}$start=self::feed_publication_timestamp($event);return $pid.'|fallback|'.self::normalize_title($title).'|'.$start;}
-    private static function feed_publication_timestamp(array $event): int {foreach(['first_seen','started_at','startedAt','published','created_at','detected_at'] as $key){$v=$event[$key]??null;$ts=is_numeric($v)?(int)$v:self::parse_time((string)$v);if($ts>0)return$ts;}return 0;}
+    private static function official_incident_identity(array $event,string $pid,string $title): string {foreach(['episode_guid','guid','incident_id','id'] as $key){if(trim((string)($event[$key]??''))!=='')return $pid.'|id|'.trim((string)$event[$key]);}foreach(['incident_url','shortlink','url'] as $key){$url=trim((string)($event[$key]??''));if($url!==''&&preg_match('#^https?://#i',$url))return $pid.'|url|'.strtolower(rtrim($url,'/'));}$start=self::feed_publication_timestamp($event);return $pid.'|fallback|'.self::normalize_title($title).'|'.$start;}
+    private static function feed_publication_timestamp(array $event): int {foreach(['first_detected','first_seen','started_at','startedAt','published','created_at','detected_at'] as $key){$v=$event[$key]??null;$ts=is_numeric($v)?(int)$v:self::parse_time((string)$v);if($ts>0)return$ts;}return 0;}
     private static function signal_logical_key(array $row,string $pid): string {foreach(['episode_id','signal_id','id'] as $key){if(trim((string)($row[$key]??''))!=='')return$pid.'|'.trim((string)$row[$key]);}return$pid.'|'.sanitize_key((string)($row['source_type']??$row['_kind']??'signal'));}
     /** Pin a matching v2 item during rollout so an active official incident is not replayed. */
     private static function legacy_cached_identity(string $pid,string $title): array {$old=get_option('lousy_outages_status_feed_cache_v2',[]);foreach((array)($old['items']??[]) as $item){$itemTitle=strtolower((string)($item['title']??''));if(strpos($itemTitle,strtolower($title))===false||($pid!==''&&strpos($itemTitle,strtolower($pid))===false&&strpos($itemTitle,strtolower(str_replace('_',' ',$pid)))===false))continue;$started=self::parse_time((string)($item['pubDate']??''));if(!empty($item['guid'])&&$started)return['guid'=>(string)$item['guid'],'started_at'=>$started];}return[];}

--- a/lousy-outages/includes/IncidentAlerts.php
+++ b/lousy-outages/includes/IncidentAlerts.php
@@ -10,6 +10,7 @@ use SuzyEaston\LousyOutages\Providers;
 use SuzyEaston\LousyOutages\Sources\Sources;
 use SuzyEaston\LousyOutages\Sources\StatuspageSource;
 use SuzyEaston\LousyOutages\Storage\IncidentStore;
+use SuzyEaston\LousyOutages\Storage\EpisodeStore;
 use WP_REST_Request;
 
 class IncidentAlerts {
@@ -352,8 +353,16 @@ class IncidentAlerts {
         }
 
         update_option(self::OPTION_LAST_CHECK, gmdate('c'), false);
+        $providerStates = [];
+        foreach ((array)($snapshot['providers'] ?? []) as $provider) {
+            if (is_array($provider) && !empty($provider['id'])) {
+                $providerStates[(string)$provider['id']] = (string)($provider['stateCode'] ?? $provider['state'] ?? 'unknown');
+            }
+        }
+        $episodeStore = $options['episode_store'] ?? new EpisodeStore();
+        $transitions = $episodeStore->observe($incidents, $providerStates);
         try {
-            $result = self::process_incidents($incidents, array_merge(['mode' => 'canonical_refresh', 'store' => $store], $options));
+            $result = self::process_episodes(array_merge($transitions['opened'], array_filter($transitions['continuing'], static fn($e) => !empty($e['email_pending_recipients']))), $episodeStore, $options);
         } catch (\Throwable $e) {
             $result = ['total_incidents'=>count($incidents),'considered'=>0,'sent'=>0,'skipped'=>0,'failed'=>1,'recipients'=>[],'failures'=>[$e->getMessage()],'skipped_reasons'=>[],'mode'=>'canonical_refresh'];
         }
@@ -373,10 +382,43 @@ class IncidentAlerts {
             'next_canonical_refresh' => function_exists('wp_next_scheduled') ? (wp_next_scheduled('lousy_outages_refresh_official_providers') ? gmdate('c', (int) wp_next_scheduled('lousy_outages_refresh_official_providers')) : '') : '',
             'history_persisted' => $historyPersisted,
             'persistence_failures' => $persistenceFailures,
+            'snapshot_incident_count' => count($incidents),
+            'newly_opened_episodes' => count($transitions['opened']),
+            'continuing_episodes' => count($transitions['continuing']),
+            'closed_episodes' => count($transitions['closed']),
             'result' => $result,
         ];
         update_option(self::OPTION_LAST_ALERT_PROCESSING_DIAGNOSTICS, $diag, false);
         return $diag;
+    }
+
+    private static function process_episodes(array $episodes, EpisodeStore $store, array $options): array
+    {
+        $result=['total_incidents'=>count($episodes),'considered'=>count($episodes),'sent'=>0,'skipped'=>0,'failed'=>0,'recipients'=>[],'failures'=>[],'skipped_reasons'=>[],'mode'=>'canonical_refresh'];
+        foreach($episodes as $episode){
+            if(!empty($episode['legacy_suppressed'])){$result['skipped']++;$result['skipped_reasons'][]='legacy_active_incident_imported';continue;}
+            $incident=new Incident((string)$episode['provider_id'],(string)$episode['episode_guid'],(string)$episode['title'],(string)$episode['status'],(string)$episode['url'],null,(string)$episode['severity'],(int)$episode['first_detected'],null);
+            $eligible=self::eligible_recipients($incident);
+            $pending=$store->pendingRecipients((string)$episode['episode_guid'],$eligible);
+            if(!$pending){$result['skipped']++;$result['skipped_reasons'][]='all_eligible_recipients_already_sent';continue;}
+            $send=self::send_incident_alert_email($incident,['explicit_recipients'=>$pending,'mode'=>'canonical_refresh']);
+            $success=(array)($send['accepted_recipients']??[]);$failed=(array)($send['failed_recipients']??[]);
+            $store->saveDelivery((string)$episode['episode_guid'],$success,$failed,$eligible);
+            $result['recipients']=array_values(array_unique(array_merge($result['recipients'],$success)));
+            $result['sent']+=count($success);$result['failed']+=count($failed);
+            if($failed)$result['failures'][]='recipient_send_failed';
+            self::record_alert_delivery(!empty($success),$incident,array_merge($success,$failed),$failed?'recipient_send_failed':'',false,$options);
+        }
+        return $result;
+    }
+
+    private static function eligible_recipients(Incident $incident): array
+    {
+        $preview=self::recipient_preview(sanitize_key($incident->provider));
+        $emails=(array)($preview['subscriber_recipients']??[]);
+        $inbox=sanitize_email((string)get_option('lousy_outages_email',get_option('admin_email')));
+        if($inbox&&is_email($inbox))$emails[]=$inbox;
+        return array_values(array_unique(array_filter(array_map('sanitize_email',$emails))));
     }
 
 
@@ -384,6 +426,8 @@ class IncidentAlerts {
     {
         $stats = class_exists(__NAMESPACE__ . '\Subscriptions') && method_exists(__NAMESPACE__ . '\Subscriptions', 'stats') ? Subscriptions::stats() : [];
         $next = function_exists('wp_next_scheduled') ? wp_next_scheduled('lousy_outages_refresh_official_providers') : false;
+        $finish=(string)get_option('lousy_outages_last_refresh_finish','');$finishTs=$finish?strtotime($finish):0;$interval=max(60,(int)get_option('lousy_outages_interval',300));
+        $feed=class_exists(__NAMESPACE__.'\\Feeds')?Feeds::get_status_feed_diagnostics():[];
         return [
             'notification_email' => (string) get_option('lousy_outages_email', get_option('admin_email')),
             'confirmed_subscribers' => (int) ($stats['confirmed'] ?? 0),
@@ -391,6 +435,14 @@ class IncidentAlerts {
             'last_canonical_refresh' => (string) get_option('lousy_outages_last_refresh_at', get_option(self::OPTION_LAST_CHECK, '')),
             'next_canonical_refresh' => $next ? gmdate('c', (int) $next) : '',
             'canonical_cron_scheduled' => (bool) $next,
+            'last_canonical_refresh_start'=>(string)get_option('lousy_outages_last_refresh_start',''),
+            'last_canonical_refresh_finish'=>$finish,
+            'refresh_age_seconds'=>$finishTs?time()-$finishTs:null,
+            'refresh_stale'=>!$finishTs||time()-$finishTs>2*$interval,
+            'wp_cron_disabled'=>defined('DISABLE_WP_CRON')&&DISABLE_WP_CRON,
+            'refresh_lock_age'=>get_transient('lousy_outages_refresh_lock')?time()-(int)get_transient('lousy_outages_refresh_lock'):null,
+            'refresh_runtime'=>(array)get_option('lousy_outages_refresh_runtime',[]),
+            'rss_item_count'=>(int)($feed['item_count']??0),'rss_latest_guid'=>(string)($feed['latest_guid']??''),'rss_content_fingerprint'=>(string)($feed['feed_content_fingerprint']??''),
             'processing' => (array) get_option(self::OPTION_LAST_ALERT_PROCESSING_DIAGNOSTICS, []),
             'recipient_diagnostics' => (array) get_option(self::OPTION_LAST_ALERT_RECIPIENT_DIAGNOSTICS, []),
             'last_successful_real_alert' => (array) get_option(self::OPTION_LAST_ALERT_SUCCESS, []),
@@ -1637,18 +1689,18 @@ class IncidentAlerts {
         if (!empty($options['dry_run'])) { return ['ok'=>true,'recipients'=>$subscribers,'error'=>'']; }
 
         $provider=$incident->provider; $impact=$incident->impact ?? self::impact_from_status($incident->status); $timestamp=gmdate('c',$incident->detected_at); $components=$incident->component?array_map('trim',explode(',',$incident->component)):[]; $componentLine=$incident->component ?: 'All monitored components'; $url=$incident->url ?: self::provider_url(sanitize_key($provider)); $summary=$incident->title;
-        $accepted=0; $failed=0; $results=[]; $lastError='';
+        $accepted=0; $failed=0; $results=[]; $lastError=''; $acceptedRecipients=[]; $failedRecipients=[];
         foreach ($subscribers as $email) {
             $token=self::build_unsubscribe_token($email);
             $unsubscribe=add_query_arg(['lo_unsub'=>1,'email'=>rawurlencode($email),'token'=>$token], home_url('/lousy-outages/'));
             $payload=['service'=>$provider,'status'=>$incident->status,'impact'=>$impact,'summary'=>$summary,'notes'=>!empty($options['manual_replay'])?'Administrator-requested replay of a real stored incident. Public subscribers were not notified.':'','timestamp'=>$timestamp,'components'=>$componentLine,'components_list'=>$components,'url'=>$url,'unsubscribe_url'=>$unsubscribe];
             $sent=send_lo_outage_alert_email($email,$payload);
-            if ($sent) { $accepted++; $results[]=['recipient'=>self::mask_email($email),'accepted_for_sending'=>true]; }
-            else { $failed++; $lastError='wp_mail returned false for '.self::mask_email($email); $results[]=['recipient'=>self::mask_email($email),'accepted_for_sending'=>false,'error'=>$lastError]; self::log_error($provider,$lastError); }
+            if ($sent) { $accepted++; $acceptedRecipients[]=$email; $results[]=['recipient'=>self::mask_email($email),'accepted_for_sending'=>true]; }
+            else { $failed++; $failedRecipients[]=$email; $lastError='wp_mail returned false for '.self::mask_email($email); $results[]=['recipient'=>self::mask_email($email),'accepted_for_sending'=>false,'error'=>$lastError]; self::log_error($provider,$lastError); }
         }
         $attempt=['timestamp'=>gmdate('c'),'attempted'=>count($subscribers),'accepted_for_sending'=>$accepted,'immediate_failures'=>$failed,'transport'=>class_exists(__NAMESPACE__.'\MailTransport')?MailTransport::currentTransport():'wordpress','results'=>$results,'last_error'=>$lastError];
         update_option(self::OPTION_LAST_ALERT_DELIVERY_RESULT, $attempt, false);
-        return ['ok'=>$accepted>0,'recipients'=>$subscribers,'error'=>$failed?($lastError ?: 'one_or_more_failed'):'','attempt'=>$attempt];
+        return ['ok'=>$accepted>0,'recipients'=>$subscribers,'accepted_recipients'=>$acceptedRecipients,'failed_recipients'=>$failedRecipients,'error'=>$failed?($lastError ?: 'one_or_more_failed'):'','attempt'=>$attempt];
     }
 
     /**

--- a/lousy-outages/includes/Storage/EpisodeStore.php
+++ b/lousy-outages/includes/Storage/EpisodeStore.php
@@ -1,0 +1,118 @@
+<?php
+declare(strict_types=1);
+
+namespace SuzyEaston\LousyOutages\Storage;
+
+use SuzyEaston\LousyOutages\Model\Incident;
+
+/** Persistent lifecycle ledger shared by realtime mail and RSS. */
+final class EpisodeStore
+{
+    public const OPTION = 'lousy_outages_incident_episodes_v1';
+    private const MAX_RECORDS = 250;
+    private const CLOSED_RETENTION = 90 * DAY_IN_SECONDS;
+
+    /** @return array{opened:array,continuing:array,closed:array,active:array} */
+    public function observe(array $incidents, array $providerStates, ?int $now = null): array
+    {
+        $now = $now ?: time();
+        $episodes = $this->all();
+        $migration = !get_option('lousy_outages_episode_migration_complete', false);
+        $suppressImported = $migration && (bool)(get_option('lousy_outages_alerted_incidents', []) || get_option('lousy_outages_alerted_subjects', []));
+        $opened = $continuing = $closed = $seen = [];
+
+        foreach ($incidents as $incident) {
+            if (!$incident instanceof Incident || $this->isHealthy($incident->status)) {
+                continue;
+            }
+            $provider = sanitize_key($incident->provider) ?: 'provider';
+            $identity = $this->identity($incident, $provider);
+            $key = $this->findActive($episodes, $provider, $identity);
+            if ($key === '') {
+                $guid = 'lo-episode-' . wp_generate_uuid4();
+                $key = $guid;
+                $episodes[$key] = [
+                    'provider_id' => $provider, 'source_incident_id' => $identity['source_id'],
+                    'canonical_url' => $identity['url'], 'fallback_signature' => $identity['fallback'],
+                    'identity_type' => $identity['type'], 'identity_value' => $identity['value'],
+                    'episode_guid' => $guid, 'first_detected' => $now, 'last_observed' => $now,
+                    'active' => true, 'closed_at' => null, 'rss_published' => !$suppressImported,
+                    'legacy_suppressed' => $suppressImported,
+                    'email_successful_recipients' => [], 'email_pending_recipients' => [],
+                    'email_failed_recipients' => [], 'title' => $incident->title,
+                    'description' => $incident->title, 'status' => $incident->status,
+                    'severity' => (string)($incident->impact ?: $incident->status), 'url' => $incident->url,
+                ];
+                $opened[] = $key;
+            } else {
+                $continuing[] = $key;
+            }
+            $episodes[$key]['last_observed'] = $now;
+            $episodes[$key]['title'] = $incident->title;
+            $episodes[$key]['description'] = $incident->title;
+            $episodes[$key]['status'] = $incident->status;
+            $episodes[$key]['severity'] = (string)($incident->impact ?: $incident->status);
+            $episodes[$key]['url'] = $incident->url;
+            $seen[$key] = true;
+        }
+
+        foreach ($providerStates as $provider => $status) {
+            $provider = sanitize_key((string)$provider);
+            if (!$this->isHealthy((string)$status)) continue;
+            foreach ($episodes as $key => &$episode) {
+                if (!empty($episode['active']) && ($episode['provider_id'] ?? '') === $provider) {
+                    $episode['active'] = false; $episode['closed_at'] = $now; $closed[] = $key;
+                }
+            }
+            unset($episode);
+        }
+
+        $episodes = $this->prune($episodes, $now);
+        update_option(self::OPTION, $episodes, false);
+        update_option('lousy_outages_episode_migration_complete', 1, false);
+        return ['opened'=>$this->select($episodes,$opened),'continuing'=>$this->select($episodes,$continuing),
+            'closed'=>$this->select($episodes,$closed),'active'=>array_values(array_filter($episodes, static fn($e)=>!empty($e['active'])))];
+    }
+
+    public function all(): array { $v=get_option(self::OPTION,[]); return is_array($v)?$v:[]; }
+    public function publications(int $limit = 15): array
+    {
+        $rows=array_values(array_filter($this->all(),static fn($e)=>!empty($e['rss_published'])));
+        usort($rows,static fn($a,$b)=>(int)($b['first_detected']??0)<=>(int)($a['first_detected']??0));
+        return array_slice($rows,0,max(1,$limit));
+    }
+    public function saveDelivery(string $guid, array $successful, array $failed, array $eligible): void
+    {
+        $all=$this->all(); if(!isset($all[$guid])) return;
+        $ok=array_values(array_unique(array_merge((array)$all[$guid]['email_successful_recipients'],$successful)));
+        $all[$guid]['email_successful_recipients']=$ok;
+        $all[$guid]['email_failed_recipients']=array_values(array_unique($failed));
+        $all[$guid]['email_pending_recipients']=array_values(array_diff(array_unique($eligible),$ok));
+        update_option(self::OPTION,$all,false);
+    }
+    public function pendingRecipients(string $guid,array $eligible): array
+    { $all=$this->all(); $sent=(array)($all[$guid]['email_successful_recipients']??[]); return array_values(array_diff(array_unique($eligible),$sent)); }
+
+    private function identity(Incident $i,string $provider): array
+    {
+        $id=trim($i->id); $isFallback=(bool)preg_match('/(^|:)status:/',$id);
+        if($id!==''&&!$isFallback) return ['type'=>'source_id','value'=>$id,'source_id'=>$id,'url'=>'','fallback'=>''];
+        $url=$this->canonicalUrl($i->url);
+        if($url!==''&&!$isFallback) return ['type'=>'url','value'=>$url,'source_id'=>'','url'=>$url,'fallback'=>''];
+        // Provider-state fallbacks represent one explicit active transition. Mutable
+        // status, prose, severity and poll timestamps deliberately are not identity.
+        $fallback=$provider.'|provider-state';
+        return ['type'=>'fallback','value'=>$fallback,'source_id'=>'','url'=>$url,'fallback'=>$fallback];
+    }
+    private function findActive(array $all,string $provider,array $identity): string
+    { foreach($all as $key=>$e) if(!empty($e['active'])&&($e['provider_id']??'')===$provider&&($e['identity_type']??'')===$identity['type']&&($e['identity_value']??'')===$identity['value']) return (string)$key; return ''; }
+    private function canonicalUrl(string $url): string { $url=trim(strtolower($url)); return preg_match('#^https?://#',$url)?rtrim($url,'/'):''; }
+    private function isHealthy(string $status): bool { return in_array(strtolower(trim($status)),['operational','resolved','none','ok'],true); }
+    private function select(array $all,array $keys): array { $out=[]; foreach(array_unique($keys) as $k) if(isset($all[$k]))$out[]=$all[$k]; return $out; }
+    private function prune(array $all,int $now): array
+    {
+        foreach($all as $k=>$e) if(empty($e['active'])&&(int)($e['closed_at']??0)<$now-self::CLOSED_RETENTION)unset($all[$k]);
+        if(count($all)>self::MAX_RECORDS){uasort($all,static fn($a,$b)=>(int)($b['last_observed']??0)<=>(int)($a['last_observed']??0));$all=array_slice($all,0,self::MAX_RECORDS,true);}
+        return $all;
+    }
+}

--- a/lousy-outages/includes/Storage/IncidentStore.php
+++ b/lousy-outages/includes/Storage/IncidentStore.php
@@ -10,7 +10,6 @@ class IncidentStore
     private const OPTION_EVENTS = 'lo_event_log';
     private const OPTION_EVENTS_COMPACTED = 'lo_event_log_compacted_v1';
     private const OPTION_LAST_DIGEST = 'lousy_outages_daily_digest_last_sent';
-    private const ALERT_COOLDOWN = 90; // Minutes.
     // Keep events long enough for multi-year comparisons.
     private const EVENT_RETENTION = 2 * YEAR_IN_SECONDS; // (~24 months)
     private const IMPORTANT_EVENT_RETENTION = 4 * YEAR_IN_SECONDS;
@@ -61,12 +60,6 @@ class IncidentStore
 
         $lastGuid = (string) get_option($this->lastGuidOption($providerKey), '');
         if ('' !== $lastGuid && '' !== $guid && hash_equals($lastGuid, $guid)) {
-            return false;
-        }
-
-        $lastAlertAt = (int) get_option($this->lastAlertOption($providerKey), 0);
-        $now         = time();
-        if ($lastAlertAt && ($now - $lastAlertAt) < (self::ALERT_COOLDOWN * MINUTE_IN_SECONDS)) {
             return false;
         }
 

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -3,7 +3,7 @@ declare( strict_types=1 );
 /**
  * Plugin Name: Lousy Outages
  * Description: WordPress-native outage intelligence, community reporting, and early-warning signals for third-party service dependencies.
- * Version: 0.5.0
+ * Version: 0.5.1
  * Author: Suzy Easton
  * Text Domain: lousy-outages
  */
@@ -24,7 +24,7 @@ if ( defined( 'LOUSY_OUTAGES_DISABLE' ) && LOUSY_OUTAGES_DISABLE ) {
 }
 
 if ( ! defined( 'LOUSY_OUTAGES_VERSION' ) ) {
-    define( 'LOUSY_OUTAGES_VERSION', '0.5.0' );
+    define( 'LOUSY_OUTAGES_VERSION', '0.5.1' );
 }
 if ( ! defined( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION' ) ) {
     define( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION', 5 );
@@ -90,6 +90,7 @@ lousy_outages_require( 'includes/Sources/StatuspageSource.php' );
 lousy_outages_require( 'includes/Model/Incident.php' );
 lousy_outages_require( 'includes/Storage/HistoryStore.php' );
 lousy_outages_require( 'includes/Storage/IncidentStore.php' );
+lousy_outages_require( 'includes/Storage/EpisodeStore.php' );
 lousy_outages_require( 'includes/Email/Composer.php' );
 lousy_outages_require( 'includes/Sources/Sources.php' );
 lousy_outages_require( 'includes/Sources/SourceRegistry.php' );
@@ -225,11 +226,23 @@ function lousy_outages_refresh_official_providers( bool $bypass_cache = true ): 
 }
 
 function lousy_outages_ensure_canonical_cron_scheduled(): void {
-    if ( wp_next_scheduled( 'lousy_outages_refresh_official_providers' ) ) {
+    $hook = 'lousy_outages_refresh_official_providers';
+    $next = wp_next_scheduled( $hook );
+    $interval = max( 60, (int) get_option( 'lousy_outages_interval', 300 ) );
+    $last = strtotime( (string) get_option( 'lousy_outages_last_refresh_finish', get_option( 'lousy_outages_last_refresh_at', '' ) ) ) ?: 0;
+    $stale = ! $last || time() - $last > 2 * $interval;
+    $disabled = defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON;
+    update_option( 'lousy_outages_cron_health', [ 'checked_at'=>gmdate('c'), 'next_scheduled'=>$next?gmdate('c',(int)$next):'', 'last_finish'=>$last?gmdate('c',$last):'', 'age_seconds'=>$last?time()-$last:null, 'stale'=>$stale, 'wp_cron_disabled'=>$disabled, 'external_cron_required'=>$disabled ], false );
+    if ( $disabled ) {
         return;
     }
-    $recurrence = 'lousy_outages_interval';
-    wp_schedule_event( time() + MINUTE_IN_SECONDS, $recurrence, 'lousy_outages_refresh_official_providers' );
+    if ( ! $next ) wp_schedule_event( time() + MINUTE_IN_SECONDS, 'lousy_outages_interval', $hook );
+    // A short-lived atomic transient prevents multiple frontend requests from
+    // enqueueing duplicate recovery jobs. Provider I/O still happens in WP-Cron.
+    if ( $stale && ! get_transient( 'lousy_outages_cron_repair_lock' ) ) {
+        set_transient( 'lousy_outages_cron_repair_lock', time(), $interval );
+        wp_schedule_single_event( time() + 5, $hook );
+    }
 }
 add_action( 'init', 'lousy_outages_ensure_canonical_cron_scheduled', 30 );
 
@@ -558,7 +571,11 @@ function lousy_outages_refresh_data( bool $bypass_cache = true ): array {
         ];
     }
 
-    set_transient( $lock_key, 1, 5 * MINUTE_IN_SECONDS );
+    $started_micro = microtime( true );
+    $started_at = gmdate( 'c' );
+    set_transient( $lock_key, time(), 5 * MINUTE_IN_SECONDS );
+    update_option( 'lousy_outages_last_refresh_start', $started_at, false );
+    update_option( 'lousy_outages_refresh_runtime', [ 'scheduled_time'=>(string)(wp_next_scheduled('lousy_outages_refresh_official_providers')?gmdate('c',(int)wp_next_scheduled('lousy_outages_refresh_official_providers')):''), 'actual_start'=>$started_at, 'finish'=>'', 'duration_ms'=>0, 'lock_state'=>'held', 'result'=>'running', 'next_scheduled_run'=>'' ], false );
 
     $response = [
         'ok'           => false,
@@ -669,6 +686,8 @@ function lousy_outages_refresh_data( bool $bypass_cache = true ): array {
         $response['message'] = $e->getMessage();
     } finally {
         delete_transient( $lock_key );
+        $finish=gmdate('c'); update_option('lousy_outages_last_refresh_finish',$finish,false);
+        update_option('lousy_outages_refresh_runtime',[ 'scheduled_time'=>(string)(wp_next_scheduled('lousy_outages_refresh_official_providers')?gmdate('c',(int)wp_next_scheduled('lousy_outages_refresh_official_providers')):''), 'actual_start'=>$started_at, 'finish'=>$finish, 'duration_ms'=>(int)round((microtime(true)-$started_micro)*1000), 'lock_state'=>'released', 'result'=>!empty($response['ok'])?'success':(!empty($response['skipped'])?'skipped':'failed'), 'next_scheduled_run'=>(string)(wp_next_scheduled('lousy_outages_refresh_official_providers')?gmdate('c',(int)wp_next_scheduled('lousy_outages_refresh_official_providers')):'') ],false);
     }
 
     return $response;

--- a/lousy-outages/tests/incident-episode-test.php
+++ b/lousy-outages/tests/incident-episode-test.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+const DAY_IN_SECONDS=86400;
+$GLOBALS['opts']=[];
+function get_option($k,$d=false){return $GLOBALS['opts'][$k]??$d;} function update_option($k,$v,$autoload=false){$GLOBALS['opts'][$k]=$v;return true;}
+function sanitize_key($v){return trim(preg_replace('/[^a-z0-9_-]/','',strtolower((string)$v)),'_-');}
+function wp_generate_uuid4(){static $n=0;return sprintf('00000000-0000-4000-8000-%012d',++$n);}
+require __DIR__.'/../includes/Model/Incident.php'; require __DIR__.'/../includes/Storage/EpisodeStore.php';
+use SuzyEaston\LousyOutages\Model\Incident; use SuzyEaston\LousyOutages\Storage\EpisodeStore;
+function incident($id,$title='API outage',$status='major_outage',$impact='critical',$url='https://status.test/incidents/1'){return new Incident('acme',$id,$title,$status,$url,null,$impact,1000,null);}
+function ok($condition,$message){if(!$condition){fwrite(STDERR,"FAIL: $message\n");exit(1);}}
+$store=new EpisodeStore();$first=$store->observe([incident('acme:one')],['acme'=>'major_outage'],1000);ok(count($first['opened'])===1,'first poll opens');$guid=$first['opened'][0]['episode_guid'];$pub=$first['opened'][0]['first_detected'];
+$repeat=$store->observe([incident('acme:one','Renamed','investigating','minor')],['acme'=>'degraded'],1100);ok(count($repeat['opened'])===0&&$repeat['continuing'][0]['episode_guid']===$guid&&$repeat['continuing'][0]['first_detected']===$pub,'mutable fields retain episode');
+$second=$store->observe([incident('acme:one','Renamed'),incident('acme:two','Second incident')],['acme'=>'outage'],1150);ok(count($second['opened'])===1,'distinct same-provider incident opens without cooldown');
+$store->saveDelivery($guid,['a@example.test'],['b@example.test'],['a@example.test','b@example.test']);ok($store->pendingRecipients($guid,['a@example.test','b@example.test'])===['b@example.test'],'partial batch retries only failure');
+$closed=$store->observe([],['acme'=>'operational'],1200);ok(count($closed['closed'])===2,'recovery closes active episodes');
+$fallback=$store->observe([incident('acme:status:abc','Acme degraded','degraded','minor','https://status.test')],['acme'=>'degraded'],1300);$fallbackGuid=$fallback['opened'][0]['episode_guid'];
+$store->observe([],['acme'=>'operational'],1400);$recurrence=$store->observe([incident('acme:status:def','Changed wording','major_outage','critical','https://status.test')],['acme'=>'major_outage'],1500);ok($recurrence['opened'][0]['episode_guid']!==$fallbackGuid,'fallback recurrence gets new GUID');
+ok(count($store->publications(2))===2,'feed publications are bounded');
+echo "incident episode behavioural tests passed\n";

--- a/lousy-outages/wp-cli/class-wp-cli-lousy.php
+++ b/lousy-outages/wp-cli/class-wp-cli-lousy.php
@@ -136,6 +136,7 @@ WP_CLI::add_command( 'lousy:alert-test', AlertTestCommand::class );
 class AlertHealthCommand {
     public function __invoke( array $args, array $assoc_args ): void {
         $subscribers = get_option( 'lo_subscribers', [] );
+        $health = \SuzyEaston\LousyOutages\IncidentAlerts::alert_health();
         $rows = [
             [ 'key' => 'configured_notification_email', 'value' => (string) get_option( 'lousy_outages_email', get_option( 'admin_email' ) ) ],
             [ 'key' => 'subscriber_count', 'value' => is_array( $subscribers ) ? (string) count( $subscribers ) : '0' ],
@@ -144,6 +145,7 @@ class AlertHealthCommand {
             [ 'key' => 'last_synthetic_test', 'value' => wp_json_encode( get_option( 'lousy_outages_last_synthetic_alert', [] ) ) ?: '{}' ],
             [ 'key' => 'cron_lo_check_statuses_scheduled', 'value' => wp_next_scheduled( 'lo_check_statuses' ) ? 'yes' : 'no' ],
             [ 'key' => 'recent_failure_exists', 'value' => get_option( 'lousy_outages_alert_delivery_failure' ) ? 'yes' : 'no' ],
+            [ 'key' => 'canonical_refresh_health', 'value' => wp_json_encode( $health ) ?: '{}' ],
         ];
         format_items( 'table', $rows, [ 'key', 'value' ] );
     }


### PR DESCRIPTION
### Motivation
- Make RSS and realtime email semantics consistent by converging deduplication and delivery around a single canonical, persistent episode identity so ongoing incidents do not republish or re-alert on mutable fields. 
- Ensure the canonical refresh (snapshot → history → alerts → RSS) is registered and repaired safely so missing or stale WP-Cron schedules do not leave email and RSS stale. 
- Replace brittle provider-wide cooldowns and ad-hoc ledgers with per-episode delivery accounting so partial batches retry only failed recipients and successful recipients are not re-notified. 
- Expose clear admin and CLI diagnostics for refresh timing, lock state, and feed publication state to aid operations and installs that require an external cron runner.

### Description
- Add `includes/Storage/EpisodeStore.php` implementing a bounded episode ledger with identity precedence (source incident id → canonical URL → provider-state fallback), episode GUID, first/last timestamps, active/closed state, RSS publication flag, and per-episode recipient success/failure tracking; includes pruning and migration-safety logic. 
- Wire episode lifecycle into canonical refresh: `IncidentAlerts::process_snapshot()` persists incidents, computes provider-state transitions, records opened/continuing/closed episodes, and processes episodes for email delivery via a new `process_episodes()` path that uses `EpisodeStore` for recipient-level retries. 
- Publish RSS from the shared episode ledger by updating `includes/Feeds.php` to use `EpisodeStore::publications()` so `guid` and `pubDate` are stable for ongoing episodes while descriptions may refresh in place. 
- Remove the provider-level 90-minute global cooldown from `IncidentStore` so distinct same-provider incidents are not erroneously suppressed. 
- Consolidate cron registration and repair: stop duplicate hook registrations, avoid clearing healthy recurring events on ordinary requests, detect stale/missing canonical refreshes, schedule one guarded single-event repair (transient-locked), and record refresh start/finish/duration/lock/result in options. 
- Add diagnostics: extend `IncidentAlerts::alert_health()`, admin diagnostics page and `wp lousy:alert-health` output with last start/finish, refresh age/stale indicator, cron-disabled flag, refresh runtime and RSS fingerprint/count/latest GUID, and alert processing summary. 
- Bump plugin version to `0.5.1` and update `README.md` with release notes describing the episode model and cron behaviour. 
- Add focused behavioural PHP test `lousy-outages/tests/incident-episode-test.php` covering open/continue/close/recur and per-recipient retry semantics.

### Testing
- PHP syntax: every changed PHP file passed `php -l` (all modified plugin PHP files validated). (passed)
- Episode behaviour: `php lousy-outages/tests/incident-episode-test.php` — episode lifecycle, recovery and publication bounds tests passed. (passed)
- Targeted Node wiring/static checks: ran the selected Lousy Outages wiring/static tests (`__tests__/lousy-outages-*.test.js`) and observed the expected wiring behavior updates; 16 targeted checks passed while 3 static assertions failed because they expected the old `0.5.0` version or prior implementation shape. (16 pass, 3 static regressions due to deliberate API/version changes)
- Full Node suite: `npm test` (repository-wide) completed with the pre-existing unrelated baseline failures (72 pass, 25 fail); failures include unrelated Gastown, teaser/open-data/music and refresh-loop items that were not touched. (72 pass, 25 fail — unrelated baseline)
- History-store test: `php lousy-outages/tests/history-store-test.php` failed under the test harness due to its fixture expectations and is unchanged by this PR; realtime email and RSS publication remain isolated from optional history persistence. (test harness failure unrelated to episode changes)
- Release build: `bash scripts/build-lousy-outages-release.sh` produced `dist/lousy-outages.zip`; archive contains a single top-level `lousy-outages/` directory and SHA-256 `1d309da9ddf1edb7be0c21c2a7c8b8d372e162e1dbce782f1f70e059315af6b2`. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67ced3342c8331b4d4129a633f07c9)