### PR TITLE
Vancouver-shaped metro map + expandable Leaflet view

### DIFF
--- a/assets/css/home-hero-cabinet.css
+++ b/assets/css/home-hero-cabinet.css
@@ -421,9 +421,17 @@
 .home-yvr-map__anchor-label {
   font-family: "IBM Plex Mono", "Courier New", monospace;
   font-size: 6.5px;
-  fill: rgba(180, 220, 210, 0.45);
+  fill: rgba(180, 220, 210, 0);
   letter-spacing: 0.04em;
   pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.12s linear, fill 0.12s linear;
+}
+
+.home-yvr-map__anchor:hover .home-yvr-map__anchor-label,
+.home-yvr-map__anchor.is-active .home-yvr-map__anchor-label {
+  fill: rgba(210, 240, 230, 0.92);
+  opacity: 1;
 }
 
 .home-yvr-map__anchor.is-active .home-yvr-map__anchor-dot {
@@ -455,8 +463,9 @@
 .home-yvr-broadcaster__map-head {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.35rem;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  gap: 0.28rem 0.4rem;
   margin-bottom: 0.18rem;
   font-size: clamp(0.38rem, 0.72vw, 0.46rem);
   letter-spacing: 0.08em;
@@ -465,10 +474,30 @@
 }
 
 .home-yvr-broadcaster__map-legend {
+  flex: 1 1 auto;
   display: flex;
   flex-wrap: wrap;
   gap: 0.28rem;
   font-size: clamp(0.36rem, 0.68vw, 0.44rem);
+}
+
+.home-yvr-broadcaster__map-expand {
+  flex: 0 0 auto;
+  margin: 0;
+  padding: 0.12rem 0.38rem;
+  border: 1px solid rgba(57, 255, 20, 0.45);
+  border-radius: 3px;
+  background: rgba(57, 255, 20, 0.08);
+  color: #39ff14;
+  font-size: clamp(0.36rem, 0.68vw, 0.44rem);
+  letter-spacing: 0.1em;
+  cursor: pointer;
+}
+
+.home-yvr-broadcaster__map-expand:hover,
+.home-yvr-broadcaster__map-expand:focus-visible {
+  background: rgba(57, 255, 20, 0.18);
+  color: #fff;
 }
 
 .home-yvr-broadcaster__map-legend-item.is-ooc {
@@ -493,12 +522,12 @@
     radial-gradient(circle at 78% 62%, rgba(87, 243, 255, 0.05), transparent 38%),
     #030508;
   overflow: hidden;
-  cursor: grab;
+  cursor: pointer;
   touch-action: none;
   box-shadow: inset 0 0 22px rgba(0, 0, 0, 0.75);
 }
 
-.home-yvr-broadcaster__map-stage:active {
+.home-yvr-broadcaster__map-stage.is-panning {
   cursor: grabbing;
 }
 
@@ -509,9 +538,34 @@
   pointer-events: none;
 }
 
-.home-yvr-broadcaster__map-svg [data-map-marker] {
+.home-yvr-broadcaster__map-svg [data-map-marker],
+.home-yvr-broadcaster__map-svg [data-map-anchor] {
   pointer-events: auto;
   cursor: pointer;
+}
+
+.home-yvr-map__region-label {
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  font-size: 6px;
+  fill: rgba(120, 170, 150, 0.35);
+  letter-spacing: 0.06em;
+  pointer-events: none;
+}
+
+.home-yvr-map__water-label {
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  font-size: 5.5px;
+  fill: rgba(87, 243, 255, 0.28);
+  letter-spacing: 0.04em;
+  pointer-events: none;
+}
+
+.home-yvr-map__river {
+  pointer-events: none;
+}
+
+.home-yvr-map__land {
+  pointer-events: none;
 }
 
 .home-yvr-map__label-text {
@@ -589,6 +643,106 @@
   mix-blend-mode: screen;
   opacity: 0.28;
   animation: homeBcastScan 5s linear infinite;
+}
+
+.home-yvr-broadcaster__map-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 12000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.home-yvr-broadcaster__map-modal[hidden] {
+  display: none;
+}
+
+.home-yvr-broadcaster__map-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: rgba(2, 4, 8, 0.88);
+  cursor: pointer;
+}
+
+.home-yvr-broadcaster__map-modal-panel {
+  position: relative;
+  z-index: 1;
+  width: min(92vw, 920px);
+  max-height: 92vh;
+  padding: 0.55rem 0.55rem 0.45rem;
+  border: 2px solid rgba(57, 255, 20, 0.35);
+  background: linear-gradient(180deg, #0a0c12, #040608);
+  box-shadow: 0 0 40px rgba(57, 255, 20, 0.12);
+}
+
+.home-yvr-broadcaster__map-modal-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+  font-size: clamp(0.5rem, 1vw, 0.62rem);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(87, 243, 255, 0.85);
+}
+
+.home-yvr-broadcaster__map-modal-close {
+  border: 1px solid rgba(255, 107, 107, 0.55);
+  border-radius: 3px;
+  background: rgba(255, 80, 80, 0.12);
+  color: #ff8a8a;
+  padding: 0.15rem 0.45rem;
+  cursor: pointer;
+  letter-spacing: 0.08em;
+}
+
+.home-yvr-broadcaster__map-modal-close:hover,
+.home-yvr-broadcaster__map-modal-close:focus-visible {
+  background: rgba(255, 80, 80, 0.25);
+  color: #fff;
+}
+
+.home-yvr-broadcaster__map-modal-stage {
+  height: min(62vh, 520px);
+  min-height: 280px;
+  border-radius: 4px;
+  border: 1px solid rgba(87, 243, 255, 0.22);
+  overflow: hidden;
+  background: #020610;
+}
+
+.home-yvr-broadcaster__map-modal-stage .leaflet-container {
+  width: 100%;
+  height: 100%;
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  background: #020610;
+}
+
+.home-yvr-broadcaster__map-modal-hint {
+  margin: 0.35rem 0 0;
+  font-size: clamp(0.4rem, 0.78vw, 0.5rem);
+  letter-spacing: 0.06em;
+  color: rgba(150, 190, 180, 0.65);
+}
+
+.home-yvr-leaflet-pin {
+  background: transparent;
+  border: 0;
+}
+
+.home-yvr-leaflet-pin span {
+  display: block;
+  border-radius: 50%;
+  border: 2px solid #020308;
+  box-shadow: 0 0 8px currentColor;
+}
+
+body.home-yvr-map-modal-open {
+  overflow: hidden;
 }
 
 .home-yvr-teleprompt__meta {

--- a/js/home-yvr-metro-map.js
+++ b/js/home-yvr-metro-map.js
@@ -4,6 +4,11 @@
   var MAP_WIDTH = 360;
   var MAP_HEIGHT = 200;
 
+  var LEAFLET_CSS = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css';
+  var LEAFLET_JS = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js';
+  var TILE_URL = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
+  var TILE_ATTR = '&copy; OpenStreetMap &copy; CARTO';
+
   var ANCHOR_COLORS = {
     dave: '#39ff14',
     translink: '#39ff14',
@@ -24,18 +29,71 @@
     ferry: '#57f3ff'
   };
 
-  // Greater Vancouver land mask (lon, lat).
-  var METRO_LAND = [
-    [-123.40, 49.38],
-    [-123.36, 49.34],
-    [-123.28, 49.30],
-    [-123.18, 49.28],
-    [-123.08, 49.27],
-    [-122.28, 49.22],
-    [-122.28, 49.02],
-    [-123.02, 48.97],
-    [-123.40, 48.97],
-    [-123.40, 49.38]
+  // Hand-tuned Greater Vancouver land regions (lon, lat).
+  var METRO_REGIONS = [
+    {
+      id: 'north-shore',
+      label: 'North Shore',
+      points: [
+        [-123.40, 49.38], [-123.40, 49.33], [-123.32, 49.325], [-123.18, 49.318],
+        [-123.08, 49.312], [-122.92, 49.308], [-122.78, 49.304],
+        [-122.78, 49.32], [-122.88, 49.34], [-123.05, 49.36], [-123.25, 49.37], [-123.40, 49.38]
+      ]
+    },
+    {
+      id: 'vancouver',
+      label: 'Vancouver',
+      points: [
+        [-123.40, 49.29], [-123.36, 49.31], [-123.28, 49.315], [-123.22, 49.312],
+        [-123.18, 49.308], [-123.15, 49.302], [-123.14, 49.288], [-123.13, 49.272],
+        [-123.11, 49.262], [-123.04, 49.258], [-122.86, 49.248], [-122.78, 49.238],
+        [-122.78, 49.22], [-122.92, 49.218], [-123.08, 49.232], [-123.18, 49.255],
+        [-123.28, 49.275], [-123.36, 49.285], [-123.40, 49.29]
+      ]
+    },
+    {
+      id: 'stanley-park',
+      label: '',
+      points: [
+        [-123.22, 49.308], [-123.17, 49.312], [-123.14, 49.304], [-123.15, 49.292],
+        [-123.19, 49.295], [-123.22, 49.308]
+      ]
+    },
+    {
+      id: 'burnaby',
+      label: 'Burnaby',
+      points: [
+        [-122.78, 49.238], [-122.78, 49.304], [-122.92, 49.308], [-123.04, 49.288],
+        [-123.04, 49.258], [-122.90, 49.242], [-122.78, 49.238]
+      ]
+    },
+    {
+      id: 'richmond',
+      label: 'Richmond',
+      points: [
+        [-123.40, 49.26], [-123.34, 49.23], [-123.22, 49.18], [-123.10, 49.155],
+        [-123.02, 49.158], [-123.04, 49.19], [-123.10, 49.22], [-123.22, 49.245],
+        [-123.34, 49.255], [-123.40, 49.26]
+      ]
+    },
+    {
+      id: 'surrey-delta',
+      label: 'Surrey / Delta',
+      points: [
+        [-122.78, 49.238], [-122.28, 49.20], [-122.28, 48.97], [-123.02, 48.97],
+        [-123.06, 49.10], [-123.02, 49.155], [-122.92, 49.20], [-122.78, 49.238]
+      ]
+    }
+  ];
+
+  var FRASER_RIVER = [
+    [-123.22, 49.24], [-123.12, 49.18], [-123.06, 49.12], [-123.08, 48.98]
+  ];
+
+  var WATER_LABELS = [
+    { text: 'Burrard Inlet', lon: -123.14, lat: 49.305 },
+    { text: 'Strait of Georgia', lon: -123.34, lat: 49.22 },
+    { text: 'Fraser River', lon: -123.10, lat: 49.14 }
   ];
 
   function escapeHtml(str) {
@@ -46,10 +104,47 @@
       .replace(/"/g, '&quot;');
   }
 
-  function project(lon, lat, bounds) {
-    var x = ((lon - bounds.west) / (bounds.east - bounds.west)) * MAP_WIDTH;
-    var y = ((bounds.north - lat) / (bounds.north - bounds.south)) * MAP_HEIGHT;
+  function project(lon, lat, bounds, width, height) {
+    width = width || MAP_WIDTH;
+    height = height || MAP_HEIGHT;
+    var x = ((lon - bounds.west) / (bounds.east - bounds.west)) * width;
+    var y = ((bounds.north - lat) / (bounds.north - bounds.south)) * height;
     return { x: x, y: y };
+  }
+
+  function polyPoints(coords, bounds, width, height) {
+    return coords.map(function (pt) {
+      var p = project(pt[0], pt[1], bounds, width, height);
+      return p.x.toFixed(1) + ',' + p.y.toFixed(1);
+    }).join(' ');
+  }
+
+  function loadScript(src) {
+    return new Promise(function (resolve, reject) {
+      var existing = document.querySelector('script[src="' + src + '"]');
+      if (existing) {
+        if (existing.dataset.loaded === '1') resolve();
+        else existing.addEventListener('load', resolve);
+        return;
+      }
+      var script = document.createElement('script');
+      script.src = src;
+      script.async = true;
+      script.onload = function () {
+        script.dataset.loaded = '1';
+        resolve();
+      };
+      script.onerror = reject;
+      document.head.appendChild(script);
+    });
+  }
+
+  function loadStyle(href) {
+    if (document.querySelector('link[href="' + href + '"]')) return;
+    var link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = href;
+    document.head.appendChild(link);
   }
 
   function MetroMap(root, onChannelSelect) {
@@ -59,6 +154,10 @@
     this.svg = root.querySelector('[data-broadcaster-map-svg]');
     this.tooltip = root.querySelector('[data-broadcaster-map-tooltip]');
     this.legendEl = root.querySelector('[data-broadcaster-map-legend]');
+    this.expandBtn = root.querySelector('[data-broadcaster-map-expand]');
+    this.modal = root.querySelector('[data-broadcaster-map-modal]');
+    this.modalStage = root.querySelector('[data-broadcaster-map-modal-stage]');
+    this.modalTooltip = root.querySelector('[data-broadcaster-map-modal-tooltip]');
     this.onChannelSelect = onChannelSelect || null;
     this.bounds = null;
     this.anchors = [];
@@ -71,10 +170,13 @@
     this.ty = 0;
     this.dragging = false;
     this.dragStart = null;
+    this.leafletMap = null;
+    this.leafletLayer = null;
     this._boundWheel = this.onWheel.bind(this);
     this._boundPointerDown = this.onPointerDown.bind(this);
     this._boundPointerMove = this.onPointerMove.bind(this);
     this._boundPointerUp = this.onPointerUp.bind(this);
+    this._boundKeydown = this.onKeydown.bind(this);
   }
 
   MetroMap.prototype.bindStage = function () {
@@ -120,32 +222,94 @@
     this.applyTransform();
   };
 
-  MetroMap.prototype.onPointerUp = function () {
+  MetroMap.prototype.onPointerUp = function (event) {
+    if (this.dragging && this.dragStart && this.scale <= 1) {
+      var dx = event.clientX - this.dragStart.x;
+      var dy = event.clientY - this.dragStart.y;
+      if (Math.abs(dx) < 6 && Math.abs(dy) < 6) {
+        this.openExpand();
+      }
+    }
     this.dragging = false;
     this.dragStart = null;
   };
 
-  MetroMap.prototype.hideTooltip = function () {
-    if (!this.tooltip) return;
-    this.tooltip.hidden = true;
-    this.tooltip.textContent = '';
+  MetroMap.prototype.onKeydown = function (event) {
+    if (event.key === 'Escape' && this.modal && !this.modal.hidden) {
+      this.closeExpand();
+    }
   };
 
-  MetroMap.prototype.showTooltip = function (parts, clientX, clientY) {
-    if (!this.tooltip || !this.stage) return;
-    this.tooltip.innerHTML = escapeHtml(parts.filter(Boolean).join(' · '));
-    this.tooltip.hidden = false;
-    var rect = this.stage.getBoundingClientRect();
-    var left = Math.max(4, Math.min(clientX - rect.left + 8, rect.width - this.tooltip.offsetWidth - 4));
-    var top = Math.max(4, Math.min(clientY - rect.top - 28, rect.height - this.tooltip.offsetHeight - 4));
-    this.tooltip.style.left = left + 'px';
-    this.tooltip.style.top = top + 'px';
+  MetroMap.prototype.hideTooltip = function (el) {
+    var node = el || this.tooltip;
+    if (!node) return;
+    node.hidden = true;
+    node.textContent = '';
+  };
+
+  MetroMap.prototype.showTooltip = function (parts, clientX, clientY, container, tooltipEl) {
+    var tip = tooltipEl || this.tooltip;
+    var box = container || this.stage;
+    if (!tip || !box) return;
+    tip.innerHTML = escapeHtml(parts.filter(Boolean).join(' · '));
+    tip.hidden = false;
+    var rect = box.getBoundingClientRect();
+    var left = Math.max(4, Math.min(clientX - rect.left + 8, rect.width - tip.offsetWidth - 4));
+    var top = Math.max(4, Math.min(clientY - rect.top - 28, rect.height - tip.offsetHeight - 4));
+    tip.style.left = left + 'px';
+    tip.style.top = top + 'px';
   };
 
   MetroMap.prototype.setLegend = function (text) {
     if (!this.legendEl) return;
     this.legendEl.innerHTML = text || '';
     this.legendEl.setAttribute('aria-hidden', text ? 'false' : 'true');
+  };
+
+  MetroMap.prototype.buildGeographySvg = function (bounds, width, height) {
+    var parts = [];
+    parts.push(
+      '<rect x="0" y="0" width="' + width + '" height="' + height + '" fill="#020610"></rect>'
+    );
+
+    METRO_REGIONS.forEach(function (region) {
+      parts.push(
+        '<polygon class="home-yvr-map__land" data-region="' + region.id + '" points="' +
+          polyPoints(region.points, bounds, width, height) +
+          '" fill="#0c1814" stroke="#1e4a38" stroke-width="1" stroke-linejoin="round"></polygon>'
+      );
+      if (region.label) {
+        var c = region.points[Math.floor(region.points.length / 2)];
+        var lp = project(c[0], c[1], bounds, width, height);
+        parts.push(
+          '<text class="home-yvr-map__region-label" x="' + lp.x.toFixed(1) + '" y="' + lp.y.toFixed(1) +
+            '" text-anchor="middle">' + escapeHtml(region.label) + '</text>'
+        );
+      }
+    });
+
+    var riverPts = FRASER_RIVER.map(function (pt, i) {
+      var p = project(pt[0], pt[1], bounds, width, height);
+      return (i === 0 ? 'M' : 'L') + p.x.toFixed(1) + ',' + p.y.toFixed(1);
+    }).join(' ');
+    parts.push(
+      '<path class="home-yvr-map__river" d="' + riverPts + '" fill="none" stroke="rgba(87,243,255,0.35)" stroke-width="2.5" stroke-linecap="round"></path>'
+    );
+
+    WATER_LABELS.forEach(function (label) {
+      var p = project(label.lon, label.lat, bounds, width, height);
+      parts.push(
+        '<text class="home-yvr-map__water-label" x="' + p.x.toFixed(1) + '" y="' + p.y.toFixed(1) +
+          '" text-anchor="middle">' + escapeHtml(label.text) + '</text>'
+      );
+    });
+
+    parts.push(
+      '<rect x="1" y="1" width="' + (width - 2) + '" height="' + (height - 2) +
+        '" fill="none" stroke="rgba(87,243,255,0.18)" stroke-width="1"></rect>'
+    );
+
+    return parts.join('');
   };
 
   MetroMap.prototype.buildBase = function (config) {
@@ -159,29 +323,7 @@
     var bounds = this.bounds;
     var parts = [];
     parts.push('<g data-map-world>');
-
-    parts.push(
-      '<rect x="0" y="0" width="' + MAP_WIDTH + '" height="' + MAP_HEIGHT + '" fill="#030810"></rect>'
-    );
-
-    var landPts = METRO_LAND.map(function (pt) {
-      var p = project(pt[0], pt[1], bounds);
-      return p.x.toFixed(1) + ',' + p.y.toFixed(1);
-    }).join(' ');
-    parts.push(
-      '<polygon points="' + landPts + '" fill="#0a1418" stroke="#1a3a32" stroke-width="1.2"></polygon>'
-    );
-
-    for (var gx = 0; gx <= MAP_WIDTH; gx += 36) {
-      parts.push('<line x1="' + gx + '" y1="0" x2="' + gx + '" y2="' + MAP_HEIGHT + '" stroke="rgba(57,255,20,0.06)" stroke-width="1"></line>');
-    }
-    for (var gy = 0; gy <= MAP_HEIGHT; gy += 40) {
-      parts.push('<line x1="0" y1="' + gy + '" x2="' + MAP_WIDTH + '" y2="' + gy + '" stroke="rgba(57,255,20,0.06)" stroke-width="1"></line>');
-    }
-
-    parts.push(
-      '<rect x="1" y="1" width="' + (MAP_WIDTH - 2) + '" height="' + (MAP_HEIGHT - 2) + '" fill="none" stroke="rgba(87,243,255,0.22)" stroke-width="1"></rect>'
-    );
+    parts.push(this.buildGeographySvg(bounds, MAP_WIDTH, MAP_HEIGHT));
 
     parts.push('<g data-map-anchors>');
     this.anchors.forEach(function (anchor) {
@@ -194,21 +336,25 @@
           (isDave ? '<circle class="home-yvr-map__yvr-ring" r="7" fill="none" stroke="rgba(57,255,20,0.5)" stroke-width="1"></circle>' : '') +
           '<circle class="home-yvr-map__anchor-pulse" r="8" fill="' + color + '" opacity="0.12"></circle>' +
           '<circle class="home-yvr-map__anchor-dot" r="3.8" fill="' + color + '" stroke="#020308" stroke-width="1.2"></circle>' +
-          '<text class="home-yvr-map__anchor-label" y="-10" text-anchor="middle">' + escapeHtml(anchor.label || key) + '</text>' +
+          '<text class="home-yvr-map__anchor-label">' + escapeHtml(anchor.label || key) + '</text>' +
         '</g>'
       );
     });
     parts.push('</g>');
-
     parts.push('<g data-map-overlay></g>');
     parts.push('</g>');
 
     this.svg.innerHTML = parts.join('');
+    this.bindAnchorEvents(this.svg);
+    this.applyTransform();
+    this.setActiveChannel(this.activeChannel);
+  };
 
+  MetroMap.prototype.bindAnchorEvents = function (root) {
     var self = this;
     this.anchors.forEach(function (anchor) {
       var key = anchor.key || '';
-      var el = self.svg.querySelector('[data-map-anchor="' + CSS.escape(key) + '"]');
+      var el = root.querySelector('[data-map-anchor="' + CSS.escape(key) + '"]');
       if (!el) return;
 
       el.addEventListener('pointerenter', function (event) {
@@ -220,7 +366,8 @@
       el.addEventListener('pointerleave', function () {
         self.hideTooltip();
       });
-      el.addEventListener('click', function () {
+      el.addEventListener('click', function (event) {
+        event.stopPropagation();
         if (key === 'dave') return;
         if (self.onChannelSelect) self.onChannelSelect(key);
       });
@@ -231,13 +378,11 @@
         }
       });
     });
-
-    this.applyTransform();
-    this.setActiveChannel(this.activeChannel);
   };
 
-  MetroMap.prototype.renderOverlay = function (channelKey) {
-    var layer = this.svg && this.svg.querySelector('[data-map-overlay]');
+  MetroMap.prototype.renderOverlay = function (channelKey, root) {
+    var svg = root || this.svg;
+    var layer = svg && svg.querySelector('[data-map-overlay]');
     if (!layer || !this.bounds) return;
 
     var overlay = this.overlays[channelKey] || {};
@@ -247,6 +392,7 @@
 
     var bounds = this.bounds;
     var html = '';
+    var self = this;
 
     markers.forEach(function (marker) {
       var pt = project(marker.lon, marker.lat, bounds);
@@ -262,7 +408,6 @@
 
     layer.innerHTML = html;
 
-    var self = this;
     markers.forEach(function (marker) {
       var id = marker.id || marker.name;
       var el = layer.querySelector('[data-map-marker="' + CSS.escape(id) + '"]');
@@ -278,17 +423,20 @@
       el.addEventListener('pointerleave', function () {
         self.hideTooltip();
       });
-      el.addEventListener('click', function () {
+      el.addEventListener('click', function (event) {
+        event.stopPropagation();
         if (marker.url) window.open(marker.url, '_blank', 'noopener,noreferrer');
       });
     });
 
-    if (markers.length) {
-      this.setLegend('<span class="home-yvr-broadcaster__map-legend-item is-other">' + markers.length + ' on map</span>');
-    } else if (channelKey) {
-      this.setLegend('<span class="home-yvr-broadcaster__map-legend-item">no pins in metro</span>');
-    } else {
-      this.setLegend('');
+    if (!root) {
+      if (markers.length) {
+        this.setLegend('<span class="home-yvr-broadcaster__map-legend-item is-other">' + markers.length + ' on map</span>');
+      } else if (channelKey) {
+        this.setLegend('<span class="home-yvr-broadcaster__map-legend-item">no pins in metro</span>');
+      } else {
+        this.setLegend('<span class="home-yvr-broadcaster__map-legend-item">tap map to expand</span>');
+      }
     }
   };
 
@@ -305,12 +453,18 @@
     });
 
     this.renderOverlay(channelKey);
+    if (this.leafletMap) {
+      this.syncLeafletMarkers();
+    }
   };
 
   MetroMap.prototype.setOverlays = function (overlays) {
     this.overlays = overlays || {};
     if (this.activeChannel) {
       this.renderOverlay(this.activeChannel);
+    }
+    if (this.leafletMap) {
+      this.syncLeafletMarkers();
     }
   };
 
@@ -340,12 +494,139 @@
     }, this);
   };
 
+  MetroMap.prototype.makeLeafletIcon = function (color, large) {
+    var size = large ? 14 : 10;
+    return window.L.divIcon({
+      className: 'home-yvr-leaflet-pin',
+      html: '<span style="background:' + color + ';width:' + size + 'px;height:' + size + 'px"></span>',
+      iconSize: [size, size],
+      iconAnchor: [size / 2, size / 2]
+    });
+  };
+
+  MetroMap.prototype.syncLeafletMarkers = function () {
+    if (!this.leafletMap || !window.L) return;
+    var self = this;
+
+    if (this.leafletLayer) {
+      this.leafletMap.removeLayer(this.leafletLayer);
+    }
+
+    this.leafletLayer = window.L.layerGroup().addTo(this.leafletMap);
+
+    this.anchors.forEach(function (anchor) {
+      var key = anchor.key || '';
+      var color = ANCHOR_COLORS[key] || '#57f3ff';
+      var marker = window.L.marker([anchor.lat, anchor.lon], {
+        icon: self.makeLeafletIcon(color, true),
+        zIndexOffset: key === self.activeChannel ? 500 : 100
+      });
+      marker.bindTooltip(anchor.label + ' — ' + anchor.hint);
+      if (key !== 'dave') {
+        marker.on('click', function () {
+          if (self.onChannelSelect) self.onChannelSelect(key);
+        });
+      }
+      marker.addTo(self.leafletLayer);
+    });
+
+    var overlay = self.overlays[self.activeChannel] || {};
+    (overlay.markers || []).forEach(function (m) {
+      var tier = m.tier || 'other';
+      var color = TIER_COLORS[tier] || TIER_COLORS.other;
+      var om = window.L.marker([m.lat, m.lon], {
+        icon: self.makeLeafletIcon(color, false),
+        zIndexOffset: 200
+      });
+      om.bindTooltip((m.name || '') + (m.detail ? ' — ' + m.detail : ''));
+      if (m.url) {
+        om.on('click', function () {
+          window.open(m.url, '_blank', 'noopener,noreferrer');
+        });
+      }
+      om.addTo(self.leafletLayer);
+    });
+  };
+
+  MetroMap.prototype.initLeaflet = function () {
+    if (!this.modalStage || !window.L || this.leafletMap) return;
+
+    var bounds = this.bounds;
+    this.leafletMap = window.L.map(this.modalStage, {
+      zoomControl: true,
+      attributionControl: true,
+      minZoom: 9,
+      maxZoom: 15
+    });
+
+    window.L.tileLayer(TILE_URL, {
+      attribution: TILE_ATTR,
+      subdomains: 'abcd',
+      maxZoom: 20
+    }).addTo(this.leafletMap);
+
+    var latLngBounds = window.L.latLngBounds(
+      [bounds.south, bounds.west],
+      [bounds.north, bounds.east]
+    );
+    this.leafletMap.fitBounds(latLngBounds, { padding: [24, 24] });
+    this.leafletMap.setMaxBounds(latLngBounds.pad(0.15));
+
+    this.syncLeafletMarkers();
+
+    setTimeout(function () {
+      if (this.leafletMap) this.leafletMap.invalidateSize();
+    }.bind(this), 80);
+  };
+
+  MetroMap.prototype.openExpand = function () {
+    var self = this;
+    if (!this.modal) return;
+
+    this.modal.hidden = false;
+    document.body.classList.add('home-yvr-map-modal-open');
+    document.addEventListener('keydown', this._boundKeydown);
+
+    loadStyle(LEAFLET_CSS);
+    loadScript(LEAFLET_JS)
+      .then(function () {
+        self.initLeaflet();
+      })
+      .catch(function () {
+        /* widget SVG remains usable */
+      });
+  };
+
+  MetroMap.prototype.closeExpand = function () {
+    if (!this.modal) return;
+    this.modal.hidden = true;
+    document.body.classList.remove('home-yvr-map-modal-open');
+    document.removeEventListener('keydown', this._boundKeydown);
+  };
+
   MetroMap.prototype.boot = function (config) {
     if (!this.wrap) return;
     this.wrap.hidden = false;
     this.bindStage();
     this.buildBase(config);
-    this.setLegend('tap a pin · scroll zoom');
+    this.setLegend('tap map to expand · pins switch channels');
+
+    var self = this;
+    if (this.expandBtn) {
+      this.expandBtn.addEventListener('click', function (event) {
+        event.stopPropagation();
+        self.openExpand();
+      });
+    }
+
+    if (this.modal) {
+      var closeBtns = this.modal.querySelectorAll('[data-broadcaster-map-close]');
+      closeBtns.forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          self.closeExpand();
+        });
+      });
+    }
   };
 
   window.HomeYvrMetroMap = MetroMap;

--- a/page-home.php
+++ b/page-home.php
@@ -49,11 +49,23 @@ get_header();
                             <div class="home-yvr-broadcaster__map-head pixel-font">
                                 <span class="home-yvr-broadcaster__map-kicker"><?php echo esc_html( 'greater vancouver // yvr bcast' ); ?></span>
                                 <span class="home-yvr-broadcaster__map-legend" data-broadcaster-map-legend aria-hidden="true"></span>
+                                <button type="button" class="home-yvr-broadcaster__map-expand pixel-font" data-broadcaster-map-expand aria-label="<?php echo esc_attr( 'Expand Greater Vancouver map' ); ?>"><?php echo esc_html( 'EXPAND' ); ?></button>
                             </div>
-                            <div class="home-yvr-broadcaster__map-stage" data-broadcaster-map-stage>
+                            <div class="home-yvr-broadcaster__map-stage" data-broadcaster-map-stage title="<?php echo esc_attr( 'Click map to expand' ); ?>">
                                 <svg class="home-yvr-broadcaster__map-svg" data-broadcaster-map-svg viewBox="0 0 360 200" preserveAspectRatio="xMidYMid meet" role="img" aria-label="<?php echo esc_attr( 'Greater Vancouver broadcaster map' ); ?>"></svg>
                                 <div class="home-yvr-broadcaster__map-tooltip pixel-font" data-broadcaster-map-tooltip hidden></div>
                                 <div class="home-yvr-broadcaster__map-scan" aria-hidden="true"></div>
+                            </div>
+                        </div>
+                        <div class="home-yvr-broadcaster__map-modal" data-broadcaster-map-modal hidden>
+                            <button type="button" class="home-yvr-broadcaster__map-modal-backdrop" data-broadcaster-map-close aria-label="<?php echo esc_attr( 'Close map' ); ?>"></button>
+                            <div class="home-yvr-broadcaster__map-modal-panel crt-block" role="dialog" aria-modal="true" aria-label="<?php echo esc_attr( 'Greater Vancouver map' ); ?>">
+                                <div class="home-yvr-broadcaster__map-modal-head pixel-font">
+                                    <span><?php echo esc_html( 'greater vancouver // live map' ); ?></span>
+                                    <button type="button" class="home-yvr-broadcaster__map-modal-close pixel-font" data-broadcaster-map-close><?php echo esc_html( 'CLOSE' ); ?></button>
+                                </div>
+                                <div class="home-yvr-broadcaster__map-modal-stage" data-broadcaster-map-modal-stage></div>
+                                <p class="home-yvr-broadcaster__map-modal-hint pixel-font"><?php echo esc_html( 'Pins match channel homes · tap to tune · scroll to zoom' ); ?></p>
                             </div>
                         </div>
                         <p class="home-yvr-teleprompt__script" data-broadcaster-script><?php echo esc_html( 'Tap a channel. Dave reads the feed — words light up.' ); ?></p>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The metro widget map read as a generic grid with a single curved line — not recognizable as Vancouver. No way to expand for a proper map view.

## Fix

### Widget (CRT preview)
- Multi-polygon geography: North Shore, Vancouver, Stanley Park bump, Burnaby, Richmond, Surrey/Delta
- Burrard Inlet gap between North Shore and city
- Fraser River stroke + water labels (Strait of Georgia, inlet, river)
- Region labels at low opacity
- Channel pin labels only on hover/active (fixes overlapping text clutter)

### Expand
- **EXPAND** button in map header
- **Click the widget map** (when not zoomed) opens full-screen modal
- Leaflet + Carto dark basemap — real streets and coastline
- Same channel pins + live overlays; tap pin to tune channel
- CLOSE / backdrop / Escape to dismiss
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8847567f-6559-4baa-822d-02ae416215a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8847567f-6559-4baa-822d-02ae416215a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

