### PR TITLE
Compact YVR amp-stack homepage hero

### DIFF
--- a/assets/css/home-hero-cabinet.css
+++ b/assets/css/home-hero-cabinet.css
@@ -1,0 +1,352 @@
+/* Compact YVR + amp-stack homepage hero — overrides layered legacy title-screen rules. */
+
+.home-arcade-title-screen.home-amp-cabinet {
+  display: grid;
+  grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+  align-items: stretch;
+  gap: clamp(0.75rem, 2vw, 1.25rem);
+  min-height: 0;
+  max-height: none;
+  height: auto;
+  min-height: clamp(300px, 42vh, 400px);
+  padding: clamp(0.85rem, 2vw, 1.15rem);
+  margin-bottom: clamp(0.65rem, 1.4vw, 1rem);
+  overflow: hidden;
+  border: 2px solid rgba(87, 243, 255, 0.55);
+  border-radius: 16px;
+  background:
+    radial-gradient(circle at 18% 82%, rgba(87, 243, 255, 0.14), transparent 34%),
+    radial-gradient(circle at 88% 18%, rgba(255, 79, 216, 0.1), transparent 28%),
+    linear-gradient(165deg, #04060f 0%, #07111f 42%, #020308 100%);
+  box-shadow:
+    0 0 0 1px rgba(57, 255, 20, 0.12),
+    0 16px 48px rgba(0, 0, 0, 0.55),
+    inset 0 0 40px rgba(0, 0, 0, 0.35);
+}
+
+.home-amp-cabinet::before {
+  background: repeating-linear-gradient(180deg, rgba(223, 255, 234, 0.05) 0 1px, transparent 1px 4px);
+  opacity: 0.65;
+}
+
+.home-amp-cabinet::after {
+  background:
+    linear-gradient(90deg, rgba(57, 255, 20, 0.08), transparent 14%, transparent 86%, rgba(87, 243, 255, 0.08)),
+    linear-gradient(180deg, rgba(0, 0, 0, 0.35), transparent 32%, transparent 78%, rgba(0, 0, 0, 0.45));
+}
+
+.home-amp-cabinet .home-arcade-screen__backdrop {
+  position: relative;
+  z-index: 1;
+  min-height: 0;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid rgba(87, 243, 255, 0.22);
+  background: linear-gradient(180deg, rgba(2, 8, 18, 0.4), rgba(0, 0, 0, 0.75));
+}
+
+.home-amp-cabinet .home-arcade-vancouver {
+  position: absolute;
+  inset: auto 0 0;
+  width: 100%;
+  height: clamp(110px, 38%, 168px);
+  opacity: 0.92;
+  filter: drop-shadow(0 -4px 18px rgba(87, 243, 255, 0.2));
+}
+
+.home-amp-cabinet .home-arcade-vancouver__mountains {
+  fill: rgba(6, 18, 36, 0.95);
+  stroke: rgba(87, 243, 255, 0.45);
+}
+
+.home-amp-cabinet .home-arcade-vancouver__city {
+  fill: rgba(1, 4, 10, 0.98);
+  stroke: rgba(57, 255, 20, 0.35);
+}
+
+.home-amp-cabinet .home-arcade-vancouver__sails {
+  fill: rgba(232, 255, 243, 0.88);
+  stroke: rgba(87, 243, 255, 0.8);
+}
+
+.home-amp-cabinet .home-arcade-vancouver__water {
+  stroke: rgba(87, 243, 255, 0.65);
+}
+
+/* Hide Miami-noir leftovers */
+.home-amp-cabinet .home-palm,
+.home-amp-cabinet .home-arcade-moon,
+.home-amp-cabinet .home-pixel-star,
+.home-amp-cabinet .home-pixel-rain {
+  display: none !important;
+}
+
+.home-amp-stack {
+  position: absolute;
+  left: clamp(0.5rem, 2vw, 1rem);
+  bottom: clamp(0.35rem, 1.2vw, 0.75rem);
+  z-index: 3;
+  width: min(46%, 220px);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.home-amp {
+  position: relative;
+  padding: 0.55rem 0.65rem 0.5rem;
+  border-radius: 10px;
+  border: 2px solid rgba(20, 20, 20, 0.95);
+  background:
+    linear-gradient(180deg, #1a1a1a 0%, #0d0d0d 55%, #050505 100%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    inset 0 -8px 16px rgba(0, 0, 0, 0.65),
+    4px 6px 0 rgba(255, 79, 216, 0.35);
+}
+
+.home-amp__badge {
+  position: absolute;
+  top: 0.35rem;
+  right: 0.45rem;
+  font-family: "Press Start 2P", monospace;
+  font-size: 0.42rem;
+  letter-spacing: 0.08em;
+  color: #57f3ff;
+  text-shadow: 0 0 8px rgba(87, 243, 255, 0.45);
+}
+
+.home-amp__grille {
+  height: clamp(52px, 9vw, 72px);
+  border-radius: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.9);
+  background:
+    repeating-linear-gradient(90deg, #111 0 3px, #2a2a2a 3px 6px),
+    repeating-linear-gradient(0deg, transparent 0 5px, rgba(0, 0, 0, 0.35) 5px 6px);
+  box-shadow: inset 0 0 18px rgba(0, 0, 0, 0.85);
+}
+
+.home-amp__face {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.45rem;
+  margin-top: 0.45rem;
+}
+
+.home-amp__vu {
+  display: flex;
+  gap: 0.22rem;
+  align-items: flex-end;
+  height: 28px;
+  flex: 1;
+}
+
+.home-amp__vu-bar {
+  display: block;
+  width: 0.38rem;
+  height: 35%;
+  border-radius: 2px;
+  background: linear-gradient(180deg, #39ff14, #ffe66d 72%, #ff4b4b);
+  box-shadow: 0 0 6px rgba(57, 255, 20, 0.35);
+  animation: homeAmpVu 1.1s steps(4, end) infinite;
+}
+
+.home-amp__vu-bar:nth-child(2) { animation-delay: 0.15s; height: 55%; }
+.home-amp__vu-bar:nth-child(3) { animation-delay: 0.3s; height: 72%; }
+.home-amp__vu-bar:nth-child(4) { animation-delay: 0.45s; height: 48%; }
+.home-amp__vu-bar:nth-child(5) { animation-delay: 0.6s; height: 64%; }
+
+.home-amp__knobs {
+  display: flex;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.home-amp__knob {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid #333;
+  background: radial-gradient(circle at 30% 30%, #666, #111);
+  box-shadow: inset 0 -2px 3px rgba(0, 0, 0, 0.8);
+}
+
+.home-amp__knob--gain { border-color: rgba(255, 79, 216, 0.55); }
+.home-amp__knob--tone { border-color: rgba(87, 243, 255, 0.55); }
+
+.home-amp__plate {
+  margin-top: 0.35rem;
+  font-family: "Press Start 2P", monospace;
+  font-size: 0.42rem;
+  letter-spacing: 0.06em;
+  color: rgba(255, 242, 207, 0.82);
+  text-transform: uppercase;
+}
+
+.home-amp-cabinet .home-arcade-screen__panel {
+  position: relative;
+  z-index: 4;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  text-align: left;
+  gap: clamp(0.4rem, 1vw, 0.65rem);
+  padding: clamp(0.35rem, 1vw, 0.65rem) clamp(0.5rem, 1.2vw, 0.85rem);
+  max-width: none;
+  width: 100%;
+}
+
+.home-amp-cabinet .home-arcade-kicker {
+  margin: 0;
+  color: #57f3ff;
+  font-size: clamp(0.48rem, 0.95vw, 0.68rem);
+}
+
+.home-amp-cabinet .home-arcade-title {
+  margin: 0;
+  font-size: clamp(1.85rem, 5.2vw, 3.35rem);
+  line-height: 0.98;
+  max-width: 11ch;
+  text-shadow:
+    0.05em 0.05em 0 #ff4fd8,
+    -0.03em -0.03em 0 #57f3ff,
+    0 0 18px rgba(255, 255, 102, 0.35);
+}
+
+.home-amp-cabinet .home-arcade-subtitle {
+  margin: 0;
+  font-size: clamp(0.52rem, 1vw, 0.72rem);
+  line-height: 1.45;
+  max-width: 36ch;
+  color: rgba(223, 255, 234, 0.88);
+}
+
+.home-amp-cabinet .home-arcade-positioning {
+  margin: 0;
+  max-width: 38ch;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  font-size: clamp(0.82rem, 1.35vw, 0.98rem);
+  line-height: 1.45;
+  color: rgba(232, 247, 255, 0.9);
+}
+
+.home-amp-console {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.55rem 0.75rem;
+  margin-top: 0.15rem;
+}
+
+.home-amp-cabinet .home-title-screen-prompt {
+  position: relative;
+  top: auto;
+  left: auto;
+  margin: 0;
+  padding: 0.38rem 0.65rem;
+  font-size: clamp(0.48rem, 0.85vw, 0.62rem);
+  color: #020308;
+  background: #ffe66d;
+  border: 2px solid #020308;
+  box-shadow: 3px 3px 0 #ff4fd8;
+}
+
+.home-amp-cabinet .home-press-start {
+  min-width: 0;
+  width: auto;
+  padding: 0.65rem 1rem;
+  font-size: clamp(0.62rem, 1.1vw, 0.78rem);
+  background: #39ff14;
+  border-color: #ffff66;
+  color: #020805;
+  box-shadow: 4px 4px 0 #ff4fd8, 0 0 16px rgba(57, 255, 20, 0.28);
+}
+
+.home-title-screen-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.5rem;
+  margin: 0.15rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.home-title-screen-meta li {
+  font-family: "Press Start 2P", monospace;
+  font-size: clamp(0.42rem, 0.75vw, 0.55rem);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.28rem 0.45rem;
+  border: 1px solid rgba(87, 243, 255, 0.32);
+  border-radius: 999px;
+  color: rgba(200, 240, 255, 0.88);
+  background: rgba(0, 12, 20, 0.55);
+}
+
+@keyframes homeAmpVu {
+  0%, 100% { transform: scaleY(0.55); opacity: 0.65; }
+  40% { transform: scaleY(1); opacity: 1; }
+  70% { transform: scaleY(0.72); opacity: 0.85; }
+}
+
+@media (max-width: 820px) {
+  .home-arcade-title-screen.home-amp-cabinet {
+    grid-template-columns: 1fr;
+    min-height: 0;
+    max-height: none;
+  }
+
+  .home-amp-cabinet .home-arcade-screen__backdrop {
+    min-height: clamp(140px, 28vw, 180px);
+  }
+
+  .home-amp-stack {
+    width: min(52%, 200px);
+  }
+
+  .home-amp-cabinet .home-arcade-screen__panel {
+    align-items: center;
+    text-align: center;
+  }
+
+  .home-amp-console {
+    justify-content: center;
+  }
+
+  .home-title-screen-meta {
+    justify-content: center;
+  }
+}
+
+@media (max-width: 520px) {
+  .home-arcade-title-screen.home-amp-cabinet {
+    padding: 0.7rem;
+  }
+
+  .home-amp-cabinet .home-arcade-title {
+    font-size: clamp(1.65rem, 11vw, 2.35rem);
+    max-width: 100%;
+  }
+
+  .home-amp-stack {
+    width: min(58%, 170px);
+  }
+
+  .home-amp-cabinet .home-arcade-vancouver {
+    height: clamp(90px, 34%, 130px);
+    opacity: 0.78;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-amp__vu-bar,
+  .home-amp-cabinet .home-title-screen-prompt,
+  .home-amp-cabinet .home-press-start {
+    animation: none !important;
+  }
+}

--- a/functions.php
+++ b/functions.php
@@ -69,6 +69,16 @@ function retro_game_music_theme_scripts() {
     }
 
     if ( is_front_page() || is_page_template( 'page-home.php' ) ) {
+        $hero_css = get_template_directory() . '/assets/css/home-hero-cabinet.css';
+        if ( file_exists( $hero_css ) ) {
+            wp_enqueue_style(
+                'home-hero-cabinet',
+                get_template_directory_uri() . '/assets/css/home-hero-cabinet.css',
+                array( 'main-styles' ),
+                filemtime( $hero_css )
+            );
+        }
+
         wp_enqueue_script(
             'home-arcade-start',
             get_template_directory_uri() . '/js/home-arcade-start.js',

--- a/page-home.php
+++ b/page-home.php
@@ -5,30 +5,50 @@ get_header();
 
 <main id="homepage-content" class="home-layout home-arcade-layout">
 
-    <section class="home-arcade-title-screen crt-block" aria-labelledby="home-hero-title" data-arcade-hero>
+    <section class="home-arcade-title-screen crt-block home-amp-cabinet" aria-labelledby="home-hero-title" data-arcade-hero>
         <div class="home-arcade-screen__backdrop" aria-hidden="true">
-            <span class="home-pixel-star home-pixel-star--one"></span>
-            <span class="home-pixel-star home-pixel-star--two"></span>
-            <span class="home-pixel-star home-pixel-star--three"></span>
-            <span class="home-pixel-rain home-pixel-rain--one"></span>
-            <span class="home-pixel-rain home-pixel-rain--two"></span>
-            <span class="home-arcade-moon"></span>
-            <span class="home-palm home-palm--left"></span>
-            <span class="home-palm home-palm--right"></span>
-            <svg class="home-arcade-vancouver" viewBox="0 0 1200 280" focusable="false">
+            <svg class="home-arcade-vancouver" viewBox="0 0 1200 280" focusable="false" role="img" aria-label="<?php echo esc_attr( 'Pixel Vancouver harbor skyline' ); ?>">
                 <path class="home-arcade-vancouver__mountains" d="M0 154 78 126 146 82 215 122 286 48 360 132 428 84 508 140 584 76 646 126 718 52 794 136 878 82 948 130 1016 58 1094 136 1200 94 1200 280 0 280Z" />
                 <path class="home-arcade-vancouver__city" d="M0 214h46v-34h34v-24h28v58h34v-82h38v82h24v-48h36v48h24v-92h40v92h24v-58h34v58h22v-40h28v40h30v-74h22v-20h30v20h22v74h18v-42h28v42h30l18-38 18 38h20l22-52 24 52h18l18-34 24 34h26v-62h44v62h30v48h112v66H0Z" />
                 <path class="home-arcade-vancouver__sails" d="M760 204 790 138 820 204Zm48 0 36-82 34 82Zm58 0 40-68 30 68Z" />
                 <path class="home-arcade-vancouver__water" d="M64 242h164M282 252h240M580 240h332M182 266h190M464 270h310" />
             </svg>
+            <div class="home-amp-stack">
+                <div class="home-amp">
+                    <span class="home-amp__badge"><?php echo esc_html( 'YVR' ); ?></span>
+                    <div class="home-amp__grille"></div>
+                    <div class="home-amp__face">
+                        <div class="home-amp__vu" aria-hidden="true">
+                            <span class="home-amp__vu-bar"></span>
+                            <span class="home-amp__vu-bar"></span>
+                            <span class="home-amp__vu-bar"></span>
+                            <span class="home-amp__vu-bar"></span>
+                            <span class="home-amp__vu-bar"></span>
+                        </div>
+                        <div class="home-amp__knobs" aria-hidden="true">
+                            <span class="home-amp__knob home-amp__knob--gain"></span>
+                            <span class="home-amp__knob home-amp__knob--tone"></span>
+                            <span class="home-amp__knob"></span>
+                        </div>
+                    </div>
+                    <p class="home-amp__plate"><?php echo esc_html( 'bass stack // headroom limited' ); ?></p>
+                </div>
+            </div>
         </div>
         <div class="home-arcade-screen__panel">
-            <p class="home-arcade-kicker pixel-font"><?php echo esc_html( 'VANCOUVER CABINET // SYSTEM BOOT' ); ?></p>
+            <p class="home-arcade-kicker pixel-font"><?php echo esc_html( 'YVR practice room // cabinet online' ); ?></p>
             <h1 id="home-hero-title" class="home-arcade-title pixel-font"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>
             <p class="home-arcade-subtitle pixel-font"><?php echo esc_html( 'music // AI strategy // creative technology' ); ?></p>
-            <p class="home-arcade-positioning"><?php echo esc_html( 'AI strategist and systems builder working across infrastructure, creative technology and music.' ); ?></p>
-            <div class="home-title-screen-prompt pixel-font" role="status" aria-live="polite" data-arcade-status><?php echo esc_html( 'INSERT COIN' ); ?></div>
-            <button type="button" class="pixel-button home-press-start" data-home-start data-start-label="PRESS START // VIEW WORK"><?php echo esc_html( 'PRESS START // VIEW WORK' ); ?></button>
+            <p class="home-arcade-positioning"><?php echo esc_html( 'Punk bassist brain. Builds infra, creative tech, and browser tools that shouldn\'t work but do.' ); ?></p>
+            <div class="home-amp-console">
+                <div class="home-title-screen-prompt pixel-font" role="status" aria-live="polite" data-arcade-status><?php echo esc_html( 'INSERT COIN' ); ?></div>
+                <button type="button" class="pixel-button home-press-start" data-home-start data-start-label="PRESS START // VIEW WORK"><?php echo esc_html( 'PRESS START // VIEW WORK' ); ?></button>
+            </div>
+            <ul class="home-title-screen-meta pixel-font" aria-label="<?php echo esc_attr( 'Scene tags' ); ?>">
+                <li><?php echo esc_html( 'Vancouver' ); ?></li>
+                <li><?php echo esc_html( 'harbor rain' ); ?></li>
+                <li><?php echo esc_html( 'amp glow' ); ?></li>
+            </ul>
         </div>
     </section>
 

--- a/scripts/deploy-lousy-outages-ssh.py
+++ b/scripts/deploy-lousy-outages-ssh.py
@@ -29,8 +29,10 @@ THEME_DIR = f"{HOME}/public_html/wp-content/themes/suzyeastonca-main"
 # theme, but only these files affect the Lousy Outages page.
 THEME_FILES = [
     "functions.php",
+    "page-home.php",
     "page-lousy-outages.php",
     "parts/lousy-outages-teaser.php",
+    "assets/css/home-hero-cabinet.css",
     "assets/css/lousy-outages-page.css",
     "assets/css/lousy-outages-theme-isolation.css",
     "assets/css/lousy-outages-teaser.css",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The homepage title screen was eating the viewport — full `100svh` height, Miami diagonal stripes, palm trees — and the Vancouver skyline was buried underneath. This PR shrinks the hero and makes the local + music identity obvious.

## Changes

- **Compact cabinet layout** (~42vh max, ~400px tall on desktop) — Lousy Outages widget and level select show without a full scroll
- **Vancouver harbor** — skyline SVG promoted to the backdrop (mountains, downtown blocks, sail masts, animated water lines)
- **Amp stack** — CSS speaker grille, bouncing VU bars, gain/tone knobs, `YVR` badge, `bass stack // headroom limited` plate
- **Removed** palm trees, neon moon, pixel rain (Miami-noir leftovers)
- **Copy refresh** — kicker `YVR practice room // cabinet online`, shorter positioning line, scene tags: Vancouver / harbor rain / amp glow
- **New asset** `assets/css/home-hero-cabinet.css` — scoped overrides so we don't fight the legacy `style.css` layers

## Layout

| Desktop | Mobile |
|---------|--------|
| 2-column grid: skyline + amp left, title + CTA right | Stacked: skyline/amp band then copy |

PRESS START still scrolls to level select (unchanged JS).

## Deployed

Theme files deployed to suzyeaston.ca for preview before merge.

## Test plan

- [x] Visual check on live homepage after SFTP deploy
- [x] `home-arcade-start.js` unchanged — coin/start flow still works
- [ ] Merge + clear LiteSpeed cache if hero looks stale
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24402609-4a4a-4d1b-8083-fa2f9483c210?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24402609-4a4a-4d1b-8083-fa2f9483c210&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

