### PR TITLE
Polish wildfire feed ranking and deploy SSH timeout

### DIFF
--- a/inc/home-yvr-broadcaster.php
+++ b/inc/home-yvr-broadcaster.php
@@ -488,6 +488,9 @@ function se_broadcaster_weather_script(): array {
 function se_broadcaster_wildfire_status_rank( string $status ): int {
     $status = strtolower( $status );
     if ( str_contains( $status, 'out of control' ) ) {
+        return 4;
+    }
+    if ( str_contains( $status, 'fire of note' ) ) {
         return 3;
     }
     if ( str_contains( $status, 'being held' ) ) {
@@ -497,6 +500,18 @@ function se_broadcaster_wildfire_status_rank( string $status ): int {
         return 1;
     }
     return 0;
+}
+
+function se_broadcaster_wildfire_name( array $row ): string {
+    $geo = wp_strip_all_tags( (string) ( $row['GEOGRAPHIC_DESCRIPTION'] ?? '' ) );
+    $inc = wp_strip_all_tags( (string) ( $row['INCIDENT_NAME'] ?? '' ) );
+    if ( $geo ) {
+        return $geo;
+    }
+    if ( $inc && ! preg_match( '/^V\d+$/i', $inc ) ) {
+        return $inc;
+    }
+    return $inc ? 'BC wildfire ' . $inc : 'BC wildfire';
 }
 
 function se_fetch_bc_wildfire_near_yvr(): array {
@@ -527,8 +542,11 @@ function se_fetch_bc_wildfire_near_yvr(): array {
     );
 
     if ( is_wp_error( $response ) || (int) wp_remote_retrieve_response_code( $response ) !== 200 ) {
+        set_transient( 'se_bc_wildfire_near_yvr_error', 1, 2 * MINUTE_IN_SECONDS );
         return array();
     }
+
+    delete_transient( 'se_bc_wildfire_near_yvr_error' );
 
     $body = json_decode( wp_remote_retrieve_body( $response ), true );
     if ( ! is_array( $body ) || empty( $body['features'] ) || ! is_array( $body['features'] ) ) {
@@ -545,7 +563,7 @@ function se_fetch_bc_wildfire_near_yvr(): array {
         if ( ! is_array( $row ) ) {
             continue;
         }
-        $name   = wp_strip_all_tags( (string) ( $row['GEOGRAPHIC_DESCRIPTION'] ?? $row['INCIDENT_NAME'] ?? 'BC wildfire' ) );
+        $name   = se_broadcaster_wildfire_name( $row );
         $status = wp_strip_all_tags( (string) ( $row['FIRE_STATUS'] ?? '' ) );
         $size   = isset( $row['CURRENT_SIZE'] ) ? (float) $row['CURRENT_SIZE'] : 0;
         $url    = esc_url_raw( (string) ( $row['FIRE_URL'] ?? 'https://wildfiresituation.nrs.gov.bc.ca/map' ) );
@@ -570,17 +588,23 @@ function se_fetch_bc_wildfire_near_yvr(): array {
         );
     }
 
-    $out = se_broadcaster_prioritize_recent( $out, 'posted', 120 );
-
+    // Urgency first, then largest active fires, then newest ignition.
     usort(
         $out,
         static function ( array $a, array $b ): int {
+            $ra = (int) ( $a['status_rank'] ?? 0 );
+            $rb = (int) ( $b['status_rank'] ?? 0 );
+            if ( $rb !== $ra ) {
+                return $rb <=> $ra;
+            }
+            $sa = (float) ( $a['size'] ?? 0 );
+            $sb = (float) ( $b['size'] ?? 0 );
+            if ( $sb !== $sa ) {
+                return $sb <=> $sa;
+            }
             $ta = strtotime( (string) ( $a['posted'] ?? '' ) ) ?: 0;
             $tb = strtotime( (string) ( $b['posted'] ?? '' ) ) ?: 0;
-            if ( $tb !== $ta ) {
-                return $tb <=> $ta;
-            }
-            return ( $b['status_rank'] ?? 0 ) <=> ( $a['status_rank'] ?? 0 );
+            return $tb <=> $ta;
         }
     );
 
@@ -591,6 +615,17 @@ function se_fetch_bc_wildfire_near_yvr(): array {
 function se_broadcaster_wildfire_script(): array {
     $fires = se_fetch_bc_wildfire_near_yvr();
     if ( ! $fires ) {
+        if ( get_transient( 'se_bc_wildfire_near_yvr_error' ) ) {
+            return array(
+                'caption'       => 'BC Wildfire feed temporarily unavailable.',
+                'script'        => 'BC Wildfire Service data did not load. Try again in a minute.',
+                'source'        => 'BC Wildfire Service',
+                'source_url'    => 'https://wildfiresituation.nrs.gov.bc.ca/map',
+                'items'         => array(),
+                'fetched_label' => 'Pulled ' . wp_date( 'M j, Y g:i a T' ),
+            );
+        }
+
         return array(
             'caption'       => 'No active wildfires in southwest Coastal Fire Centre.',
             'script'        => 'BC Wildfire Service shows no active fires in the southwest Coastal corridor right now.',
@@ -621,7 +656,7 @@ function se_broadcaster_wildfire_script(): array {
 
     return se_broadcaster_pack_from_items(
         $items,
-        'BC Wildfire update for southwest Coastal Fire Centre. ',
+        'BC Wildfire — southwest coast. ',
         'BC Wildfire Service',
         'https://wildfiresituation.nrs.gov.bc.ca/map'
     );
@@ -735,6 +770,7 @@ function se_get_broadcaster_feeds_rest( WP_REST_Request $request ): WP_REST_Resp
         delete_transient( 'se_bc_ferries_capacity' );
         delete_transient( 'se_ec_weather_alerts' );
         delete_transient( 'se_bc_wildfire_near_yvr' );
+        delete_transient( 'se_bc_wildfire_near_yvr_error' );
         delete_transient( 'se_ec_aqhi_metro' );
     }
 

--- a/scripts/deploy-lousy-outages-ssh.py
+++ b/scripts/deploy-lousy-outages-ssh.py
@@ -140,7 +140,7 @@ def main() -> None:
         port=int(env.get("LOUSY_SSH_PORT", "22")),
         username=env.get("LOUSY_SSH_USER", ""),
         password=env.get("LOUSY_SSH_PASSWORD", ""),
-        timeout=30,
+        timeout=60,
     )
     sftp = paramiko.SFTPClient.from_transport(client.get_transport())
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Review fixes

Follow-up polish after #587 after re-checking ranking logic and deploy reliability.

### Wildfire feed
- Sort by **urgency → size → ignition date** (not date-first, which surfaced tiny Jul 23 "Being Held" fires ahead of Jul 17 out-of-control incidents)
- Remove redundant `prioritize_recent` + conflicting second sort
- Treat **Fire of Note** status in ranking
- Cleaner display names when only a fire number exists (`V11109` → `BC wildfire V11109`)
- Distinguish **API failure** vs truly no active fires

### Deploy
- Bump Paramiko SSH connect timeout 30s → 60s (previous #587 theme deploy timed out)

Expected top stories after deploy: Twin Two Creek, Hozomeen Mountain, Norwegian Creek (all out of control, southwest Coastal).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8847567f-6559-4baa-822d-02ae416215a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8847567f-6559-4baa-822d-02ae416215a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

