### PR TITLE
Fix GitHub Actions deploy: verify SSH secrets before SFTP

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -79,8 +79,29 @@ jobs:
     needs: changes
     if: needs.changes.outputs.theme == 'true' || needs.changes.outputs.plugin == 'true'
     runs-on: ubuntu-latest
+    env:
+      LOUSY_SSH_HOST: ${{ secrets.LOUSY_SSH_HOST }}
+      LOUSY_SSH_PORT: ${{ secrets.LOUSY_SSH_PORT }}
+      LOUSY_SSH_USER: ${{ secrets.LOUSY_SSH_USER }}
+      LOUSY_SSH_PASSWORD: ${{ secrets.LOUSY_SSH_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Verify deploy secrets are configured
+        run: |
+          missing=()
+          [ -z "$LOUSY_SSH_HOST" ] && missing+=("LOUSY_SSH_HOST")
+          [ -z "$LOUSY_SSH_USER" ] && missing+=("LOUSY_SSH_USER")
+          [ -z "$LOUSY_SSH_PASSWORD" ] && missing+=("LOUSY_SSH_PASSWORD")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error title=Missing deploy secrets::GitHub Actions cannot read .env.deploy.local. Add repository secrets: ${missing[*]}."
+            echo "Go to: Settings → Secrets and variables → Actions → New repository secret"
+            echo "Use the same values as your local .env.deploy.local (see docs/deploy-production.md)."
+            exit 1
+          fi
+          if [ -z "$LOUSY_SSH_PORT" ]; then
+            echo "LOUSY_SSH_PORT=22" >> "$GITHUB_ENV"
+          fi
 
       - uses: actions/setup-python@v5
         with:
@@ -98,18 +119,8 @@ jobs:
 
       - name: Deploy theme files
         if: needs.changes.outputs.theme == 'true'
-        env:
-          LOUSY_SSH_HOST: ${{ secrets.LOUSY_SSH_HOST }}
-          LOUSY_SSH_PORT: ${{ secrets.LOUSY_SSH_PORT }}
-          LOUSY_SSH_USER: ${{ secrets.LOUSY_SSH_USER }}
-          LOUSY_SSH_PASSWORD: ${{ secrets.LOUSY_SSH_PASSWORD }}
         run: python3 scripts/deploy-lousy-outages-ssh.py --theme
 
       - name: Deploy Lousy Outages plugin
         if: needs.changes.outputs.plugin == 'true'
-        env:
-          LOUSY_SSH_HOST: ${{ secrets.LOUSY_SSH_HOST }}
-          LOUSY_SSH_PORT: ${{ secrets.LOUSY_SSH_PORT }}
-          LOUSY_SSH_USER: ${{ secrets.LOUSY_SSH_USER }}
-          LOUSY_SSH_PASSWORD: ${{ secrets.LOUSY_SSH_PASSWORD }}
         run: python3 scripts/deploy-lousy-outages-ssh.py --plugin

--- a/docs/deploy-production.md
+++ b/docs/deploy-production.md
@@ -32,6 +32,23 @@ In the repo: **Settings → Secrets and variables → Actions → New repository
 
 These match the local-only file `.env.deploy.local` (never commit that file).
 
+**Important:** GitHub Actions does **not** read `.env.deploy.local`. If deploy fails with “Missing deploy credentials”, the secrets above are not set in GitHub yet — earlier workflow runs may have “succeeded” only because no theme/plugin paths changed and the deploy job was skipped.
+
+## Troubleshooting
+
+### `Missing deploy credentials` on GitHub Actions
+
+1. Open the repo on GitHub → **Settings** → **Secrets and variables** → **Actions**
+2. Create repository secrets (names must match exactly):
+   - `LOUSY_SSH_HOST`
+   - `LOUSY_SSH_PORT` (optional; defaults to `22`)
+   - `LOUSY_SSH_USER`
+   - `LOUSY_SSH_PASSWORD`
+3. Copy values from your local `.env.deploy.local`
+4. Re-run the failed workflow (Actions → Deploy to Production → Re-run jobs) or push again
+
+Local deploys from Cursor/cloud agents can still work via `.env.deploy.local` even when GitHub Actions fails.
+
 ## Local deploy (same script)
 
 ```bash

--- a/docs/deploy-production.md
+++ b/docs/deploy-production.md
@@ -32,6 +32,14 @@ In the repo: **Settings → Secrets and variables → Actions → New repository
 
 These match the local-only file `.env.deploy.local` (never commit that file).
 
+From a machine with `gh` logged in as a repo admin:
+
+```bash
+cp scripts/env.deploy.example .env.deploy.local   # if needed
+# edit .env.deploy.local with your hosting panel values
+./scripts/setup-github-deploy-secrets.sh
+```
+
 **Important:** GitHub Actions does **not** read `.env.deploy.local`. If deploy fails with “Missing deploy credentials”, the secrets above are not set in GitHub yet — earlier workflow runs may have “succeeded” only because no theme/plugin paths changed and the deploy job was skipped.
 
 ## Troubleshooting

--- a/scripts/deploy-lousy-outages-ssh.py
+++ b/scripts/deploy-lousy-outages-ssh.py
@@ -65,9 +65,14 @@ def load_env(path: Path) -> dict:
             k, v = line.split("=", 1)
             data.setdefault(k.strip(), v.strip())
     if not data.get("LOUSY_SSH_HOST") or not data.get("LOUSY_SSH_USER") or not data.get("LOUSY_SSH_PASSWORD"):
+        hint = (
+            "For GitHub Actions, add LOUSY_SSH_* as repository secrets "
+            "(Settings → Secrets and variables → Actions). "
+            "See docs/deploy-production.md."
+        )
         raise SystemExit(
             f"Missing deploy credentials. Set {', '.join(DEPLOY_ENV_KEYS)} in the environment "
-            f"or in {path}."
+            f"or in {path}. {hint}"
         )
     return data
 

--- a/scripts/env.deploy.example
+++ b/scripts/env.deploy.example
@@ -1,0 +1,10 @@
+# Copy to repo-root .env.deploy.local and fill in hosting SFTP/SSH credentials.
+# Never commit .env.deploy.local — it is gitignored.
+#
+# For GitHub Actions deploys, add the same four values as repository secrets
+# or run: ./scripts/setup-github-deploy-secrets.sh (local gh admin required)
+#
+LOUSY_SSH_HOST=
+LOUSY_SSH_PORT=22
+LOUSY_SSH_USER=
+LOUSY_SSH_PASSWORD=

--- a/scripts/setup-github-deploy-secrets-interactive.ps1
+++ b/scripts/setup-github-deploy-secrets-interactive.ps1
@@ -1,0 +1,39 @@
+# One-time setup: GitHub Actions deploy secrets (run on YOUR Windows PC in PowerShell).
+# Prerequisites: winget install GitHub.cli   then   gh auth login   (login as suzyeaston)
+#
+# Usage: cd to your suzyeastonca repo, then:
+#   powershell -ExecutionPolicy Bypass -File scripts\setup-github-deploy-secrets-interactive.ps1
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    Write-Host "Install GitHub CLI first: winget install GitHub.cli"
+    Write-Host "Then run: gh auth login"
+    exit 1
+}
+
+$auth = gh auth status 2>&1
+if ($auth -match "not logged in") {
+    Write-Host "Run: gh auth login"
+    exit 1
+}
+
+Write-Host "Enter SFTP credentials from your hosting panel (same as cPanel SFTP & SSH Access)."
+$host = Read-Host "LOUSY_SSH_HOST"
+$port = Read-Host "LOUSY_SSH_PORT (e.g. 27)"
+$user = Read-Host "LOUSY_SSH_USER"
+$pass = Read-Host "LOUSY_SSH_PASSWORD" -AsSecureString
+$bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($pass)
+$passPlain = [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
+
+$repo = gh repo view --json nameWithOwner -q .nameWithOwner
+Write-Host "Setting secrets on $repo ..."
+
+gh secret set LOUSY_SSH_HOST --body $host
+gh secret set LOUSY_SSH_PORT --body $port
+gh secret set LOUSY_SSH_USER --body $user
+gh secret set LOUSY_SSH_PASSWORD --body $passPlain
+
+Write-Host ""
+Write-Host "Done. Open GitHub -> Actions -> Deploy to Production -> Run workflow (main, both)."
+Write-Host "Or Re-run any failed deploy job."

--- a/scripts/setup-github-deploy-secrets.ps1
+++ b/scripts/setup-github-deploy-secrets.ps1
@@ -1,0 +1,39 @@
+# Push LOUSY_SSH_* from .env.deploy.local to GitHub Actions repository secrets.
+# Run in PowerShell from the repo root after: gh auth login
+param()
+
+$ErrorActionPreference = "Stop"
+$Root = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+if (Test-Path (Join-Path $PSScriptRoot "..")) {
+    $Root = Resolve-Path (Join-Path $PSScriptRoot "..")
+}
+$EnvFile = Join-Path $Root ".env.deploy.local"
+
+if (-not (Test-Path $EnvFile)) {
+    Write-Error "Missing $EnvFile — copy scripts/env.deploy.example to .env.deploy.local and fill in credentials."
+}
+
+Get-Content $EnvFile | ForEach-Object {
+    $line = $_.Trim()
+    if ($line -and -not $line.StartsWith("#") -and $line.Contains("=")) {
+        $parts = $line.Split("=", 2)
+        $name = $parts[0].Trim()
+        $value = $parts[1].Trim()
+        Set-Item -Path "env:$name" -Value $value
+    }
+}
+
+$required = @("LOUSY_SSH_HOST", "LOUSY_SSH_PORT", "LOUSY_SSH_USER", "LOUSY_SSH_PASSWORD")
+foreach ($key in $required) {
+    if (-not $env:$key) {
+        Write-Error "Missing $key in $EnvFile"
+    }
+}
+
+$repo = gh repo view --json nameWithOwner -q .nameWithOwner
+Write-Host "Setting GitHub Actions secrets for $repo..."
+gh secret set LOUSY_SSH_HOST --body $env:LOUSY_SSH_HOST
+gh secret set LOUSY_SSH_PORT --body $env:LOUSY_SSH_PORT
+gh secret set LOUSY_SSH_USER --body $env:LOUSY_SSH_USER
+gh secret set LOUSY_SSH_PASSWORD --body $env:LOUSY_SSH_PASSWORD
+Write-Host "Done. Re-run Deploy to Production in GitHub Actions."

--- a/scripts/setup-github-deploy-secrets.sh
+++ b/scripts/setup-github-deploy-secrets.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Push LOUSY_SSH_* from .env.deploy.local to GitHub Actions repository secrets.
+# Run locally after: gh auth login (needs repo admin / secrets permission).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="$ROOT/.env.deploy.local"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Missing $ENV_FILE — copy scripts/env.deploy.example to .env.deploy.local and fill in credentials." >&2
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+for key in LOUSY_SSH_HOST LOUSY_SSH_PORT LOUSY_SSH_USER LOUSY_SSH_PASSWORD; do
+  val="${!key:-}"
+  if [[ -z "$val" ]]; then
+    echo "Missing $key in $ENV_FILE" >&2
+    exit 1
+  fi
+done
+
+echo "Setting GitHub Actions secrets for $(gh repo view --json nameWithOwner -q .nameWithOwner)..."
+gh secret set LOUSY_SSH_HOST --body "$LOUSY_SSH_HOST"
+gh secret set LOUSY_SSH_PORT --body "$LOUSY_SSH_PORT"
+gh secret set LOUSY_SSH_USER --body "$LOUSY_SSH_USER"
+gh secret set LOUSY_SSH_PASSWORD --body "$LOUSY_SSH_PASSWORD"
+echo "Done. Re-run Deploy to Production in GitHub Actions."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Deploy to Production failed because GitHub Actions cannot read `.env.deploy.local`.

## Changes

- Verify secrets before SFTP with clear error message
- `scripts/env.deploy.example` — template (no real creds)
- `scripts/setup-github-deploy-secrets.sh` — push `.env.deploy.local` to GitHub via `gh` (run locally as repo admin)

## GitHub secrets (required once)

Cloud agents cannot set repository secrets (API 403). **Repo owner** must either:

**Option A — script (from your laptop, with `gh auth login`):**
```bash
# .env.deploy.local already has your hosting creds locally
./scripts/setup-github-deploy-secrets.sh
```

**Option B — GitHub UI:** Settings → Secrets and variables → Actions → add `LOUSY_SSH_HOST`, `LOUSY_SSH_PORT`, `LOUSY_SSH_USER`, `LOUSY_SSH_PASSWORD` (same values as hosting SFTP panel).

Then re-run **Deploy to Production**.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24402609-4a4a-4d1b-8083-fa2f9483c210?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24402609-4a4a-4d1b-8083-fa2f9483c210&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

