### PR TITLE
Fix Lousy Outages manual refresh wiring

### DIFF
--- a/__tests__/refresh-loop.test.js
+++ b/__tests__/refresh-loop.test.js
@@ -137,7 +137,7 @@ test('manual refresh falls back to status endpoint when refresh endpoint fails',
 
   const calls = mockFetch.calls;
   assert.ok(calls.length >= 2);
-  const refreshCall = calls.find(call => call[0] === '/wp-json/lousy/v1/refresh');
+  const refreshCall = calls.find(call => String(call[0] || '').includes('/wp-json/lousy/v1/refresh'));
   assert.ok(refreshCall);
   const summaryCall = calls.find(call => {
     const target = String(call[0] || '');
@@ -242,7 +242,7 @@ test('manual refresh treats skipped lock as success and keeps timestamp aligned'
   await wait(120);
   await flushPromises();
 
-  const refreshCall = mockFetch.calls.find(call => call[0] === '/wp-json/lousy-outages/v1/refresh');
+  const refreshCall = mockFetch.calls.find(call => String(call[0] || '').includes('/wp-json/lousy-outages/v1/refresh'));
   assert.ok(refreshCall);
 
   const updatedText = lastUpdated.textContent;

--- a/lousy-outages/assets/lousy-outages.js
+++ b/lousy-outages/assets/lousy-outages.js
@@ -3616,7 +3616,17 @@
     state.manualQueued = false;
     state.pendingManual = false;
     setLoading(true);
-    refreshSummary(true, true)
+    var refreshChain = state.refreshEndpoint
+      ? callRefreshEndpoint().catch(function (err) {
+          if (state.debug && state.root && state.root.console && typeof state.root.console.error === 'function') {
+            state.root.console.error(err);
+          }
+        })
+      : Promise.resolve();
+    refreshChain
+      .then(function () {
+        return refreshSummary(true, true);
+      })
       .catch(function (err) {
         if (state.debug && state.root && state.root.console && typeof state.root.console.error === 'function') {
           state.root.console.error(err);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

QA on production found the dashboard polling read-only summary/snapshot endpoints while the canonical provider collection cron had not completed since July 25–26. One contributing frontend bug: the "Insert coin to refresh" handler never called the admin refresh REST route (`callRefreshEndpoint` was dead code).

This PR wires manual refresh to POST to the refresh endpoint (when configured for admins) before re-reading summary.

## QA context (production)

- Last successful canonical refresh: ~2026-07-25/26 (`cron-status` / `lousy/v1/snapshot`)
- Summary/history REST: HTTP 200 but snapshot `fetched_at` stuck at 2026-07-28
- `/wp-json/lousy-outages/v1/status`: HTTP 500 (legacy endpoint; dashboard uses `/summary`)
- Failed integrations on last collection: Google Cloud, Zscaler
- History table empty (0 incidents returned)

**Production remediation still needed:** run/trigger `lousy_outages_refresh_official_providers`, clear stuck canonical lease/cycle if present, purge LiteSpeed cache for LO REST routes.

## Test plan

- [x] `node --test __tests__/refresh-loop.test.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f07e3715-e643-4237-8952-0b2cf6818148?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f07e3715-e643-4237-8952-0b2cf6818148&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

