### PR TITLE
Fix YVR BCAST player clicks and improve UX

### DIFF
--- a/assets/css/home-hero-cabinet.css
+++ b/assets/css/home-hero-cabinet.css
@@ -57,7 +57,7 @@
 .home-yvr-rack {
   position: relative;
   width: 100%;
-  max-width: 300px;
+  max-width: 320px;
   margin: 0 auto;
 }
 
@@ -514,15 +514,30 @@
 .home-yvr-broadcaster__channels {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 0.22rem;
+  gap: 0.2rem;
+  max-height: 5.8rem;
+  overflow-y: auto;
+  overflow-x: hidden;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(87, 243, 255, 0.3) transparent;
+  padding-right: 0.1rem;
+}
+
+.home-yvr-broadcaster__channels::-webkit-scrollbar {
+  width: 3px;
+}
+
+.home-yvr-broadcaster__channels::-webkit-scrollbar-thumb {
+  background: rgba(87, 243, 255, 0.35);
+  border-radius: 3px;
 }
 
 .home-yvr-broadcaster__ch {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 0.12rem;
-  padding: 0.28rem 0.3rem;
+  gap: 0.1rem;
+  padding: 0.24rem 0.28rem;
   text-align: left;
   cursor: pointer;
   border: 2px solid #020308;
@@ -530,21 +545,21 @@
   background: linear-gradient(180deg, #1e2430 0%, #12161e 100%);
   color: #dfe7ff;
   box-shadow: 2px 2px 0 rgba(87, 243, 255, 0.18);
-  min-height: 2.35rem;
+  min-height: 2.1rem;
 }
 
 .home-yvr-broadcaster__ch-label {
   font-family: "Press Start 2P", monospace;
-  font-size: 0.36rem;
-  letter-spacing: 0.04em;
+  font-size: 0.34rem;
+  letter-spacing: 0.03em;
   line-height: 1.25;
   color: #e8f4ff;
 }
 
 .home-yvr-broadcaster__ch-hint {
   font-family: "IBM Plex Mono", "Courier New", monospace;
-  font-size: 0.38rem;
-  line-height: 1.25;
+  font-size: 0.36rem;
+  line-height: 1.2;
   color: rgba(160, 200, 215, 0.78);
 }
 

--- a/assets/css/home-hero-cabinet.css
+++ b/assets/css/home-hero-cabinet.css
@@ -214,7 +214,7 @@
   display: none;
 }
 
-/* YVR broadcaster — CHIP avatar + rack */
+/* YVR broadcaster — Dave the pigeon + rack */
 .home-yvr-broadcaster {
   position: relative;
   z-index: 1;
@@ -261,108 +261,128 @@
 
 .home-yvr-broadcaster__avatar-frame {
   position: relative;
-  width: 52px;
-  height: 58px;
+  width: 56px;
+  height: 60px;
 }
 
-.home-yvr-broadcaster__avatar-hair {
+.home-yvr-broadcaster__pigeon-tail {
   position: absolute;
-  top: 2px;
-  left: 8px;
-  right: 8px;
-  height: 14px;
-  border-radius: 6px 6px 2px 2px;
-  background: linear-gradient(180deg, #57f3ff, #2a8aa8);
-  box-shadow: 0 0 10px rgba(87, 243, 255, 0.35);
-}
-
-.home-yvr-broadcaster__avatar-head {
-  position: absolute;
-  top: 12px;
-  left: 10px;
-  right: 10px;
-  height: 34px;
-  border-radius: 8px 8px 12px 12px;
-  background: linear-gradient(180deg, #f0c9a8 0%, #d4a574 100%);
+  bottom: 10px;
+  left: 4px;
+  width: 14px;
+  height: 10px;
+  border-radius: 2px 0 8px 8px;
+  background: linear-gradient(135deg, #6a7588, #4a5568);
   border: 2px solid #0a0c10;
-  box-shadow: inset 0 -4px 8px rgba(0, 0, 0, 0.2);
+  transform: rotate(-18deg);
 }
 
-.home-yvr-broadcaster__avatar-visor {
-  display: flex;
-  justify-content: center;
-  gap: 8px;
-  margin-top: 7px;
-  padding: 3px 4px;
-  border-radius: 4px;
-  background: linear-gradient(180deg, #1a2030, #050608);
-  border: 1px solid rgba(87, 243, 255, 0.35);
-  box-shadow: inset 0 0 8px rgba(87, 243, 255, 0.15);
+.home-yvr-broadcaster__pigeon-body {
+  position: absolute;
+  bottom: 8px;
+  left: 12px;
+  width: 30px;
+  height: 26px;
+  border-radius: 50% 50% 45% 45%;
+  background: linear-gradient(160deg, #9aa5b8 0%, #6a7588 55%, #505a68 100%);
+  border: 2px solid #0a0c10;
+  box-shadow: inset 0 -6px 10px rgba(0, 0, 0, 0.25);
 }
 
-.home-yvr-broadcaster__eye {
-  width: 7px;
-  height: 7px;
-  border-radius: 1px;
-  background: #39ff14;
-  box-shadow: 0 0 8px rgba(57, 255, 20, 0.75);
+.home-yvr-broadcaster__pigeon-wing {
+  position: absolute;
+  bottom: 12px;
+  left: 18px;
+  width: 18px;
+  height: 14px;
+  border-radius: 0 60% 40% 60%;
+  background: linear-gradient(180deg, #7a8598, #525c6e);
+  border: 2px solid #0a0c10;
+  transform: rotate(-8deg);
+  box-shadow: inset 0 -3px 6px rgba(0, 0, 0, 0.2);
+}
+
+.home-yvr-broadcaster__pigeon-head {
+  position: absolute;
+  top: 8px;
+  left: 22px;
+  width: 24px;
+  height: 22px;
+  border-radius: 55% 55% 45% 45%;
+  background: linear-gradient(180deg, #b8c0d0 0%, #8a94a8 100%);
+  border: 2px solid #0a0c10;
+  box-shadow: inset 0 -3px 6px rgba(0, 0, 0, 0.15);
+}
+
+.home-yvr-broadcaster__pigeon-head .home-yvr-broadcaster__eye {
+  position: absolute;
+  top: 7px;
+  left: 6px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #0a0c10;
+  box-shadow: inset -1px -1px 0 #39ff14, 0 0 6px rgba(57, 255, 20, 0.55);
   animation: homeBcastBlink 5s steps(2, end) infinite;
 }
 
-.home-yvr-broadcaster__mouth {
+.home-yvr-broadcaster__pigeon-beak {
   position: absolute;
-  bottom: 4px;
-  left: 50%;
-  width: 16px;
+  top: 10px;
+  right: -2px;
+  width: 14px;
+  height: 12px;
+}
+
+.home-yvr-broadcaster__pigeon-beak-top {
+  display: block;
+  width: 14px;
+  height: 5px;
+  border-radius: 0 6px 2px 2px;
+  background: linear-gradient(180deg, #ffb347, #e8922a);
+  border: 2px solid #0a0c10;
+  border-bottom: none;
+}
+
+.home-yvr-broadcaster__pigeon-beak .home-yvr-broadcaster__mouth {
+  position: relative;
+  display: block;
+  width: 12px;
   height: 4px;
-  margin-left: -8px;
-  border-radius: 0 0 8px 8px;
-  background: #1a0a14;
-  border: 1px solid rgba(255, 79, 216, 0.65);
-  box-shadow: inset 0 -2px 5px rgba(255, 79, 216, 0.4);
+  margin-top: -1px;
+  border-radius: 0 0 6px 6px;
+  background: linear-gradient(180deg, #e8922a, #c9781a);
+  border: 2px solid #0a0c10;
+  border-top: none;
   transform-origin: center top;
-  transition: height 0.07s ease-out, border-radius 0.07s ease-out;
+  transition: height 0.07s ease-out;
 }
 
-.home-yvr-broadcaster__avatar-headset {
+.home-yvr-broadcaster__pigeon-mic {
   position: absolute;
-  top: 22px;
-  width: 10px;
-  height: 22px;
-  border: 2px solid #2a3040;
-  border-radius: 6px;
-  background: linear-gradient(180deg, #3a4458, #1a1e28);
-  box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.5);
-}
-
-.home-yvr-broadcaster__avatar-headset--l { left: 0; }
-.home-yvr-broadcaster__avatar-headset--r { right: 0; }
-
-.home-yvr-broadcaster__avatar-mic {
-  position: absolute;
-  bottom: 6px;
-  left: 50%;
-  width: 4px;
-  height: 10px;
-  margin-left: -2px;
+  bottom: 14px;
+  right: 6px;
+  width: 5px;
+  height: 8px;
   border-radius: 2px;
-  background: #888;
-  box-shadow: -14px 0 0 -2px #666, -14px 8px 0 0 #555;
+  background: #555;
+  border: 1px solid #0a0c10;
+  box-shadow: -10px 2px 0 -1px #444, -10px 10px 0 0 #333;
 }
 
 .home-yvr-broadcaster__avatar-name {
   margin: 0;
   font-size: 0.42rem;
   letter-spacing: 0.08em;
-  color: #39ff14;
-  text-shadow: 0 0 8px rgba(57, 255, 20, 0.45);
+  color: #ffe66d;
+  text-shadow: 0 0 8px rgba(255, 230, 109, 0.45);
 }
 
 .home-yvr-broadcaster__avatar-tag {
   margin: 0;
   font-family: "IBM Plex Mono", "Courier New", monospace;
-  font-size: 0.38rem;
-  letter-spacing: 0.06em;
+  font-size: 0.36rem;
+  letter-spacing: 0.04em;
   color: rgba(180, 220, 235, 0.65);
   text-transform: lowercase;
 }
@@ -372,21 +392,24 @@
   animation: homeBcastBlinkFast 1.2s steps(2, end) infinite;
 }
 
-.home-yvr-broadcaster__avatar.is-talking .home-yvr-broadcaster__avatar-head,
-.home-yvr-broadcaster__face.is-talking .home-yvr-broadcaster__avatar-head {
-  box-shadow: inset 0 -4px 8px rgba(0, 0, 0, 0.2), 0 0 12px rgba(57, 255, 20, 0.15);
+.home-yvr-broadcaster__avatar.is-talking .home-yvr-broadcaster__pigeon-head,
+.home-yvr-broadcaster__face.is-talking .home-yvr-broadcaster__pigeon-head {
+  box-shadow: inset 0 -3px 6px rgba(0, 0, 0, 0.15), 0 0 10px rgba(255, 230, 109, 0.25);
 }
 
-.home-yvr-broadcaster__mouth.is-open {
-  height: 11px;
-  border-radius: 0 0 10px 10px;
-  background: linear-gradient(180deg, #2a1020 0%, #ff4fd8 90%);
-  border-color: rgba(255, 79, 216, 0.85);
-  box-shadow: 0 0 10px rgba(255, 79, 216, 0.55);
+.home-yvr-broadcaster__pigeon-beak .home-yvr-broadcaster__mouth.is-open {
+  height: 9px;
+  background: linear-gradient(180deg, #ff4fd8 0%, #e8922a 80%);
+  box-shadow: 0 0 8px rgba(255, 79, 216, 0.4);
 }
 
-.home-yvr-broadcaster__mouth.is-flap {
-  animation: homeBcastMouthFlap 0.26s steps(3, end) infinite;
+.home-yvr-broadcaster__pigeon-beak .home-yvr-broadcaster__mouth.is-flap {
+  animation: homeDaveBeakFlap 0.26s steps(3, end) infinite;
+}
+
+@keyframes homeDaveBeakFlap {
+  0%, 100% { height: 4px; }
+  50% { height: 10px; }
 }
 
 @keyframes homeBcastBlink {
@@ -397,11 +420,6 @@
 @keyframes homeBcastBlinkFast {
   0%, 70%, 100% { opacity: 1; }
   80% { opacity: 0.4; }
-}
-
-@keyframes homeBcastMouthFlap {
-  0%, 100% { height: 4px; border-radius: 2px; }
-  50% { height: 12px; border-radius: 0 0 11px 11px; }
 }
 
 .home-yvr-broadcaster__header {

--- a/assets/css/home-hero-cabinet.css
+++ b/assets/css/home-hero-cabinet.css
@@ -57,12 +57,12 @@
 .home-yvr-rack {
   position: relative;
   width: 100%;
-  max-width: 320px;
-  margin: 0 auto;
+  max-width: none;
+  margin: 0;
 }
 
 .home-yvr-rack__kicker {
-  margin: 0 0 0.28rem;
+  margin: 0 0 0.32rem;
   font-size: 0.38rem;
   letter-spacing: 0.1em;
   color: rgba(87, 243, 255, 0.55);
@@ -83,146 +83,15 @@
 .home-yvr-rack::before { left: 0; }
 .home-yvr-rack::after { right: 0; }
 
-/* CRT teleprompter — inside broadcaster rack */
-.home-yvr-broadcaster__crt[data-broadcaster-teleprompt].is-live .home-yvr-teleprompt__script {
-  border-color: rgba(57, 255, 20, 0.45);
-  box-shadow: inset 0 0 16px rgba(57, 255, 20, 0.12);
-}
-
-.home-yvr-broadcaster__crt[data-broadcaster-teleprompt].is-radio .home-yvr-teleprompt__script {
-  border-color: rgba(255, 230, 109, 0.5);
-  box-shadow: inset 0 0 16px rgba(255, 230, 109, 0.12);
-}
-
-.home-yvr-teleprompt__meta {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-  max-height: 3.2rem;
-  overflow: hidden;
-}
-
-.home-yvr-teleprompt__meta[hidden] {
-  display: none;
-}
-
-.home-yvr-teleprompt__item {
-  font-family: "IBM Plex Mono", "Courier New", monospace;
-  font-size: clamp(0.42rem, 0.82vw, 0.52rem);
-  line-height: 1.35;
-  color: rgba(180, 220, 235, 0.88);
-}
-
-.home-yvr-teleprompt__time {
-  display: block;
-  color: #ffe66d;
-  font-size: clamp(0.4rem, 0.78vw, 0.48rem);
-  letter-spacing: 0.03em;
-}
-
-.home-yvr-teleprompt__title {
-  color: rgba(200, 235, 220, 0.92);
-}
-
-.home-yvr-teleprompt__link {
-  color: #57f3ff;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-  pointer-events: auto;
-}
-
-.home-yvr-teleprompt__link:hover,
-.home-yvr-teleprompt__link:focus-visible {
-  color: #39ff14;
-}
-
-.home-yvr-teleprompt__item--source {
-  opacity: 0.85;
-}
-
-.home-yvr-teleprompt__item--fetched {
-  opacity: 0.72;
-  border-top: 1px solid rgba(87, 243, 255, 0.12);
-  padding-top: 0.2rem;
-  margin-top: 0.1rem;
-}
-
-.home-yvr-teleprompt__script {
-  margin: 0;
-  min-height: 3.4rem;
-  max-height: 4.6rem;
-  padding: 0.32rem 0.36rem;
-  overflow-y: auto;
-  overflow-x: hidden;
-  scrollbar-width: thin;
-  scrollbar-color: rgba(87, 243, 255, 0.35) transparent;
-  border-radius: 4px;
-  border: 1px solid rgba(0, 0, 0, 0.85);
-  background: rgba(0, 4, 2, 0.95);
-  font-family: "IBM Plex Mono", "Courier New", monospace;
-  font-size: clamp(0.44rem, 0.84vw, 0.54rem);
-  line-height: 1.4;
-  letter-spacing: 0.02em;
-  color: rgba(170, 210, 200, 0.5);
-  scroll-behavior: smooth;
-}
-
-.home-yvr-teleprompt__script::-webkit-scrollbar {
-  width: 4px;
-}
-
-.home-yvr-teleprompt__script::-webkit-scrollbar-thumb {
-  background: rgba(87, 243, 255, 0.35);
-  border-radius: 4px;
-}
-
-.home-yvr-teleprompt__word {
-  transition: color 0.08s linear, background 0.08s linear, text-shadow 0.08s linear;
-}
-
-.home-yvr-teleprompt__word.is-spoken {
-  color: rgba(87, 243, 255, 0.72);
-}
-
-.home-yvr-teleprompt__word.is-current {
-  color: #39ff14;
-  background: rgba(57, 255, 20, 0.14);
-  text-shadow: 0 0 10px rgba(57, 255, 20, 0.55);
-  border-radius: 2px;
-}
-
-.home-yvr-ascii {
-  display: none !important;
-}
-
-.home-amp-cabinet .home-arcade-vancouver {
-  display: none !important;
-}
-
-/* Hide Miami-noir leftovers */
-.home-amp-cabinet .home-palm,
-.home-amp-cabinet .home-arcade-moon,
-.home-amp-cabinet .home-pixel-star,
-.home-amp-cabinet .home-pixel-rain {
-  display: none !important;
-}
-
-.home-amp-stack {
-  display: none;
-}
-
 /* YVR broadcaster — Dave the pigeon + rack */
 .home-yvr-broadcaster {
   position: relative;
   z-index: 1;
   pointer-events: auto;
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 0.45rem 0.5rem;
-  padding: 0.45rem 0.48rem 0.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.38rem;
+  padding: 0.48rem 0.5rem 0.42rem;
   border-radius: 8px;
   border: 2px solid #0a0c10;
   background:
@@ -243,19 +112,25 @@
   pointer-events: none;
 }
 
-.home-yvr-broadcaster__body {
+.home-yvr-broadcaster__mast {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.45rem;
+}
+
+.home-yvr-broadcaster__mast-info {
+  flex: 1;
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.28rem;
+  gap: 0.3rem;
 }
 
 .home-yvr-broadcaster__avatar {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.22rem;
-  padding: 0.2rem 0.15rem 0;
+  gap: 0.15rem;
   flex-shrink: 0;
 }
 
@@ -378,15 +253,6 @@
   text-shadow: 0 0 8px rgba(255, 230, 109, 0.45);
 }
 
-.home-yvr-broadcaster__avatar-tag {
-  margin: 0;
-  font-family: "IBM Plex Mono", "Courier New", monospace;
-  font-size: 0.36rem;
-  letter-spacing: 0.04em;
-  color: rgba(180, 220, 235, 0.65);
-  text-transform: lowercase;
-}
-
 .home-yvr-broadcaster__avatar.is-talking .home-yvr-broadcaster__eye,
 .home-yvr-broadcaster__face.is-talking .home-yvr-broadcaster__eye {
   animation: homeBcastBlinkFast 1.2s steps(2, end) infinite;
@@ -429,21 +295,6 @@
   gap: 0.35rem;
 }
 
-.home-yvr-broadcaster__status {
-  display: flex;
-  align-items: center;
-  gap: 0.28rem;
-  min-width: 0;
-}
-
-.home-yvr-broadcaster__legend {
-  margin: 0;
-  font-family: "IBM Plex Mono", "Courier New", monospace;
-  font-size: clamp(0.4rem, 0.78vw, 0.48rem);
-  line-height: 1.35;
-  color: rgba(170, 210, 200, 0.72);
-}
-
 .home-yvr-broadcaster__badge {
   font-family: "Press Start 2P", monospace;
   font-size: 0.38rem;
@@ -453,26 +304,80 @@
   flex-shrink: 0;
 }
 
+.home-yvr-broadcaster__on-air {
+  display: flex;
+  align-items: center;
+  gap: 0.32rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.home-yvr-broadcaster__led {
+  flex-shrink: 0;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: rgba(87, 243, 255, 0.3);
+  box-shadow: 0 0 4px rgba(87, 243, 255, 0.15);
+}
+
+.home-yvr-broadcaster.is-live .home-yvr-broadcaster__led {
+  background: #39ff14;
+  box-shadow: 0 0 8px rgba(57, 255, 20, 0.75);
+  animation: homeBcastLedPulse 1.4s ease-in-out infinite;
+}
+
+.home-yvr-broadcaster.is-radio .home-yvr-broadcaster__led {
+  background: #ffe66d;
+  box-shadow: 0 0 8px rgba(255, 230, 109, 0.7);
+  animation: none;
+}
+
+@keyframes homeBcastLedPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+
 .home-yvr-broadcaster__channel {
   font-family: "Press Start 2P", monospace;
-  font-size: 0.34rem;
+  font-size: clamp(0.36rem, 0.82vw, 0.42rem);
   line-height: 1.2;
   letter-spacing: 0.05em;
   color: #57f3ff;
   text-shadow: 0 0 8px rgba(87, 243, 255, 0.35);
-  padding: 0.1rem 0.26rem;
-  border-radius: 3px;
-  border: 1px solid rgba(87, 243, 255, 0.25);
-  background: rgba(0, 12, 20, 0.65);
   white-space: nowrap;
 }
 
 .home-yvr-broadcaster__freq {
   font-family: "IBM Plex Mono", "Courier New", monospace;
-  font-size: 0.56rem;
+  font-size: clamp(0.5rem, 0.9vw, 0.58rem);
   letter-spacing: 0.04em;
   color: #ffe66d;
   text-shadow: 0 0 6px rgba(255, 230, 109, 0.35);
+  flex-shrink: 0;
+}
+
+.home-yvr-broadcaster__bars {
+  display: flex;
+  gap: 0.16rem;
+  align-items: flex-end;
+  height: 24px;
+  padding-bottom: 0.08rem;
+}
+
+.home-yvr-broadcaster__bar {
+  display: block;
+  width: 0.34rem;
+  height: 35%;
+  border-radius: 2px;
+  background: linear-gradient(180deg, #39ff14, #ffe66d 72%, #ff4b4b);
+  opacity: 0.35;
+  transform: scaleY(0.5);
+}
+
+.home-yvr-broadcaster__bar.is-live {
+  opacity: 1;
+  animation: homeScannerBar 0.9s steps(4, end) infinite;
 }
 
 .home-yvr-broadcaster__crt {
@@ -504,63 +409,171 @@
   100% { transform: translateY(3px); }
 }
 
-.home-yvr-broadcaster__deck {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: 0.28rem;
-  align-items: stretch;
+.home-yvr-broadcaster__crt[data-broadcaster-teleprompt].is-live .home-yvr-teleprompt__script {
+  border-color: rgba(57, 255, 20, 0.45);
+  box-shadow: inset 0 0 16px rgba(57, 255, 20, 0.12);
 }
 
-.home-yvr-broadcaster__channels {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
+.home-yvr-broadcaster__crt[data-broadcaster-teleprompt].is-radio .home-yvr-teleprompt__script {
+  border-color: rgba(255, 230, 109, 0.5);
+  box-shadow: inset 0 0 16px rgba(255, 230, 109, 0.12);
+}
+
+.home-yvr-teleprompt__meta {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
   gap: 0.2rem;
-  max-height: 5.8rem;
+  max-height: 3.2rem;
+  overflow: hidden;
+}
+
+.home-yvr-teleprompt__meta[hidden] {
+  display: none;
+}
+
+.home-yvr-teleprompt__item {
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  font-size: clamp(0.42rem, 0.82vw, 0.52rem);
+  line-height: 1.35;
+  color: rgba(180, 220, 235, 0.88);
+}
+
+.home-yvr-teleprompt__time {
+  display: block;
+  color: #ffe66d;
+  font-size: clamp(0.4rem, 0.78vw, 0.48rem);
+  letter-spacing: 0.03em;
+}
+
+.home-yvr-teleprompt__title {
+  color: rgba(200, 235, 220, 0.92);
+}
+
+.home-yvr-teleprompt__link {
+  color: #57f3ff;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  pointer-events: auto;
+}
+
+.home-yvr-teleprompt__link:hover,
+.home-yvr-teleprompt__link:focus-visible {
+  color: #39ff14;
+}
+
+.home-yvr-teleprompt__item--source {
+  opacity: 0.85;
+}
+
+.home-yvr-teleprompt__item--fetched {
+  opacity: 0.72;
+  border-top: 1px solid rgba(87, 243, 255, 0.12);
+  padding-top: 0.2rem;
+  margin-top: 0.1rem;
+}
+
+.home-yvr-teleprompt__script {
+  margin: 0;
+  min-height: 3.2rem;
+  max-height: 4.2rem;
+  padding: 0.36rem 0.4rem;
   overflow-y: auto;
   overflow-x: hidden;
   scrollbar-width: thin;
-  scrollbar-color: rgba(87, 243, 255, 0.3) transparent;
-  padding-right: 0.1rem;
+  scrollbar-color: rgba(87, 243, 255, 0.35) transparent;
+  border-radius: 4px;
+  border: 1px solid rgba(0, 0, 0, 0.85);
+  background: rgba(0, 4, 2, 0.95);
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  font-size: clamp(0.48rem, 0.95vw, 0.58rem);
+  line-height: 1.45;
+  letter-spacing: 0.02em;
+  color: rgba(170, 210, 200, 0.55);
+  scroll-behavior: smooth;
 }
 
-.home-yvr-broadcaster__channels::-webkit-scrollbar {
-  width: 3px;
+.home-yvr-teleprompt__script::-webkit-scrollbar {
+  width: 4px;
 }
 
-.home-yvr-broadcaster__channels::-webkit-scrollbar-thumb {
+.home-yvr-teleprompt__script::-webkit-scrollbar-thumb {
   background: rgba(87, 243, 255, 0.35);
-  border-radius: 3px;
+  border-radius: 4px;
+}
+
+.home-yvr-teleprompt__word {
+  transition: color 0.08s linear, background 0.08s linear, text-shadow 0.08s linear;
+}
+
+.home-yvr-teleprompt__word.is-spoken {
+  color: rgba(87, 243, 255, 0.72);
+}
+
+.home-yvr-teleprompt__word.is-current {
+  color: #39ff14;
+  background: rgba(57, 255, 20, 0.14);
+  text-shadow: 0 0 10px rgba(57, 255, 20, 0.55);
+  border-radius: 2px;
+}
+
+.home-yvr-broadcaster__feeds {
+  display: flex;
+  flex-direction: column;
+  gap: 0.28rem;
+}
+
+.home-yvr-broadcaster__feeds-label {
+  margin: 0;
+  font-size: clamp(0.38rem, 0.82vw, 0.44rem);
+  letter-spacing: 0.1em;
+  color: rgba(87, 243, 255, 0.55);
+  text-transform: lowercase;
+}
+
+.home-yvr-broadcaster__channels {
+  display: flex;
+  flex-direction: column;
+  gap: 0.22rem;
 }
 
 .home-yvr-broadcaster__ch {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.1rem;
-  padding: 0.24rem 0.28rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.35rem 0.5rem;
+  padding: 0.38rem 0.45rem;
   text-align: left;
   cursor: pointer;
   border: 2px solid #020308;
-  border-radius: 4px;
+  border-radius: 5px;
   background: linear-gradient(180deg, #1e2430 0%, #12161e 100%);
   color: #dfe7ff;
-  box-shadow: 2px 2px 0 rgba(87, 243, 255, 0.18);
-  min-height: 2.1rem;
+  box-shadow: 2px 2px 0 rgba(87, 243, 255, 0.16);
+  min-height: 0;
 }
 
 .home-yvr-broadcaster__ch-label {
   font-family: "Press Start 2P", monospace;
-  font-size: 0.34rem;
+  font-size: clamp(0.42rem, 0.92vw, 0.5rem);
   letter-spacing: 0.03em;
-  line-height: 1.25;
+  line-height: 1.3;
   color: #e8f4ff;
 }
 
 .home-yvr-broadcaster__ch-hint {
   font-family: "IBM Plex Mono", "Courier New", monospace;
-  font-size: 0.36rem;
-  line-height: 1.2;
+  font-size: clamp(0.4rem, 0.85vw, 0.48rem);
+  line-height: 1.25;
   color: rgba(160, 200, 215, 0.78);
+  text-align: right;
+  white-space: nowrap;
+}
+
+.home-yvr-broadcaster__ch--radio .home-yvr-broadcaster__ch-hint {
+  color: rgba(255, 230, 109, 0.82);
 }
 
 .home-yvr-broadcaster__ch:hover,
@@ -577,6 +590,7 @@
 .home-yvr-broadcaster__ch.is-active {
   background: linear-gradient(180deg, #39ff14 0%, #2ad010 100%);
   box-shadow: 2px 2px 0 #ff4fd8;
+  border-color: #020805;
 }
 
 .home-yvr-broadcaster__ch.is-active .home-yvr-broadcaster__ch-label {
@@ -587,14 +601,10 @@
   color: rgba(2, 12, 6, 0.75);
 }
 
-.home-yvr-broadcaster__display {
-  display: none;
-}
-
 .home-yvr-broadcaster__caption {
-  margin: 0.2rem 0 0;
+  margin: 0.15rem 0 0;
   font-family: "IBM Plex Mono", "Courier New", monospace;
-  font-size: 0.4rem;
+  font-size: clamp(0.4rem, 0.8vw, 0.48rem);
   line-height: 1.35;
   color: rgba(200, 235, 220, 0.72);
 }
@@ -603,50 +613,46 @@
   display: none;
 }
 
-.home-yvr-broadcaster__bars {
-  display: flex;
-  gap: 0.16rem;
-  align-items: flex-end;
-  height: 28px;
-  padding-bottom: 0.12rem;
-}
-
-.home-yvr-broadcaster__bar {
-  display: block;
-  width: 0.34rem;
-  height: 35%;
-  border-radius: 2px;
-  background: linear-gradient(180deg, #39ff14, #ffe66d 72%, #ff4b4b);
-  opacity: 0.35;
-  transform: scaleY(0.5);
-}
-
-.home-yvr-broadcaster__bar.is-live {
-  opacity: 1;
-  animation: homeScannerBar 0.9s steps(4, end) infinite;
-}
-
-.home-yvr-broadcaster__controls {
-  display: none;
-}
-
 .home-yvr-broadcaster__btn {
-  padding: 0.34rem 0.35rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  width: 100%;
+  min-width: 0;
+  min-height: 1.85rem;
+  height: auto;
+  padding: 0.32rem 0.5rem;
   font-family: "Press Start 2P", monospace;
-  font-size: 0.36rem;
+  font-size: clamp(0.38rem, 0.85vw, 0.44rem);
   letter-spacing: 0.05em;
   cursor: pointer;
   border: 2px solid #020308;
-  border-radius: 3px;
-  min-width: 2.6rem;
-  height: 100%;
-  min-height: 2.1rem;
+  border-radius: 4px;
 }
 
 .home-yvr-broadcaster__stop {
-  background: #ff4b4b;
+  margin-top: 0.08rem;
+  background: linear-gradient(180deg, #ff5c5c 0%, #e03a3a 100%);
   color: #fff;
   box-shadow: 2px 2px 0 #020308;
+}
+
+.home-yvr-broadcaster__stop:hover,
+.home-yvr-broadcaster__stop:focus-visible {
+  background: linear-gradient(180deg, #ff7070 0%, #ff4b4b 100%);
+}
+
+.home-yvr-broadcaster__stop-label {
+  flex-shrink: 0;
+}
+
+.home-yvr-broadcaster__stop-hint {
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  font-size: clamp(0.36rem, 0.78vw, 0.44rem);
+  letter-spacing: 0.03em;
+  opacity: 0.88;
+  text-transform: lowercase;
 }
 
 .home-yvr-broadcaster.is-speaking .home-yvr-broadcaster__channel {
@@ -656,6 +662,27 @@
 
 .home-yvr-broadcaster.is-radio .home-yvr-broadcaster__channel {
   color: #ffe66d;
+  text-shadow: 0 0 8px rgba(255, 230, 109, 0.35);
+}
+
+.home-yvr-ascii {
+  display: none !important;
+}
+
+.home-amp-cabinet .home-arcade-vancouver {
+  display: none !important;
+}
+
+/* Hide Miami-noir leftovers */
+.home-amp-cabinet .home-palm,
+.home-amp-cabinet .home-arcade-moon,
+.home-amp-cabinet .home-pixel-star,
+.home-amp-cabinet .home-pixel-rain {
+  display: none !important;
+}
+
+.home-amp-stack {
+  display: none;
 }
 
 /* legacy scanner styles (unused) */
@@ -1050,11 +1077,7 @@
   }
 
   .home-yvr-rack {
-    max-width: min(100%, 320px);
-  }
-
-  .home-yvr-broadcaster {
-    grid-template-columns: auto minmax(0, 1fr);
+    max-width: min(100%, 380px);
   }
 
   .home-yvr-teleprompt__script {
@@ -1090,10 +1113,6 @@
     max-width: 100%;
   }
 
-  .home-yvr-broadcaster__deck {
-    grid-template-columns: 1fr;
-  }
-
   .home-yvr-broadcaster__bars {
     justify-content: center;
     height: 22px;
@@ -1114,7 +1133,8 @@
   .home-yvr-broadcaster__bar,
   .home-yvr-broadcaster__crt-scan,
   .home-yvr-broadcaster__eye,
-  .home-yvr-broadcaster__mouth.is-flap {
+  .home-yvr-broadcaster__mouth.is-flap,
+  .home-yvr-broadcaster.is-live .home-yvr-broadcaster__led {
     animation: none !important;
   }
 }

--- a/inc/home-yvr-broadcaster.php
+++ b/inc/home-yvr-broadcaster.php
@@ -22,6 +22,17 @@ function se_broadcaster_format_posted( string $raw ): string {
     return wp_date( 'M j, Y g:i a', $ts );
 }
 
+function se_broadcaster_format_arcgis_ms( mixed $raw ): string {
+    if ( ! $raw || ! is_numeric( $raw ) ) {
+        return '';
+    }
+    $ms = (float) $raw;
+    if ( $ms < 1e11 ) {
+        return '';
+    }
+    return wp_date( 'M j, Y g:i a', (int) round( $ms / 1000 ) );
+}
+
 function se_broadcaster_drivebc_url( string $api_url ): string {
     if ( preg_match( '/(DBC-\d+)/', $api_url, $m ) ) {
         return 'https://www.drivebc.ca/mobile/event/' . $m[1];
@@ -536,7 +547,7 @@ function se_fetch_bc_wildfire_near_yvr(): array {
             'url'             => $url,
             'fire_of_note'    => $note,
             'ignition'        => $ignition,
-            'ignition_label'  => se_broadcaster_format_posted( $ignition ),
+            'ignition_label'  => se_broadcaster_format_arcgis_ms( $row['IGNITION_DATE'] ?? '' ),
             'priority'        => ( $note ? 1000 : 0 ) + ( str_contains( strtolower( $status ), 'out of control' ) ? 500 : 0 ) + min( 400, (int) $size ),
         );
     }

--- a/inc/home-yvr-broadcaster.php
+++ b/inc/home-yvr-broadcaster.php
@@ -365,11 +365,340 @@ function se_broadcaster_ferries_script(): array {
     );
 }
 
+function se_aqhi_risk_label( float $aqhi ): string {
+    if ( $aqhi >= 11 ) {
+        return 'very high risk';
+    }
+    if ( $aqhi >= 7 ) {
+        return 'high risk';
+    }
+    if ( $aqhi >= 4 ) {
+        return 'moderate risk';
+    }
+    return 'low risk';
+}
+
+function se_fetch_ec_weather_alerts(): array {
+    $cached = get_transient( 'se_ec_weather_alerts' );
+    if ( false !== $cached && is_array( $cached ) ) {
+        return $cached;
+    }
+
+    $bbox = '-123.6,48.9,-122.1,49.6';
+    $response = wp_remote_get(
+        'https://api.weather.gc.ca/collections/weather-alerts/items?bbox=' . rawurlencode( $bbox ) . '&limit=25',
+        array(
+            'timeout' => 15,
+            'headers' => array( 'Accept' => 'application/geo+json' ),
+        )
+    );
+
+    if ( is_wp_error( $response ) || (int) wp_remote_retrieve_response_code( $response ) !== 200 ) {
+        return array();
+    }
+
+    $body = json_decode( wp_remote_retrieve_body( $response ), true );
+    if ( ! is_array( $body ) || empty( $body['features'] ) || ! is_array( $body['features'] ) ) {
+        set_transient( 'se_ec_weather_alerts', array(), 5 * MINUTE_IN_SECONDS );
+        return array();
+    }
+
+    $out = array();
+    foreach ( $body['features'] as $feature ) {
+        if ( ! is_array( $feature ) ) {
+            continue;
+        }
+        $props = $feature['properties'] ?? array();
+        if ( ! is_array( $props ) ) {
+            continue;
+        }
+        $event    = wp_strip_all_tags( (string) ( $props['event'] ?? $props['alert_type'] ?? 'Weather alert' ) );
+        $headline = wp_strip_all_tags( (string) ( $props['headline'] ?? '' ) );
+        $desc     = wp_strip_all_tags( (string) ( $props['description'] ?? '' ) );
+        $effective = (string) ( $props['effective'] ?? $props['sent'] ?? '' );
+        $areas    = (string) ( $props['area_desc'] ?? $props['location_name_en'] ?? 'Metro Vancouver' );
+
+        $out[] = array(
+            'event'         => $event,
+            'headline'      => $headline,
+            'description'   => se_broadcaster_trim_script( $desc, 240 ),
+            'effective'     => $effective,
+            'effective_label' => se_broadcaster_format_posted( $effective ),
+            'areas'         => se_broadcaster_trim_script( $areas, 120 ),
+            'url'           => 'https://weather.gc.ca/warnings/index_e.html?prov=bc',
+        );
+    }
+
+    set_transient( 'se_ec_weather_alerts', $out, 5 * MINUTE_IN_SECONDS );
+
+    return se_broadcaster_prioritize_recent( $out, 'effective', 30 );
+}
+
+function se_broadcaster_weather_script(): array {
+    $alerts = se_fetch_ec_weather_alerts();
+    if ( ! $alerts ) {
+        return array(
+            'caption'       => 'No active Environment Canada warnings for Metro Vancouver.',
+            'script'        => 'Environment Canada shows no weather warnings for Metro Vancouver right now.',
+            'source'        => 'Environment Canada',
+            'source_url'    => 'https://weather.gc.ca/warnings/index_e.html?prov=bc',
+            'items'         => array(),
+            'fetched_label' => 'Pulled ' . wp_date( 'M j, Y g:i a T' ),
+        );
+    }
+
+    $items = array();
+    foreach ( array_slice( $alerts, 0, 3 ) as $alert ) {
+        $line = $alert['event'];
+        if ( ! empty( $alert['headline'] ) ) {
+            $line .= '. ' . $alert['headline'];
+        }
+        if ( ! empty( $alert['description'] ) ) {
+            $line .= '. ' . $alert['description'];
+        }
+        $items[] = array(
+            'title'        => se_broadcaster_trim_script( $alert['event'], 80 ),
+            'text'         => se_broadcaster_trim_script( $line, 200 ),
+            'posted'       => (string) ( $alert['effective'] ?? '' ),
+            'posted_label' => (string) ( $alert['effective_label'] ?? '' ),
+            'url'          => (string) ( $alert['url'] ?? '' ),
+            'link_label'   => 'EC weather warnings',
+        );
+    }
+
+    return se_broadcaster_pack_from_items(
+        $items,
+        'Environment Canada weather. ',
+        'Environment Canada',
+        'https://weather.gc.ca/warnings/index_e.html?prov=bc'
+    );
+}
+
+function se_fetch_bc_wildfire_near_yvr(): array {
+    $cached = get_transient( 'se_bc_wildfire_near_yvr' );
+    if ( false !== $cached && is_array( $cached ) ) {
+        return $cached;
+    }
+
+    $query = add_query_arg(
+        array(
+            'where'              => "FIRE_STATUS NOT IN ('Out')",
+            'geometry'           => '-123.5,49.0,-121.0,50.5',
+            'geometryType'       => 'esriGeometryEnvelope',
+            'inSR'               => '4326',
+            'spatialRel'         => 'esriSpatialRelIntersects',
+            'outFields'          => 'INCIDENT_NAME,GEOGRAPHIC_DESCRIPTION,CURRENT_SIZE,FIRE_STATUS,FIRE_URL,FIRE_OF_NOTE_IND,IGNITION_DATE',
+            'returnGeometry'     => 'false',
+            'resultRecordCount'  => '40',
+            'f'                  => 'json',
+        ),
+        'https://delivery.maps.gov.bc.ca/arcgis/rest/services/mpcm/bcgwpub/MapServer/502/query'
+    );
+
+    $response = wp_remote_get(
+        $query,
+        array(
+            'timeout' => 15,
+            'headers' => array( 'Accept' => 'application/json' ),
+        )
+    );
+
+    if ( is_wp_error( $response ) || (int) wp_remote_retrieve_response_code( $response ) !== 200 ) {
+        return array();
+    }
+
+    $body = json_decode( wp_remote_retrieve_body( $response ), true );
+    if ( ! is_array( $body ) || empty( $body['features'] ) || ! is_array( $body['features'] ) ) {
+        set_transient( 'se_bc_wildfire_near_yvr', array(), 5 * MINUTE_IN_SECONDS );
+        return array();
+    }
+
+    $out = array();
+    foreach ( $body['features'] as $feature ) {
+        if ( ! is_array( $feature ) ) {
+            continue;
+        }
+        $row = $feature['attributes'] ?? array();
+        if ( ! is_array( $row ) ) {
+            continue;
+        }
+        $name   = wp_strip_all_tags( (string) ( $row['GEOGRAPHIC_DESCRIPTION'] ?? $row['INCIDENT_NAME'] ?? 'BC wildfire' ) );
+        $status = wp_strip_all_tags( (string) ( $row['FIRE_STATUS'] ?? '' ) );
+        $size   = isset( $row['CURRENT_SIZE'] ) ? (float) $row['CURRENT_SIZE'] : 0;
+        $url    = esc_url_raw( (string) ( $row['FIRE_URL'] ?? 'https://www2.gov.bc.ca/gov/content/safety/wildfire-status' ) );
+        $note   = ! empty( $row['FIRE_OF_NOTE_IND'] ) && strtoupper( (string) $row['FIRE_OF_NOTE_IND'] ) === 'Y';
+        $ignition = (string) ( $row['IGNITION_DATE'] ?? '' );
+
+        $out[] = array(
+            'name'            => $name,
+            'status'          => $status,
+            'size'            => $size,
+            'url'             => $url,
+            'fire_of_note'    => $note,
+            'ignition'        => $ignition,
+            'ignition_label'  => se_broadcaster_format_posted( $ignition ),
+            'priority'        => ( $note ? 1000 : 0 ) + ( str_contains( strtolower( $status ), 'out of control' ) ? 500 : 0 ) + min( 400, (int) $size ),
+        );
+    }
+
+    usort(
+        $out,
+        static function ( array $a, array $b ): int {
+            return ( $b['priority'] ?? 0 ) <=> ( $a['priority'] ?? 0 );
+        }
+    );
+
+    set_transient( 'se_bc_wildfire_near_yvr', $out, 5 * MINUTE_IN_SECONDS );
+    return $out;
+}
+
+function se_broadcaster_wildfire_script(): array {
+    $fires = se_fetch_bc_wildfire_near_yvr();
+    if ( ! $fires ) {
+        return array(
+            'caption'       => 'No active wildfires near Metro Vancouver and Sea to Sky.',
+            'script'        => 'BC Wildfire Service shows no active fires in the southwest corridor right now.',
+            'source'        => 'BC Wildfire Service',
+            'source_url'    => 'https://www2.gov.bc.ca/gov/content/safety/wildfire-status',
+            'items'         => array(),
+            'fetched_label' => 'Pulled ' . wp_date( 'M j, Y g:i a T' ),
+        );
+    }
+
+    $items = array();
+    foreach ( array_slice( $fires, 0, 3 ) as $fire ) {
+        $size_text = $fire['size'] >= 1 ? round( $fire['size'], 1 ) . ' hectares' : 'under one hectare';
+        $line      = $fire['name'] . ', status ' . $fire['status'] . ', size ' . $size_text;
+        if ( ! empty( $fire['fire_of_note'] ) ) {
+            $line = 'Fire of note. ' . $line;
+        }
+        $items[] = array(
+            'title'        => se_broadcaster_trim_script( $fire['name'], 80 ),
+            'text'         => se_broadcaster_trim_script( $line, 200 ),
+            'posted'       => (string) ( $fire['ignition'] ?? '' ),
+            'posted_label' => (string) ( $fire['ignition_label'] ?? '' ),
+            'url'          => (string) ( $fire['url'] ?? '' ),
+            'link_label'   => 'BC wildfire incident',
+        );
+    }
+
+    return se_broadcaster_pack_from_items(
+        $items,
+        'BC Wildfire update for southwest BC. ',
+        'BC Wildfire Service',
+        'https://www2.gov.bc.ca/gov/content/safety/wildfire-status'
+    );
+}
+
+function se_fetch_ec_aqhi_metro(): array {
+    $cached = get_transient( 'se_ec_aqhi_metro' );
+    if ( false !== $cached && is_array( $cached ) ) {
+        return $cached;
+    }
+
+    $bbox = '-123.4,49.1,-122.5,49.4';
+    $response = wp_remote_get(
+        'https://api.weather.gc.ca/collections/aqhi-observations-realtime/items?bbox=' . rawurlencode( $bbox ) . '&latest=true&limit=20',
+        array(
+            'timeout' => 15,
+            'headers' => array( 'Accept' => 'application/geo+json' ),
+        )
+    );
+
+    if ( is_wp_error( $response ) || (int) wp_remote_retrieve_response_code( $response ) !== 200 ) {
+        return array();
+    }
+
+    $body = json_decode( wp_remote_retrieve_body( $response ), true );
+    if ( ! is_array( $body ) || empty( $body['features'] ) || ! is_array( $body['features'] ) ) {
+        set_transient( 'se_ec_aqhi_metro', array(), 5 * MINUTE_IN_SECONDS );
+        return array();
+    }
+
+    $out = array();
+    $seen = array();
+    foreach ( $body['features'] as $feature ) {
+        if ( ! is_array( $feature ) ) {
+            continue;
+        }
+        $props = $feature['properties'] ?? array();
+        if ( ! is_array( $props ) ) {
+            continue;
+        }
+        $lid = (string) ( $props['location_id'] ?? '' );
+        if ( $lid && isset( $seen[ $lid ] ) ) {
+            continue;
+        }
+        if ( $lid ) {
+            $seen[ $lid ] = true;
+        }
+        $aqhi = isset( $props['aqhi'] ) ? (float) $props['aqhi'] : 0;
+        $out[] = array(
+            'location'       => wp_strip_all_tags( (string) ( $props['location_name_en'] ?? 'Metro Vancouver' ) ),
+            'aqhi'           => $aqhi,
+            'risk'           => se_aqhi_risk_label( $aqhi ),
+            'observed'       => (string) ( $props['observation_datetime'] ?? '' ),
+            'observed_label' => wp_strip_all_tags( (string) ( $props['observation_datetime_text_en'] ?? '' ) ),
+        );
+    }
+
+    usort(
+        $out,
+        static function ( array $a, array $b ): int {
+            return ( $b['aqhi'] ?? 0 ) <=> ( $a['aqhi'] ?? 0 );
+        }
+    );
+
+    set_transient( 'se_ec_aqhi_metro', $out, 5 * MINUTE_IN_SECONDS );
+    return $out;
+}
+
+function se_broadcaster_air_script(): array {
+    $readings = se_fetch_ec_aqhi_metro();
+    if ( ! $readings ) {
+        return array(
+            'caption'       => 'Metro Vancouver AQHI unavailable.',
+            'script'        => 'Environment Canada air quality data is offline right now. Check metrovancouver.org for AQHI.',
+            'source'        => 'Environment Canada',
+            'source_url'    => 'https://metrovancouver.org/services/air-quality-climate-action/air-quality-data-and-advisories',
+            'items'         => array(),
+            'fetched_label' => 'Pulled ' . wp_date( 'M j, Y g:i a T' ),
+        );
+    }
+
+    $items = array();
+    foreach ( array_slice( $readings, 0, 4 ) as $row ) {
+        $aqhi_round = round( (float) $row['aqhi'], 1 );
+        $line       = $row['location'] . ', AQHI ' . $aqhi_round . ', ' . $row['risk'];
+        $items[] = array(
+            'title'        => se_broadcaster_trim_script( $row['location'], 80 ),
+            'text'         => se_broadcaster_trim_script( $line, 160 ),
+            'posted'       => (string) ( $row['observed'] ?? '' ),
+            'posted_label' => (string) ( $row['observed_label'] ?? '' ),
+            'url'          => 'https://metrovancouver.org/services/air-quality-climate-action/air-quality-data-and-advisories',
+            'link_label'   => 'Metro Vancouver AQ',
+        );
+    }
+
+    $max = $readings[0];
+    $prefix = 'Metro Vancouver air quality. Highest reading ' . round( (float) $max['aqhi'], 1 ) . ' at ' . $max['location'] . '. ';
+
+    return se_broadcaster_pack_from_items(
+        $items,
+        $prefix,
+        'Environment Canada AQHI',
+        'https://metrovancouver.org/services/air-quality-climate-action/air-quality-data-and-advisories'
+    );
+}
+
 function se_get_broadcaster_feeds_rest( WP_REST_Request $request ): WP_REST_Response {
     if ( $request->get_param( 'refresh' ) ) {
         delete_transient( 'se_translink_alerts' );
         delete_transient( 'se_open511_bc_events' );
         delete_transient( 'se_bc_ferries_capacity' );
+        delete_transient( 'se_ec_weather_alerts' );
+        delete_transient( 'se_bc_wildfire_near_yvr' );
+        delete_transient( 'se_ec_aqhi_metro' );
     }
 
     return rest_ensure_response(
@@ -379,6 +708,9 @@ function se_get_broadcaster_feeds_rest( WP_REST_Request $request ): WP_REST_Resp
             'translink'     => se_broadcaster_translink_script(),
             'drivers'       => se_broadcaster_drivers_script(),
             'ferries'       => se_broadcaster_ferries_script(),
+            'weather'       => se_broadcaster_weather_script(),
+            'wildfire'      => se_broadcaster_wildfire_script(),
+            'air'           => se_broadcaster_air_script(),
         )
     );
 }

--- a/js/home-yvr-broadcaster.js
+++ b/js/home-yvr-broadcaster.js
@@ -336,7 +336,7 @@
 
   HomeYvrBroadcaster.prototype.setTelepromptStandby = function () {
     this.renderMeta(null);
-    this.renderScript('Pick a channel. Dave narrates. Words light up.', 'plain');
+    this.renderScript('Pick a feed below. Dave narrates — words light up.', 'plain');
     if (this.telepromptRoot) {
       this.telepromptRoot.classList.remove('is-live', 'is-radio');
     }

--- a/js/home-yvr-broadcaster.js
+++ b/js/home-yvr-broadcaster.js
@@ -5,9 +5,12 @@
 
   var CHANNELS = {
     translink: { label: 'SKYTRAIN', freq: '410.287', key: 'translink' },
-    cknw: { label: 'CKNW 980', freq: '980.000', key: 'cknw', stream: true },
     drivers: { label: 'DRIVE BC', freq: '154.100', key: 'drivers' },
-    ferries: { label: 'BC FERRIES', freq: '156.800', key: 'ferries' }
+    ferries: { label: 'BC FERRIES', freq: '156.800', key: 'ferries' },
+    weather: { label: 'WEATHER', freq: '162.550', key: 'weather' },
+    wildfire: { label: 'WILDFIRE', freq: '168.050', key: 'wildfire' },
+    air: { label: 'AIR QUALITY', freq: '153.785', key: 'air' },
+    cknw: { label: 'CKNW 980', freq: '980.000', key: 'cknw', stream: true }
   };
 
   var VOICE_PREFS = [

--- a/js/home-yvr-broadcaster.js
+++ b/js/home-yvr-broadcaster.js
@@ -333,7 +333,7 @@
 
   HomeYvrBroadcaster.prototype.setTelepromptStandby = function () {
     this.renderMeta(null);
-    this.renderScript('Pick a channel. Words light up as CHIP talks.', 'plain');
+    this.renderScript('Pick a channel. Dave narrates. Words light up.', 'plain');
     if (this.telepromptRoot) {
       this.telepromptRoot.classList.remove('is-live', 'is-radio');
     }
@@ -545,7 +545,7 @@
         link_label: 'cknw.com'
       }]
     });
-    this.renderScript('Live CKNW 980 — Vancouver AM radio. Computer voice channels are on the buttons below. Hit STOP to silence.', 'plain');
+    this.renderScript('Live CKNW 980 — Vancouver AM radio. Dave goes quiet — hit STOP to silence.', 'plain');
     if (this.telepromptRoot) {
       this.telepromptRoot.classList.add('is-live', 'is-radio');
     }

--- a/page-home.php
+++ b/page-home.php
@@ -35,7 +35,7 @@ get_header();
                             </div>
                             <span class="home-yvr-broadcaster__freq pixel-font" data-broadcaster-freq>000.000</span>
                         </div>
-                        <p class="home-yvr-broadcaster__legend"><?php echo esc_html( 'Live Lower Mainland feeds. Dave reads the script — 980 is real radio.' ); ?></p>
+                        <p class="home-yvr-broadcaster__legend"><?php echo esc_html( 'Free public feeds only — no API keys. Dave reads scripts; 980 is live radio.' ); ?></p>
                         <div class="home-yvr-broadcaster__crt" data-broadcaster-teleprompt>
                             <ul class="home-yvr-teleprompt__meta" data-broadcaster-meta hidden></ul>
                             <p class="home-yvr-teleprompt__script" data-broadcaster-script><?php echo esc_html( 'Pick a channel. Dave narrates. Words light up.' ); ?></p>
@@ -54,10 +54,6 @@ get_header();
                                     <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'SkyTrain' ); ?></span>
                                     <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'TransLink service alerts' ); ?></span>
                                 </button>
-                                <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="cknw" aria-pressed="false">
-                                    <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'CKNW 980' ); ?></span>
-                                    <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'Live Vancouver AM radio' ); ?></span>
-                                </button>
                                 <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="drivers" aria-pressed="false">
                                     <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'DriveBC' ); ?></span>
                                     <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'Road incidents & closures' ); ?></span>
@@ -65,6 +61,22 @@ get_header();
                                 <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="ferries" aria-pressed="false">
                                     <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'BC Ferries' ); ?></span>
                                     <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'Sailings & car deck fill' ); ?></span>
+                                </button>
+                                <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="weather" aria-pressed="false">
+                                    <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'Weather' ); ?></span>
+                                    <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'Environment Canada warnings' ); ?></span>
+                                </button>
+                                <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="wildfire" aria-pressed="false">
+                                    <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'Wildfire' ); ?></span>
+                                    <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'Active fires — SW BC corridor' ); ?></span>
+                                </button>
+                                <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="air" aria-pressed="false">
+                                    <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'Air quality' ); ?></span>
+                                    <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'Metro AQHI — EC, free' ); ?></span>
+                                </button>
+                                <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="cknw" aria-pressed="false">
+                                    <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'CKNW 980' ); ?></span>
+                                    <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'Live Vancouver AM radio' ); ?></span>
                                 </button>
                             </div>
                             <button type="button" class="home-yvr-broadcaster__btn home-yvr-broadcaster__stop pixel-font" data-broadcaster-stop aria-label="<?php echo esc_attr( 'Stop audio' ); ?>"><?php echo esc_html( 'STOP' ); ?></button>

--- a/page-home.php
+++ b/page-home.php
@@ -11,21 +11,21 @@ get_header();
                 <p class="home-yvr-rack__kicker pixel-font"><?php echo esc_html( 'live feeds // yvr' ); ?></p>
                 <div class="home-yvr-broadcaster" data-yvr-broadcaster aria-label="<?php echo esc_attr( 'YVR broadcaster — live feeds and radio' ); ?>">
                     <div class="home-yvr-broadcaster__avatar" data-broadcaster-face aria-hidden="true">
-                        <div class="home-yvr-broadcaster__avatar-frame">
-                            <div class="home-yvr-broadcaster__avatar-hair"></div>
-                            <div class="home-yvr-broadcaster__avatar-head">
-                                <div class="home-yvr-broadcaster__avatar-visor">
-                                    <span class="home-yvr-broadcaster__eye"></span>
-                                    <span class="home-yvr-broadcaster__eye"></span>
+                        <div class="home-yvr-broadcaster__avatar-frame home-yvr-broadcaster__pigeon">
+                            <div class="home-yvr-broadcaster__pigeon-tail"></div>
+                            <div class="home-yvr-broadcaster__pigeon-body"></div>
+                            <div class="home-yvr-broadcaster__pigeon-wing"></div>
+                            <div class="home-yvr-broadcaster__pigeon-head">
+                                <span class="home-yvr-broadcaster__eye"></span>
+                                <div class="home-yvr-broadcaster__pigeon-beak">
+                                    <span class="home-yvr-broadcaster__pigeon-beak-top"></span>
+                                    <span class="home-yvr-broadcaster__mouth" data-broadcaster-mouth></span>
                                 </div>
-                                <div class="home-yvr-broadcaster__mouth" data-broadcaster-mouth></div>
                             </div>
-                            <div class="home-yvr-broadcaster__avatar-headset home-yvr-broadcaster__avatar-headset--l"></div>
-                            <div class="home-yvr-broadcaster__avatar-headset home-yvr-broadcaster__avatar-headset--r"></div>
-                            <div class="home-yvr-broadcaster__avatar-mic"></div>
+                            <div class="home-yvr-broadcaster__pigeon-mic" aria-hidden="true"></div>
                         </div>
-                        <p class="home-yvr-broadcaster__avatar-name pixel-font"><?php echo esc_html( 'CHIP' ); ?></p>
-                        <p class="home-yvr-broadcaster__avatar-tag"><?php echo esc_html( 'on-air bot' ); ?></p>
+                        <p class="home-yvr-broadcaster__avatar-name pixel-font"><?php echo esc_html( 'DAVE' ); ?></p>
+                        <p class="home-yvr-broadcaster__avatar-tag"><?php echo esc_html( 'yvr pigeon // broadcaster' ); ?></p>
                     </div>
                     <div class="home-yvr-broadcaster__body">
                         <div class="home-yvr-broadcaster__header">
@@ -35,10 +35,10 @@ get_header();
                             </div>
                             <span class="home-yvr-broadcaster__freq pixel-font" data-broadcaster-freq>000.000</span>
                         </div>
-                        <p class="home-yvr-broadcaster__legend"><?php echo esc_html( 'Live Lower Mainland feeds. CHIP reads scripts aloud — 980 is real radio.' ); ?></p>
+                        <p class="home-yvr-broadcaster__legend"><?php echo esc_html( 'Live Lower Mainland feeds. Dave reads the script — 980 is real radio.' ); ?></p>
                         <div class="home-yvr-broadcaster__crt" data-broadcaster-teleprompt>
                             <ul class="home-yvr-teleprompt__meta" data-broadcaster-meta hidden></ul>
-                            <p class="home-yvr-teleprompt__script" data-broadcaster-script><?php echo esc_html( 'Pick a channel. Words light up as CHIP talks.' ); ?></p>
+                            <p class="home-yvr-teleprompt__script" data-broadcaster-script><?php echo esc_html( 'Pick a channel. Dave narrates. Words light up.' ); ?></p>
                             <div class="home-yvr-broadcaster__crt-scan" aria-hidden="true"></div>
                         </div>
                         <div class="home-yvr-broadcaster__deck">

--- a/page-home.php
+++ b/page-home.php
@@ -10,38 +10,32 @@ get_header();
             <div class="home-yvr-rack">
                 <p class="home-yvr-rack__kicker pixel-font"><?php echo esc_html( 'live feeds // yvr' ); ?></p>
                 <div class="home-yvr-broadcaster" data-yvr-broadcaster aria-label="<?php echo esc_attr( 'YVR broadcaster — live feeds and radio' ); ?>">
-                    <div class="home-yvr-broadcaster__avatar" data-broadcaster-face aria-hidden="true">
-                        <div class="home-yvr-broadcaster__avatar-frame home-yvr-broadcaster__pigeon">
-                            <div class="home-yvr-broadcaster__pigeon-tail"></div>
-                            <div class="home-yvr-broadcaster__pigeon-body"></div>
-                            <div class="home-yvr-broadcaster__pigeon-wing"></div>
-                            <div class="home-yvr-broadcaster__pigeon-head">
-                                <span class="home-yvr-broadcaster__eye"></span>
-                                <div class="home-yvr-broadcaster__pigeon-beak">
-                                    <span class="home-yvr-broadcaster__pigeon-beak-top"></span>
-                                    <span class="home-yvr-broadcaster__mouth" data-broadcaster-mouth></span>
+                    <div class="home-yvr-broadcaster__mast">
+                        <div class="home-yvr-broadcaster__avatar" data-broadcaster-face aria-hidden="true">
+                            <div class="home-yvr-broadcaster__avatar-frame home-yvr-broadcaster__pigeon">
+                                <div class="home-yvr-broadcaster__pigeon-tail"></div>
+                                <div class="home-yvr-broadcaster__pigeon-body"></div>
+                                <div class="home-yvr-broadcaster__pigeon-wing"></div>
+                                <div class="home-yvr-broadcaster__pigeon-head">
+                                    <span class="home-yvr-broadcaster__eye"></span>
+                                    <div class="home-yvr-broadcaster__pigeon-beak">
+                                        <span class="home-yvr-broadcaster__pigeon-beak-top"></span>
+                                        <span class="home-yvr-broadcaster__mouth" data-broadcaster-mouth></span>
+                                    </div>
                                 </div>
+                                <div class="home-yvr-broadcaster__pigeon-mic" aria-hidden="true"></div>
                             </div>
-                            <div class="home-yvr-broadcaster__pigeon-mic" aria-hidden="true"></div>
+                            <p class="home-yvr-broadcaster__avatar-name pixel-font"><?php echo esc_html( 'DAVE' ); ?></p>
                         </div>
-                        <p class="home-yvr-broadcaster__avatar-name pixel-font"><?php echo esc_html( 'DAVE' ); ?></p>
-                        <p class="home-yvr-broadcaster__avatar-tag"><?php echo esc_html( 'yvr pigeon // broadcaster' ); ?></p>
-                    </div>
-                    <div class="home-yvr-broadcaster__body">
-                        <div class="home-yvr-broadcaster__header">
-                            <div class="home-yvr-broadcaster__status">
+                        <div class="home-yvr-broadcaster__mast-info">
+                            <div class="home-yvr-broadcaster__header">
                                 <span class="home-yvr-broadcaster__badge pixel-font"><?php echo esc_html( 'YVR BCAST' ); ?></span>
-                                <span class="home-yvr-broadcaster__channel pixel-font" data-broadcaster-channel><?php echo esc_html( 'STANDBY' ); ?></span>
+                                <span class="home-yvr-broadcaster__on-air" role="status" aria-live="polite">
+                                    <span class="home-yvr-broadcaster__led" aria-hidden="true"></span>
+                                    <span class="home-yvr-broadcaster__channel pixel-font" data-broadcaster-channel><?php echo esc_html( 'STANDBY' ); ?></span>
+                                </span>
+                                <span class="home-yvr-broadcaster__freq pixel-font" data-broadcaster-freq>000.000</span>
                             </div>
-                            <span class="home-yvr-broadcaster__freq pixel-font" data-broadcaster-freq>000.000</span>
-                        </div>
-                        <p class="home-yvr-broadcaster__legend"><?php echo esc_html( 'Free public feeds only — no API keys. Dave reads scripts; 980 is live radio.' ); ?></p>
-                        <div class="home-yvr-broadcaster__crt" data-broadcaster-teleprompt>
-                            <ul class="home-yvr-teleprompt__meta" data-broadcaster-meta hidden></ul>
-                            <p class="home-yvr-teleprompt__script" data-broadcaster-script><?php echo esc_html( 'Pick a channel. Dave narrates. Words light up.' ); ?></p>
-                            <div class="home-yvr-broadcaster__crt-scan" aria-hidden="true"></div>
-                        </div>
-                        <div class="home-yvr-broadcaster__deck">
                             <div class="home-yvr-broadcaster__bars" aria-hidden="true">
                                 <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
                                 <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
@@ -49,39 +43,50 @@ get_header();
                                 <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
                                 <span class="home-yvr-broadcaster__bar" data-broadcaster-bar></span>
                             </div>
-                            <div class="home-yvr-broadcaster__channels">
-                                <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="translink" aria-pressed="false">
-                                    <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'SkyTrain' ); ?></span>
-                                    <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'TransLink service alerts' ); ?></span>
-                                </button>
-                                <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="drivers" aria-pressed="false">
-                                    <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'DriveBC' ); ?></span>
-                                    <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'Road incidents & closures' ); ?></span>
-                                </button>
-                                <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="ferries" aria-pressed="false">
-                                    <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'BC Ferries' ); ?></span>
-                                    <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'Sailings & car deck fill' ); ?></span>
-                                </button>
-                                <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="weather" aria-pressed="false">
-                                    <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'Weather' ); ?></span>
-                                    <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'Environment Canada warnings' ); ?></span>
-                                </button>
-                                <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="wildfire" aria-pressed="false">
-                                    <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'Wildfire' ); ?></span>
-                                    <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'Active fires — SW BC corridor' ); ?></span>
-                                </button>
-                                <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="air" aria-pressed="false">
-                                    <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'Air quality' ); ?></span>
-                                    <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'Metro AQHI — EC, free' ); ?></span>
-                                </button>
-                                <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="cknw" aria-pressed="false">
-                                    <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'CKNW 980' ); ?></span>
-                                    <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'Live Vancouver AM radio' ); ?></span>
-                                </button>
-                            </div>
-                            <button type="button" class="home-yvr-broadcaster__btn home-yvr-broadcaster__stop pixel-font" data-broadcaster-stop aria-label="<?php echo esc_attr( 'Stop audio' ); ?>"><?php echo esc_html( 'STOP' ); ?></button>
                         </div>
                     </div>
+                    <div class="home-yvr-broadcaster__crt" data-broadcaster-teleprompt>
+                        <ul class="home-yvr-teleprompt__meta" data-broadcaster-meta hidden></ul>
+                        <p class="home-yvr-teleprompt__script" data-broadcaster-script><?php echo esc_html( 'Pick a feed below. Dave narrates — words light up.' ); ?></p>
+                        <div class="home-yvr-broadcaster__crt-scan" aria-hidden="true"></div>
+                    </div>
+                    <div class="home-yvr-broadcaster__feeds">
+                        <p class="home-yvr-broadcaster__feeds-label pixel-font"><?php echo esc_html( 'pick a feed' ); ?></p>
+                        <div class="home-yvr-broadcaster__channels">
+                            <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="translink" aria-pressed="false">
+                                <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'SkyTrain' ); ?></span>
+                                <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'TransLink alerts' ); ?></span>
+                            </button>
+                            <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="drivers" aria-pressed="false">
+                                <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'DriveBC' ); ?></span>
+                                <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'Road incidents' ); ?></span>
+                            </button>
+                            <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="ferries" aria-pressed="false">
+                                <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'BC Ferries' ); ?></span>
+                                <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'Sailings & fill' ); ?></span>
+                            </button>
+                            <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="weather" aria-pressed="false">
+                                <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'Weather' ); ?></span>
+                                <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'EC warnings' ); ?></span>
+                            </button>
+                            <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="wildfire" aria-pressed="false">
+                                <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'Wildfire' ); ?></span>
+                                <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'SW BC fires' ); ?></span>
+                            </button>
+                            <button type="button" class="home-yvr-broadcaster__ch" data-broadcaster-channel-btn="air" aria-pressed="false">
+                                <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'Air quality' ); ?></span>
+                                <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'Metro AQHI' ); ?></span>
+                            </button>
+                            <button type="button" class="home-yvr-broadcaster__ch home-yvr-broadcaster__ch--radio" data-broadcaster-channel-btn="cknw" aria-pressed="false">
+                                <span class="home-yvr-broadcaster__ch-label pixel-font"><?php echo esc_html( 'CKNW 980' ); ?></span>
+                                <span class="home-yvr-broadcaster__ch-hint"><?php echo esc_html( 'Live radio' ); ?></span>
+                            </button>
+                        </div>
+                    </div>
+                    <button type="button" class="home-yvr-broadcaster__btn home-yvr-broadcaster__stop pixel-font" data-broadcaster-stop aria-label="<?php echo esc_attr( 'Stop audio' ); ?>">
+                        <span class="home-yvr-broadcaster__stop-label"><?php echo esc_html( 'STOP' ); ?></span>
+                        <span class="home-yvr-broadcaster__stop-hint"><?php echo esc_html( 'silence dave' ); ?></span>
+                    </button>
                     <p class="home-yvr-broadcaster__caption" data-broadcaster-caption hidden></p>
                     <audio data-broadcaster-audio preload="none" crossorigin="anonymous"></audio>
                 </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Click fix**: `pointer-events` on the hero backdrop was swallowing broadcaster controls.
- **UX overhaul**: Player layout is now a vertical stack — Dave mast row, CRT teleprompter, full-width single-column feed list, slim STOP bar.
- **Status LED**: STANDBY is no longer a pill button; a small LED + label shows on-air state (green = narrating, yellow = CKNW radio).
- **Legibility**: Larger teleprompter text and feed row labels/hints; removed cramped 2-column scroll grid.
- **Dave**: Pigeon avatar with word-synced beak animation; auto-mute back to STANDBY after TTS ends.
- **Feeds** (all free public APIs): SkyTrain, DriveBC, BC Ferries, EC weather, wildfire, Metro AQHI, CKNW 980 live radio.

## Test plan

- [ ] Click each feed — Dave narrates, words highlight in CRT
- [ ] CKNW plays live radio, beak flaps
- [ ] STOP silences and returns to STANDBY
- [ ] Feed rows readable without scrolling on desktop/mobile
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24402609-4a4a-4d1b-8083-fa2f9483c210?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24402609-4a4a-4d1b-8083-fa2f9483c210&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

