### PR TITLE
YVR Radar Deck — live map as the hero centerpiece

### DIFF
--- a/assets/css/home-hero-cabinet.css
+++ b/assets/css/home-hero-cabinet.css
@@ -1,20 +1,43 @@
-/* Compact YVR + amp-stack homepage hero — map banner + Dave rack overlay. */
+/* Compact YVR + amp-stack homepage hero — split banner: map left, bio right. */
 
 .home-map-hero {
   position: relative;
   isolation: isolate;
-  min-height: clamp(380px, 48vh, 560px);
-  padding: 0;
-  border: 2px solid rgba(87, 243, 255, 0.55);
+}
+
+.home-map-hero__content {
+  display: grid;
+  grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+  align-items: stretch;
+  gap: clamp(0.65rem, 1.6vw, 1rem);
+  min-height: clamp(280px, 38vh, 420px);
+}
+
+.home-map-hero__left {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.45rem, 1vw, 0.65rem);
+  min-width: 0;
+  min-height: 0;
+}
+
+.home-map-hero__map-frame {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: clamp(200px, 30vh, 340px);
+  border-radius: 10px;
+  border: 2px solid rgba(87, 243, 255, 0.42);
   background: #020610;
+  overflow: hidden;
+  box-shadow:
+    inset 0 0 28px rgba(0, 0, 0, 0.65),
+    0 0 18px rgba(87, 243, 255, 0.08);
 }
 
 .home-map-hero__map-stage {
   position: absolute;
   inset: 0;
   z-index: 0;
-  border-radius: 14px;
-  overflow: hidden;
 }
 
 .home-map-hero__map-stage .leaflet-container {
@@ -24,88 +47,47 @@
   background: #020610;
 }
 
-.home-map-hero__shade {
+.home-map-hero__map-scan {
   position: absolute;
   inset: 0;
   z-index: 1;
   pointer-events: none;
-  border-radius: 14px;
-  background:
-    radial-gradient(ellipse 42% 58% at 10% 92%, rgba(4, 8, 14, 0.78), transparent 72%),
-    radial-gradient(ellipse 38% 52% at 92% 14%, rgba(4, 8, 14, 0.74), transparent 70%),
-    linear-gradient(180deg, rgba(2, 4, 8, 0.12), transparent 38%, rgba(2, 4, 8, 0.22));
-}
-
-.home-map-hero__scan {
-  position: absolute;
-  inset: 0;
-  z-index: 2;
-  pointer-events: none;
-  border-radius: 14px;
   background: repeating-linear-gradient(
     180deg,
     rgba(255, 255, 255, 0.03) 0 1px,
     transparent 1px 3px
   );
   mix-blend-mode: screen;
-  opacity: 0.22;
+  opacity: 0.2;
   animation: homeBcastScan 6s linear infinite;
 }
 
-.home-map-hero__content {
-  position: relative;
-  z-index: 3;
-  display: block;
-  min-height: clamp(380px, 48vh, 560px);
-  padding: 0;
-  pointer-events: none;
-}
-
-.home-map-hero__lane {
+.home-map-hero__map-label {
   position: absolute;
-  top: clamp(0.55rem, 1.4vw, 0.85rem);
-  left: 50%;
+  top: 0.38rem;
+  left: 0.38rem;
   z-index: 2;
-  transform: translateX(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  pointer-events: none;
-}
-
-.home-map-hero__lane-label {
   margin: 0;
-  padding: 0.22rem 0.45rem;
+  padding: 0.2rem 0.42rem;
   border-radius: 3px;
   border: 1px solid rgba(87, 243, 255, 0.28);
-  background: rgba(2, 6, 10, 0.45);
+  background: rgba(2, 6, 10, 0.72);
   font-size: clamp(0.38rem, 0.72vw, 0.48rem);
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(180, 230, 220, 0.82);
+  color: rgba(180, 230, 220, 0.88);
   pointer-events: none;
-  backdrop-filter: blur(4px);
 }
 
-.home-map-hero__content > .home-arcade-screen__backdrop {
-  position: absolute;
-  bottom: clamp(0.55rem, 1.4vw, 0.85rem);
-  left: clamp(0.55rem, 1.4vw, 0.85rem);
-  z-index: 4;
-  width: min(280px, 42vw);
-  max-width: 280px;
-  pointer-events: auto;
+.home-map-hero__map-stage .leaflet-control-zoom {
+  border: 1px solid rgba(87, 243, 255, 0.35);
+  background: rgba(2, 6, 10, 0.82);
 }
 
-.home-map-hero__content > .home-arcade-screen__panel {
-  position: absolute;
-  top: clamp(0.55rem, 1.4vw, 0.85rem);
-  right: clamp(0.55rem, 1.4vw, 0.85rem);
-  z-index: 4;
-  width: min(320px, 46vw);
-  max-width: 320px;
-  pointer-events: none;
+.home-map-hero__map-stage .leaflet-top.leaflet-left {
+  top: 0.38rem;
+  left: auto;
+  right: 0.38rem;
 }
 
 .home-arcade-title-screen.home-amp-cabinet {
@@ -134,27 +116,34 @@
 
 .home-map-hero.home-amp-cabinet {
   display: block;
-  grid-template-columns: unset;
-  gap: 0;
-  min-height: clamp(380px, 48vh, 560px);
-  padding: 0;
-  background: transparent;
+  min-height: clamp(320px, 42vh, 480px);
+  padding: clamp(0.85rem, 2vw, 1.15rem);
+  background:
+    radial-gradient(circle at 18% 82%, rgba(87, 243, 255, 0.14), transparent 34%),
+    radial-gradient(circle at 88% 18%, rgba(255, 79, 216, 0.1), transparent 28%),
+    linear-gradient(165deg, #04060f 0%, #07111f 42%, #020308 100%);
   box-shadow:
     0 0 0 1px rgba(57, 255, 20, 0.12),
-    0 16px 48px rgba(0, 0, 0, 0.55);
+    0 16px 48px rgba(0, 0, 0, 0.55),
+    inset 0 0 40px rgba(0, 0, 0, 0.35);
 }
 
-.home-map-hero__map-stage .leaflet-top.leaflet-left {
-  left: 50%;
-  right: auto;
-  top: auto;
-  bottom: 12px;
-  transform: translateX(-50%);
+.home-map-hero.home-amp-cabinet .home-arcade-screen__backdrop {
+  position: relative;
+  flex: 0 0 auto;
+  width: 100%;
+  min-height: 0;
 }
 
-.home-map-hero__map-stage .leaflet-control-zoom {
-  border: 1px solid rgba(87, 243, 255, 0.35);
-  background: rgba(2, 6, 10, 0.72);
+.home-map-hero.home-amp-cabinet .home-arcade-screen__panel {
+  position: relative;
+  width: 100%;
+  max-width: none;
+  align-self: stretch;
+}
+
+.home-map-hero .home-arcade-screen__backdrop {
+  background: rgba(2, 8, 18, 0.45);
 }
 
 .home-amp-cabinet::before {
@@ -186,25 +175,11 @@
   backdrop-filter: blur(6px);
 }
 
-.home-map-hero.home-amp-cabinet .home-arcade-screen__backdrop {
-  position: absolute;
-  bottom: clamp(0.55rem, 1.4vw, 0.85rem);
-  left: clamp(0.55rem, 1.4vw, 0.85rem);
-  width: min(280px, 42vw);
-  max-width: 280px;
-}
-
-.home-map-hero.home-amp-cabinet .home-arcade-screen__panel {
-  position: absolute;
-  top: clamp(0.55rem, 1.4vw, 0.85rem);
-  right: clamp(0.55rem, 1.4vw, 0.85rem);
-  width: min(320px, 46vw);
-  max-width: 320px;
-}
-
-.home-map-hero .home-arcade-screen__backdrop {
-  background: rgba(2, 8, 18, 0.58);
-  backdrop-filter: blur(8px);
+.home-amp-cabinet .home-arcade-screen__backdrop {
+  position: relative;
+  width: 100%;
+  max-width: none;
+  margin: 0;
 }
 
 .home-yvr-rack {
@@ -1272,8 +1247,10 @@ body.home-yvr-map-modal-open {
 }
 
 .home-map-hero .home-arcade-screen__panel {
-  background: rgba(4, 8, 14, 0.48);
-  box-shadow: 0 0 24px rgba(0, 0, 0, 0.25);
+  background: transparent;
+  border-color: rgba(87, 243, 255, 0.2);
+  box-shadow: none;
+  backdrop-filter: none;
 }
 
 .home-map-hero .home-arcade-screen__panel .home-arcade-kicker,
@@ -1384,55 +1361,26 @@ body.home-yvr-map-modal-open {
 }
 
 @media (max-width: 820px) {
-  .home-map-hero {
-    min-height: clamp(420px, 58vh, 620px);
-  }
-
   .home-map-hero__content {
-    min-height: clamp(420px, 58vh, 620px);
+    grid-template-columns: 1fr;
+    min-height: 0;
   }
 
-  .home-map-hero__lane {
-    top: 0.45rem;
-    max-width: calc(100% - 1rem);
-  }
-
-  .home-map-hero__lane-label {
-    font-size: 0.36rem;
-    text-align: center;
-  }
-
-  .home-map-hero.home-amp-cabinet .home-arcade-screen__backdrop {
-    left: 0.45rem;
-    right: 0.45rem;
-    bottom: 0.45rem;
-    width: auto;
-    max-width: none;
+  .home-map-hero__map-frame {
+    min-height: clamp(200px, 36vh, 300px);
   }
 
   .home-map-hero.home-amp-cabinet .home-arcade-screen__panel {
-    top: 2.1rem;
-    right: 0.45rem;
-    width: min(320px, 72vw);
-    max-width: none;
-  }
-
-  .home-map-hero .home-arcade-screen__panel {
-    align-items: flex-end;
-    text-align: right;
-    padding: 0.45rem 0.55rem;
+    align-items: center;
+    text-align: center;
   }
 
   .home-map-hero .home-amp-console {
-    justify-content: flex-end;
+    justify-content: center;
   }
 
   .home-map-hero .home-title-screen-meta {
-    justify-content: flex-end;
-  }
-
-  .home-map-hero__map-stage .leaflet-top.leaflet-left {
-    bottom: 12px;
+    justify-content: center;
   }
 
   .home-arcade-title-screen.home-amp-cabinet {

--- a/assets/css/home-hero-cabinet.css
+++ b/assets/css/home-hero-cabinet.css
@@ -3,7 +3,7 @@
 .home-map-hero {
   position: relative;
   isolation: isolate;
-  min-height: clamp(340px, 44vh, 520px);
+  min-height: clamp(380px, 48vh, 560px);
   padding: 0;
   border: 2px solid rgba(87, 243, 255, 0.55);
   background: #020610;
@@ -31,8 +31,9 @@
   pointer-events: none;
   border-radius: 14px;
   background:
-    linear-gradient(105deg, rgba(4, 8, 14, 0.82) 0%, rgba(4, 8, 14, 0.45) 42%, rgba(4, 8, 14, 0.25) 68%, rgba(4, 8, 14, 0.55) 100%),
-    linear-gradient(180deg, rgba(2, 4, 8, 0.35), transparent 40%, rgba(2, 4, 8, 0.5));
+    radial-gradient(ellipse 42% 58% at 10% 92%, rgba(4, 8, 14, 0.78), transparent 72%),
+    radial-gradient(ellipse 38% 52% at 92% 14%, rgba(4, 8, 14, 0.74), transparent 70%),
+    linear-gradient(180deg, rgba(2, 4, 8, 0.12), transparent 38%, rgba(2, 4, 8, 0.22));
 }
 
 .home-map-hero__scan {
@@ -54,17 +55,57 @@
 .home-map-hero__content {
   position: relative;
   z-index: 3;
-  display: grid;
-  grid-template-columns: minmax(0, 0.76fr) minmax(0, 1.24fr);
-  align-items: stretch;
-  gap: clamp(0.65rem, 1.6vw, 1rem);
-  min-height: clamp(340px, 44vh, 520px);
-  padding: clamp(0.85rem, 2vw, 1.15rem);
+  display: block;
+  min-height: clamp(380px, 48vh, 560px);
+  padding: 0;
   pointer-events: none;
 }
 
-.home-map-hero__content > * {
+.home-map-hero__lane {
+  position: absolute;
+  top: clamp(0.55rem, 1.4vw, 0.85rem);
+  left: 50%;
+  z-index: 2;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  pointer-events: none;
+}
+
+.home-map-hero__lane-label {
+  margin: 0;
+  padding: 0.22rem 0.45rem;
+  border-radius: 3px;
+  border: 1px solid rgba(87, 243, 255, 0.28);
+  background: rgba(2, 6, 10, 0.45);
+  font-size: clamp(0.38rem, 0.72vw, 0.48rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(180, 230, 220, 0.82);
+  pointer-events: none;
+  backdrop-filter: blur(4px);
+}
+
+.home-map-hero__content > .home-arcade-screen__backdrop {
+  position: absolute;
+  bottom: clamp(0.55rem, 1.4vw, 0.85rem);
+  left: clamp(0.55rem, 1.4vw, 0.85rem);
+  z-index: 4;
+  width: min(280px, 42vw);
+  max-width: 280px;
   pointer-events: auto;
+}
+
+.home-map-hero__content > .home-arcade-screen__panel {
+  position: absolute;
+  top: clamp(0.55rem, 1.4vw, 0.85rem);
+  right: clamp(0.55rem, 1.4vw, 0.85rem);
+  z-index: 4;
+  width: min(320px, 46vw);
+  max-width: 320px;
+  pointer-events: none;
 }
 
 .home-arcade-title-screen.home-amp-cabinet {
@@ -95,12 +136,25 @@
   display: block;
   grid-template-columns: unset;
   gap: 0;
-  min-height: clamp(340px, 44vh, 520px);
+  min-height: clamp(380px, 48vh, 560px);
   padding: 0;
   background: transparent;
   box-shadow:
     0 0 0 1px rgba(57, 255, 20, 0.12),
     0 16px 48px rgba(0, 0, 0, 0.55);
+}
+
+.home-map-hero__map-stage .leaflet-top.leaflet-left {
+  left: 50%;
+  right: auto;
+  top: auto;
+  bottom: 12px;
+  transform: translateX(-50%);
+}
+
+.home-map-hero__map-stage .leaflet-control-zoom {
+  border: 1px solid rgba(87, 243, 255, 0.35);
+  background: rgba(2, 6, 10, 0.72);
 }
 
 .home-amp-cabinet::before {
@@ -124,12 +178,33 @@
   align-items: stretch;
   gap: 0;
   min-height: 0;
-  padding: clamp(0.35rem, 1vw, 0.5rem);
+  padding: clamp(0.3rem, 0.8vw, 0.45rem);
   border-radius: 12px;
   overflow: hidden;
   border: 1px solid rgba(87, 243, 255, 0.28);
-  background: rgba(2, 8, 18, 0.55);
-  backdrop-filter: blur(4px);
+  background: rgba(2, 8, 18, 0.38);
+  backdrop-filter: blur(6px);
+}
+
+.home-map-hero.home-amp-cabinet .home-arcade-screen__backdrop {
+  position: absolute;
+  bottom: clamp(0.55rem, 1.4vw, 0.85rem);
+  left: clamp(0.55rem, 1.4vw, 0.85rem);
+  width: min(280px, 42vw);
+  max-width: 280px;
+}
+
+.home-map-hero.home-amp-cabinet .home-arcade-screen__panel {
+  position: absolute;
+  top: clamp(0.55rem, 1.4vw, 0.85rem);
+  right: clamp(0.55rem, 1.4vw, 0.85rem);
+  width: min(320px, 46vw);
+  max-width: 320px;
+}
+
+.home-map-hero .home-arcade-screen__backdrop {
+  background: rgba(2, 8, 18, 0.58);
+  backdrop-filter: blur(8px);
 }
 
 .home-yvr-rack {
@@ -1196,6 +1271,11 @@ body.home-yvr-map-modal-open {
   backdrop-filter: blur(3px);
 }
 
+.home-map-hero .home-arcade-screen__panel {
+  background: rgba(4, 8, 14, 0.48);
+  box-shadow: 0 0 24px rgba(0, 0, 0, 0.25);
+}
+
 .home-map-hero .home-arcade-screen__panel .home-arcade-kicker,
 .home-map-hero .home-arcade-screen__panel .home-arcade-title,
 .home-map-hero .home-arcade-screen__panel .home-arcade-subtitle,
@@ -1304,6 +1384,57 @@ body.home-yvr-map-modal-open {
 }
 
 @media (max-width: 820px) {
+  .home-map-hero {
+    min-height: clamp(420px, 58vh, 620px);
+  }
+
+  .home-map-hero__content {
+    min-height: clamp(420px, 58vh, 620px);
+  }
+
+  .home-map-hero__lane {
+    top: 0.45rem;
+    max-width: calc(100% - 1rem);
+  }
+
+  .home-map-hero__lane-label {
+    font-size: 0.36rem;
+    text-align: center;
+  }
+
+  .home-map-hero.home-amp-cabinet .home-arcade-screen__backdrop {
+    left: 0.45rem;
+    right: 0.45rem;
+    bottom: 0.45rem;
+    width: auto;
+    max-width: none;
+  }
+
+  .home-map-hero.home-amp-cabinet .home-arcade-screen__panel {
+    top: 2.1rem;
+    right: 0.45rem;
+    width: min(320px, 72vw);
+    max-width: none;
+  }
+
+  .home-map-hero .home-arcade-screen__panel {
+    align-items: flex-end;
+    text-align: right;
+    padding: 0.45rem 0.55rem;
+  }
+
+  .home-map-hero .home-amp-console {
+    justify-content: flex-end;
+  }
+
+  .home-map-hero .home-title-screen-meta {
+    justify-content: flex-end;
+  }
+
+  .home-map-hero__map-stage .leaflet-top.leaflet-left {
+    bottom: 12px;
+  }
+
   .home-arcade-title-screen.home-amp-cabinet {
     grid-template-columns: 1fr;
     min-height: 0;
@@ -1343,6 +1474,15 @@ body.home-yvr-map-modal-open {
 }
 
 @media (max-width: 520px) {
+  .home-map-hero .home-arcade-title {
+    font-size: clamp(1.45rem, 9vw, 2.1rem);
+  }
+
+  .home-map-hero .home-arcade-positioning {
+    font-size: clamp(0.72rem, 3.2vw, 0.88rem);
+    max-width: 100%;
+  }
+
   .home-arcade-title-screen.home-amp-cabinet {
     padding: 0.7rem;
   }

--- a/assets/css/home-yvr-radar-deck.css
+++ b/assets/css/home-yvr-radar-deck.css
@@ -1,0 +1,445 @@
+/* YVR Radar Deck — map-first homepage hero (no title-screen overlay stack). */
+
+.home-yvr-radar-deck {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.75rem, 1.8vw, 1.15rem);
+  width: min(1220px, calc(100% - clamp(1rem, 3vw, 2rem)));
+  margin: 0 auto clamp(1rem, 2vw, 1.5rem);
+  padding: clamp(0.85rem, 2vw, 1.35rem);
+  border: 3px solid rgba(57, 255, 20, 0.65);
+  border-radius: 18px;
+  background:
+    radial-gradient(circle at 14% 88%, rgba(87, 243, 255, 0.12), transparent 38%),
+    radial-gradient(circle at 88% 12%, rgba(255, 79, 216, 0.1), transparent 32%),
+    linear-gradient(165deg, #04060f 0%, #07111f 42%, #020308 100%);
+  box-shadow:
+    0 0 0 4px rgba(0, 0, 0, 0.85),
+    0 24px 64px rgba(0, 0, 0, 0.65),
+    inset 0 0 40px rgba(57, 255, 20, 0.06);
+  scroll-margin-top: calc(var(--se-header-height, 72px) + 1rem);
+}
+
+.home-yvr-radar-deck__mast {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  text-align: center;
+}
+
+.home-yvr-radar-deck__kicker {
+  margin: 0;
+  color: #57f3ff;
+  font-size: clamp(0.48rem, 1vw, 0.68rem);
+  letter-spacing: 0.12em;
+}
+
+.home-yvr-radar-deck__title {
+  margin: 0;
+  color: #ffff66;
+  font-size: clamp(1.75rem, 5.5vw, 3.25rem);
+  line-height: 0.98;
+  letter-spacing: 0.04em;
+  text-shadow:
+    0.05em 0.05em 0 #ff4fd8,
+    -0.03em -0.03em 0 #57f3ff,
+    0 0 18px rgba(255, 255, 102, 0.35);
+}
+
+/* —— Radar unit (the map IS the hero) —— */
+.home-yvr-radar-deck__radar-unit {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.45rem;
+  width: 100%;
+}
+
+.home-yvr-radar-deck__unit-head {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+  width: 100%;
+  max-width: min(92vw, 680px);
+}
+
+.home-yvr-radar-deck__unit-badge {
+  padding: 0.28rem 0.55rem;
+  border: 2px solid rgba(255, 79, 216, 0.55);
+  border-radius: 4px;
+  background: rgba(255, 79, 216, 0.12);
+  color: #ff4fd8;
+  font-size: clamp(0.42rem, 0.9vw, 0.55rem);
+  letter-spacing: 0.1em;
+  text-shadow: 0 0 10px rgba(255, 79, 216, 0.45);
+}
+
+.home-yvr-radar-deck__unit-status {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: rgba(180, 230, 220, 0.85);
+  font-size: clamp(0.4rem, 0.85vw, 0.52rem);
+  letter-spacing: 0.08em;
+}
+
+.home-yvr-radar-deck__unit-status::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #39ff14;
+  box-shadow: 0 0 10px rgba(57, 255, 20, 0.85);
+  animation: homeYvrRadarPulse 1.4s ease-in-out infinite;
+}
+
+@keyframes homeYvrRadarPulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.45; transform: scale(0.85); }
+}
+
+.home-yvr-radar-deck__bezel {
+  position: relative;
+  width: min(100%, 680px);
+  padding: clamp(0.65rem, 1.5vw, 1rem);
+  border-radius: 20px;
+  border: 4px solid #1a1e28;
+  background:
+    linear-gradient(145deg, #2a3040 0%, #12161e 45%, #080a10 100%);
+  box-shadow:
+    inset 0 2px 0 rgba(255, 255, 255, 0.08),
+    inset 0 -12px 24px rgba(0, 0, 0, 0.75),
+    6px 8px 0 rgba(255, 79, 216, 0.35),
+    0 0 32px rgba(87, 243, 255, 0.12);
+}
+
+.home-yvr-radar-deck__bezel::before {
+  content: "";
+  position: absolute;
+  inset: 6px;
+  border-radius: 14px;
+  border: 1px solid rgba(87, 243, 255, 0.15);
+  pointer-events: none;
+}
+
+.home-yvr-radar-deck__crt-ring {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1;
+  max-height: min(52vh, 520px);
+  margin: 0 auto;
+}
+
+.home-yvr-radar-deck__map-wrap {
+  position: absolute;
+  inset: 7%;
+  z-index: 1;
+  border-radius: 50%;
+  overflow: hidden;
+  border: 3px solid rgba(57, 255, 20, 0.55);
+  box-shadow:
+    inset 0 0 40px rgba(0, 0, 0, 0.65),
+    0 0 24px rgba(57, 255, 20, 0.15);
+  background: #020610;
+}
+
+.home-yvr-radar-deck__map {
+  width: 100%;
+  height: 100%;
+  min-height: 200px;
+}
+
+.home-yvr-radar-deck__map .leaflet-container {
+  width: 100%;
+  height: 100%;
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  background: #020610;
+  cursor: grab;
+}
+
+.home-yvr-radar-deck__map .leaflet-container:active {
+  cursor: grabbing;
+}
+
+.home-yvr-radar-deck__map .leaflet-control-zoom {
+  border: 1px solid rgba(87, 243, 255, 0.4);
+  background: rgba(2, 6, 10, 0.88);
+}
+
+.home-yvr-radar-deck__map .leaflet-top.leaflet-left {
+  top: 0.35rem;
+  left: auto;
+  right: 0.35rem;
+}
+
+.home-yvr-radar-deck__grid {
+  position: absolute;
+  inset: 7%;
+  z-index: 2;
+  border-radius: 50%;
+  pointer-events: none;
+  background:
+    linear-gradient(rgba(57, 255, 20, 0.12) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(57, 255, 20, 0.12) 1px, transparent 1px);
+  background-size: 18% 18%;
+  opacity: 0.45;
+  mask-image: radial-gradient(circle, black 62%, transparent 70%);
+}
+
+.home-yvr-radar-deck__sweep {
+  position: absolute;
+  inset: 7%;
+  z-index: 3;
+  border-radius: 50%;
+  pointer-events: none;
+  background: conic-gradient(
+    from 0deg,
+    transparent 0deg,
+    rgba(57, 255, 20, 0.22) 28deg,
+    rgba(87, 243, 255, 0.08) 32deg,
+    transparent 56deg
+  );
+  animation: homeYvrRadarSweep 5s linear infinite;
+  mask-image: radial-gradient(circle, black 64%, transparent 70%);
+}
+
+@keyframes homeYvrRadarSweep {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.home-yvr-radar-deck__scan {
+  position: absolute;
+  inset: 7%;
+  z-index: 4;
+  border-radius: 50%;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.04) 0 1px,
+    transparent 1px 3px
+  );
+  mix-blend-mode: screen;
+  opacity: 0.35;
+  animation: homeYvrRadarScan 6s linear infinite;
+}
+
+@keyframes homeYvrRadarScan {
+  0% { transform: translateY(0); }
+  100% { transform: translateY(4px); }
+}
+
+.home-yvr-radar-deck__ring-label {
+  position: absolute;
+  left: 50%;
+  bottom: 2%;
+  z-index: 5;
+  transform: translateX(-50%);
+  margin: 0;
+  padding: 0.2rem 0.5rem;
+  border-radius: 3px;
+  border: 1px solid rgba(87, 243, 255, 0.3);
+  background: rgba(2, 6, 10, 0.82);
+  font-size: clamp(0.36rem, 0.72vw, 0.48rem);
+  letter-spacing: 0.08em;
+  color: rgba(180, 230, 220, 0.88);
+  pointer-events: none;
+}
+
+.home-yvr-radar-deck__knobs {
+  display: flex;
+  justify-content: center;
+  gap: 0.55rem;
+  margin-top: 0.55rem;
+}
+
+.home-yvr-radar-deck__knobs span {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid #333;
+  background: radial-gradient(circle at 30% 30%, #666, #111);
+  box-shadow: inset 0 -2px 3px rgba(0, 0, 0, 0.8);
+}
+
+.home-yvr-radar-deck__knobs span:nth-child(1) { border-color: rgba(255, 79, 216, 0.55); }
+.home-yvr-radar-deck__knobs span:nth-child(2) { border-color: rgba(57, 255, 20, 0.55); }
+.home-yvr-radar-deck__knobs span:nth-child(3) { border-color: rgba(87, 243, 255, 0.55); }
+
+.home-yvr-radar-deck__hint {
+  margin: 0;
+  color: rgba(150, 190, 180, 0.72);
+  font-size: clamp(0.38rem, 0.78vw, 0.5rem);
+  letter-spacing: 0.08em;
+  text-align: center;
+}
+
+/* —— Console: Dave + CTA —— */
+.home-yvr-radar-deck__console {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: clamp(0.65rem, 1.5vw, 1rem);
+  align-items: start;
+}
+
+.home-yvr-radar-deck__rack {
+  min-width: 0;
+  padding: clamp(0.35rem, 0.8vw, 0.5rem);
+  border-radius: 12px;
+  border: 1px solid rgba(87, 243, 255, 0.28);
+  background: rgba(2, 8, 18, 0.55);
+}
+
+.home-yvr-radar-deck__cta {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: clamp(0.4rem, 1vw, 0.65rem);
+  min-width: 0;
+  padding: clamp(0.35rem, 1vw, 0.65rem);
+}
+
+.home-yvr-radar-deck__subtitle {
+  margin: 0;
+  color: rgba(223, 255, 234, 0.88);
+  font-size: clamp(0.52rem, 1vw, 0.72rem);
+  line-height: 1.45;
+  letter-spacing: 0.08em;
+}
+
+.home-yvr-radar-deck__positioning {
+  margin: 0;
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  font-size: clamp(0.78rem, 1.25vw, 0.94rem);
+  line-height: 1.45;
+  color: rgba(232, 247, 255, 0.9);
+}
+
+.home-yvr-radar-deck__cta .home-amp-console {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.55rem 0.75rem;
+  margin-top: 0.15rem;
+}
+
+.home-yvr-radar-deck__cta .home-title-screen-prompt {
+  position: relative;
+  margin: 0;
+  padding: 0.38rem 0.65rem;
+  font-size: clamp(0.48rem, 0.85vw, 0.62rem);
+  color: #020308;
+  background: #ffe66d;
+  border: 2px solid #020308;
+  box-shadow: 3px 3px 0 #ff4fd8;
+}
+
+.home-yvr-radar-deck__cta .home-press-start {
+  min-width: 0;
+  width: auto;
+  padding: 0.65rem 1rem;
+  font-size: clamp(0.62rem, 1.1vw, 0.78rem);
+  background: #39ff14;
+  border-color: #ffff66;
+  color: #020805;
+  box-shadow: 4px 4px 0 #ff4fd8, 0 0 16px rgba(57, 255, 20, 0.28);
+}
+
+.home-yvr-radar-deck__cta .home-title-screen-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.home-yvr-radar-deck__cta .home-title-screen-meta li {
+  font-family: "Press Start 2P", monospace;
+  font-size: clamp(0.42rem, 0.75vw, 0.55rem);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.28rem 0.45rem;
+  border: 1px solid rgba(87, 243, 255, 0.32);
+  border-radius: 999px;
+  color: rgba(200, 240, 255, 0.88);
+  background: rgba(0, 12, 20, 0.55);
+}
+
+/* Radar deck start animation (arcade-start.js) */
+.home-yvr-radar-deck.is-starting {
+  animation: homeYvrRadarCoin 900ms steps(4, end) 1;
+}
+
+.home-yvr-radar-deck.is-signal-locking .home-yvr-radar-deck__sweep {
+  animation-duration: 1.2s;
+}
+
+@keyframes homeYvrRadarCoin {
+  0%, 100% { filter: none; }
+  25% { filter: brightness(1.15); }
+  50% { filter: brightness(0.92); }
+  75% { filter: brightness(1.08); }
+}
+
+@media (max-width: 820px) {
+  .home-yvr-radar-deck__crt-ring {
+    max-height: min(46vh, 380px);
+  }
+
+  .home-yvr-radar-deck__console {
+    grid-template-columns: 1fr;
+  }
+
+  .home-yvr-radar-deck__cta {
+    text-align: center;
+    align-items: center;
+  }
+
+  .home-yvr-radar-deck__cta .home-amp-console {
+    justify-content: center;
+  }
+
+  .home-yvr-radar-deck__cta .home-title-screen-meta {
+    justify-content: center;
+  }
+}
+
+@media (max-width: 520px) {
+  .home-yvr-radar-deck {
+    padding: 0.75rem;
+  }
+
+  .home-yvr-radar-deck__title {
+    font-size: clamp(1.5rem, 9vw, 2.2rem);
+  }
+
+  .home-yvr-radar-deck__crt-ring {
+    max-height: min(42vh, 320px);
+  }
+
+  .home-yvr-radar-deck__map-wrap {
+    inset: 6%;
+  }
+
+  .home-yvr-radar-deck__grid,
+  .home-yvr-radar-deck__sweep,
+  .home-yvr-radar-deck__scan {
+    inset: 6%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-yvr-radar-deck__sweep,
+  .home-yvr-radar-deck__scan,
+  .home-yvr-radar-deck__unit-status::before,
+  .home-yvr-radar-deck.is-starting,
+  .home-yvr-radar-deck__cta .home-title-screen-prompt,
+  .home-yvr-radar-deck__cta .home-press-start {
+    animation: none !important;
+  }
+}

--- a/functions.php
+++ b/functions.php
@@ -81,6 +81,16 @@ function retro_game_music_theme_scripts() {
             );
         }
 
+        $radar_css = get_template_directory() . '/assets/css/home-yvr-radar-deck.css';
+        if ( file_exists( $radar_css ) ) {
+            wp_enqueue_style(
+                'home-yvr-radar-deck',
+                get_template_directory_uri() . '/assets/css/home-yvr-radar-deck.css',
+                array( 'main-styles', 'home-hero-cabinet' ),
+                filemtime( $radar_css )
+            );
+        }
+
         wp_enqueue_script(
             'home-arcade-start',
             get_template_directory_uri() . '/js/home-arcade-start.js',

--- a/js/home-hero-map.js
+++ b/js/home-hero-map.js
@@ -154,9 +154,16 @@
     this.booted = true;
 
     var self = this;
-    requestAnimationFrame(function () {
+    var resize = function () {
       if (self.map) self.map.invalidateSize({ animate: false });
-    });
+    };
+    requestAnimationFrame(resize);
+    if (typeof ResizeObserver !== 'undefined' && self.stage.parentElement) {
+      var observer = new ResizeObserver(function () {
+        requestAnimationFrame(resize);
+      });
+      observer.observe(self.stage.parentElement);
+    }
   };
 
   HeroMap.prototype.boot = function (config) {

--- a/js/home-hero-map.js
+++ b/js/home-hero-map.js
@@ -158,11 +158,15 @@
       if (self.map) self.map.invalidateSize({ animate: false });
     };
     requestAnimationFrame(resize);
-    if (typeof ResizeObserver !== 'undefined' && self.stage.parentElement) {
+    if (typeof ResizeObserver !== 'undefined') {
+      var observeTarget = self.stage.parentElement || self.stage;
       var observer = new ResizeObserver(function () {
         requestAnimationFrame(resize);
       });
-      observer.observe(self.stage.parentElement);
+      observer.observe(observeTarget);
+      if (observeTarget.parentElement && observeTarget.parentElement !== observeTarget) {
+        observer.observe(observeTarget.parentElement);
+      }
     }
   };
 

--- a/page-home.php
+++ b/page-home.php
@@ -5,16 +5,37 @@ get_header();
 
 <main id="homepage-content" class="home-layout home-arcade-layout">
 
-    <section class="home-arcade-title-screen crt-block home-amp-cabinet home-map-hero" aria-labelledby="home-hero-title" data-arcade-hero>
-        <div class="home-map-hero__content">
-        <div class="home-map-hero__left">
-            <div class="home-map-hero__map-frame" data-home-hero-map-lane>
-                <div class="home-map-hero__map-stage" data-home-hero-map aria-label="<?php echo esc_attr( 'Greater Vancouver live map' ); ?>"></div>
-                <div class="home-map-hero__map-scan" aria-hidden="true"></div>
-                <p class="home-map-hero__map-label pixel-font"><?php echo esc_html( 'greater vancouver // drag · tap pins' ); ?></p>
+    <section class="home-yvr-radar-deck" aria-labelledby="home-hero-title" data-arcade-hero>
+        <header class="home-yvr-radar-deck__mast">
+            <p class="home-yvr-radar-deck__kicker pixel-font"><?php echo esc_html( 'founder // principal technologist' ); ?></p>
+            <h1 id="home-hero-title" class="home-yvr-radar-deck__title pixel-font"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>
+        </header>
+
+        <div class="home-yvr-radar-deck__radar-unit">
+            <div class="home-yvr-radar-deck__unit-head pixel-font">
+                <span class="home-yvr-radar-deck__unit-badge"><?php echo esc_html( 'YVR RADAR' ); ?></span>
+                <span class="home-yvr-radar-deck__unit-status"><?php echo esc_html( 'live greater vancouver' ); ?></span>
             </div>
-            <div class="home-arcade-screen__backdrop" aria-label="<?php echo esc_attr( 'YVR live feed radio rack' ); ?>">
-            <div class="home-yvr-rack">
+            <div class="home-yvr-radar-deck__bezel">
+                <div class="home-yvr-radar-deck__crt-ring">
+                    <div class="home-yvr-radar-deck__map-wrap">
+                        <div class="home-yvr-radar-deck__map" data-home-hero-map></div>
+                    </div>
+                    <div class="home-yvr-radar-deck__grid" aria-hidden="true"></div>
+                    <div class="home-yvr-radar-deck__sweep" aria-hidden="true"></div>
+                    <div class="home-yvr-radar-deck__scan" aria-hidden="true"></div>
+                    <p class="home-yvr-radar-deck__ring-label pixel-font"><?php echo esc_html( 'drag · tap pins' ); ?></p>
+                </div>
+                <div class="home-yvr-radar-deck__knobs" aria-hidden="true">
+                    <span></span><span></span><span></span>
+                </div>
+            </div>
+            <p class="home-yvr-radar-deck__hint pixel-font"><?php echo esc_html( "map pins match dave's channels — wildfire, skytrain, drivebc" ); ?></p>
+        </div>
+
+        <div class="home-yvr-radar-deck__console">
+            <div class="home-yvr-radar-deck__rack">
+                <div class="home-yvr-rack">
                 <div class="home-yvr-broadcaster" data-yvr-broadcaster aria-label="<?php echo esc_attr( 'YVR broadcaster — live feeds and radio' ); ?>">
                     <div class="home-yvr-broadcaster__mast">
                         <div class="home-yvr-broadcaster__avatar" data-broadcaster-face aria-hidden="true">
@@ -94,25 +115,22 @@ get_header();
                     </button>
                     <audio data-broadcaster-audio preload="none" crossorigin="anonymous"></audio>
                 </div>
+                </div>
             </div>
+            <div class="home-yvr-radar-deck__cta">
+                <p class="home-yvr-radar-deck__subtitle pixel-font"><?php echo esc_html( 'AI strategy // systems integration // creative technology' ); ?></p>
+                <p class="home-yvr-radar-deck__positioning"><?php echo esc_html( 'Punk bassist brain. Builds infra, creative tech, browser tools and applications that are practical and cool.' ); ?></p>
+                <div class="home-amp-console">
+                    <div class="home-title-screen-prompt pixel-font" role="status" aria-live="polite" data-arcade-status><?php echo esc_html( 'INSERT COIN' ); ?></div>
+                    <button type="button" class="pixel-button home-press-start" data-home-start data-start-label="PRESS START // VIEW WORK"><?php echo esc_html( 'PRESS START // VIEW WORK' ); ?></button>
+                </div>
+                <ul class="home-title-screen-meta pixel-font" aria-label="<?php echo esc_attr( 'Scene tags' ); ?>">
+                    <li><?php echo esc_html( 'Vancouver' ); ?></li>
+                    <li><?php echo esc_html( 'independent practice' ); ?></li>
+                    <li><?php echo esc_html( 'civic tech' ); ?></li>
+                    <li><?php echo esc_html( 'west coast' ); ?></li>
+                </ul>
             </div>
-        </div>
-        <div class="home-arcade-screen__panel">
-            <p class="home-arcade-kicker pixel-font"><?php echo esc_html( 'founder // principal technologist' ); ?></p>
-            <h1 id="home-hero-title" class="home-arcade-title pixel-font"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>
-            <p class="home-arcade-subtitle pixel-font"><?php echo esc_html( 'AI strategy // systems integration // creative technology' ); ?></p>
-            <p class="home-arcade-positioning"><?php echo esc_html( 'Punk bassist brain. Builds infra, creative tech, browser tools and applications that are practical and cool.' ); ?></p>
-            <div class="home-amp-console">
-                <div class="home-title-screen-prompt pixel-font" role="status" aria-live="polite" data-arcade-status><?php echo esc_html( 'INSERT COIN' ); ?></div>
-                <button type="button" class="pixel-button home-press-start" data-home-start data-start-label="PRESS START // VIEW WORK"><?php echo esc_html( 'PRESS START // VIEW WORK' ); ?></button>
-            </div>
-            <ul class="home-title-screen-meta pixel-font" aria-label="<?php echo esc_attr( 'Scene tags' ); ?>">
-                <li><?php echo esc_html( 'Vancouver' ); ?></li>
-                <li><?php echo esc_html( 'independent practice' ); ?></li>
-                <li><?php echo esc_html( 'civic tech' ); ?></li>
-                <li><?php echo esc_html( 'west coast' ); ?></li>
-            </ul>
-        </div>
         </div>
     </section>
 

--- a/page-home.php
+++ b/page-home.php
@@ -6,11 +6,14 @@ get_header();
 <main id="homepage-content" class="home-layout home-arcade-layout">
 
     <section class="home-arcade-title-screen crt-block home-amp-cabinet home-map-hero" aria-labelledby="home-hero-title" data-arcade-hero>
-        <div class="home-map-hero__map-stage" data-home-hero-map aria-hidden="true"></div>
-        <div class="home-map-hero__shade" aria-hidden="true"></div>
-        <div class="home-map-hero__scan" aria-hidden="true"></div>
         <div class="home-map-hero__content">
-        <div class="home-arcade-screen__backdrop" aria-label="<?php echo esc_attr( 'YVR live feed radio rack' ); ?>">
+        <div class="home-map-hero__left">
+            <div class="home-map-hero__map-frame" data-home-hero-map-lane>
+                <div class="home-map-hero__map-stage" data-home-hero-map aria-label="<?php echo esc_attr( 'Greater Vancouver live map' ); ?>"></div>
+                <div class="home-map-hero__map-scan" aria-hidden="true"></div>
+                <p class="home-map-hero__map-label pixel-font"><?php echo esc_html( 'greater vancouver // drag · tap pins' ); ?></p>
+            </div>
+            <div class="home-arcade-screen__backdrop" aria-label="<?php echo esc_attr( 'YVR live feed radio rack' ); ?>">
             <div class="home-yvr-rack">
                 <div class="home-yvr-broadcaster" data-yvr-broadcaster aria-label="<?php echo esc_attr( 'YVR broadcaster — live feeds and radio' ); ?>">
                     <div class="home-yvr-broadcaster__mast">
@@ -92,9 +95,7 @@ get_header();
                     <audio data-broadcaster-audio preload="none" crossorigin="anonymous"></audio>
                 </div>
             </div>
-        </div>
-        <div class="home-map-hero__lane" data-home-hero-map-lane>
-            <p class="home-map-hero__lane-label pixel-font"><?php echo esc_html( 'greater vancouver // drag map · tap pins' ); ?></p>
+            </div>
         </div>
         <div class="home-arcade-screen__panel">
             <p class="home-arcade-kicker pixel-font"><?php echo esc_html( 'founder // principal technologist' ); ?></p>

--- a/page-home.php
+++ b/page-home.php
@@ -93,6 +93,9 @@ get_header();
                 </div>
             </div>
         </div>
+        <div class="home-map-hero__lane" data-home-hero-map-lane>
+            <p class="home-map-hero__lane-label pixel-font"><?php echo esc_html( 'greater vancouver // drag map · tap pins' ); ?></p>
+        </div>
         <div class="home-arcade-screen__panel">
             <p class="home-arcade-kicker pixel-font"><?php echo esc_html( 'founder // principal technologist' ); ?></p>
             <h1 id="home-hero-title" class="home-arcade-title pixel-font"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>

--- a/scripts/deploy-lousy-outages-ssh.py
+++ b/scripts/deploy-lousy-outages-ssh.py
@@ -42,6 +42,7 @@ THEME_FILES = [
     "page-lousy-outages.php",
     "parts/lousy-outages-teaser.php",
     "assets/css/home-hero-cabinet.css",
+    "assets/css/home-yvr-radar-deck.css",
     "js/home-hero-map.js",
     "js/home-yvr-broadcaster.js",
     "assets/css/lousy-outages-page.css",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why previous attempts looked broken

The hero used `home-arcade-title-screen`, which in `style.css` adds:

- `::before` / `::after` at **z-index 4** covering the **entire** section (scan lines + dark vignette)
- `.home-arcade-screen__backdrop` as `position: absolute; inset: 0` (full-bleed layer)
- `.home-arcade-screen__panel` at **z-index 5**

So even when the map was in the DOM, it read as wallpaper under the arcade title-screen stack. Layout tweaks couldn't fix that without leaving that class family.

## The rad fix: YVR Radar Deck

New hero component — **no** `home-arcade-title-screen`, **no** `crt-block`, **no** floating map behind text.

**Layout (top → bottom):**
1. Compact masthead — SUZY EASTON
2. **YVR RADAR** — chunky CRT bezel with a **circular live map scope** (Leaflet), rotating sweep, graticule grid, CRT scan (all `pointer-events: none` on overlays — map is draggable)
3. Console row — Dave rack | bio + INSERT COIN + PRESS START

Map is the obvious centerpiece (~50vh on desktop, ~42vh on mobile), not a background layer.

## Files

- `page-home.php` — new `home-yvr-radar-deck` markup
- `assets/css/home-yvr-radar-deck.css` — radar deck styles (new)
- `assets/css/home-hero-cabinet.css` — still loads Dave rack styles
- `functions.php` — enqueue radar deck CSS
- `js/home-hero-map.js` — resize observer on map wrap
- `scripts/deploy-lousy-outages-ssh.py` — deploy new CSS

## Test plan

- [ ] Map visible in circular scope; Vancouver labels readable
- [ ] Drag/pan works; pin taps switch Dave channels
- [ ] No full-screen dark overlay on top of map
- [ ] Mobile: radar scales, console stacks (rack then CTA)
- [ ] PRESS START / INSERT COIN still work
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8847567f-6559-4baa-822d-02ae416215a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8847567f-6559-4baa-822d-02ae416215a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

