### PR TITLE
CKNW live audio + GitHub Actions production deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,80 @@
+name: Deploy to Production
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      theme: ${{ steps.filter.outputs.theme }}
+      plugin: ${{ steps.filter.outputs.plugin }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            theme:
+              - 'functions.php'
+              - 'inc/**'
+              - 'page-home.php'
+              - 'page-lousy-outages.php'
+              - 'parts/**'
+              - 'assets/css/home-hero-cabinet.css'
+              - 'assets/css/lousy-outages-page.css'
+              - 'assets/css/lousy-outages-theme-isolation.css'
+              - 'assets/css/lousy-outages-teaser.css'
+              - 'assets/js/lousy-outages-teaser.js'
+              - 'js/home-city-scanner.js'
+              - 'scripts/deploy-lousy-outages-ssh.py'
+            plugin:
+              - 'lousy-outages/**'
+              - 'dist/lousy-outages.zip'
+              - 'dist/lousy-outages.zip.sha256'
+              - 'dist/release-manifest.json'
+              - 'scripts/build-lousy-outages-release.sh'
+
+  deploy:
+    needs: changes
+    if: needs.changes.outputs.theme == 'true' || needs.changes.outputs.plugin == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install deploy dependencies
+        run: pip install paramiko
+
+      - name: Build plugin release ZIP
+        if: needs.changes.outputs.plugin == 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zip unzip
+          scripts/build-lousy-outages-release.sh
+
+      - name: Deploy theme files
+        if: needs.changes.outputs.theme == 'true'
+        env:
+          LOUSY_SSH_HOST: ${{ secrets.LOUSY_SSH_HOST }}
+          LOUSY_SSH_PORT: ${{ secrets.LOUSY_SSH_PORT }}
+          LOUSY_SSH_USER: ${{ secrets.LOUSY_SSH_USER }}
+          LOUSY_SSH_PASSWORD: ${{ secrets.LOUSY_SSH_PASSWORD }}
+        run: python3 scripts/deploy-lousy-outages-ssh.py --theme
+
+      - name: Deploy Lousy Outages plugin
+        if: needs.changes.outputs.plugin == 'true'
+        env:
+          LOUSY_SSH_HOST: ${{ secrets.LOUSY_SSH_HOST }}
+          LOUSY_SSH_PORT: ${{ secrets.LOUSY_SSH_PORT }}
+          LOUSY_SSH_USER: ${{ secrets.LOUSY_SSH_USER }}
+          LOUSY_SSH_PASSWORD: ${{ secrets.LOUSY_SSH_PASSWORD }}
+        run: python3 scripts/deploy-lousy-outages-ssh.py --plugin

--- a/docs/deploy-production.md
+++ b/docs/deploy-production.md
@@ -1,0 +1,55 @@
+# Production deploy (GitHub Actions + SFTP)
+
+Pushes to `main` can deploy automatically when theme or plugin paths change.
+
+## What runs
+
+Workflow: `.github/workflows/deploy-production.yml`
+
+It uses the same script as local deploys: `scripts/deploy-lousy-outages-ssh.py`
+
+- **Theme paths** → `python3 scripts/deploy-lousy-outages-ssh.py --theme`
+- **Plugin paths** → build ZIP, then `python3 scripts/deploy-lousy-outages-ssh.py --plugin`
+
+The script uploads over SSH/SFTP to:
+
+`public_html/wp-content/themes/suzyeastonca-main/`
+
+and/or
+
+`public_html/wp-content/plugins/lousy-outages/`
+
+## One-time GitHub setup
+
+In the repo: **Settings → Secrets and variables → Actions → New repository secret**
+
+| Secret | Value |
+|--------|--------|
+| `LOUSY_SSH_HOST` | SFTP/SSH host (e.g. server IP) |
+| `LOUSY_SSH_PORT` | SSH port (often `22` or a custom port) |
+| `LOUSY_SSH_USER` | Hosting username |
+| `LOUSY_SSH_PASSWORD` | Hosting password |
+
+These match the local-only file `.env.deploy.local` (never commit that file).
+
+## Local deploy (same script)
+
+```bash
+# theme only
+python3 scripts/deploy-lousy-outages-ssh.py --theme
+
+# plugin only
+python3 scripts/deploy-lousy-outages-ssh.py --plugin
+
+# both
+python3 scripts/deploy-lousy-outages-ssh.py
+```
+
+Credentials: `.env.deploy.local` or the `LOUSY_SSH_*` environment variables.
+
+## Notes
+
+- Deploy is **not** WordPress auto-sync — it replaces specific files on the server.
+- Theme deploy backs up touched files under `theme-backups/` on the host before overwrite.
+- Plugin deploy backs up the previous plugin directory under `plugin-backups/`.
+- After deploy, the script warms WordPress cron/runtime and touches LiteSpeed cache.

--- a/js/home-city-scanner.js
+++ b/js/home-city-scanner.js
@@ -2,47 +2,15 @@
   'use strict';
 
   /**
-   * YVR band scanner — live voice via Broadcastify + live TransLink alert text.
-   * BC haulers use LADD VHF (154.100), not CB — no public LADD internet stream exists.
-   * These are legit repeater / dispatch feeds with highway-adjacent chatter.
+   * YVR scanner — one live audio stream (CKNW 980 Vancouver) + TransLink alert text on SCAN.
+   * Broadcastify embeds are deprecated; leanstream MP3/AAC is browser-safe.
    */
-  var AUDIO_CHANNELS = [
-    {
-      type: 'broadcastify',
-      label: 'LADD 1 HWY',
-      freq: '154.100',
-      feedId: 33907,
-      caption: 'Live VE7RPT ham repeater. BC truckers run LADD VHF — not CB.'
-    },
-    {
-      type: 'broadcastify',
-      label: 'HWY CH19',
-      freq: '27.185',
-      feedId: 43789,
-      caption: 'Live Fraser Valley ham repeater — hauler corridor east of Vancouver.'
-    },
-    {
-      type: 'broadcastify',
-      label: 'FIRE DISP',
-      freq: '154.400',
-      feedId: 38213,
-      caption: 'Live Burnaby Fire dispatch on 154.4 MHz.'
-    },
-    {
-      type: 'broadcastify',
-      label: 'VE7RPT HAM',
-      freq: '146.940',
-      feedId: 33907,
-      caption: 'Live Lower Mainland amateur repeater hub.'
-    },
-    {
-      type: 'broadcastify',
-      label: 'FVARESS',
-      freq: '147.120',
-      feedId: 43789,
-      caption: 'Live VE7RVA Fraser Valley repeater network.'
-    }
-  ];
+  var LIVE_STREAM = 'https://live.leanstream.co/CKNWAM';
+  var LIVE_CHANNEL = {
+    label: 'CKNW 980',
+    freq: '980.000',
+    caption: 'Live CKNW 980 — Vancouver AM news and traffic.'
+  };
 
   var TRANSIT_CHANNELS = [
     {
@@ -65,14 +33,12 @@
     }
   ];
 
-  var STANDBY_CAPTION =
-    'Live bands only. BC haulers use LADD VHF — scan locks to ham repeaters and fire dispatch.';
-  var SCAN_CAPTION = 'Sweeping live VHF bands…';
+  var STANDBY_CAPTION = LIVE_CHANNEL.caption;
+  var SCAN_CAPTION = 'Sweeping live bands…';
   var ATTRIBUTION_TRANSIT = ' Alert data: TransLink.';
 
   var SCAN_MS = 1400;
-  var AUTO_SCAN_MS = 50000;
-  var AUDIO_BIAS = 0.88;
+  var AUTO_SCAN_MS = 55000;
 
   function pick(list) {
     return list[Math.floor(Math.random() * list.length)];
@@ -105,29 +71,28 @@
 
   function HomeCityScanner(root) {
     this.root = root;
-    this.embedEl = root.querySelector('[data-scanner-embed]');
+    this.audio = root.querySelector('[data-scanner-audio]');
     this.freqEl = root.querySelector('[data-scanner-freq]');
     this.channelEl = root.querySelector('[data-scanner-channel]');
     this.captionEl = root.querySelector('[data-scanner-caption]');
     this.scanBtn = root.querySelector('[data-scanner-scan]');
     this.muteBtn = root.querySelector('[data-scanner-mute]');
     this.bars = root.querySelectorAll('[data-scanner-bar]');
-    this.audioChannels = AUDIO_CHANNELS.slice();
-    this.transitChannels = TRANSIT_CHANNELS.slice();
     this.alerts = [];
     this.skytrainAlerts = [];
     this.muted = false;
     this.scanning = false;
     this.static = null;
     this.autoTimer = null;
-    this.current = null;
-    this.embedIframe = null;
+    this.showingTransit = false;
+    this.currentTransit = null;
     this.alertsUrl = (window.HomeCityScannerConfig && HomeCityScannerConfig.alertsUrl) || '/wp-json/se/v1/translink-alerts';
   }
 
   HomeCityScanner.prototype.init = function () {
     var self = this;
     this.loadAlerts();
+    this.showLiveChannel(false);
 
     if (this.scanBtn) {
       this.scanBtn.addEventListener('click', function () { self.scan(true); });
@@ -142,19 +107,9 @@
       }, AUTO_SCAN_MS);
     }
 
-    window.setTimeout(function () { self.scan(false); }, 1800);
-  };
-
-  HomeCityScanner.prototype.pickChannel = function () {
-    var audio = this.audioChannels;
-    var transit = this.transitChannels;
-    if (audio.length && Math.random() < AUDIO_BIAS) {
-      return pick(audio);
-    }
-    if (transit.length) {
-      return pick(transit);
-    }
-    return pick(audio);
+    window.setTimeout(function () {
+      if (!self.muted) self.playLiveStream();
+    }, 1200);
   };
 
   HomeCityScanner.prototype.loadAlerts = function () {
@@ -165,8 +120,8 @@
         if (!payload) return;
         self.alerts = Array.isArray(payload.alerts) ? payload.alerts : [];
         self.skytrainAlerts = Array.isArray(payload.skytrain) ? payload.skytrain : [];
-        if (self.current && self.current.type === 'translink' && self.captionEl) {
-          self.captionEl.textContent = self.alertCaption(self.current) + ATTRIBUTION_TRANSIT;
+        if (self.showingTransit && self.captionEl) {
+          self.captionEl.textContent = self.transitCaption(self.currentTransit) + ATTRIBUTION_TRANSIT;
         }
       })
       .catch(function () { /* standby copy only */ });
@@ -180,32 +135,18 @@
     return this.alerts;
   };
 
-  HomeCityScanner.prototype.pickAlert = function (channel) {
+  HomeCityScanner.prototype.transitCaption = function (channel) {
     var pool = this.alertPool(channel);
     if (!pool.length) {
-      return {
-        header: 'No active TransLink alerts on this channel.',
-        text: 'System clear — or feed still loading.'
-      };
+      return 'No active TransLink alerts — audio stays on CKNW 980.';
     }
-    return pick(pool);
-  };
-
-  HomeCityScanner.prototype.alertCaption = function (channel) {
-    var alert = this.pickAlert(channel);
+    var alert = pick(pool);
     var line = alert.header || alert.text || 'TransLink alert';
     if (alert.header && alert.text && alert.text !== alert.header) {
       line = alert.header + ' — ' + alert.text;
     }
     if (line.length > 200) line = line.slice(0, 197) + '…';
     return line;
-  };
-
-  HomeCityScanner.prototype.channelCaption = function (channel) {
-    if (channel.type === 'translink') {
-      return this.alertCaption(channel) + ATTRIBUTION_TRANSIT;
-    }
-    return channel.caption || STANDBY_CAPTION;
   };
 
   HomeCityScanner.prototype.ensureStatic = function () {
@@ -232,42 +173,11 @@
     });
   };
 
-  HomeCityScanner.prototype.clearEmbed = function () {
-    if (this.embedIframe) {
-      this.embedIframe.remove();
-      this.embedIframe = null;
-    }
-    if (this.embedEl) {
-      this.embedEl.hidden = true;
-      this.embedEl.innerHTML = '';
-    }
-    this.root.classList.remove('is-audio-live');
-  };
-
-  HomeCityScanner.prototype.playBroadcastify = function (channel) {
-    if (!this.embedEl || !channel.feedId || this.muted) return;
-
-    this.clearEmbed();
-    this.embedEl.hidden = false;
-    this.root.classList.add('is-audio-live');
-
-    var iframe = document.createElement('iframe');
-    iframe.className = 'home-city-scanner__iframe';
-    iframe.title = channel.label + ' live feed';
-    iframe.setAttribute(
-      'src',
-      'https://api.broadcastify.com/embed/player/?feedId=' + encodeURIComponent(String(channel.feedId))
-    );
-    iframe.setAttribute('allow', 'autoplay');
-    iframe.setAttribute('loading', 'lazy');
-    iframe.setAttribute('referrerpolicy', 'no-referrer-when-downgrade');
-
-    this.embedEl.appendChild(iframe);
-    this.embedIframe = iframe;
-  };
-
-  HomeCityScanner.prototype.stopAudio = function () {
-    this.clearEmbed();
+  HomeCityScanner.prototype.showLiveChannel = function (scanning) {
+    this.showingTransit = false;
+    this.currentTransit = null;
+    this.updateDisplay(LIVE_CHANNEL, scanning, scanning ? SCAN_CAPTION : LIVE_CHANNEL.caption);
+    this.root.classList.toggle('is-live-audio', !scanning && !this.muted);
   };
 
   HomeCityScanner.prototype.updateDisplay = function (channel, scanning, caption) {
@@ -276,41 +186,68 @@
       this.channelEl.textContent = scanning ? 'SCANNING…' : channel.label || 'STANDBY';
       this.channelEl.classList.toggle('is-lock', !scanning);
     }
-    if (this.captionEl) {
-      this.captionEl.textContent = caption || channel.caption || STANDBY_CAPTION;
+    if (this.captionEl && caption) {
+      this.captionEl.textContent = caption;
     }
     this.root.classList.toggle('is-scanning', scanning);
     this.root.classList.toggle('is-locked', !scanning);
     this.root.classList.toggle('is-translink', channel.type === 'translink');
-    this.root.classList.toggle('is-broadcastify', channel.type === 'broadcastify');
+  };
+
+  HomeCityScanner.prototype.playLiveStream = function () {
+    var self = this;
+    if (!this.audio || this.muted) return;
+
+    if (!this.audio.src) {
+      this.audio.src = LIVE_STREAM;
+      this.audio.volume = 0.55;
+    }
+
+    var playPromise = this.audio.play();
+    if (playPromise && typeof playPromise.then === 'function') {
+      playPromise
+        .then(function () {
+          self.setBars(true);
+          self.root.classList.add('is-live-audio');
+        })
+        .catch(function () {
+          if (self.captionEl && !self.showingTransit) {
+            self.captionEl.textContent = LIVE_CHANNEL.caption + ' (tap SCAN or unmute to retry playback)';
+          }
+          self.setBars(false);
+          self.root.classList.remove('is-live-audio');
+        });
+    } else {
+      this.setBars(true);
+      this.root.classList.add('is-live-audio');
+    }
+  };
+
+  HomeCityScanner.prototype.stopLiveStream = function () {
+    if (!this.audio) return;
+    this.audio.pause();
+    this.root.classList.remove('is-live-audio');
   };
 
   HomeCityScanner.prototype.scan = function (userInitiated) {
     var self = this;
     if (this.scanning) return;
     this.scanning = true;
-    this.stopAudio();
-    this.updateDisplay(
-      { label: 'SCANNING…', freq: this.freqEl ? this.freqEl.textContent : '000.000', type: 'broadcastify' },
-      true,
-      SCAN_CAPTION
-    );
+    this.showLiveChannel(true);
     this.setBars(true);
 
     if (!this.muted) this.setStatic(0.22);
 
     window.setTimeout(function () {
-      var channel = self.pickChannel();
-      self.current = channel;
+      var transit = pick(TRANSIT_CHANNELS);
       self.scanning = false;
       self.setStatic(0);
-      var caption = self.channelCaption(channel);
-      self.updateDisplay(channel, false, caption);
+      self.showingTransit = true;
+      self.currentTransit = transit;
+      self.updateDisplay(transit, false, self.transitCaption(transit) + ATTRIBUTION_TRANSIT);
+      self.root.classList.toggle('is-translink', true);
       self.setBars(!self.muted);
-
-      if (!self.muted && channel.type === 'broadcastify') {
-        self.playBroadcastify(channel);
-      }
+      self.playLiveStream();
 
       if (userInitiated && self.scanBtn) {
         self.scanBtn.textContent = 'LOCKED';
@@ -327,15 +264,20 @@
     }
     if (this.muted) {
       this.setStatic(0);
-      this.stopAudio();
+      this.stopLiveStream();
       this.setBars(false);
       if (this.captionEl) {
-        this.captionEl.textContent = 'Muted. Hit SCAN to tune a live channel.';
+        this.captionEl.textContent = 'Muted. CKNW 980 stays off until you unmute.';
       }
-    } else if (this.current) {
+    } else {
       this.setBars(true);
-      if (this.current.type === 'broadcastify') {
-        this.playBroadcastify(this.current);
+      this.playLiveStream();
+      if (this.captionEl) {
+        if (this.showingTransit && this.currentTransit) {
+          this.captionEl.textContent = this.transitCaption(this.currentTransit) + ATTRIBUTION_TRANSIT;
+        } else {
+          this.captionEl.textContent = LIVE_CHANNEL.caption;
+        }
       }
     }
   };

--- a/page-home.php
+++ b/page-home.php
@@ -13,12 +13,11 @@ get_template_part( 'parts/home-yvr-ascii-art' );
                 <div class="home-city-scanner" data-city-scanner aria-label="<?php echo esc_attr( 'YVR live band scanner' ); ?>">
                     <div class="home-city-scanner__header">
                         <span class="home-city-scanner__badge pixel-font"><?php echo esc_html( 'YVR SCAN' ); ?></span>
-                        <span class="home-city-scanner__freq pixel-font" data-scanner-freq>154.100</span>
+                        <span class="home-city-scanner__freq pixel-font" data-scanner-freq>980.000</span>
                     </div>
                     <div class="home-city-scanner__display">
-                        <span class="home-city-scanner__channel pixel-font" data-scanner-channel><?php echo esc_html( 'STANDBY' ); ?></span>
-                        <p class="home-city-scanner__caption" data-scanner-caption><?php echo esc_html( 'Live bands only. BC haulers use LADD VHF — scan locks to ham repeaters and fire dispatch.' ); ?></p>
-                        <div class="home-city-scanner__embed" data-scanner-embed hidden></div>
+                        <span class="home-city-scanner__channel pixel-font" data-scanner-channel><?php echo esc_html( 'CKNW 980' ); ?></span>
+                        <p class="home-city-scanner__caption" data-scanner-caption><?php echo esc_html( 'Live CKNW 980 — Vancouver AM news and traffic.' ); ?></p>
                     </div>
                     <div class="home-city-scanner__bars" aria-hidden="true">
                         <span class="home-city-scanner__bar" data-scanner-bar></span>
@@ -31,6 +30,7 @@ get_template_part( 'parts/home-yvr-ascii-art' );
                         <button type="button" class="home-city-scanner__btn home-city-scanner__scan pixel-font" data-scanner-scan><?php echo esc_html( 'SCAN' ); ?></button>
                         <button type="button" class="home-city-scanner__btn home-city-scanner__mute pixel-font" data-scanner-mute aria-pressed="false"><?php echo esc_html( 'MUTE' ); ?></button>
                     </div>
+                    <audio data-scanner-audio preload="none" crossorigin="anonymous"></audio>
                 </div>
             </div>
         </div>

--- a/scripts/deploy-lousy-outages-ssh.py
+++ b/scripts/deploy-lousy-outages-ssh.py
@@ -9,6 +9,7 @@ Usage:
     python3 scripts/deploy-lousy-outages-ssh.py --plugin   # plugin only
     python3 scripts/deploy-lousy-outages-ssh.py --theme    # theme files only
 """
+import os
 import sys
 import time
 from pathlib import Path
@@ -17,6 +18,12 @@ import paramiko
 
 ROOT = Path(__file__).resolve().parent.parent
 ENV = ROOT / ".env.deploy.local"
+DEPLOY_ENV_KEYS = (
+    "LOUSY_SSH_HOST",
+    "LOUSY_SSH_PORT",
+    "LOUSY_SSH_USER",
+    "LOUSY_SSH_PASSWORD",
+)
 ZIP = Path("/tmp/lousy-outages-deploy.zip")
 DIST_ZIP = ROOT / "dist" / "lousy-outages.zip"
 HOME = "/home/uquklkik"
@@ -45,14 +52,22 @@ THEME_FILES = [
 
 def load_env(path: Path) -> dict:
     data = {}
-    if not path.is_file():
-        raise SystemExit(f"Missing {path}")
-    for line in path.read_text().splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        k, v = line.split("=", 1)
-        data[k.strip()] = v.strip()
+    for key in DEPLOY_ENV_KEYS:
+        value = os.environ.get(key)
+        if value:
+            data[key] = value
+    if path.is_file():
+        for line in path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            data.setdefault(k.strip(), v.strip())
+    if not data.get("LOUSY_SSH_HOST") or not data.get("LOUSY_SSH_USER") or not data.get("LOUSY_SSH_PASSWORD"):
+        raise SystemExit(
+            f"Missing deploy credentials. Set {', '.join(DEPLOY_ENV_KEYS)} in the environment "
+            f"or in {path}."
+        )
     return data
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Live audio:** one source — `https://live.leanstream.co/CKNWAM` (CKNW 980 Vancouver). Broadcastify embeds are deprecated and showed a security error in the browser.
- **SCAN** still cycles TransLink service-alert text; audio stays on CKNW.
- **GitHub Actions:** `.github/workflows/deploy-production.yml` runs the same SFTP deploy script on push to `main` when theme or plugin paths change.

## GitHub secrets required (one-time)

Add in repo Settings → Secrets → Actions:

- `LOUSY_SSH_HOST`
- `LOUSY_SSH_PORT`
- `LOUSY_SSH_USER`
- `LOUSY_SSH_PASSWORD`

See `docs/deploy-production.md`.

## Deployed

Theme files pushed manually via SFTP for immediate audio fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24402609-4a4a-4d1b-8083-fa2f9483c210?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24402609-4a4a-4d1b-8083-fa2f9483c210&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

