### PR TITLE
Fix YVR BCAST controls — restore pointer-events on amp cabinet backdrop

### DIFF
--- a/assets/css/home-hero-cabinet.css
+++ b/assets/css/home-hero-cabinet.css
@@ -121,6 +121,13 @@
   opacity: 0.85;
 }
 
+.home-yvr-teleprompt__item--fetched {
+  opacity: 0.72;
+  border-top: 1px solid rgba(87, 243, 255, 0.12);
+  padding-top: 0.2rem;
+  margin-top: 0.1rem;
+}
+
 .home-yvr-teleprompt__script {
   flex: 1 1 auto;
   min-height: clamp(72px, 14vh, 110px);
@@ -744,6 +751,11 @@
 
   .home-amp-stack {
     width: min(52%, 200px);
+  }
+
+  .home-yvr-teleprompt__script {
+    min-height: 64px;
+    max-height: 96px;
   }
 
   .home-amp-cabinet .home-arcade-screen__panel {

--- a/assets/css/home-hero-cabinet.css
+++ b/assets/css/home-hero-cabinet.css
@@ -2,13 +2,13 @@
 
 .home-arcade-title-screen.home-amp-cabinet {
   display: grid;
-  grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+  grid-template-columns: minmax(0, 0.76fr) minmax(0, 1.24fr);
   align-items: stretch;
-  gap: clamp(0.75rem, 2vw, 1.25rem);
+  gap: clamp(0.65rem, 1.6vw, 1rem);
   min-height: 0;
   max-height: none;
   height: auto;
-  min-height: clamp(300px, 42vh, 400px);
+  min-height: clamp(248px, 34vh, 320px);
   padding: clamp(0.85rem, 2vw, 1.15rem);
   margin-bottom: clamp(0.65rem, 1.4vw, 1rem);
   overflow: hidden;
@@ -41,33 +41,55 @@
   pointer-events: auto;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  gap: 0.45rem;
-  min-height: 100%;
+  justify-content: center;
+  align-items: stretch;
+  gap: 0;
+  min-height: 0;
+  padding: clamp(0.35rem, 1vw, 0.5rem);
   border-radius: 12px;
   overflow: hidden;
   border: 1px solid rgba(87, 243, 255, 0.22);
   background:
-    radial-gradient(circle at 30% 18%, rgba(87, 243, 255, 0.12), transparent 42%),
+    radial-gradient(circle at 30% 18%, rgba(87, 243, 255, 0.1), transparent 42%),
     linear-gradient(180deg, rgba(2, 8, 18, 0.55), rgba(0, 0, 0, 0.88));
 }
 
-.home-yvr-teleprompt {
-  flex: 1 1 auto;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  padding: clamp(0.35rem, 1vw, 0.55rem) clamp(0.3rem, 0.8vw, 0.45rem) 0.2rem;
+.home-yvr-rack {
+  position: relative;
+  width: 100%;
+  max-width: 252px;
+  margin: 0 auto;
+}
+
+.home-yvr-rack__kicker {
+  margin: 0 0 0.28rem;
+  font-size: 0.38rem;
+  letter-spacing: 0.1em;
+  color: rgba(87, 243, 255, 0.55);
+  text-transform: lowercase;
+}
+
+.home-yvr-rack::before,
+.home-yvr-rack::after {
+  content: "+";
+  position: absolute;
+  top: 0.15rem;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.45rem;
+  color: rgba(255, 255, 255, 0.18);
   pointer-events: none;
 }
 
-.home-yvr-teleprompt.is-live .home-yvr-teleprompt__script {
+.home-yvr-rack::before { left: 0; }
+.home-yvr-rack::after { right: 0; }
+
+/* CRT teleprompter — inside broadcaster rack */
+.home-yvr-broadcaster__crt[data-broadcaster-teleprompt].is-live .home-yvr-teleprompt__script {
   border-color: rgba(57, 255, 20, 0.45);
   box-shadow: inset 0 0 16px rgba(57, 255, 20, 0.12);
 }
 
-.home-yvr-teleprompt.is-radio .home-yvr-teleprompt__script {
+.home-yvr-broadcaster__crt[data-broadcaster-teleprompt].is-radio .home-yvr-teleprompt__script {
   border-color: rgba(255, 230, 109, 0.5);
   box-shadow: inset 0 0 16px rgba(255, 230, 109, 0.12);
 }
@@ -78,8 +100,8 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.28rem;
-  max-height: 4.2rem;
+  gap: 0.2rem;
+  max-height: 3.2rem;
   overflow: hidden;
 }
 
@@ -129,23 +151,22 @@
 }
 
 .home-yvr-teleprompt__script {
-  flex: 1 1 auto;
-  min-height: clamp(72px, 14vh, 110px);
-  max-height: clamp(88px, 18vh, 130px);
   margin: 0;
-  padding: 0.4rem 0.42rem;
+  min-height: 3.4rem;
+  max-height: 4.6rem;
+  padding: 0.32rem 0.36rem;
   overflow-y: auto;
   overflow-x: hidden;
   scrollbar-width: thin;
   scrollbar-color: rgba(87, 243, 255, 0.35) transparent;
-  border-radius: 6px;
-  border: 1px solid rgba(87, 243, 255, 0.22);
-  background: rgba(0, 6, 12, 0.82);
+  border-radius: 4px;
+  border: 1px solid rgba(0, 0, 0, 0.85);
+  background: rgba(0, 4, 2, 0.95);
   font-family: "IBM Plex Mono", "Courier New", monospace;
-  font-size: clamp(0.46rem, 0.9vw, 0.58rem);
-  line-height: 1.45;
+  font-size: clamp(0.44rem, 0.84vw, 0.54rem);
+  line-height: 1.4;
   letter-spacing: 0.02em;
-  color: rgba(170, 210, 200, 0.55);
+  color: rgba(170, 210, 200, 0.5);
   scroll-behavior: smooth;
 }
 
@@ -190,83 +211,120 @@
 }
 
 .home-amp-stack {
-  position: relative;
-  z-index: 3;
-  pointer-events: auto;
-  width: 100%;
-  max-width: 268px;
-  margin: 0 auto 0 clamp(0.25rem, 1vw, 0.5rem);
-  display: grid;
-  gap: 0.35rem;
+  display: none;
 }
 
-/* YVR broadcaster — computer voice + CKNW */
+/* YVR broadcaster — rack-mounted CRT + deck */
 .home-yvr-broadcaster {
   position: relative;
   z-index: 1;
   pointer-events: auto;
-  padding: 0.5rem 0.55rem 0.45rem;
-  border-radius: 10px;
-  border: 2px solid rgba(20, 20, 20, 0.95);
+  padding: 0.42rem 0.45rem 0.38rem;
+  border-radius: 8px;
+  border: 2px solid #0a0c10;
   background:
-    linear-gradient(180deg, #141820 0%, #0a0c12 55%, #050608 100%);
+    linear-gradient(145deg, #1a1e28 0%, #0c0e14 48%, #050608 100%);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.06),
-    inset 0 -6px 14px rgba(0, 0, 0, 0.65),
-    4px 5px 0 rgba(255, 79, 216, 0.32);
+    inset 0 1px 0 rgba(255, 255, 255, 0.07),
+    inset 0 -8px 16px rgba(0, 0, 0, 0.7),
+    3px 4px 0 rgba(255, 79, 216, 0.28),
+    0 0 20px rgba(87, 243, 255, 0.06);
+}
+
+.home-yvr-broadcaster::before {
+  content: "";
+  position: absolute;
+  inset: 3px;
+  border-radius: 6px;
+  border: 1px solid rgba(87, 243, 255, 0.08);
+  pointer-events: none;
 }
 
 .home-yvr-broadcaster__header {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.35rem;
-  margin-bottom: 0.35rem;
+  gap: 0.28rem;
+  margin-bottom: 0.28rem;
 }
 
 .home-yvr-broadcaster__badge {
   font-family: "Press Start 2P", monospace;
-  font-size: 0.4rem;
-  letter-spacing: 0.06em;
+  font-size: 0.38rem;
+  letter-spacing: 0.05em;
   color: #ff4fd8;
   text-shadow: 0 0 8px rgba(255, 79, 216, 0.45);
 }
 
+.home-yvr-broadcaster__channel {
+  justify-self: center;
+  font-family: "Press Start 2P", monospace;
+  font-size: 0.36rem;
+  line-height: 1.2;
+  letter-spacing: 0.05em;
+  color: #57f3ff;
+  text-shadow: 0 0 8px rgba(87, 243, 255, 0.35);
+  padding: 0.12rem 0.28rem;
+  border-radius: 3px;
+  border: 1px solid rgba(87, 243, 255, 0.25);
+  background: rgba(0, 12, 20, 0.65);
+}
+
 .home-yvr-broadcaster__freq {
   font-family: "IBM Plex Mono", "Courier New", monospace;
-  font-size: 0.62rem;
+  font-size: 0.56rem;
   letter-spacing: 0.04em;
   color: #ffe66d;
   text-shadow: 0 0 6px rgba(255, 230, 109, 0.35);
 }
 
-.home-yvr-broadcaster__display {
+.home-yvr-broadcaster__crt {
+  position: relative;
+  margin-bottom: 0.32rem;
   border-radius: 6px;
-  border: 1px solid rgba(0, 0, 0, 0.85);
-  background: rgba(0, 8, 4, 0.92);
-  padding: 0.35rem 0.4rem;
-  min-height: 3rem;
-  box-shadow: inset 0 0 12px rgba(87, 243, 255, 0.1);
+  padding: 0.22rem;
+  border: 2px solid #020308;
+  background: linear-gradient(180deg, #0a0c12, #040608);
+  box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.85);
 }
 
-.home-yvr-broadcaster__channel {
-  display: block;
-  font-family: "Press Start 2P", monospace;
-  font-size: 0.44rem;
-  line-height: 1.35;
-  letter-spacing: 0.05em;
-  color: #57f3ff;
-  text-shadow: 0 0 8px rgba(87, 243, 255, 0.35);
+.home-yvr-broadcaster__crt-scan {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: 4px;
+  background: repeating-linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.04) 0 1px,
+    transparent 1px 3px
+  );
+  mix-blend-mode: screen;
+  opacity: 0.35;
+  animation: homeBcastScan 6s linear infinite;
+}
+
+@keyframes homeBcastScan {
+  0% { transform: translateY(0); }
+  100% { transform: translateY(3px); }
+}
+
+.home-yvr-broadcaster__deck {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.28rem;
+  align-items: end;
+}
+
+.home-yvr-broadcaster__display {
+  display: none;
 }
 
 .home-yvr-broadcaster__caption {
-  margin: 0.28rem 0 0;
+  margin: 0.2rem 0 0;
   font-family: "IBM Plex Mono", "Courier New", monospace;
-  font-size: 0.46rem;
+  font-size: 0.4rem;
   line-height: 1.35;
-  color: rgba(200, 235, 220, 0.82);
-  max-height: 4.4em;
-  overflow: hidden;
+  color: rgba(200, 235, 220, 0.72);
 }
 
 .home-yvr-broadcaster__caption[hidden] {
@@ -275,10 +333,10 @@
 
 .home-yvr-broadcaster__bars {
   display: flex;
-  gap: 0.22rem;
+  gap: 0.16rem;
   align-items: flex-end;
-  height: 20px;
-  margin-top: 0.32rem;
+  height: 28px;
+  padding-bottom: 0.12rem;
 }
 
 .home-yvr-broadcaster__bar {
@@ -298,23 +356,22 @@
 
 .home-yvr-broadcaster__channels {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 0.28rem;
-  margin-top: 0.38rem;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.18rem;
 }
 
 .home-yvr-broadcaster__ch {
-  padding: 0.32rem 0.2rem;
+  padding: 0.28rem 0.1rem;
   font-family: "Press Start 2P", monospace;
-  font-size: 0.38rem;
-  letter-spacing: 0.04em;
-  line-height: 1.35;
+  font-size: 0.34rem;
+  letter-spacing: 0.03em;
+  line-height: 1.25;
   cursor: pointer;
   border: 2px solid #020308;
-  border-radius: 4px;
+  border-radius: 3px;
   background: #1a1f28;
   color: #dfe7ff;
-  box-shadow: 2px 2px 0 rgba(87, 243, 255, 0.25);
+  box-shadow: 1px 1px 0 rgba(87, 243, 255, 0.22);
 }
 
 .home-yvr-broadcaster__ch:hover,
@@ -330,24 +387,26 @@
 }
 
 .home-yvr-broadcaster__controls {
-  margin-top: 0.32rem;
+  display: none;
 }
 
 .home-yvr-broadcaster__btn {
-  width: 100%;
   padding: 0.34rem 0.35rem;
   font-family: "Press Start 2P", monospace;
-  font-size: 0.42rem;
-  letter-spacing: 0.06em;
+  font-size: 0.36rem;
+  letter-spacing: 0.05em;
   cursor: pointer;
   border: 2px solid #020308;
-  border-radius: 4px;
+  border-radius: 3px;
+  min-width: 2.6rem;
+  height: 100%;
+  min-height: 2.1rem;
 }
 
 .home-yvr-broadcaster__stop {
   background: #ff4b4b;
   color: #fff;
-  box-shadow: 3px 3px 0 #020308;
+  box-shadow: 2px 2px 0 #020308;
 }
 
 .home-yvr-broadcaster.is-speaking .home-yvr-broadcaster__channel {

--- a/assets/css/home-hero-cabinet.css
+++ b/assets/css/home-hero-cabinet.css
@@ -52,23 +52,122 @@
     linear-gradient(180deg, rgba(2, 8, 18, 0.55), rgba(0, 0, 0, 0.88));
 }
 
-.home-yvr-ascii {
+.home-yvr-teleprompt {
   flex: 1 1 auto;
-  margin: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: clamp(0.35rem, 1vw, 0.55rem) clamp(0.3rem, 0.8vw, 0.45rem) 0.2rem;
   pointer-events: none;
-  padding: clamp(0.35rem, 1vw, 0.55rem) clamp(0.25rem, 0.8vw, 0.45rem) 0;
-  font-family: "IBM Plex Mono", "Courier New", monospace;
-  font-size: clamp(0.44rem, 0.92vw, 0.58rem);
-  line-height: 1.14;
-  letter-spacing: 0.02em;
-  white-space: pre;
+}
+
+.home-yvr-teleprompt.is-live .home-yvr-teleprompt__script {
+  border-color: rgba(57, 255, 20, 0.45);
+  box-shadow: inset 0 0 16px rgba(57, 255, 20, 0.12);
+}
+
+.home-yvr-teleprompt.is-radio .home-yvr-teleprompt__script {
+  border-color: rgba(255, 230, 109, 0.5);
+  box-shadow: inset 0 0 16px rgba(255, 230, 109, 0.12);
+}
+
+.home-yvr-teleprompt__meta {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.28rem;
+  max-height: 4.2rem;
   overflow: hidden;
-  user-select: none;
-  background: linear-gradient(180deg, rgba(57, 255, 20, 0.92) 0%, #57f3ff 38%, #8fdcff 62%, rgba(255, 230, 109, 0.88) 100%);
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
-  filter: drop-shadow(0 0 12px rgba(87, 243, 255, 0.22));
+}
+
+.home-yvr-teleprompt__meta[hidden] {
+  display: none;
+}
+
+.home-yvr-teleprompt__item {
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  font-size: clamp(0.42rem, 0.82vw, 0.52rem);
+  line-height: 1.35;
+  color: rgba(180, 220, 235, 0.88);
+}
+
+.home-yvr-teleprompt__time {
+  display: block;
+  color: #ffe66d;
+  font-size: clamp(0.4rem, 0.78vw, 0.48rem);
+  letter-spacing: 0.03em;
+}
+
+.home-yvr-teleprompt__title {
+  color: rgba(200, 235, 220, 0.92);
+}
+
+.home-yvr-teleprompt__link {
+  color: #57f3ff;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  pointer-events: auto;
+}
+
+.home-yvr-teleprompt__link:hover,
+.home-yvr-teleprompt__link:focus-visible {
+  color: #39ff14;
+}
+
+.home-yvr-teleprompt__item--source {
+  opacity: 0.85;
+}
+
+.home-yvr-teleprompt__script {
+  flex: 1 1 auto;
+  min-height: clamp(72px, 14vh, 110px);
+  max-height: clamp(88px, 18vh, 130px);
+  margin: 0;
+  padding: 0.4rem 0.42rem;
+  overflow-y: auto;
+  overflow-x: hidden;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(87, 243, 255, 0.35) transparent;
+  border-radius: 6px;
+  border: 1px solid rgba(87, 243, 255, 0.22);
+  background: rgba(0, 6, 12, 0.82);
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  font-size: clamp(0.46rem, 0.9vw, 0.58rem);
+  line-height: 1.45;
+  letter-spacing: 0.02em;
+  color: rgba(170, 210, 200, 0.55);
+  scroll-behavior: smooth;
+}
+
+.home-yvr-teleprompt__script::-webkit-scrollbar {
+  width: 4px;
+}
+
+.home-yvr-teleprompt__script::-webkit-scrollbar-thumb {
+  background: rgba(87, 243, 255, 0.35);
+  border-radius: 4px;
+}
+
+.home-yvr-teleprompt__word {
+  transition: color 0.08s linear, background 0.08s linear, text-shadow 0.08s linear;
+}
+
+.home-yvr-teleprompt__word.is-spoken {
+  color: rgba(87, 243, 255, 0.72);
+}
+
+.home-yvr-teleprompt__word.is-current {
+  color: #39ff14;
+  background: rgba(57, 255, 20, 0.14);
+  text-shadow: 0 0 10px rgba(57, 255, 20, 0.55);
+  border-radius: 2px;
+}
+
+.home-yvr-ascii {
+  display: none !important;
 }
 
 .home-amp-cabinet .home-arcade-vancouver {
@@ -161,6 +260,10 @@
   color: rgba(200, 235, 220, 0.82);
   max-height: 4.4em;
   overflow: hidden;
+}
+
+.home-yvr-broadcaster__caption[hidden] {
+  display: none;
 }
 
 .home-yvr-broadcaster__bars {

--- a/assets/css/home-hero-cabinet.css
+++ b/assets/css/home-hero-cabinet.css
@@ -38,6 +38,7 @@
 .home-amp-cabinet .home-arcade-screen__backdrop {
   position: relative;
   z-index: 1;
+  pointer-events: auto;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -54,6 +55,7 @@
 .home-yvr-ascii {
   flex: 1 1 auto;
   margin: 0;
+  pointer-events: none;
   padding: clamp(0.35rem, 1vw, 0.55rem) clamp(0.25rem, 0.8vw, 0.45rem) 0;
   font-family: "IBM Plex Mono", "Courier New", monospace;
   font-size: clamp(0.44rem, 0.92vw, 0.58rem);
@@ -83,7 +85,8 @@
 
 .home-amp-stack {
   position: relative;
-  z-index: 2;
+  z-index: 3;
+  pointer-events: auto;
   width: 100%;
   max-width: 268px;
   margin: 0 auto 0 clamp(0.25rem, 1vw, 0.5rem);
@@ -94,6 +97,8 @@
 /* YVR broadcaster — computer voice + CKNW */
 .home-yvr-broadcaster {
   position: relative;
+  z-index: 1;
+  pointer-events: auto;
   padding: 0.5rem 0.55rem 0.45rem;
   border-radius: 10px;
   border: 2px solid rgba(20, 20, 20, 0.95);

--- a/assets/css/home-hero-cabinet.css
+++ b/assets/css/home-hero-cabinet.css
@@ -57,7 +57,7 @@
 .home-yvr-rack {
   position: relative;
   width: 100%;
-  max-width: 252px;
+  max-width: 300px;
   margin: 0 auto;
 }
 
@@ -214,12 +214,15 @@
   display: none;
 }
 
-/* YVR broadcaster — rack-mounted CRT + deck */
+/* YVR broadcaster — CHIP avatar + rack */
 .home-yvr-broadcaster {
   position: relative;
   z-index: 1;
   pointer-events: auto;
-  padding: 0.42rem 0.45rem 0.38rem;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.45rem 0.5rem;
+  padding: 0.45rem 0.48rem 0.4rem;
   border-radius: 8px;
   border: 2px solid #0a0c10;
   background:
@@ -240,66 +243,146 @@
   pointer-events: none;
 }
 
-.home-yvr-broadcaster__header {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
-  align-items: center;
-  gap: 0.28rem 0.35rem;
-  margin-bottom: 0.28rem;
-}
-
-.home-yvr-broadcaster__identity {
-  display: flex;
-  align-items: center;
-  gap: 0.32rem;
+.home-yvr-broadcaster__body {
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.28rem;
 }
 
-.home-yvr-broadcaster__face {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 3px;
-  width: 22px;
+.home-yvr-broadcaster__avatar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.22rem;
+  padding: 0.2rem 0.15rem 0;
   flex-shrink: 0;
-  padding: 2px;
+}
+
+.home-yvr-broadcaster__avatar-frame {
+  position: relative;
+  width: 52px;
+  height: 58px;
+}
+
+.home-yvr-broadcaster__avatar-hair {
+  position: absolute;
+  top: 2px;
+  left: 8px;
+  right: 8px;
+  height: 14px;
+  border-radius: 6px 6px 2px 2px;
+  background: linear-gradient(180deg, #57f3ff, #2a8aa8);
+  box-shadow: 0 0 10px rgba(87, 243, 255, 0.35);
+}
+
+.home-yvr-broadcaster__avatar-head {
+  position: absolute;
+  top: 12px;
+  left: 10px;
+  right: 10px;
+  height: 34px;
+  border-radius: 8px 8px 12px 12px;
+  background: linear-gradient(180deg, #f0c9a8 0%, #d4a574 100%);
+  border: 2px solid #0a0c10;
+  box-shadow: inset 0 -4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.home-yvr-broadcaster__avatar-visor {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 7px;
+  padding: 3px 4px;
   border-radius: 4px;
-  border: 1px solid rgba(87, 243, 255, 0.22);
-  background: rgba(0, 8, 14, 0.85);
-  box-shadow: inset 0 0 8px rgba(87, 243, 255, 0.08);
+  background: linear-gradient(180deg, #1a2030, #050608);
+  border: 1px solid rgba(87, 243, 255, 0.35);
+  box-shadow: inset 0 0 8px rgba(87, 243, 255, 0.15);
 }
 
 .home-yvr-broadcaster__eye {
-  width: 5px;
-  height: 5px;
-  margin: 0 auto;
+  width: 7px;
+  height: 7px;
+  border-radius: 1px;
   background: #39ff14;
-  box-shadow: 0 0 6px rgba(57, 255, 20, 0.65);
+  box-shadow: 0 0 8px rgba(57, 255, 20, 0.75);
   animation: homeBcastBlink 5s steps(2, end) infinite;
 }
 
 .home-yvr-broadcaster__mouth {
-  grid-column: 1 / -1;
-  width: 12px;
-  height: 3px;
-  margin: 1px auto 0;
-  border-radius: 0 0 6px 6px;
-  background: #0a0c12;
-  border: 1px solid rgba(87, 243, 255, 0.55);
-  box-shadow: inset 0 -2px 4px rgba(255, 79, 216, 0.35);
+  position: absolute;
+  bottom: 4px;
+  left: 50%;
+  width: 16px;
+  height: 4px;
+  margin-left: -8px;
+  border-radius: 0 0 8px 8px;
+  background: #1a0a14;
+  border: 1px solid rgba(255, 79, 216, 0.65);
+  box-shadow: inset 0 -2px 5px rgba(255, 79, 216, 0.4);
   transform-origin: center top;
   transition: height 0.07s ease-out, border-radius 0.07s ease-out;
 }
 
+.home-yvr-broadcaster__avatar-headset {
+  position: absolute;
+  top: 22px;
+  width: 10px;
+  height: 22px;
+  border: 2px solid #2a3040;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #3a4458, #1a1e28);
+  box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.5);
+}
+
+.home-yvr-broadcaster__avatar-headset--l { left: 0; }
+.home-yvr-broadcaster__avatar-headset--r { right: 0; }
+
+.home-yvr-broadcaster__avatar-mic {
+  position: absolute;
+  bottom: 6px;
+  left: 50%;
+  width: 4px;
+  height: 10px;
+  margin-left: -2px;
+  border-radius: 2px;
+  background: #888;
+  box-shadow: -14px 0 0 -2px #666, -14px 8px 0 0 #555;
+}
+
+.home-yvr-broadcaster__avatar-name {
+  margin: 0;
+  font-size: 0.42rem;
+  letter-spacing: 0.08em;
+  color: #39ff14;
+  text-shadow: 0 0 8px rgba(57, 255, 20, 0.45);
+}
+
+.home-yvr-broadcaster__avatar-tag {
+  margin: 0;
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  font-size: 0.38rem;
+  letter-spacing: 0.06em;
+  color: rgba(180, 220, 235, 0.65);
+  text-transform: lowercase;
+}
+
+.home-yvr-broadcaster__avatar.is-talking .home-yvr-broadcaster__eye,
 .home-yvr-broadcaster__face.is-talking .home-yvr-broadcaster__eye {
   animation: homeBcastBlinkFast 1.2s steps(2, end) infinite;
 }
 
+.home-yvr-broadcaster__avatar.is-talking .home-yvr-broadcaster__avatar-head,
+.home-yvr-broadcaster__face.is-talking .home-yvr-broadcaster__avatar-head {
+  box-shadow: inset 0 -4px 8px rgba(0, 0, 0, 0.2), 0 0 12px rgba(57, 255, 20, 0.15);
+}
+
 .home-yvr-broadcaster__mouth.is-open {
-  height: 9px;
-  border-radius: 0 0 9px 9px;
-  background: linear-gradient(180deg, #1a1020 0%, #ff4fd8 88%);
-  border-color: rgba(255, 79, 216, 0.75);
-  box-shadow: 0 0 8px rgba(255, 79, 216, 0.45);
+  height: 11px;
+  border-radius: 0 0 10px 10px;
+  background: linear-gradient(180deg, #2a1020 0%, #ff4fd8 90%);
+  border-color: rgba(255, 79, 216, 0.85);
+  box-shadow: 0 0 10px rgba(255, 79, 216, 0.55);
 }
 
 .home-yvr-broadcaster__mouth.is-flap {
@@ -317,8 +400,30 @@
 }
 
 @keyframes homeBcastMouthFlap {
-  0%, 100% { height: 3px; border-radius: 2px; }
-  50% { height: 10px; border-radius: 0 0 10px 10px; }
+  0%, 100% { height: 4px; border-radius: 2px; }
+  50% { height: 12px; border-radius: 0 0 11px 11px; }
+}
+
+.home-yvr-broadcaster__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.35rem;
+}
+
+.home-yvr-broadcaster__status {
+  display: flex;
+  align-items: center;
+  gap: 0.28rem;
+  min-width: 0;
+}
+
+.home-yvr-broadcaster__legend {
+  margin: 0;
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  font-size: clamp(0.4rem, 0.78vw, 0.48rem);
+  line-height: 1.35;
+  color: rgba(170, 210, 200, 0.72);
 }
 
 .home-yvr-broadcaster__badge {
@@ -327,20 +432,21 @@
   letter-spacing: 0.05em;
   color: #ff4fd8;
   text-shadow: 0 0 8px rgba(255, 79, 216, 0.45);
+  flex-shrink: 0;
 }
 
 .home-yvr-broadcaster__channel {
-  justify-self: center;
   font-family: "Press Start 2P", monospace;
-  font-size: 0.36rem;
+  font-size: 0.34rem;
   line-height: 1.2;
   letter-spacing: 0.05em;
   color: #57f3ff;
   text-shadow: 0 0 8px rgba(87, 243, 255, 0.35);
-  padding: 0.12rem 0.28rem;
+  padding: 0.1rem 0.26rem;
   border-radius: 3px;
   border: 1px solid rgba(87, 243, 255, 0.25);
   background: rgba(0, 12, 20, 0.65);
+  white-space: nowrap;
 }
 
 .home-yvr-broadcaster__freq {
@@ -353,7 +459,6 @@
 
 .home-yvr-broadcaster__crt {
   position: relative;
-  margin-bottom: 0.32rem;
   border-radius: 6px;
   padding: 0.22rem;
   border: 2px solid #020308;
@@ -385,7 +490,68 @@
   display: grid;
   grid-template-columns: auto 1fr auto;
   gap: 0.28rem;
-  align-items: end;
+  align-items: stretch;
+}
+
+.home-yvr-broadcaster__channels {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.22rem;
+}
+
+.home-yvr-broadcaster__ch {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.12rem;
+  padding: 0.28rem 0.3rem;
+  text-align: left;
+  cursor: pointer;
+  border: 2px solid #020308;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #1e2430 0%, #12161e 100%);
+  color: #dfe7ff;
+  box-shadow: 2px 2px 0 rgba(87, 243, 255, 0.18);
+  min-height: 2.35rem;
+}
+
+.home-yvr-broadcaster__ch-label {
+  font-family: "Press Start 2P", monospace;
+  font-size: 0.36rem;
+  letter-spacing: 0.04em;
+  line-height: 1.25;
+  color: #e8f4ff;
+}
+
+.home-yvr-broadcaster__ch-hint {
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  font-size: 0.38rem;
+  line-height: 1.25;
+  color: rgba(160, 200, 215, 0.78);
+}
+
+.home-yvr-broadcaster__ch:hover,
+.home-yvr-broadcaster__ch:focus-visible {
+  border-color: rgba(87, 243, 255, 0.45);
+  background: linear-gradient(180deg, #243040 0%, #1a2030 100%);
+}
+
+.home-yvr-broadcaster__ch:hover .home-yvr-broadcaster__ch-label,
+.home-yvr-broadcaster__ch:focus-visible .home-yvr-broadcaster__ch-label {
+  color: #57f3ff;
+}
+
+.home-yvr-broadcaster__ch.is-active {
+  background: linear-gradient(180deg, #39ff14 0%, #2ad010 100%);
+  box-shadow: 2px 2px 0 #ff4fd8;
+}
+
+.home-yvr-broadcaster__ch.is-active .home-yvr-broadcaster__ch-label {
+  color: #020805;
+}
+
+.home-yvr-broadcaster__ch.is-active .home-yvr-broadcaster__ch-hint {
+  color: rgba(2, 12, 6, 0.75);
 }
 
 .home-yvr-broadcaster__display {
@@ -425,38 +591,6 @@
 .home-yvr-broadcaster__bar.is-live {
   opacity: 1;
   animation: homeScannerBar 0.9s steps(4, end) infinite;
-}
-
-.home-yvr-broadcaster__channels {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 0.18rem;
-}
-
-.home-yvr-broadcaster__ch {
-  padding: 0.28rem 0.1rem;
-  font-family: "Press Start 2P", monospace;
-  font-size: 0.34rem;
-  letter-spacing: 0.03em;
-  line-height: 1.25;
-  cursor: pointer;
-  border: 2px solid #020308;
-  border-radius: 3px;
-  background: #1a1f28;
-  color: #dfe7ff;
-  box-shadow: 1px 1px 0 rgba(87, 243, 255, 0.22);
-}
-
-.home-yvr-broadcaster__ch:hover,
-.home-yvr-broadcaster__ch:focus-visible {
-  color: #57f3ff;
-  background: #243040;
-}
-
-.home-yvr-broadcaster__ch.is-active {
-  background: #39ff14;
-  color: #020805;
-  box-shadow: 2px 2px 0 #ff4fd8;
 }
 
 .home-yvr-broadcaster__controls {
@@ -883,11 +1017,11 @@
   }
 
   .home-yvr-rack {
-    max-width: min(100%, 280px);
+    max-width: min(100%, 320px);
   }
 
-  .home-yvr-broadcaster__deck {
-    grid-template-columns: auto 1fr auto;
+  .home-yvr-broadcaster {
+    grid-template-columns: auto minmax(0, 1fr);
   }
 
   .home-yvr-teleprompt__script {
@@ -921,6 +1055,20 @@
 
   .home-yvr-rack {
     max-width: 100%;
+  }
+
+  .home-yvr-broadcaster__deck {
+    grid-template-columns: 1fr;
+  }
+
+  .home-yvr-broadcaster__bars {
+    justify-content: center;
+    height: 22px;
+  }
+
+  .home-yvr-broadcaster__stop {
+    min-height: 2rem;
+    width: 100%;
   }
 }
 

--- a/assets/css/home-hero-cabinet.css
+++ b/assets/css/home-hero-cabinet.css
@@ -242,10 +242,83 @@
 
 .home-yvr-broadcaster__header {
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: minmax(0, 1fr) auto auto;
   align-items: center;
-  gap: 0.28rem;
+  gap: 0.28rem 0.35rem;
   margin-bottom: 0.28rem;
+}
+
+.home-yvr-broadcaster__identity {
+  display: flex;
+  align-items: center;
+  gap: 0.32rem;
+  min-width: 0;
+}
+
+.home-yvr-broadcaster__face {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 3px;
+  width: 22px;
+  flex-shrink: 0;
+  padding: 2px;
+  border-radius: 4px;
+  border: 1px solid rgba(87, 243, 255, 0.22);
+  background: rgba(0, 8, 14, 0.85);
+  box-shadow: inset 0 0 8px rgba(87, 243, 255, 0.08);
+}
+
+.home-yvr-broadcaster__eye {
+  width: 5px;
+  height: 5px;
+  margin: 0 auto;
+  background: #39ff14;
+  box-shadow: 0 0 6px rgba(57, 255, 20, 0.65);
+  animation: homeBcastBlink 5s steps(2, end) infinite;
+}
+
+.home-yvr-broadcaster__mouth {
+  grid-column: 1 / -1;
+  width: 12px;
+  height: 3px;
+  margin: 1px auto 0;
+  border-radius: 0 0 6px 6px;
+  background: #0a0c12;
+  border: 1px solid rgba(87, 243, 255, 0.55);
+  box-shadow: inset 0 -2px 4px rgba(255, 79, 216, 0.35);
+  transform-origin: center top;
+  transition: height 0.07s ease-out, border-radius 0.07s ease-out;
+}
+
+.home-yvr-broadcaster__face.is-talking .home-yvr-broadcaster__eye {
+  animation: homeBcastBlinkFast 1.2s steps(2, end) infinite;
+}
+
+.home-yvr-broadcaster__mouth.is-open {
+  height: 9px;
+  border-radius: 0 0 9px 9px;
+  background: linear-gradient(180deg, #1a1020 0%, #ff4fd8 88%);
+  border-color: rgba(255, 79, 216, 0.75);
+  box-shadow: 0 0 8px rgba(255, 79, 216, 0.45);
+}
+
+.home-yvr-broadcaster__mouth.is-flap {
+  animation: homeBcastMouthFlap 0.26s steps(3, end) infinite;
+}
+
+@keyframes homeBcastBlink {
+  0%, 92%, 100% { opacity: 1; transform: scaleY(1); }
+  96% { opacity: 0.35; transform: scaleY(0.15); }
+}
+
+@keyframes homeBcastBlinkFast {
+  0%, 70%, 100% { opacity: 1; }
+  80% { opacity: 0.4; }
+}
+
+@keyframes homeBcastMouthFlap {
+  0%, 100% { height: 3px; border-radius: 2px; }
+  50% { height: 10px; border-radius: 0 0 10px 10px; }
 }
 
 .home-yvr-broadcaster__badge {
@@ -805,16 +878,21 @@
   }
 
   .home-amp-cabinet .home-arcade-screen__backdrop {
-    min-height: clamp(140px, 28vw, 180px);
+    min-height: 0;
+    padding: 0.4rem;
   }
 
-  .home-amp-stack {
-    width: min(52%, 200px);
+  .home-yvr-rack {
+    max-width: min(100%, 280px);
+  }
+
+  .home-yvr-broadcaster__deck {
+    grid-template-columns: auto 1fr auto;
   }
 
   .home-yvr-teleprompt__script {
-    min-height: 64px;
-    max-height: 96px;
+    min-height: 3rem;
+    max-height: 4rem;
   }
 
   .home-amp-cabinet .home-arcade-screen__panel {
@@ -841,13 +919,8 @@
     max-width: 100%;
   }
 
-  .home-amp-stack {
-    width: min(58%, 170px);
-  }
-
-  .home-amp-cabinet .home-arcade-vancouver {
-    height: clamp(90px, 34%, 130px);
-    opacity: 0.78;
+  .home-yvr-rack {
+    max-width: 100%;
   }
 }
 
@@ -857,7 +930,10 @@
   .home-amp-cabinet .home-press-start,
   .home-city-scanner__bar,
   .home-city-scanner.is-scanning .home-city-scanner__freq,
-  .home-yvr-broadcaster__bar {
+  .home-yvr-broadcaster__bar,
+  .home-yvr-broadcaster__crt-scan,
+  .home-yvr-broadcaster__eye,
+  .home-yvr-broadcaster__mouth.is-flap {
     animation: none !important;
   }
 }

--- a/inc/home-translink-alerts.php
+++ b/inc/home-translink-alerts.php
@@ -64,7 +64,8 @@ function se_fetch_translink_alerts(): array {
         }
 
         $header = wp_strip_all_tags( (string) ( $row['header'] ?? '' ) );
-        $raw    = (string) ( $row['description'] ?? $row['alertText'] ?? $header );
+        $alert_text = wp_strip_all_tags( (string) ( $row['alertText'] ?? '' ) );
+        $raw    = (string) ( $row['description'] ?? $alert_text ?? $header );
         $text   = preg_replace( '/\s+/', ' ', trim( wp_strip_all_tags( $raw ) ) );
         if ( mb_strlen( $text ) > 320 ) {
             $text = mb_substr( $text, 0, 317 ) . '…';
@@ -81,6 +82,7 @@ function se_fetch_translink_alerts(): array {
             'group'        => isset( $row['group'] ) ? (int) $row['group'] : null,
             'route'        => wp_strip_all_tags( (string) ( $row['routeLongName'] ?? '' ) ),
             'header'       => $header,
+            'alert_text'   => $alert_text,
             'text'         => $text,
             'critical'     => ! empty( $row['critical'] ),
             'url'          => esc_url_raw( (string) ( $row['url'] ?? '' ) ),
@@ -92,7 +94,7 @@ function se_fetch_translink_alerts(): array {
         $out[] = $entry;
     }
 
-    set_transient( 'se_translink_alerts', $out, 3 * MINUTE_IN_SECONDS );
+    set_transient( 'se_translink_alerts', $out, 2 * MINUTE_IN_SECONDS );
     return $out;
 }
 

--- a/inc/home-translink-alerts.php
+++ b/inc/home-translink-alerts.php
@@ -70,13 +70,22 @@ function se_fetch_translink_alerts(): array {
             $text = mb_substr( $text, 0, 317 ) . '…';
         }
 
+        $posted_raw = (string) ( $row['lastModified'] ?? $row['startTime'] ?? '' );
+        $posted_label = '';
+        if ( $posted_raw ) {
+            $posted_label = wp_date( 'M j, Y g:i a', strtotime( $posted_raw ) );
+        }
+
         $entry = array(
-            'id'       => $row['alertId'] ?? $row['id'] ?? null,
-            'group'    => isset( $row['group'] ) ? (int) $row['group'] : null,
-            'route'    => wp_strip_all_tags( (string) ( $row['routeLongName'] ?? '' ) ),
-            'header'   => $header,
-            'text'     => $text,
-            'critical' => ! empty( $row['critical'] ),
+            'id'           => $row['alertId'] ?? $row['id'] ?? null,
+            'group'        => isset( $row['group'] ) ? (int) $row['group'] : null,
+            'route'        => wp_strip_all_tags( (string) ( $row['routeLongName'] ?? '' ) ),
+            'header'       => $header,
+            'text'         => $text,
+            'critical'     => ! empty( $row['critical'] ),
+            'url'          => esc_url_raw( (string) ( $row['url'] ?? '' ) ),
+            'posted'       => $posted_raw,
+            'posted_label' => $posted_label,
         );
 
         $entry['skytrain'] = se_translink_alert_is_skytrain( $entry );

--- a/inc/home-yvr-broadcaster.php
+++ b/inc/home-yvr-broadcaster.php
@@ -40,12 +40,42 @@ function se_broadcaster_pack_from_items( array $items, string $prefix, string $s
     $script = $lines ? $prefix . implode( ' Next. ', $lines ) : '';
 
     return array(
-        'caption'    => se_broadcaster_trim_script( $lines[0] ?? $prefix, 220 ),
-        'script'     => se_broadcaster_trim_script( $script ),
-        'source'     => $source,
-        'source_url' => $source_url,
-        'items'      => $items,
+        'caption'       => se_broadcaster_trim_script( $lines[0] ?? $prefix, 220 ),
+        'script'        => se_broadcaster_trim_script( $script ),
+        'source'        => $source,
+        'source_url'    => $source_url,
+        'items'         => $items,
+        'fetched_label' => 'Pulled ' . wp_date( 'M j, Y g:i a T' ),
     );
+}
+
+/**
+ * Sort rows by a datetime field (newest first), preferring recent window then older.
+ */
+function se_broadcaster_prioritize_recent( array $rows, string $key = 'posted', int $recent_days = 21 ): array {
+    $cutoff = time() - ( $recent_days * DAY_IN_SECONDS );
+    $recent = array();
+    $older  = array();
+
+    foreach ( $rows as $row ) {
+        $ts = strtotime( (string) ( $row[ $key ] ?? '' ) ) ?: 0;
+        if ( $ts >= $cutoff ) {
+            $recent[] = $row;
+        } else {
+            $older[] = $row;
+        }
+    }
+
+    $sort = static function ( array $a, array $b ) use ( $key ): int {
+        $ta = strtotime( (string) ( $a[ $key ] ?? '' ) ) ?: 0;
+        $tb = strtotime( (string) ( $b[ $key ] ?? '' ) ) ?: 0;
+        return $tb <=> $ta;
+    };
+
+    usort( $recent, $sort );
+    usort( $older, $sort );
+
+    return array_merge( $recent, $older );
 }
 
 function se_broadcaster_translink_script(): array {
@@ -60,22 +90,27 @@ function se_broadcaster_translink_script(): array {
     );
 
     if ( ! $sky ) {
-        $sky = array_slice( $alerts, 0, 5 );
+        $sky = array_slice( $alerts, 0, 8 );
     }
+
+    $sky = se_broadcaster_prioritize_recent( $sky, 'posted', 21 );
 
     $items = array();
     foreach ( array_slice( $sky, 0, 3 ) as $row ) {
-        $line = $row['header'] ?? '';
-        if ( ! empty( $row['text'] ) && $row['text'] !== $line ) {
-            $line = trim( $line . '. ' . $row['text'] );
+        $snippet = (string) ( $row['alert_text'] ?? '' );
+        if ( ! $snippet ) {
+            $snippet = $row['header'] ?? '';
         }
-        if ( ! $line ) {
+        if ( ! empty( $row['text'] ) && $row['text'] !== $snippet && mb_strlen( $snippet ) < 40 ) {
+            $snippet = trim( $snippet . '. ' . mb_substr( $row['text'], 0, 120 ) );
+        }
+        if ( ! $snippet ) {
             continue;
         }
         $title = $row['route'] ? $row['route'] : ( $row['header'] ?? 'TransLink alert' );
         $items[] = array(
             'title'        => se_broadcaster_trim_script( $title, 80 ),
-            'text'         => se_broadcaster_trim_script( $line, 200 ),
+            'text'         => se_broadcaster_trim_script( $snippet, 180 ),
             'posted'       => (string) ( $row['posted'] ?? '' ),
             'posted_label' => (string) ( $row['posted_label'] ?? '' ),
             'url'          => (string) ( $row['url'] ?? '' ),
@@ -85,11 +120,12 @@ function se_broadcaster_translink_script(): array {
 
     if ( ! $items ) {
         return array(
-            'caption'    => 'TransLink reports all clear on SkyTrain lines.',
-            'script'     => 'TransLink feed is quiet. No major SkyTrain service alerts right now.',
-            'source'     => 'TransLink',
-            'source_url' => 'https://www.translink.ca/alerts',
-            'items'      => array(),
+            'caption'       => 'TransLink reports all clear on SkyTrain lines.',
+            'script'        => 'TransLink feed is quiet. No major SkyTrain service alerts right now.',
+            'source'        => 'TransLink',
+            'source_url'    => 'https://www.translink.ca/alerts',
+            'items'         => array(),
+            'fetched_label' => 'Pulled ' . wp_date( 'M j, Y g:i a T' ),
         );
     }
 
@@ -181,19 +217,21 @@ function se_fetch_open511_bc_events(): array {
         );
     }
 
-    set_transient( 'se_open511_bc_events', $out, 5 * MINUTE_IN_SECONDS );
-    return $out;
+    set_transient( 'se_open511_bc_events', $out, 2 * MINUTE_IN_SECONDS );
+
+    return se_broadcaster_prioritize_recent( $out, 'updated', 14 );
 }
 
 function se_broadcaster_drivers_script(): array {
     $events = se_fetch_open511_bc_events();
     if ( ! $events ) {
         return array(
-            'caption'    => 'BC Open511 — no active Lower Mainland road alerts.',
-            'script'     => 'DriveBC and Open511 show no major active incidents around Metro Vancouver right now.',
-            'source'     => 'BC Open511',
-            'source_url' => 'https://www.drivebc.ca/',
-            'items'      => array(),
+            'caption'       => 'BC Open511 — no active Lower Mainland road alerts.',
+            'script'        => 'DriveBC and Open511 show no major active incidents around Metro Vancouver right now.',
+            'source'        => 'BC Open511',
+            'source_url'    => 'https://www.drivebc.ca/',
+            'items'         => array(),
+            'fetched_label' => 'Pulled ' . wp_date( 'M j, Y g:i a T' ),
         );
     }
 
@@ -258,7 +296,7 @@ function se_fetch_bc_ferries_capacity(): array {
         $routes[] = $route;
     }
 
-    set_transient( 'se_bc_ferries_capacity', $routes, 5 * MINUTE_IN_SECONDS );
+    set_transient( 'se_bc_ferries_capacity', $routes, 2 * MINUTE_IN_SECONDS );
     return $routes;
 }
 
@@ -279,11 +317,12 @@ function se_broadcaster_ferries_script(): array {
     $routes = se_fetch_bc_ferries_capacity();
     if ( ! $routes ) {
         return array(
-            'caption'    => 'BC Ferries capacity feed unavailable.',
-            'script'     => 'BC Ferries sailing data is offline right now. Check bcferries.com before you drive to the terminal.',
-            'source'     => 'bcferriesapi.ca',
-            'source_url' => 'https://www.bcferries.com/current_conditions',
-            'items'      => array(),
+            'caption'       => 'BC Ferries capacity feed unavailable.',
+            'script'        => 'BC Ferries sailing data is offline right now. Check bcferries.com before you drive to the terminal.',
+            'source'        => 'bcferriesapi.ca',
+            'source_url'    => 'https://www.bcferries.com/current_conditions',
+            'items'         => array(),
+            'fetched_label' => 'Pulled ' . wp_date( 'M j, Y g:i a T' ),
         );
     }
 
@@ -312,9 +351,9 @@ function se_broadcaster_ferries_script(): array {
             'title'        => $from . ' → ' . $to,
             'text'         => $bit,
             'posted'       => $time,
-            'posted_label' => 'Sails ' . $time,
+            'posted_label' => 'Next sail ' . $time . ' PT',
             'url'          => 'https://www.bcferries.com/current_conditions',
-            'link_label'   => 'BC Ferries conditions',
+            'link_label'   => 'Live conditions',
         );
     }
 
@@ -327,12 +366,19 @@ function se_broadcaster_ferries_script(): array {
 }
 
 function se_get_broadcaster_feeds_rest( WP_REST_Request $request ): WP_REST_Response {
+    if ( $request->get_param( 'refresh' ) ) {
+        delete_transient( 'se_translink_alerts' );
+        delete_transient( 'se_open511_bc_events' );
+        delete_transient( 'se_bc_ferries_capacity' );
+    }
+
     return rest_ensure_response(
         array(
-            'updated'   => current_time( 'mysql' ),
-            'translink' => se_broadcaster_translink_script(),
-            'drivers'   => se_broadcaster_drivers_script(),
-            'ferries'   => se_broadcaster_ferries_script(),
+            'updated'       => current_time( 'mysql' ),
+            'fetched_label' => 'Pulled ' . wp_date( 'M j, Y g:i a T' ),
+            'translink'     => se_broadcaster_translink_script(),
+            'drivers'       => se_broadcaster_drivers_script(),
+            'ferries'       => se_broadcaster_ferries_script(),
         )
     );
 }

--- a/inc/home-yvr-broadcaster.php
+++ b/inc/home-yvr-broadcaster.php
@@ -11,6 +11,43 @@ function se_broadcaster_trim_script( string $text, int $max = 520 ): string {
     return $text;
 }
 
+function se_broadcaster_format_posted( string $raw ): string {
+    if ( ! $raw ) {
+        return '';
+    }
+    $ts = strtotime( $raw );
+    if ( ! $ts ) {
+        return '';
+    }
+    return wp_date( 'M j, Y g:i a', $ts );
+}
+
+function se_broadcaster_drivebc_url( string $api_url ): string {
+    if ( preg_match( '/(DBC-\d+)/', $api_url, $m ) ) {
+        return 'https://www.drivebc.ca/mobile/event/' . $m[1];
+    }
+    return 'https://www.drivebc.ca/';
+}
+
+function se_broadcaster_pack_from_items( array $items, string $prefix, string $source, string $source_url = '' ): array {
+    $lines = array();
+    foreach ( $items as $item ) {
+        if ( ! empty( $item['text'] ) ) {
+            $lines[] = $item['text'];
+        }
+    }
+
+    $script = $lines ? $prefix . implode( ' Next. ', $lines ) : '';
+
+    return array(
+        'caption'    => se_broadcaster_trim_script( $lines[0] ?? $prefix, 220 ),
+        'script'     => se_broadcaster_trim_script( $script ),
+        'source'     => $source,
+        'source_url' => $source_url,
+        'items'      => $items,
+    );
+}
+
 function se_broadcaster_translink_script(): array {
     $alerts = function_exists( 'se_fetch_translink_alerts' ) ? se_fetch_translink_alerts() : array();
     $sky    = array_values(
@@ -26,28 +63,41 @@ function se_broadcaster_translink_script(): array {
         $sky = array_slice( $alerts, 0, 5 );
     }
 
-    $lines = array();
+    $items = array();
     foreach ( array_slice( $sky, 0, 3 ) as $row ) {
         $line = $row['header'] ?? '';
         if ( ! empty( $row['text'] ) && $row['text'] !== $line ) {
             $line = trim( $line . '. ' . $row['text'] );
         }
-        if ( $line ) {
-            $lines[] = se_broadcaster_trim_script( $line, 200 );
+        if ( ! $line ) {
+            continue;
         }
-    }
-
-    if ( ! $lines ) {
-        return array(
-            'caption' => 'TransLink reports all clear on SkyTrain lines.',
-            'script'  => 'TransLink feed is quiet. No major SkyTrain service alerts right now.',
+        $title = $row['route'] ? $row['route'] : ( $row['header'] ?? 'TransLink alert' );
+        $items[] = array(
+            'title'        => se_broadcaster_trim_script( $title, 80 ),
+            'text'         => se_broadcaster_trim_script( $line, 200 ),
+            'posted'       => (string) ( $row['posted'] ?? '' ),
+            'posted_label' => (string) ( $row['posted_label'] ?? '' ),
+            'url'          => (string) ( $row['url'] ?? '' ),
+            'link_label'   => 'TransLink alert',
         );
     }
 
-    $script = 'TransLink update. ' . implode( ' Next. ', $lines );
-    return array(
-        'caption' => se_broadcaster_trim_script( $lines[0], 220 ),
-        'script'  => se_broadcaster_trim_script( $script ),
+    if ( ! $items ) {
+        return array(
+            'caption'    => 'TransLink reports all clear on SkyTrain lines.',
+            'script'     => 'TransLink feed is quiet. No major SkyTrain service alerts right now.',
+            'source'     => 'TransLink',
+            'source_url' => 'https://www.translink.ca/alerts',
+            'items'      => array(),
+        );
+    }
+
+    return se_broadcaster_pack_from_items(
+        $items,
+        'TransLink update. ',
+        'TransLink',
+        'https://www.translink.ca/alerts'
     );
 }
 
@@ -119,10 +169,15 @@ function se_fetch_open511_bc_events(): array {
         }
         $headline = wp_strip_all_tags( (string) ( $event['headline'] ?? '' ) );
         $desc     = wp_strip_all_tags( (string) ( $event['description'] ?? '' ) );
-        $out[]    = array(
-            'headline'    => $headline,
-            'description' => se_broadcaster_trim_script( $desc, 240 ),
-            'type'        => (string) ( $event['event_type'] ?? '' ),
+        $api_url   = (string) ( $event['url'] ?? '' );
+        $updated   = (string) ( $event['updated'] ?? $event['created'] ?? '' );
+        $out[]     = array(
+            'headline'     => $headline,
+            'description'  => se_broadcaster_trim_script( $desc, 240 ),
+            'type'         => (string) ( $event['event_type'] ?? '' ),
+            'updated'      => $updated,
+            'updated_label' => se_broadcaster_format_posted( $updated ),
+            'url'          => se_broadcaster_drivebc_url( $api_url ),
         );
     }
 
@@ -134,26 +189,35 @@ function se_broadcaster_drivers_script(): array {
     $events = se_fetch_open511_bc_events();
     if ( ! $events ) {
         return array(
-            'caption' => 'BC Open511 — no active Lower Mainland road alerts.',
-            'script'  => 'DriveBC and Open511 show no major active incidents around Metro Vancouver right now.',
-            'source'  => 'BC Open511',
+            'caption'    => 'BC Open511 — no active Lower Mainland road alerts.',
+            'script'     => 'DriveBC and Open511 show no major active incidents around Metro Vancouver right now.',
+            'source'     => 'BC Open511',
+            'source_url' => 'https://www.drivebc.ca/',
+            'items'      => array(),
         );
     }
 
-    $lines = array();
+    $items = array();
     foreach ( array_slice( $events, 0, 3 ) as $event ) {
         $line = $event['headline'];
         if ( ! empty( $event['description'] ) ) {
             $line .= '. ' . $event['description'];
         }
-        $lines[] = se_broadcaster_trim_script( $line, 200 );
+        $items[] = array(
+            'title'        => se_broadcaster_trim_script( $event['headline'], 80 ),
+            'text'         => se_broadcaster_trim_script( $line, 200 ),
+            'posted'       => (string) ( $event['updated'] ?? '' ),
+            'posted_label' => (string) ( $event['updated_label'] ?? '' ),
+            'url'          => (string) ( $event['url'] ?? '' ),
+            'link_label'   => 'DriveBC incident',
+        );
     }
 
-    $script = 'Lower Mainland roads. ' . implode( ' Next. ', $lines );
-    return array(
-        'caption' => se_broadcaster_trim_script( $lines[0], 220 ),
-        'script'  => se_broadcaster_trim_script( $script ),
-        'source'  => 'BC Open511',
+    return se_broadcaster_pack_from_items(
+        $items,
+        'Lower Mainland roads. ',
+        'BC Open511',
+        'https://www.drivebc.ca/'
     );
 }
 
@@ -215,13 +279,15 @@ function se_broadcaster_ferries_script(): array {
     $routes = se_fetch_bc_ferries_capacity();
     if ( ! $routes ) {
         return array(
-            'caption' => 'BC Ferries capacity feed unavailable.',
-            'script'  => 'BC Ferries sailing data is offline right now. Check bcferries.com before you drive to the terminal.',
-            'source'  => 'bcferriesapi.ca',
+            'caption'    => 'BC Ferries capacity feed unavailable.',
+            'script'     => 'BC Ferries sailing data is offline right now. Check bcferries.com before you drive to the terminal.',
+            'source'     => 'bcferriesapi.ca',
+            'source_url' => 'https://www.bcferries.com/current_conditions',
+            'items'      => array(),
         );
     }
 
-    $lines = array();
+    $items = array();
     foreach ( array_slice( $routes, 0, 4 ) as $route ) {
         $from = se_terminal_label( (string) ( $route['fromTerminalCode'] ?? '' ) );
         $to   = se_terminal_label( (string) ( $route['toTerminalCode'] ?? '' ) );
@@ -241,14 +307,22 @@ function se_broadcaster_ferries_script(): array {
         if ( $status ) {
             $bit .= ', status ' . $status;
         }
-        $lines[] = $bit;
+
+        $items[] = array(
+            'title'        => $from . ' → ' . $to,
+            'text'         => $bit,
+            'posted'       => $time,
+            'posted_label' => 'Sails ' . $time,
+            'url'          => 'https://www.bcferries.com/current_conditions',
+            'link_label'   => 'BC Ferries conditions',
+        );
     }
 
-    $script = 'BC Ferries check. ' . implode( ' Next route. ', $lines );
-    return array(
-        'caption' => se_broadcaster_trim_script( $lines[0] ?? 'BC Ferries routes loaded.', 220 ),
-        'script'  => se_broadcaster_trim_script( $script ),
-        'source'  => 'bcferriesapi.ca',
+    return se_broadcaster_pack_from_items(
+        $items,
+        'BC Ferries check. ',
+        'bcferriesapi.ca',
+        'https://www.bcferries.com/current_conditions'
     );
 }
 

--- a/js/home-yvr-broadcaster.js
+++ b/js/home-yvr-broadcaster.js
@@ -210,13 +210,16 @@
 
     this.stopAll(false);
     this.activeKey = key;
+    this.updateDisplay(channel, 'Tuning ' + channel.label + '…');
+    this.root.classList.add('is-live');
+    this.setBars(true);
 
     if (channel.stream) {
       this.playRadio(channel);
       return;
     }
 
-  this.ensureFeeds().then(function (feeds) {
+    this.ensureFeeds().then(function (feeds) {
       var pack = feeds && feeds[channel.key] ? feeds[channel.key] : null;
       if (!pack) {
         self.updateDisplay(channel, 'Feed still loading — try again in a moment.');

--- a/js/home-yvr-broadcaster.js
+++ b/js/home-yvr-broadcaster.js
@@ -4,7 +4,7 @@
   var CKNW_STREAM = 'https://live.leanstream.co/CKNWAM';
 
   var CHANNELS = {
-    translink: { label: 'TRANSLINK', freq: '410.287', key: 'translink' },
+    translink: { label: 'SKYTRAIN', freq: '410.287', key: 'translink' },
     cknw: { label: 'CKNW 980', freq: '980.000', key: 'cknw', stream: true },
     drivers: { label: 'DRIVE BC', freq: '154.100', key: 'drivers' },
     ferries: { label: 'BC FERRIES', freq: '156.800', key: 'ferries' }
@@ -333,7 +333,7 @@
 
   HomeYvrBroadcaster.prototype.setTelepromptStandby = function () {
     this.renderMeta(null);
-    this.renderScript('Tap a channel. Words track the voice.', 'plain');
+    this.renderScript('Pick a channel. Words light up as CHIP talks.', 'plain');
     if (this.telepromptRoot) {
       this.telepromptRoot.classList.remove('is-live', 'is-radio');
     }

--- a/js/home-yvr-broadcaster.js
+++ b/js/home-yvr-broadcaster.js
@@ -10,14 +10,81 @@
     ferries: { label: 'BC FERRIES', freq: '156.800', key: 'ferries' }
   };
 
-  function pickComputerVoice() {
+  var VOICE_PREFS = [
+    'Microsoft Aria Online (Natural)',
+    'Microsoft Aria',
+    'Microsoft Jenny Online (Natural)',
+    'Microsoft Jenny',
+    'Google US English',
+    'Samantha (Enhanced)',
+    'Samantha',
+    'Microsoft Zira',
+    'Karen',
+    'Moira'
+  ];
+
+  var VOICE_BLOCK = [
+    'David',
+    'UK English Male',
+    'Fred',
+    'Albert',
+    'Bad News',
+    'Cellos',
+    'Trinoids',
+    'Whisper'
+  ];
+
+  function scoreVoice(voice) {
+    if (!voice || !voice.lang || !/^en/i.test(voice.lang)) {
+      return -1000;
+    }
+
+    var name = voice.name || '';
+    var lang = voice.lang.toLowerCase();
+    var score = 0;
+
+    if (lang === 'en-us') score += 24;
+    else if (lang === 'en-gb') score -= 18;
+    else if (lang.indexOf('en') !== -1) score += 8;
+
+    if (/natural|neural|online|premium|enhanced/i.test(name)) score += 42;
+
+    VOICE_PREFS.forEach(function (pref, i) {
+      if (name.indexOf(pref) !== -1) score += 36 - i;
+    });
+
+    VOICE_BLOCK.forEach(function (bad) {
+      if (name.indexOf(bad) !== -1) score -= 80;
+    });
+
+    if (voice.localService) score += 4;
+
+    return score;
+  }
+
+  function pickModernVoice() {
     if (!('speechSynthesis' in window)) return null;
     var voices = window.speechSynthesis.getVoices();
-    return voices.find(function (v) {
-      return v.name.indexOf('Google UK English Male') !== -1 ||
-        v.name.indexOf('Microsoft David') !== -1 ||
-        /en/i.test(v.lang);
-    }) || voices[0] || null;
+    if (!voices.length) return null;
+
+    var best = null;
+    var bestScore = -9999;
+    voices.forEach(function (v) {
+      var s = scoreVoice(v);
+      if (s > bestScore) {
+        bestScore = s;
+        best = v;
+      }
+    });
+    return best;
+  }
+
+  function escapeHtml(str) {
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
   }
 
   function splitWords(text) {
@@ -53,6 +120,7 @@
     this.speechUtterance = null;
     this.wordSpans = [];
     this.fallbackTimer = null;
+    this.voice = null;
   }
 
   HomeYvrBroadcaster.prototype.init = function () {
@@ -73,7 +141,12 @@
     }
 
     if ('speechSynthesis' in window) {
-      window.speechSynthesis.addEventListener('voiceschanged', function () { pickComputerVoice(); });
+      var self = this;
+      var primeVoice = function () {
+        self.voice = pickModernVoice();
+      };
+      primeVoice();
+      window.speechSynthesis.addEventListener('voiceschanged', primeVoice);
     }
 
     this.loadFeeds();
@@ -124,10 +197,10 @@
     var html = '';
 
     items.forEach(function (item) {
-      var title = item.title || 'Update';
-      var when = item.posted_label || item.posted || '';
+      var title = escapeHtml(item.title || 'Update');
+      var when = escapeHtml(item.posted_label || item.posted || '');
       var url = item.url || '';
-      var linkLabel = item.link_label || 'Open source';
+      var linkLabel = escapeHtml(item.link_label || 'Open source');
 
       html += '<li class="home-yvr-teleprompt__item">';
       if (when) {
@@ -135,15 +208,21 @@
       }
       html += '<span class="home-yvr-teleprompt__title">' + title + '</span>';
       if (url) {
-        html += ' <a class="home-yvr-teleprompt__link" href="' + url + '" target="_blank" rel="noopener noreferrer">' + linkLabel + '</a>';
+        html += ' <a class="home-yvr-teleprompt__link" href="' + escapeHtml(url) + '" target="_blank" rel="noopener noreferrer">' + linkLabel + '</a>';
       }
       html += '</li>';
     });
 
+    if (pack && pack.fetched_label) {
+      html += '<li class="home-yvr-teleprompt__item home-yvr-teleprompt__item--fetched">';
+      html += '<span class="home-yvr-teleprompt__time">' + escapeHtml(pack.fetched_label) + '</span>';
+      html += '</li>';
+    }
+
     if (pack && pack.source_url) {
       html += '<li class="home-yvr-teleprompt__item home-yvr-teleprompt__item--source">';
-      html += '<a class="home-yvr-teleprompt__link" href="' + pack.source_url + '" target="_blank" rel="noopener noreferrer">';
-      html += (pack.source || 'Source') + '</a>';
+      html += '<a class="home-yvr-teleprompt__link" href="' + escapeHtml(pack.source_url) + '" target="_blank" rel="noopener noreferrer">';
+      html += escapeHtml(pack.source || 'Source') + '</a>';
       html += '</li>';
     }
 
@@ -222,9 +301,13 @@
     });
   };
 
-  HomeYvrBroadcaster.prototype.loadFeeds = function () {
+  HomeYvrBroadcaster.prototype.loadFeeds = function (refresh) {
     var self = this;
-    fetch(this.feedsUrl, { credentials: 'same-origin' })
+    var url = this.feedsUrl;
+    if (refresh) {
+      url += (url.indexOf('?') === -1 ? '?' : '&') + 'refresh=1';
+    }
+    fetch(url, { credentials: 'same-origin' })
       .then(function (r) { return r.ok ? r.json() : null; })
       .then(function (data) {
         if (data) self.feeds = data;
@@ -232,10 +315,14 @@
       .catch(function () { /* standby */ });
   };
 
-  HomeYvrBroadcaster.prototype.ensureFeeds = function () {
+  HomeYvrBroadcaster.prototype.ensureFeeds = function (refresh) {
     var self = this;
-    if (this.feeds) return Promise.resolve(this.feeds);
-    return fetch(this.feedsUrl, { credentials: 'same-origin' })
+    if (this.feeds && !refresh) return Promise.resolve(this.feeds);
+    var url = this.feedsUrl;
+    if (refresh) {
+      url += (url.indexOf('?') === -1 ? '?' : '&') + 'refresh=1';
+    }
+    return fetch(url, { credentials: 'same-origin' })
       .then(function (r) { return r.ok ? r.json() : null; })
       .then(function (data) {
         if (data) self.feeds = data;
@@ -321,10 +408,13 @@
     this.setBars(true);
 
     var utterance = new SpeechSynthesisUtterance(text);
-    var voice = pickComputerVoice();
-    if (voice) utterance.voice = voice;
-    utterance.rate = 0.92;
-    utterance.pitch = 0.88;
+    var voice = this.voice || pickModernVoice();
+    if (voice) {
+      utterance.voice = voice;
+      this.voice = voice;
+    }
+    utterance.rate = 1.02;
+    utterance.pitch = 1.0;
 
     var boundarySeen = false;
 
@@ -423,7 +513,7 @@
       return;
     }
 
-    this.ensureFeeds().then(function (feeds) {
+    this.ensureFeeds(true).then(function (feeds) {
       var pack = feeds && feeds[channel.key] ? feeds[channel.key] : null;
       if (!pack) {
         self.renderScript('Feed still loading — try again in a moment.', 'plain');

--- a/js/home-yvr-broadcaster.js
+++ b/js/home-yvr-broadcaster.js
@@ -113,6 +113,8 @@
     this.telepromptRoot = document.querySelector('[data-broadcaster-teleprompt]');
     this.scriptEl = document.querySelector('[data-broadcaster-script]');
     this.metaEl = document.querySelector('[data-broadcaster-meta]');
+    this.mouthEl = root.querySelector('[data-broadcaster-mouth]');
+    this.faceEl = root.querySelector('[data-broadcaster-face]');
     this.feedsUrl = (window.HomeYvrBroadcasterConfig && HomeYvrBroadcasterConfig.feedsUrl) ||
       '/wp-json/se/v1/broadcaster/feeds';
     this.feeds = null;
@@ -121,6 +123,8 @@
     this.wordSpans = [];
     this.fallbackTimer = null;
     this.voice = null;
+    this.mouthTimer = null;
+    this.autoMuteTimer = null;
   }
 
   HomeYvrBroadcaster.prototype.init = function () {
@@ -151,6 +155,61 @@
 
     this.loadFeeds();
     this.setStandby();
+
+    document.addEventListener('visibilitychange', function () {
+      if (document.hidden) self.stopAll(true);
+    });
+  };
+
+  HomeYvrBroadcaster.prototype.clearAutoMuteTimer = function () {
+    if (this.autoMuteTimer) {
+      clearTimeout(this.autoMuteTimer);
+      this.autoMuteTimer = null;
+    }
+  };
+
+  HomeYvrBroadcaster.prototype.setMouthIdle = function () {
+    if (this.mouthTimer) {
+      clearTimeout(this.mouthTimer);
+      this.mouthTimer = null;
+    }
+    if (this.mouthEl) {
+      this.mouthEl.classList.remove('is-open', 'is-flap');
+    }
+    if (this.faceEl) {
+      this.faceEl.classList.remove('is-talking');
+    }
+  };
+
+  HomeYvrBroadcaster.prototype.setMouthTalking = function (mode) {
+    if (this.faceEl) {
+      this.faceEl.classList.add('is-talking');
+    }
+    if (!this.mouthEl) return;
+    this.mouthEl.classList.toggle('is-flap', mode === 'radio');
+    if (mode !== 'radio') {
+      this.mouthEl.classList.remove('is-flap');
+    }
+  };
+
+  HomeYvrBroadcaster.prototype.pulseMouth = function () {
+    var self = this;
+    if (!this.mouthEl) return;
+    this.mouthEl.classList.add('is-open');
+    if (this.mouthTimer) clearTimeout(this.mouthTimer);
+    this.mouthTimer = setTimeout(function () {
+      if (self.mouthEl) self.mouthEl.classList.remove('is-open');
+    }, 110);
+  };
+
+  HomeYvrBroadcaster.prototype.scheduleAutoMute = function (channelKey) {
+    var self = this;
+    this.clearAutoMuteTimer();
+    this.autoMuteTimer = setTimeout(function () {
+      if (self.activeKey === channelKey) {
+        self.stopAll(true);
+      }
+    }, 900);
   };
 
   HomeYvrBroadcaster.prototype.clearFallbackTimer = function () {
@@ -288,6 +347,8 @@
       this.captionEl.hidden = true;
     }
     this.setTelepromptStandby();
+    this.setMouthIdle();
+    this.clearAutoMuteTimer();
     this.root.classList.remove('is-live', 'is-speaking', 'is-radio');
     this.setBars(false);
     this.highlightChannel(null);
@@ -337,18 +398,24 @@
     }
     this.speechUtterance = null;
     this.root.classList.remove('is-speaking');
+    if (!this.root.classList.contains('is-radio')) {
+      this.setMouthIdle();
+    }
   };
 
   HomeYvrBroadcaster.prototype.stopRadio = function () {
+    this.clearAutoMuteTimer();
     if (this.audio) {
       this.audio.pause();
       this.audio.removeAttribute('src');
     }
     this.root.classList.remove('is-radio');
     if (this.telepromptRoot) this.telepromptRoot.classList.remove('is-radio');
+    this.setMouthIdle();
   };
 
   HomeYvrBroadcaster.prototype.stopAll = function (toStandby) {
+    this.clearAutoMuteTimer();
     this.stopSpeech();
     this.stopRadio();
     this.activeKey = null;
@@ -386,6 +453,7 @@
         return;
       }
       self.highlightWordAt(words[idx].start);
+      self.pulseMouth();
     }, msPerWord);
   };
 
@@ -406,6 +474,7 @@
     }
     this.root.classList.add('is-live', 'is-speaking');
     this.setBars(true);
+    this.setMouthTalking('speech');
 
     var utterance = new SpeechSynthesisUtterance(text);
     var voice = this.voice || pickModernVoice();
@@ -423,10 +492,12 @@
         boundarySeen = true;
         self.clearFallbackTimer();
         self.highlightWordAt(event.charIndex);
+        self.pulseMouth();
       }
     };
 
     utterance.onstart = function () {
+      self.setMouthTalking('speech');
       if (!boundarySeen && self.wordSpans.length) {
         self.startFallbackHighlight(text);
       }
@@ -439,13 +510,19 @@
         self.wordSpans.forEach(function (span) { span.classList.add('is-spoken'); });
       }
       self.root.classList.remove('is-speaking');
-      if (self.activeKey === channel.key) self.setBars(false);
+      self.setMouthIdle();
+      if (self.activeKey === channel.key) {
+        self.setBars(false);
+        self.scheduleAutoMute(channel.key);
+      }
     };
 
     utterance.onerror = function () {
       self.clearFallbackTimer();
       self.root.classList.remove('is-speaking');
       self.setBars(false);
+      self.setMouthIdle();
+      self.scheduleAutoMute(channel.key);
     };
 
     this.speechUtterance = utterance;
@@ -473,6 +550,7 @@
       this.telepromptRoot.classList.add('is-live', 'is-radio');
     }
     this.root.classList.add('is-live', 'is-radio');
+    this.setMouthTalking('radio');
     this.audio.src = CKNW_STREAM;
     this.audio.volume = 0.55;
 
@@ -485,6 +563,7 @@
         .catch(function () {
           self.renderScript('CKNW blocked autoplay — tap CKNW 980 again or STOP then retry.', 'plain');
           self.setBars(false);
+          self.setMouthIdle();
         });
     } else {
       this.setBars(true);

--- a/js/home-yvr-broadcaster.js
+++ b/js/home-yvr-broadcaster.js
@@ -20,6 +20,20 @@
     }) || voices[0] || null;
   }
 
+  function splitWords(text) {
+    var words = [];
+    var regex = /\S+/g;
+    var match;
+    while ((match = regex.exec(text)) !== null) {
+      words.push({
+        word: match[0],
+        start: match.index,
+        end: match.index + match[0].length
+      });
+    }
+    return words;
+  }
+
   function HomeYvrBroadcaster(root) {
     this.root = root;
     this.audio = root.querySelector('[data-broadcaster-audio]');
@@ -29,11 +43,16 @@
     this.stopBtn = root.querySelector('[data-broadcaster-stop]');
     this.bars = root.querySelectorAll('[data-broadcaster-bar]');
     this.channelBtns = root.querySelectorAll('[data-broadcaster-channel-btn]');
+    this.telepromptRoot = document.querySelector('[data-broadcaster-teleprompt]');
+    this.scriptEl = document.querySelector('[data-broadcaster-script]');
+    this.metaEl = document.querySelector('[data-broadcaster-meta]');
     this.feedsUrl = (window.HomeYvrBroadcasterConfig && HomeYvrBroadcasterConfig.feedsUrl) ||
       '/wp-json/se/v1/broadcaster/feeds';
     this.feeds = null;
     this.activeKey = null;
     this.speechUtterance = null;
+    this.wordSpans = [];
+    this.fallbackTimer = null;
   }
 
   HomeYvrBroadcaster.prototype.init = function () {
@@ -61,12 +80,135 @@
     this.setStandby();
   };
 
+  HomeYvrBroadcaster.prototype.clearFallbackTimer = function () {
+    if (this.fallbackTimer) {
+      clearInterval(this.fallbackTimer);
+      this.fallbackTimer = null;
+    }
+  };
+
+  HomeYvrBroadcaster.prototype.clearWordHighlights = function () {
+    this.wordSpans.forEach(function (span) {
+      span.classList.remove('is-current', 'is-spoken');
+    });
+  };
+
+  HomeYvrBroadcaster.prototype.highlightWordAt = function (charIndex) {
+    var idx = -1;
+    for (var i = 0; i < this.wordSpans.length; i++) {
+      var start = parseInt(this.wordSpans[i].getAttribute('data-start'), 10);
+      if (start <= charIndex) idx = i;
+      if (start > charIndex) break;
+    }
+    if (idx < 0) return;
+
+    for (var j = 0; j < this.wordSpans.length; j++) {
+      var span = this.wordSpans[j];
+      span.classList.toggle('is-spoken', j < idx);
+      span.classList.toggle('is-current', j === idx);
+    }
+
+    var current = this.wordSpans[idx];
+    if (current && this.scriptEl) {
+      var box = this.scriptEl;
+      var top = current.offsetTop - box.offsetTop;
+      var target = top - (box.clientHeight / 2) + (current.clientHeight / 2);
+      box.scrollTop = Math.max(0, target);
+    }
+  };
+
+  HomeYvrBroadcaster.prototype.renderMeta = function (pack) {
+    if (!this.metaEl) return;
+
+    var items = (pack && pack.items) ? pack.items : [];
+    var html = '';
+
+    items.forEach(function (item) {
+      var title = item.title || 'Update';
+      var when = item.posted_label || item.posted || '';
+      var url = item.url || '';
+      var linkLabel = item.link_label || 'Open source';
+
+      html += '<li class="home-yvr-teleprompt__item">';
+      if (when) {
+        html += '<time class="home-yvr-teleprompt__time">' + when + '</time>';
+      }
+      html += '<span class="home-yvr-teleprompt__title">' + title + '</span>';
+      if (url) {
+        html += ' <a class="home-yvr-teleprompt__link" href="' + url + '" target="_blank" rel="noopener noreferrer">' + linkLabel + '</a>';
+      }
+      html += '</li>';
+    });
+
+    if (pack && pack.source_url) {
+      html += '<li class="home-yvr-teleprompt__item home-yvr-teleprompt__item--source">';
+      html += '<a class="home-yvr-teleprompt__link" href="' + pack.source_url + '" target="_blank" rel="noopener noreferrer">';
+      html += (pack.source || 'Source') + '</a>';
+      html += '</li>';
+    }
+
+    if (html) {
+      this.metaEl.innerHTML = html;
+      this.metaEl.hidden = false;
+    } else {
+      this.metaEl.innerHTML = '';
+      this.metaEl.hidden = true;
+    }
+  };
+
+  HomeYvrBroadcaster.prototype.renderScript = function (text, mode) {
+    if (!this.scriptEl) return;
+
+    this.clearFallbackTimer();
+    this.clearWordHighlights();
+    this.wordSpans = [];
+
+    if (!text) {
+      this.scriptEl.textContent = '';
+      return;
+    }
+
+    if (mode === 'plain') {
+      this.scriptEl.textContent = text;
+      return;
+    }
+
+    var words = splitWords(text);
+    var frag = document.createDocumentFragment();
+
+    words.forEach(function (w, i) {
+      var span = document.createElement('span');
+      span.className = 'home-yvr-teleprompt__word';
+      span.setAttribute('data-start', String(w.start));
+      span.textContent = w.word;
+      frag.appendChild(span);
+      if (i < words.length - 1) {
+        frag.appendChild(document.createTextNode(' '));
+      }
+      this.wordSpans.push(span);
+    }, this);
+
+    this.scriptEl.innerHTML = '';
+    this.scriptEl.appendChild(frag);
+    this.scriptEl.scrollTop = 0;
+  };
+
+  HomeYvrBroadcaster.prototype.setTelepromptStandby = function () {
+    this.renderMeta(null);
+    this.renderScript('Pick a channel below. Words light up as the computer voice reads.', 'plain');
+    if (this.telepromptRoot) {
+      this.telepromptRoot.classList.remove('is-live', 'is-radio');
+    }
+  };
+
   HomeYvrBroadcaster.prototype.setStandby = function () {
     if (this.freqEl) this.freqEl.textContent = '000.000';
     if (this.channelEl) this.channelEl.textContent = 'STANDBY';
     if (this.captionEl) {
-      this.captionEl.textContent = 'Pick a channel. Computer voice reads live feeds — CKNW is live radio.';
+      this.captionEl.textContent = '';
+      this.captionEl.hidden = true;
     }
+    this.setTelepromptStandby();
     this.root.classList.remove('is-live', 'is-speaking', 'is-radio');
     this.setBars(false);
     this.highlightChannel(null);
@@ -102,6 +244,7 @@
   };
 
   HomeYvrBroadcaster.prototype.stopSpeech = function () {
+    this.clearFallbackTimer();
     if ('speechSynthesis' in window) {
       window.speechSynthesis.cancel();
     }
@@ -115,6 +258,7 @@
       this.audio.removeAttribute('src');
     }
     this.root.classList.remove('is-radio');
+    if (this.telepromptRoot) this.telepromptRoot.classList.remove('is-radio');
   };
 
   HomeYvrBroadcaster.prototype.stopAll = function (toStandby) {
@@ -133,22 +277,46 @@
     });
   };
 
-  HomeYvrBroadcaster.prototype.updateDisplay = function (channel, caption) {
+  HomeYvrBroadcaster.prototype.updateDisplay = function (channel) {
     if (this.freqEl) this.freqEl.textContent = channel.freq;
     if (this.channelEl) this.channelEl.textContent = channel.label;
-    if (this.captionEl && caption) this.captionEl.textContent = caption;
     this.highlightChannel(channel.key || null);
   };
 
-  HomeYvrBroadcaster.prototype.speak = function (text, channel, caption) {
+  HomeYvrBroadcaster.prototype.startFallbackHighlight = function (text) {
+    var self = this;
+    var words = splitWords(text);
+    if (!words.length) return;
+
+    var msPerWord = 340;
+    var idx = 0;
+    self.highlightWordAt(words[0].start);
+
+    this.fallbackTimer = setInterval(function () {
+      idx += 1;
+      if (idx >= words.length) {
+        self.clearFallbackTimer();
+        return;
+      }
+      self.highlightWordAt(words[idx].start);
+    }, msPerWord);
+  };
+
+  HomeYvrBroadcaster.prototype.speak = function (text, channel, pack) {
     var self = this;
     if (!text || !('speechSynthesis' in window)) {
-      if (this.captionEl) this.captionEl.textContent = caption || text || 'Voice not available in this browser.';
+      this.renderScript(text || 'Voice not available in this browser.', 'plain');
       return;
     }
 
     this.stopSpeech();
-    this.updateDisplay(channel, caption || text);
+    this.updateDisplay(channel);
+    this.renderMeta(pack);
+    this.renderScript(text);
+    if (this.telepromptRoot) {
+      this.telepromptRoot.classList.add('is-live');
+      this.telepromptRoot.classList.remove('is-radio');
+    }
     this.root.classList.add('is-live', 'is-speaking');
     this.setBars(true);
 
@@ -158,11 +326,34 @@
     utterance.rate = 0.92;
     utterance.pitch = 0.88;
 
+    var boundarySeen = false;
+
+    utterance.onboundary = function (event) {
+      if (event.name === 'word' || event.charIndex > 0) {
+        boundarySeen = true;
+        self.clearFallbackTimer();
+        self.highlightWordAt(event.charIndex);
+      }
+    };
+
+    utterance.onstart = function () {
+      if (!boundarySeen && self.wordSpans.length) {
+        self.startFallbackHighlight(text);
+      }
+    };
+
     utterance.onend = function () {
+      self.clearFallbackTimer();
+      self.clearWordHighlights();
+      if (self.wordSpans.length) {
+        self.wordSpans.forEach(function (span) { span.classList.add('is-spoken'); });
+      }
       self.root.classList.remove('is-speaking');
       if (self.activeKey === channel.key) self.setBars(false);
     };
+
     utterance.onerror = function () {
+      self.clearFallbackTimer();
       self.root.classList.remove('is-speaking');
       self.setBars(false);
     };
@@ -171,12 +362,26 @@
     window.speechSynthesis.speak(utterance);
   };
 
-  HomeYvrBroadcaster.prototype.playRadio = function (channel) {
+  HomeYvrBroadcaster.prototype.playRadio = function (channel, pack) {
     var self = this;
     if (!this.audio) return;
 
     this.stopRadio();
-    this.updateDisplay(channel, 'Live CKNW 980 — Vancouver AM. Hit STOP to silence.');
+    this.updateDisplay(channel);
+    this.renderMeta(pack || {
+      source: 'CKNW 980',
+      source_url: 'https://www.cknw.com/',
+      items: [{
+        title: 'CKNW 980 AM',
+        posted_label: 'Live now',
+        url: 'https://www.cknw.com/',
+        link_label: 'cknw.com'
+      }]
+    });
+    this.renderScript('Live CKNW 980 — Vancouver AM radio. Computer voice channels are on the buttons below. Hit STOP to silence.', 'plain');
+    if (this.telepromptRoot) {
+      this.telepromptRoot.classList.add('is-live', 'is-radio');
+    }
     this.root.classList.add('is-live', 'is-radio');
     this.audio.src = CKNW_STREAM;
     this.audio.volume = 0.55;
@@ -188,9 +393,7 @@
           self.setBars(true);
         })
         .catch(function () {
-          if (self.captionEl) {
-            self.captionEl.textContent = 'CKNW blocked autoplay — tap CKNW 980 again or STOP then retry.';
-          }
+          self.renderScript('CKNW blocked autoplay — tap CKNW 980 again or STOP then retry.', 'plain');
           self.setBars(false);
         });
     } else {
@@ -210,7 +413,8 @@
 
     this.stopAll(false);
     this.activeKey = key;
-    this.updateDisplay(channel, 'Tuning ' + channel.label + '…');
+    this.updateDisplay(channel);
+    this.renderScript('Tuning ' + channel.label + '…', 'plain');
     this.root.classList.add('is-live');
     this.setBars(true);
 
@@ -222,13 +426,12 @@
     this.ensureFeeds().then(function (feeds) {
       var pack = feeds && feeds[channel.key] ? feeds[channel.key] : null;
       if (!pack) {
-        self.updateDisplay(channel, 'Feed still loading — try again in a moment.');
+        self.renderScript('Feed still loading — try again in a moment.', 'plain');
+        self.setBars(false);
         return;
       }
       var script = pack.script || pack.caption || '';
-      var caption = pack.caption || script;
-      if (pack.source) caption += ' Source: ' + pack.source + '.';
-      self.speak(script, channel, caption);
+      self.speak(script, channel, pack);
     });
   };
 

--- a/js/home-yvr-broadcaster.js
+++ b/js/home-yvr-broadcaster.js
@@ -274,7 +274,7 @@
 
   HomeYvrBroadcaster.prototype.setTelepromptStandby = function () {
     this.renderMeta(null);
-    this.renderScript('Pick a channel below. Words light up as the computer voice reads.', 'plain');
+    this.renderScript('Tap a channel. Words track the voice.', 'plain');
     if (this.telepromptRoot) {
       this.telepromptRoot.classList.remove('is-live', 'is-radio');
     }

--- a/page-home.php
+++ b/page-home.php
@@ -10,38 +10,65 @@ get_header();
             <div class="home-yvr-rack">
                 <p class="home-yvr-rack__kicker pixel-font"><?php echo esc_html( 'live feeds // yvr' ); ?></p>
                 <div class="home-yvr-broadcaster" data-yvr-broadcaster aria-label="<?php echo esc_attr( 'YVR broadcaster — live feeds and radio' ); ?>">
-                    <div class="home-yvr-broadcaster__header">
-                        <div class="home-yvr-broadcaster__identity">
-                            <div class="home-yvr-broadcaster__face" data-broadcaster-face aria-hidden="true">
-                                <span class="home-yvr-broadcaster__eye"></span>
-                                <span class="home-yvr-broadcaster__eye"></span>
+                    <div class="home-yvr-broadcaster__avatar" data-broadcaster-face aria-hidden="true">
+                        <div class="home-yvr-broadcaster__avatar-frame">
+                            <div class="home-yvr-broadcaster__avatar-hair"></div>
+                            <div class="home-yvr-broadcaster__avatar-head">
+                                <div class="home-yvr-broadcaster__avatar-visor">
+                                    <span class="home-yvr-broadcaster__eye"></span>
+                                    <span class="home-yvr-broadcaster__eye"></span>
+                                </div>
                                 <div class="home-yvr-broadcaster__mouth" data-broadcaster-mouth></div>
                             </div>
-                            <span class="home-yvr-broadcaster__badge pixel-font"><?php echo esc_html( 'YVR BCAST' ); ?></span>
+                            <div class="home-yvr-broadcaster__avatar-headset home-yvr-broadcaster__avatar-headset--l"></div>
+                            <div class="home-yvr-broadcaster__avatar-headset home-yvr-broadcaster__avatar-headset--r"></div>
+                            <div class="home-yvr-broadcaster__avatar-mic"></div>
                         </div>
-                        <span class="home-yvr-broadcaster__channel pixel-font" data-broadcaster-channel><?php echo esc_html( 'STANDBY' ); ?></span>
-                        <span class="home-yvr-broadcaster__freq pixel-font" data-broadcaster-freq>000.000</span>
+                        <p class="home-yvr-broadcaster__avatar-name pixel-font"><?php echo esc_html( 'CHIP' ); ?></p>
+                        <p class="home-yvr-broadcaster__avatar-tag"><?php echo esc_html( 'on-air bot' ); ?></p>
                     </div>
-                    <div class="home-yvr-broadcaster__crt" data-broadcaster-teleprompt>
-                        <ul class="home-yvr-teleprompt__meta" data-broadcaster-meta hidden></ul>
-                        <p class="home-yvr-teleprompt__script" data-broadcaster-script><?php echo esc_html( 'Tap a channel. Words track the voice.' ); ?></p>
-                        <div class="home-yvr-broadcaster__crt-scan" aria-hidden="true"></div>
-                    </div>
-                    <div class="home-yvr-broadcaster__deck">
-                        <div class="home-yvr-broadcaster__bars" aria-hidden="true">
-                            <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
-                            <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
-                            <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
-                            <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
-                            <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
+                    <div class="home-yvr-broadcaster__body">
+                        <div class="home-yvr-broadcaster__header">
+                            <div class="home-yvr-broadcaster__status">
+                                <span class="home-yvr-broadcaster__badge pixel-font"><?php echo esc_html( 'YVR BCAST' ); ?></span>
+                                <span class="home-yvr-broadcaster__channel pixel-font" data-broadcaster-channel><?php echo esc_html( 'STANDBY' ); ?></span>
+                            </div>
+                            <span class="home-yvr-broadcaster__freq pixel-font" data-broadcaster-freq>000.000</span>
                         </div>
-                        <div class="home-yvr-broadcaster__channels">
-                            <button type="button" class="home-yvr-broadcaster__ch pixel-font" data-broadcaster-channel-btn="translink" aria-pressed="false" aria-label="<?php echo esc_attr( 'TransLink' ); ?>"><?php echo esc_html( 'TL' ); ?></button>
-                            <button type="button" class="home-yvr-broadcaster__ch pixel-font" data-broadcaster-channel-btn="cknw" aria-pressed="false" aria-label="<?php echo esc_attr( 'CKNW 980' ); ?>"><?php echo esc_html( '980' ); ?></button>
-                            <button type="button" class="home-yvr-broadcaster__ch pixel-font" data-broadcaster-channel-btn="drivers" aria-pressed="false" aria-label="<?php echo esc_attr( 'DriveBC' ); ?>"><?php echo esc_html( 'ROADS' ); ?></button>
-                            <button type="button" class="home-yvr-broadcaster__ch pixel-font" data-broadcaster-channel-btn="ferries" aria-pressed="false" aria-label="<?php echo esc_attr( 'BC Ferries' ); ?>"><?php echo esc_html( 'FERRY' ); ?></button>
+                        <p class="home-yvr-broadcaster__legend"><?php echo esc_html( 'Live Lower Mainland feeds. CHIP reads scripts aloud — 980 is real radio.' ); ?></p>
+                        <div class="home-yvr-broadcaster__crt" data-broadcaster-teleprompt>
+                            <ul class="home-yvr-teleprompt__meta" data-broadcaster-meta hidden></ul>
+                            <p class="home-yvr-teleprompt__script" data-broadcaster-script><?php echo esc_html( 'Pick a channel. Words light up as CHIP talks.' ); ?></p>
+                            <div class="home-yvr-broadcaster__crt-scan" aria-hidden="true"></div>
                         </div>
-                        <button type="button" class="home-yvr-broadcaster__btn home-yvr-broadcaster__stop pixel-font" data-broadcaster-stop><?php echo esc_html( 'STOP' ); ?></button>
+                        <div class="home-yvr-broadcaster__deck">
+                            <div class="home-yvr-broadcaster__bars" aria-hidden="true">
+                                <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
+                                <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
+                                <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
+                                <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
+                                <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
+                            </div>
+                            <div class="home-yvr-broadcaster__channels">
+                                <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="translink" aria-pressed="false">
+                                    <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'SkyTrain' ); ?></span>
+                                    <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'TransLink service alerts' ); ?></span>
+                                </button>
+                                <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="cknw" aria-pressed="false">
+                                    <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'CKNW 980' ); ?></span>
+                                    <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'Live Vancouver AM radio' ); ?></span>
+                                </button>
+                                <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="drivers" aria-pressed="false">
+                                    <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'DriveBC' ); ?></span>
+                                    <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'Road incidents & closures' ); ?></span>
+                                </button>
+                                <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="ferries" aria-pressed="false">
+                                    <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'BC Ferries' ); ?></span>
+                                    <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'Sailings & car deck fill' ); ?></span>
+                                </button>
+                            </div>
+                            <button type="button" class="home-yvr-broadcaster__btn home-yvr-broadcaster__stop pixel-font" data-broadcaster-stop aria-label="<?php echo esc_attr( 'Stop audio' ); ?>"><?php echo esc_html( 'STOP' ); ?></button>
+                        </div>
                     </div>
                     <p class="home-yvr-broadcaster__caption" data-broadcaster-caption hidden></p>
                     <audio data-broadcaster-audio preload="none" crossorigin="anonymous"></audio>

--- a/page-home.php
+++ b/page-home.php
@@ -6,37 +6,37 @@ get_header();
 <main id="homepage-content" class="home-layout home-arcade-layout">
 
     <section class="home-arcade-title-screen crt-block home-amp-cabinet" aria-labelledby="home-hero-title" data-arcade-hero>
-        <div class="home-arcade-screen__backdrop" aria-label="<?php echo esc_attr( 'YVR live feed teleprompter' ); ?>">
-            <div class="home-yvr-teleprompt" data-broadcaster-teleprompt>
-                <ul class="home-yvr-teleprompt__meta" data-broadcaster-meta hidden></ul>
-                <p class="home-yvr-teleprompt__script" data-broadcaster-script><?php echo esc_html( 'Pick a channel below. Words light up as the computer voice reads.' ); ?></p>
-            </div>
-            <div class="home-amp-stack">
+        <div class="home-arcade-screen__backdrop" aria-label="<?php echo esc_attr( 'YVR live feed radio rack' ); ?>">
+            <div class="home-yvr-rack">
+                <p class="home-yvr-rack__kicker pixel-font"><?php echo esc_html( 'live feeds // yvr' ); ?></p>
                 <div class="home-yvr-broadcaster" data-yvr-broadcaster aria-label="<?php echo esc_attr( 'YVR broadcaster — live feeds and radio' ); ?>">
                     <div class="home-yvr-broadcaster__header">
                         <span class="home-yvr-broadcaster__badge pixel-font"><?php echo esc_html( 'YVR BCAST' ); ?></span>
+                        <span class="home-yvr-broadcaster__channel pixel-font" data-broadcaster-channel><?php echo esc_html( 'STANDBY' ); ?></span>
                         <span class="home-yvr-broadcaster__freq pixel-font" data-broadcaster-freq>000.000</span>
                     </div>
-                    <div class="home-yvr-broadcaster__display">
-                        <span class="home-yvr-broadcaster__channel pixel-font" data-broadcaster-channel><?php echo esc_html( 'STANDBY' ); ?></span>
-                        <p class="home-yvr-broadcaster__caption" data-broadcaster-caption hidden><?php echo esc_html( 'Pick a channel. Computer voice reads live feeds — CKNW is live radio.' ); ?></p>
+                    <div class="home-yvr-broadcaster__crt" data-broadcaster-teleprompt>
+                        <ul class="home-yvr-teleprompt__meta" data-broadcaster-meta hidden></ul>
+                        <p class="home-yvr-teleprompt__script" data-broadcaster-script><?php echo esc_html( 'Tap a channel. Words track the voice.' ); ?></p>
+                        <div class="home-yvr-broadcaster__crt-scan" aria-hidden="true"></div>
                     </div>
-                    <div class="home-yvr-broadcaster__bars" aria-hidden="true">
-                        <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
-                        <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
-                        <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
-                        <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
-                        <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
-                    </div>
-                    <div class="home-yvr-broadcaster__channels">
-                        <button type="button" class="home-yvr-broadcaster__ch pixel-font" data-broadcaster-channel-btn="translink" aria-pressed="false"><?php echo esc_html( 'TRANSLINK' ); ?></button>
-                        <button type="button" class="home-yvr-broadcaster__ch pixel-font" data-broadcaster-channel-btn="cknw" aria-pressed="false"><?php echo esc_html( 'CKNW 980' ); ?></button>
-                        <button type="button" class="home-yvr-broadcaster__ch pixel-font" data-broadcaster-channel-btn="drivers" aria-pressed="false"><?php echo esc_html( 'DRIVE BC' ); ?></button>
-                        <button type="button" class="home-yvr-broadcaster__ch pixel-font" data-broadcaster-channel-btn="ferries" aria-pressed="false"><?php echo esc_html( 'BC FERRIES' ); ?></button>
-                    </div>
-                    <div class="home-yvr-broadcaster__controls">
+                    <div class="home-yvr-broadcaster__deck">
+                        <div class="home-yvr-broadcaster__bars" aria-hidden="true">
+                            <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
+                            <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
+                            <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
+                            <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
+                            <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
+                        </div>
+                        <div class="home-yvr-broadcaster__channels">
+                            <button type="button" class="home-yvr-broadcaster__ch pixel-font" data-broadcaster-channel-btn="translink" aria-pressed="false"><?php echo esc_html( 'TL' ); ?></button>
+                            <button type="button" class="home-yvr-broadcaster__ch pixel-font" data-broadcaster-channel-btn="cknw" aria-pressed="false"><?php echo esc_html( '980' ); ?></button>
+                            <button type="button" class="home-yvr-broadcaster__ch pixel-font" data-broadcaster-channel-btn="drivers" aria-pressed="false"><?php echo esc_html( 'ROADS' ); ?></button>
+                            <button type="button" class="home-yvr-broadcaster__ch pixel-font" data-broadcaster-channel-btn="ferries" aria-pressed="false"><?php echo esc_html( 'FERRY' ); ?></button>
+                        </div>
                         <button type="button" class="home-yvr-broadcaster__btn home-yvr-broadcaster__stop pixel-font" data-broadcaster-stop><?php echo esc_html( 'STOP' ); ?></button>
                     </div>
+                    <p class="home-yvr-broadcaster__caption" data-broadcaster-caption hidden></p>
                     <audio data-broadcaster-audio preload="none" crossorigin="anonymous"></audio>
                 </div>
             </div>

--- a/page-home.php
+++ b/page-home.php
@@ -1,14 +1,16 @@
 <?php
 /* Template Name: Homepage */
 get_header();
-get_template_part( 'parts/home-yvr-ascii-art' );
 ?>
 
 <main id="homepage-content" class="home-layout home-arcade-layout">
 
     <section class="home-arcade-title-screen crt-block home-amp-cabinet" aria-labelledby="home-hero-title" data-arcade-hero>
-        <div class="home-arcade-screen__backdrop" role="img" aria-label="<?php echo esc_attr( 'ASCII art of Vancouver downtown skyline and harbour' ); ?>">
-            <pre class="home-yvr-ascii"><?php echo esc_html( home_yvr_ascii_art() ); ?></pre>
+        <div class="home-arcade-screen__backdrop" aria-label="<?php echo esc_attr( 'YVR live feed teleprompter' ); ?>">
+            <div class="home-yvr-teleprompt" data-broadcaster-teleprompt>
+                <ul class="home-yvr-teleprompt__meta" data-broadcaster-meta hidden></ul>
+                <p class="home-yvr-teleprompt__script" data-broadcaster-script><?php echo esc_html( 'Pick a channel below. Words light up as the computer voice reads.' ); ?></p>
+            </div>
             <div class="home-amp-stack">
                 <div class="home-yvr-broadcaster" data-yvr-broadcaster aria-label="<?php echo esc_attr( 'YVR broadcaster — live feeds and radio' ); ?>">
                     <div class="home-yvr-broadcaster__header">
@@ -17,7 +19,7 @@ get_template_part( 'parts/home-yvr-ascii-art' );
                     </div>
                     <div class="home-yvr-broadcaster__display">
                         <span class="home-yvr-broadcaster__channel pixel-font" data-broadcaster-channel><?php echo esc_html( 'STANDBY' ); ?></span>
-                        <p class="home-yvr-broadcaster__caption" data-broadcaster-caption><?php echo esc_html( 'Pick a channel. Computer voice reads live feeds — CKNW is live radio.' ); ?></p>
+                        <p class="home-yvr-broadcaster__caption" data-broadcaster-caption hidden><?php echo esc_html( 'Pick a channel. Computer voice reads live feeds — CKNW is live radio.' ); ?></p>
                     </div>
                     <div class="home-yvr-broadcaster__bars" aria-hidden="true">
                         <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>

--- a/page-home.php
+++ b/page-home.php
@@ -11,7 +11,14 @@ get_header();
                 <p class="home-yvr-rack__kicker pixel-font"><?php echo esc_html( 'live feeds // yvr' ); ?></p>
                 <div class="home-yvr-broadcaster" data-yvr-broadcaster aria-label="<?php echo esc_attr( 'YVR broadcaster — live feeds and radio' ); ?>">
                     <div class="home-yvr-broadcaster__header">
-                        <span class="home-yvr-broadcaster__badge pixel-font"><?php echo esc_html( 'YVR BCAST' ); ?></span>
+                        <div class="home-yvr-broadcaster__identity">
+                            <div class="home-yvr-broadcaster__face" data-broadcaster-face aria-hidden="true">
+                                <span class="home-yvr-broadcaster__eye"></span>
+                                <span class="home-yvr-broadcaster__eye"></span>
+                                <div class="home-yvr-broadcaster__mouth" data-broadcaster-mouth></div>
+                            </div>
+                            <span class="home-yvr-broadcaster__badge pixel-font"><?php echo esc_html( 'YVR BCAST' ); ?></span>
+                        </div>
                         <span class="home-yvr-broadcaster__channel pixel-font" data-broadcaster-channel><?php echo esc_html( 'STANDBY' ); ?></span>
                         <span class="home-yvr-broadcaster__freq pixel-font" data-broadcaster-freq>000.000</span>
                     </div>
@@ -29,10 +36,10 @@ get_header();
                             <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
                         </div>
                         <div class="home-yvr-broadcaster__channels">
-                            <button type="button" class="home-yvr-broadcaster__ch pixel-font" data-broadcaster-channel-btn="translink" aria-pressed="false"><?php echo esc_html( 'TL' ); ?></button>
-                            <button type="button" class="home-yvr-broadcaster__ch pixel-font" data-broadcaster-channel-btn="cknw" aria-pressed="false"><?php echo esc_html( '980' ); ?></button>
-                            <button type="button" class="home-yvr-broadcaster__ch pixel-font" data-broadcaster-channel-btn="drivers" aria-pressed="false"><?php echo esc_html( 'ROADS' ); ?></button>
-                            <button type="button" class="home-yvr-broadcaster__ch pixel-font" data-broadcaster-channel-btn="ferries" aria-pressed="false"><?php echo esc_html( 'FERRY' ); ?></button>
+                            <button type="button" class="home-yvr-broadcaster__ch pixel-font" data-broadcaster-channel-btn="translink" aria-pressed="false" aria-label="<?php echo esc_attr( 'TransLink' ); ?>"><?php echo esc_html( 'TL' ); ?></button>
+                            <button type="button" class="home-yvr-broadcaster__ch pixel-font" data-broadcaster-channel-btn="cknw" aria-pressed="false" aria-label="<?php echo esc_attr( 'CKNW 980' ); ?>"><?php echo esc_html( '980' ); ?></button>
+                            <button type="button" class="home-yvr-broadcaster__ch pixel-font" data-broadcaster-channel-btn="drivers" aria-pressed="false" aria-label="<?php echo esc_attr( 'DriveBC' ); ?>"><?php echo esc_html( 'ROADS' ); ?></button>
+                            <button type="button" class="home-yvr-broadcaster__ch pixel-font" data-broadcaster-channel-btn="ferries" aria-pressed="false" aria-label="<?php echo esc_attr( 'BC Ferries' ); ?>"><?php echo esc_html( 'FERRY' ); ?></button>
                         </div>
                         <button type="button" class="home-yvr-broadcaster__btn home-yvr-broadcaster__stop pixel-font" data-broadcaster-stop><?php echo esc_html( 'STOP' ); ?></button>
                     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Clicks on TRANSLINK / CKNW / DRIVE BC / BC FERRIES / STOP did nothing on the homepage hero.

## Root cause

`style.css` sets `.home-arcade-screen__backdrop { pointer-events: none; }` for the legacy full-screen arcade layout. The YVR broadcaster lives inside that backdrop. `home-hero-cabinet.css` overrides layout for `.home-amp-cabinet` but never restored pointer events, so buttons never received clicks.

## Fix

- `pointer-events: auto` on backdrop / stack / broadcaster
- Immediate tuning feedback on channel click

## Teleprompter + rack UI

- Word-by-word highlight synced to speech (boundary events + fallback)
- Feed meta: dates/times, per-item links, pulled-at timestamp
- **Single rack unit**: CRT teleprompter inside YVR BCAST chassis (no separate empty box)
- Compact deck: VU meters | TL / 980 / ROADS / FERRY | STOP
- Shorter hero column, more room for name/bio

## Voice + freshness

- Modern free browser voices (Aria/Jenny/Samantha) vs UK Male/David
- Feeds sorted by recency; cache bypass on tune-in

PR #582
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24402609-4a4a-4d1b-8083-fa2f9483c210?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24402609-4a4a-4d1b-8083-fa2f9483c210&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

