### PR TITLE
Split homepage banner: map left column, bio right

### DIFF
--- a/assets/css/home-hero-cabinet.css
+++ b/assets/css/home-hero-cabinet.css
@@ -1,20 +1,43 @@
-/* Compact YVR + amp-stack homepage hero — map banner + Dave rack overlay. */
+/* Compact YVR + amp-stack homepage hero — split banner: map left, bio right. */
 
 .home-map-hero {
   position: relative;
   isolation: isolate;
-  min-height: clamp(380px, 48vh, 560px);
-  padding: 0;
-  border: 2px solid rgba(87, 243, 255, 0.55);
+}
+
+.home-map-hero__content {
+  display: grid;
+  grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+  align-items: stretch;
+  gap: clamp(0.65rem, 1.6vw, 1rem);
+  min-height: clamp(280px, 38vh, 420px);
+}
+
+.home-map-hero__left {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.45rem, 1vw, 0.65rem);
+  min-width: 0;
+  min-height: 0;
+}
+
+.home-map-hero__map-frame {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: clamp(200px, 30vh, 340px);
+  border-radius: 10px;
+  border: 2px solid rgba(87, 243, 255, 0.42);
   background: #020610;
+  overflow: hidden;
+  box-shadow:
+    inset 0 0 28px rgba(0, 0, 0, 0.65),
+    0 0 18px rgba(87, 243, 255, 0.08);
 }
 
 .home-map-hero__map-stage {
   position: absolute;
   inset: 0;
   z-index: 0;
-  border-radius: 14px;
-  overflow: hidden;
 }
 
 .home-map-hero__map-stage .leaflet-container {
@@ -24,88 +47,47 @@
   background: #020610;
 }
 
-.home-map-hero__shade {
+.home-map-hero__map-scan {
   position: absolute;
   inset: 0;
   z-index: 1;
   pointer-events: none;
-  border-radius: 14px;
-  background:
-    radial-gradient(ellipse 42% 58% at 10% 92%, rgba(4, 8, 14, 0.78), transparent 72%),
-    radial-gradient(ellipse 38% 52% at 92% 14%, rgba(4, 8, 14, 0.74), transparent 70%),
-    linear-gradient(180deg, rgba(2, 4, 8, 0.12), transparent 38%, rgba(2, 4, 8, 0.22));
-}
-
-.home-map-hero__scan {
-  position: absolute;
-  inset: 0;
-  z-index: 2;
-  pointer-events: none;
-  border-radius: 14px;
   background: repeating-linear-gradient(
     180deg,
     rgba(255, 255, 255, 0.03) 0 1px,
     transparent 1px 3px
   );
   mix-blend-mode: screen;
-  opacity: 0.22;
+  opacity: 0.2;
   animation: homeBcastScan 6s linear infinite;
 }
 
-.home-map-hero__content {
-  position: relative;
-  z-index: 3;
-  display: block;
-  min-height: clamp(380px, 48vh, 560px);
-  padding: 0;
-  pointer-events: none;
-}
-
-.home-map-hero__lane {
+.home-map-hero__map-label {
   position: absolute;
-  top: clamp(0.55rem, 1.4vw, 0.85rem);
-  left: 50%;
+  top: 0.38rem;
+  left: 0.38rem;
   z-index: 2;
-  transform: translateX(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  pointer-events: none;
-}
-
-.home-map-hero__lane-label {
   margin: 0;
-  padding: 0.22rem 0.45rem;
+  padding: 0.2rem 0.42rem;
   border-radius: 3px;
   border: 1px solid rgba(87, 243, 255, 0.28);
-  background: rgba(2, 6, 10, 0.45);
+  background: rgba(2, 6, 10, 0.72);
   font-size: clamp(0.38rem, 0.72vw, 0.48rem);
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(180, 230, 220, 0.82);
+  color: rgba(180, 230, 220, 0.88);
   pointer-events: none;
-  backdrop-filter: blur(4px);
 }
 
-.home-map-hero__content > .home-arcade-screen__backdrop {
-  position: absolute;
-  bottom: clamp(0.55rem, 1.4vw, 0.85rem);
-  left: clamp(0.55rem, 1.4vw, 0.85rem);
-  z-index: 4;
-  width: min(280px, 42vw);
-  max-width: 280px;
-  pointer-events: auto;
+.home-map-hero__map-stage .leaflet-control-zoom {
+  border: 1px solid rgba(87, 243, 255, 0.35);
+  background: rgba(2, 6, 10, 0.82);
 }
 
-.home-map-hero__content > .home-arcade-screen__panel {
-  position: absolute;
-  top: clamp(0.55rem, 1.4vw, 0.85rem);
-  right: clamp(0.55rem, 1.4vw, 0.85rem);
-  z-index: 4;
-  width: min(320px, 46vw);
-  max-width: 320px;
-  pointer-events: none;
+.home-map-hero__map-stage .leaflet-top.leaflet-left {
+  top: 0.38rem;
+  left: auto;
+  right: 0.38rem;
 }
 
 .home-arcade-title-screen.home-amp-cabinet {
@@ -134,27 +116,34 @@
 
 .home-map-hero.home-amp-cabinet {
   display: block;
-  grid-template-columns: unset;
-  gap: 0;
-  min-height: clamp(380px, 48vh, 560px);
-  padding: 0;
-  background: transparent;
+  min-height: clamp(320px, 42vh, 480px);
+  padding: clamp(0.85rem, 2vw, 1.15rem);
+  background:
+    radial-gradient(circle at 18% 82%, rgba(87, 243, 255, 0.14), transparent 34%),
+    radial-gradient(circle at 88% 18%, rgba(255, 79, 216, 0.1), transparent 28%),
+    linear-gradient(165deg, #04060f 0%, #07111f 42%, #020308 100%);
   box-shadow:
     0 0 0 1px rgba(57, 255, 20, 0.12),
-    0 16px 48px rgba(0, 0, 0, 0.55);
+    0 16px 48px rgba(0, 0, 0, 0.55),
+    inset 0 0 40px rgba(0, 0, 0, 0.35);
 }
 
-.home-map-hero__map-stage .leaflet-top.leaflet-left {
-  left: 50%;
-  right: auto;
-  top: auto;
-  bottom: 12px;
-  transform: translateX(-50%);
+.home-map-hero.home-amp-cabinet .home-arcade-screen__backdrop {
+  position: relative;
+  flex: 0 0 auto;
+  width: 100%;
+  min-height: 0;
 }
 
-.home-map-hero__map-stage .leaflet-control-zoom {
-  border: 1px solid rgba(87, 243, 255, 0.35);
-  background: rgba(2, 6, 10, 0.72);
+.home-map-hero.home-amp-cabinet .home-arcade-screen__panel {
+  position: relative;
+  width: 100%;
+  max-width: none;
+  align-self: stretch;
+}
+
+.home-map-hero .home-arcade-screen__backdrop {
+  background: rgba(2, 8, 18, 0.45);
 }
 
 .home-amp-cabinet::before {
@@ -186,25 +175,11 @@
   backdrop-filter: blur(6px);
 }
 
-.home-map-hero.home-amp-cabinet .home-arcade-screen__backdrop {
-  position: absolute;
-  bottom: clamp(0.55rem, 1.4vw, 0.85rem);
-  left: clamp(0.55rem, 1.4vw, 0.85rem);
-  width: min(280px, 42vw);
-  max-width: 280px;
-}
-
-.home-map-hero.home-amp-cabinet .home-arcade-screen__panel {
-  position: absolute;
-  top: clamp(0.55rem, 1.4vw, 0.85rem);
-  right: clamp(0.55rem, 1.4vw, 0.85rem);
-  width: min(320px, 46vw);
-  max-width: 320px;
-}
-
-.home-map-hero .home-arcade-screen__backdrop {
-  background: rgba(2, 8, 18, 0.58);
-  backdrop-filter: blur(8px);
+.home-amp-cabinet .home-arcade-screen__backdrop {
+  position: relative;
+  width: 100%;
+  max-width: none;
+  margin: 0;
 }
 
 .home-yvr-rack {
@@ -1272,8 +1247,10 @@ body.home-yvr-map-modal-open {
 }
 
 .home-map-hero .home-arcade-screen__panel {
-  background: rgba(4, 8, 14, 0.48);
-  box-shadow: 0 0 24px rgba(0, 0, 0, 0.25);
+  background: transparent;
+  border-color: rgba(87, 243, 255, 0.2);
+  box-shadow: none;
+  backdrop-filter: none;
 }
 
 .home-map-hero .home-arcade-screen__panel .home-arcade-kicker,
@@ -1384,55 +1361,26 @@ body.home-yvr-map-modal-open {
 }
 
 @media (max-width: 820px) {
-  .home-map-hero {
-    min-height: clamp(420px, 58vh, 620px);
-  }
-
   .home-map-hero__content {
-    min-height: clamp(420px, 58vh, 620px);
+    grid-template-columns: 1fr;
+    min-height: 0;
   }
 
-  .home-map-hero__lane {
-    top: 0.45rem;
-    max-width: calc(100% - 1rem);
-  }
-
-  .home-map-hero__lane-label {
-    font-size: 0.36rem;
-    text-align: center;
-  }
-
-  .home-map-hero.home-amp-cabinet .home-arcade-screen__backdrop {
-    left: 0.45rem;
-    right: 0.45rem;
-    bottom: 0.45rem;
-    width: auto;
-    max-width: none;
+  .home-map-hero__map-frame {
+    min-height: clamp(200px, 36vh, 300px);
   }
 
   .home-map-hero.home-amp-cabinet .home-arcade-screen__panel {
-    top: 2.1rem;
-    right: 0.45rem;
-    width: min(320px, 72vw);
-    max-width: none;
-  }
-
-  .home-map-hero .home-arcade-screen__panel {
-    align-items: flex-end;
-    text-align: right;
-    padding: 0.45rem 0.55rem;
+    align-items: center;
+    text-align: center;
   }
 
   .home-map-hero .home-amp-console {
-    justify-content: flex-end;
+    justify-content: center;
   }
 
   .home-map-hero .home-title-screen-meta {
-    justify-content: flex-end;
-  }
-
-  .home-map-hero__map-stage .leaflet-top.leaflet-left {
-    bottom: 12px;
+    justify-content: center;
   }
 
   .home-arcade-title-screen.home-amp-cabinet {

--- a/assets/css/home-hero-cabinet.css
+++ b/assets/css/home-hero-cabinet.css
@@ -3,7 +3,7 @@
 .home-map-hero {
   position: relative;
   isolation: isolate;
-  min-height: clamp(340px, 44vh, 520px);
+  min-height: clamp(380px, 48vh, 560px);
   padding: 0;
   border: 2px solid rgba(87, 243, 255, 0.55);
   background: #020610;
@@ -31,8 +31,9 @@
   pointer-events: none;
   border-radius: 14px;
   background:
-    linear-gradient(105deg, rgba(4, 8, 14, 0.82) 0%, rgba(4, 8, 14, 0.45) 42%, rgba(4, 8, 14, 0.25) 68%, rgba(4, 8, 14, 0.55) 100%),
-    linear-gradient(180deg, rgba(2, 4, 8, 0.35), transparent 40%, rgba(2, 4, 8, 0.5));
+    radial-gradient(ellipse 42% 58% at 10% 92%, rgba(4, 8, 14, 0.78), transparent 72%),
+    radial-gradient(ellipse 38% 52% at 92% 14%, rgba(4, 8, 14, 0.74), transparent 70%),
+    linear-gradient(180deg, rgba(2, 4, 8, 0.12), transparent 38%, rgba(2, 4, 8, 0.22));
 }
 
 .home-map-hero__scan {
@@ -54,17 +55,57 @@
 .home-map-hero__content {
   position: relative;
   z-index: 3;
-  display: grid;
-  grid-template-columns: minmax(0, 0.76fr) minmax(0, 1.24fr);
-  align-items: stretch;
-  gap: clamp(0.65rem, 1.6vw, 1rem);
-  min-height: clamp(340px, 44vh, 520px);
-  padding: clamp(0.85rem, 2vw, 1.15rem);
+  display: block;
+  min-height: clamp(380px, 48vh, 560px);
+  padding: 0;
   pointer-events: none;
 }
 
-.home-map-hero__content > * {
+.home-map-hero__lane {
+  position: absolute;
+  top: clamp(0.55rem, 1.4vw, 0.85rem);
+  left: 50%;
+  z-index: 2;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  pointer-events: none;
+}
+
+.home-map-hero__lane-label {
+  margin: 0;
+  padding: 0.22rem 0.45rem;
+  border-radius: 3px;
+  border: 1px solid rgba(87, 243, 255, 0.28);
+  background: rgba(2, 6, 10, 0.45);
+  font-size: clamp(0.38rem, 0.72vw, 0.48rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(180, 230, 220, 0.82);
+  pointer-events: none;
+  backdrop-filter: blur(4px);
+}
+
+.home-map-hero__content > .home-arcade-screen__backdrop {
+  position: absolute;
+  bottom: clamp(0.55rem, 1.4vw, 0.85rem);
+  left: clamp(0.55rem, 1.4vw, 0.85rem);
+  z-index: 4;
+  width: min(280px, 42vw);
+  max-width: 280px;
   pointer-events: auto;
+}
+
+.home-map-hero__content > .home-arcade-screen__panel {
+  position: absolute;
+  top: clamp(0.55rem, 1.4vw, 0.85rem);
+  right: clamp(0.55rem, 1.4vw, 0.85rem);
+  z-index: 4;
+  width: min(320px, 46vw);
+  max-width: 320px;
+  pointer-events: none;
 }
 
 .home-arcade-title-screen.home-amp-cabinet {
@@ -95,12 +136,25 @@
   display: block;
   grid-template-columns: unset;
   gap: 0;
-  min-height: clamp(340px, 44vh, 520px);
+  min-height: clamp(380px, 48vh, 560px);
   padding: 0;
   background: transparent;
   box-shadow:
     0 0 0 1px rgba(57, 255, 20, 0.12),
     0 16px 48px rgba(0, 0, 0, 0.55);
+}
+
+.home-map-hero__map-stage .leaflet-top.leaflet-left {
+  left: 50%;
+  right: auto;
+  top: auto;
+  bottom: 12px;
+  transform: translateX(-50%);
+}
+
+.home-map-hero__map-stage .leaflet-control-zoom {
+  border: 1px solid rgba(87, 243, 255, 0.35);
+  background: rgba(2, 6, 10, 0.72);
 }
 
 .home-amp-cabinet::before {
@@ -124,12 +178,33 @@
   align-items: stretch;
   gap: 0;
   min-height: 0;
-  padding: clamp(0.35rem, 1vw, 0.5rem);
+  padding: clamp(0.3rem, 0.8vw, 0.45rem);
   border-radius: 12px;
   overflow: hidden;
   border: 1px solid rgba(87, 243, 255, 0.28);
-  background: rgba(2, 8, 18, 0.55);
-  backdrop-filter: blur(4px);
+  background: rgba(2, 8, 18, 0.38);
+  backdrop-filter: blur(6px);
+}
+
+.home-map-hero.home-amp-cabinet .home-arcade-screen__backdrop {
+  position: absolute;
+  bottom: clamp(0.55rem, 1.4vw, 0.85rem);
+  left: clamp(0.55rem, 1.4vw, 0.85rem);
+  width: min(280px, 42vw);
+  max-width: 280px;
+}
+
+.home-map-hero.home-amp-cabinet .home-arcade-screen__panel {
+  position: absolute;
+  top: clamp(0.55rem, 1.4vw, 0.85rem);
+  right: clamp(0.55rem, 1.4vw, 0.85rem);
+  width: min(320px, 46vw);
+  max-width: 320px;
+}
+
+.home-map-hero .home-arcade-screen__backdrop {
+  background: rgba(2, 8, 18, 0.58);
+  backdrop-filter: blur(8px);
 }
 
 .home-yvr-rack {
@@ -1196,6 +1271,11 @@ body.home-yvr-map-modal-open {
   backdrop-filter: blur(3px);
 }
 
+.home-map-hero .home-arcade-screen__panel {
+  background: rgba(4, 8, 14, 0.48);
+  box-shadow: 0 0 24px rgba(0, 0, 0, 0.25);
+}
+
 .home-map-hero .home-arcade-screen__panel .home-arcade-kicker,
 .home-map-hero .home-arcade-screen__panel .home-arcade-title,
 .home-map-hero .home-arcade-screen__panel .home-arcade-subtitle,
@@ -1304,6 +1384,57 @@ body.home-yvr-map-modal-open {
 }
 
 @media (max-width: 820px) {
+  .home-map-hero {
+    min-height: clamp(420px, 58vh, 620px);
+  }
+
+  .home-map-hero__content {
+    min-height: clamp(420px, 58vh, 620px);
+  }
+
+  .home-map-hero__lane {
+    top: 0.45rem;
+    max-width: calc(100% - 1rem);
+  }
+
+  .home-map-hero__lane-label {
+    font-size: 0.36rem;
+    text-align: center;
+  }
+
+  .home-map-hero.home-amp-cabinet .home-arcade-screen__backdrop {
+    left: 0.45rem;
+    right: 0.45rem;
+    bottom: 0.45rem;
+    width: auto;
+    max-width: none;
+  }
+
+  .home-map-hero.home-amp-cabinet .home-arcade-screen__panel {
+    top: 2.1rem;
+    right: 0.45rem;
+    width: min(320px, 72vw);
+    max-width: none;
+  }
+
+  .home-map-hero .home-arcade-screen__panel {
+    align-items: flex-end;
+    text-align: right;
+    padding: 0.45rem 0.55rem;
+  }
+
+  .home-map-hero .home-amp-console {
+    justify-content: flex-end;
+  }
+
+  .home-map-hero .home-title-screen-meta {
+    justify-content: flex-end;
+  }
+
+  .home-map-hero__map-stage .leaflet-top.leaflet-left {
+    bottom: 12px;
+  }
+
   .home-arcade-title-screen.home-amp-cabinet {
     grid-template-columns: 1fr;
     min-height: 0;
@@ -1343,6 +1474,15 @@ body.home-yvr-map-modal-open {
 }
 
 @media (max-width: 520px) {
+  .home-map-hero .home-arcade-title {
+    font-size: clamp(1.45rem, 9vw, 2.1rem);
+  }
+
+  .home-map-hero .home-arcade-positioning {
+    font-size: clamp(0.72rem, 3.2vw, 0.88rem);
+    max-width: 100%;
+  }
+
   .home-arcade-title-screen.home-amp-cabinet {
     padding: 0.7rem;
   }

--- a/js/home-hero-map.js
+++ b/js/home-hero-map.js
@@ -154,9 +154,16 @@
     this.booted = true;
 
     var self = this;
-    requestAnimationFrame(function () {
+    var resize = function () {
       if (self.map) self.map.invalidateSize({ animate: false });
-    });
+    };
+    requestAnimationFrame(resize);
+    if (typeof ResizeObserver !== 'undefined' && self.stage.parentElement) {
+      var observer = new ResizeObserver(function () {
+        requestAnimationFrame(resize);
+      });
+      observer.observe(self.stage.parentElement);
+    }
   };
 
   HeroMap.prototype.boot = function (config) {

--- a/page-home.php
+++ b/page-home.php
@@ -6,11 +6,14 @@ get_header();
 <main id="homepage-content" class="home-layout home-arcade-layout">
 
     <section class="home-arcade-title-screen crt-block home-amp-cabinet home-map-hero" aria-labelledby="home-hero-title" data-arcade-hero>
-        <div class="home-map-hero__map-stage" data-home-hero-map aria-hidden="true"></div>
-        <div class="home-map-hero__shade" aria-hidden="true"></div>
-        <div class="home-map-hero__scan" aria-hidden="true"></div>
         <div class="home-map-hero__content">
-        <div class="home-arcade-screen__backdrop" aria-label="<?php echo esc_attr( 'YVR live feed radio rack' ); ?>">
+        <div class="home-map-hero__left">
+            <div class="home-map-hero__map-frame" data-home-hero-map-lane>
+                <div class="home-map-hero__map-stage" data-home-hero-map aria-label="<?php echo esc_attr( 'Greater Vancouver live map' ); ?>"></div>
+                <div class="home-map-hero__map-scan" aria-hidden="true"></div>
+                <p class="home-map-hero__map-label pixel-font"><?php echo esc_html( 'greater vancouver // drag · tap pins' ); ?></p>
+            </div>
+            <div class="home-arcade-screen__backdrop" aria-label="<?php echo esc_attr( 'YVR live feed radio rack' ); ?>">
             <div class="home-yvr-rack">
                 <div class="home-yvr-broadcaster" data-yvr-broadcaster aria-label="<?php echo esc_attr( 'YVR broadcaster — live feeds and radio' ); ?>">
                     <div class="home-yvr-broadcaster__mast">
@@ -92,9 +95,7 @@ get_header();
                     <audio data-broadcaster-audio preload="none" crossorigin="anonymous"></audio>
                 </div>
             </div>
-        </div>
-        <div class="home-map-hero__lane" data-home-hero-map-lane>
-            <p class="home-map-hero__lane-label pixel-font"><?php echo esc_html( 'greater vancouver // drag map · tap pins' ); ?></p>
+            </div>
         </div>
         <div class="home-arcade-screen__panel">
             <p class="home-arcade-kicker pixel-font"><?php echo esc_html( 'founder // principal technologist' ); ?></p>

--- a/page-home.php
+++ b/page-home.php
@@ -93,6 +93,9 @@ get_header();
                 </div>
             </div>
         </div>
+        <div class="home-map-hero__lane" data-home-hero-map-lane>
+            <p class="home-map-hero__lane-label pixel-font"><?php echo esc_html( 'greater vancouver // drag map · tap pins' ); ?></p>
+        </div>
         <div class="home-arcade-screen__panel">
             <p class="home-arcade-kicker pixel-font"><?php echo esc_html( 'founder // principal technologist' ); ?></p>
             <h1 id="home-hero-title" class="home-arcade-title pixel-font"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The map was a full-bleed background layer under the banner text and Dave rack — it read as wallpaper, not part of the hero. Floating overlays didn't fix that.

## Solution

**Split banner layout** (back to cabinet logic, map as a real column):

| Left column | Right column |
|-------------|--------------|
| **Map frame** — bordered CRT panel, ~30vh min height, drag + pin taps | **Bio** — SUZY EASTON, INSERT COIN, PRESS START |
| **Dave / YVR rack** — stacked below the map | |

- Map is no longer `position: absolute` on the whole section — it lives in `.home-map-hero__map-frame` with its own scan overlay and label.
- Banner keeps the dark amp-cabinet gradient (stars untouched on page bg).
- `ResizeObserver` on the map frame so Leaflet resizes correctly in the column.

## Files

- `page-home.php` — restructured hero markup
- `assets/css/home-hero-cabinet.css` — 2-col grid, map frame styles
- `js/home-hero-map.js` — resize observer for column layout

## Test plan

- [ ] Desktop: map visibly on left, Vancouver labels readable; drag pans map
- [ ] Tap map pins → channel switches on Dave rack
- [ ] Bio column on right, not covering map
- [ ] Mobile: stacks — map frame top, rack, then bio
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8847567f-6559-4baa-822d-02ae416215a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8847567f-6559-4baa-822d-02ae416215a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

