### PR TITLE
Fix email alerts + manual production deploy workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -4,6 +4,17 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      deploy_target:
+        description: What to deploy to production
+        required: true
+        default: both
+        type: choice
+        options:
+          - both
+          - theme
+          - plugin
 
 permissions:
   contents: read
@@ -12,12 +23,14 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      theme: ${{ steps.filter.outputs.theme }}
-      plugin: ${{ steps.filter.outputs.plugin }}
+      theme: ${{ steps.resolve.outputs.theme }}
+      plugin: ${{ steps.resolve.outputs.plugin }}
     steps:
       - uses: actions/checkout@v4
+
       - uses: dorny/paths-filter@v3
         id: filter
+        if: github.event_name == 'push'
         with:
           filters: |
             theme:
@@ -39,6 +52,28 @@ jobs:
               - 'dist/lousy-outages.zip.sha256'
               - 'dist/release-manifest.json'
               - 'scripts/build-lousy-outages-release.sh'
+
+      - id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            case "${{ inputs.deploy_target }}" in
+              theme)
+                echo "theme=true" >> "$GITHUB_OUTPUT"
+                echo "plugin=false" >> "$GITHUB_OUTPUT"
+                ;;
+              plugin)
+                echo "theme=false" >> "$GITHUB_OUTPUT"
+                echo "plugin=true" >> "$GITHUB_OUTPUT"
+                ;;
+              *)
+                echo "theme=true" >> "$GITHUB_OUTPUT"
+                echo "plugin=true" >> "$GITHUB_OUTPUT"
+                ;;
+            esac
+          else
+            echo "theme=${{ steps.filter.outputs.theme }}" >> "$GITHUB_OUTPUT"
+            echo "plugin=${{ steps.filter.outputs.plugin }}" >> "$GITHUB_OUTPUT"
+          fi
 
   deploy:
     needs: changes


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Email alert fix (0.5.7)

Episodes imported during the episode-store migration were permanently `legacy_suppressed`, so alerts never sent even when no email had been delivered. Fixed in plugin 0.5.7.

## Manual production deploy

Added `workflow_dispatch` to **Deploy to Production**:

1. GitHub → **Actions** → **Deploy to Production** → **Run workflow**
2. Pick branch (usually `main`)
3. Choose deploy target: `both`, `theme`, or `plugin`

Manual runs deploy exactly what you select. Push to `main` still uses path filters.

## Test plan

- [ ] Run workflow manually with `plugin` after merge
- [ ] Send test alert from WP Admin
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24402609-4a4a-4d1b-8083-fa2f9483c210?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24402609-4a4a-4d1b-8083-fa2f9483c210&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

