### PR TITLE
Fix YVR radar map not rendering (metroMap config overwrite)

### DIFF
--- a/assets/css/home-yvr-radar-deck.css
+++ b/assets/css/home-yvr-radar-deck.css
@@ -131,6 +131,7 @@
   width: 100%;
   aspect-ratio: 1;
   max-height: min(52vh, 520px);
+  min-height: 220px;
   margin: 0 auto;
 }
 
@@ -145,12 +146,33 @@
     inset 0 0 40px rgba(0, 0, 0, 0.65),
     0 0 24px rgba(57, 255, 20, 0.15);
   background: #020610;
+  min-height: 180px;
 }
 
 .home-yvr-radar-deck__map {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
-  min-height: 200px;
+  min-height: 180px;
+}
+
+.home-yvr-radar-deck__map.is-map-error::after {
+  content: attr(data-map-error);
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem;
+  text-align: center;
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  font-size: clamp(0.38rem, 0.75vw, 0.5rem);
+  letter-spacing: 0.06em;
+  color: rgba(255, 230, 109, 0.9);
+  background: rgba(2, 6, 10, 0.88);
+  pointer-events: none;
 }
 
 .home-yvr-radar-deck__map .leaflet-container {

--- a/functions.php
+++ b/functions.php
@@ -110,16 +110,6 @@ function retro_game_music_theme_scripts() {
                 filemtime( $hero_map_js ),
                 true
             );
-            wp_localize_script(
-                'home-hero-map',
-                'HomeYvrBroadcasterConfig',
-                array(
-                    'feedsUrl'  => rest_url( 'se/v1/broadcaster/feeds' ),
-                    'metroMap'  => function_exists( 'se_broadcaster_metro_map_static' )
-                        ? se_broadcaster_metro_map_static()
-                        : array(),
-                )
-            );
         }
         if ( file_exists( $broadcaster_js ) ) {
             wp_enqueue_script(
@@ -142,12 +132,11 @@ function retro_game_music_theme_scripts() {
             wp_localize_script(
                 'home-yvr-broadcaster',
                 'HomeYvrBroadcasterConfig',
-                array(
-                    'feedsUrl'         => rest_url( 'se/v1/broadcaster/feeds' ),
-                    'daveAmbientCycle' => function_exists( 'se_broadcaster_dave_ambient_cycle_keys' )
-                        ? se_broadcaster_dave_ambient_cycle_keys()
-                        : array(),
-                )
+                function_exists( 'se_home_yvr_broadcaster_client_config' )
+                    ? se_home_yvr_broadcaster_client_config()
+                    : array(
+                        'feedsUrl' => rest_url( 'se/v1/broadcaster/feeds' ),
+                    )
             );
         }
 

--- a/inc/home-yvr-broadcaster.php
+++ b/inc/home-yvr-broadcaster.php
@@ -302,6 +302,15 @@ function se_broadcaster_metro_map_static(): array {
     );
 }
 
+function se_home_yvr_broadcaster_client_config(): array {
+    return array(
+        'feedsUrl'         => rest_url( 'se/v1/broadcaster/feeds' ),
+        'metroMap'         => se_broadcaster_metro_map_static(),
+        'daveAmbientCycle' => se_broadcaster_dave_ambient_cycle_keys(),
+        'dataChannelPins'  => se_broadcaster_data_channel_pin_config(),
+    );
+}
+
 function se_broadcaster_metro_map_marker_row(
     string $id,
     string $name,

--- a/js/home-hero-map.js
+++ b/js/home-hero-map.js
@@ -1,8 +1,8 @@
 (function () {
   'use strict';
 
-  var LEAFLET_CSS = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css';
-  var LEAFLET_JS = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js';
+  var LEAFLET_CSS = 'https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.css';
+  var LEAFLET_JS = 'https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.js';
   var TILE_URL = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
   var TILE_ATTR = '&copy; OpenStreetMap &copy; CARTO';
 
@@ -72,6 +72,29 @@
     document.head.appendChild(link);
   }
 
+  function readMetroConfig() {
+    var cfg = window.HomeYvrBroadcasterConfig;
+    if (!cfg || !cfg.metroMap || !cfg.metroMap.bounds) return null;
+    return cfg.metroMap;
+  }
+
+  function fetchMetroConfigFromFeeds() {
+    var cfg = window.HomeYvrBroadcasterConfig || {};
+    var url = cfg.feedsUrl || '/wp-json/se/v1/broadcaster/feeds';
+    return fetch(url, { credentials: 'same-origin' })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (data) {
+        if (data && data.metro_map && data.metro_map.bounds) {
+          return {
+            bounds: data.metro_map.bounds,
+            anchors: data.metro_map.anchors || []
+          };
+        }
+        return null;
+      })
+      .catch(function () { return null; });
+  }
+
   function HeroMap(stage, onChannelSelect) {
     this.stage = stage;
     this.onChannelSelect = onChannelSelect || null;
@@ -83,6 +106,7 @@
     this.map = null;
     this.layer = null;
     this.booted = false;
+    this.booting = false;
   }
 
   HeroMap.prototype.makeIcon = function (color, large) {
@@ -140,10 +164,30 @@
     });
   };
 
+  HeroMap.prototype.scheduleInvalidate = function () {
+    var self = this;
+    if (!this.map) return;
+    var delays = [0, 80, 240, 600, 1200];
+    delays.forEach(function (ms) {
+      setTimeout(function () {
+        if (self.map) self.map.invalidateSize({ animate: false });
+      }, ms);
+    });
+  };
+
+  HeroMap.prototype.showMapError = function (message) {
+    if (!this.stage) return;
+    this.stage.classList.add('is-map-error');
+    this.stage.setAttribute('data-map-error', message);
+  };
+
   HeroMap.prototype.initMap = function () {
     if (!this.stage || !window.L || this.map) return;
 
     var bounds = this.bounds;
+    this.stage.classList.remove('is-map-error');
+    this.stage.removeAttribute('data-map-error');
+
     this.map = window.L.map(this.stage, {
       zoomControl: true,
       attributionControl: true,
@@ -167,27 +211,33 @@
 
     this.syncMarkers();
     this.booted = true;
+    this.stage.classList.add('is-map-ready');
+
+    this.scheduleInvalidate();
 
     var self = this;
-    var resize = function () {
-      if (self.map) self.map.invalidateSize({ animate: false });
-    };
-    requestAnimationFrame(resize);
     if (typeof ResizeObserver !== 'undefined') {
       var observeTarget = self.stage.parentElement || self.stage;
       var observer = new ResizeObserver(function () {
-        requestAnimationFrame(resize);
+        self.scheduleInvalidate();
       });
       observer.observe(observeTarget);
       if (observeTarget.parentElement && observeTarget.parentElement !== observeTarget) {
         observer.observe(observeTarget.parentElement);
       }
     }
+
+    window.addEventListener('orientationchange', function () {
+      self.scheduleInvalidate();
+    });
   };
 
   HeroMap.prototype.boot = function (config) {
-    if (!this.stage || !config || !config.bounds) return;
+    if (!this.stage || !config || !config.bounds || this.booted || this.booting) {
+      return Promise.resolve();
+    }
     var self = this;
+    this.booting = true;
 
     this.bounds = config.bounds;
     this.anchors = config.anchors || [];
@@ -198,8 +248,29 @@
         self.initMap();
       })
       .catch(function () {
-        /* map stage stays empty */
+        self.showMapError('Map tiles failed to load — try a refresh.');
+      })
+      .finally(function () {
+        self.booting = false;
       });
+  };
+
+  HeroMap.prototype.ensureBoot = function () {
+    var self = this;
+    if (this.booted || this.booting) return Promise.resolve();
+
+    var config = readMetroConfig();
+    if (config) {
+      return this.boot(config);
+    }
+
+    return fetchMetroConfigFromFeeds().then(function (fetched) {
+      if (fetched) {
+        return self.boot(fetched);
+      }
+      self.showMapError('Radar map config missing — try refreshing.');
+      return null;
+    });
   };
 
   HeroMap.prototype.setActiveChannel = function (channelKey) {
@@ -266,15 +337,12 @@
     if (!stage || stage.dataset.heroMapReady === '1') return;
     stage.dataset.heroMapReady = '1';
 
-    var config = window.HomeYvrBroadcasterConfig && HomeYvrBroadcasterConfig.metroMap;
     var heroMap = new HeroMap(stage);
     window.HomeHeroMap = heroMap;
 
-    if (config && config.bounds) {
-      heroMap.boot(config);
-    }
-
-    initWanderHint();
+    heroMap.ensureBoot().then(function () {
+      initWanderHint();
+    });
   }
 
   if (document.readyState === 'loading') {

--- a/js/home-yvr-broadcaster.js
+++ b/js/home-yvr-broadcaster.js
@@ -52,7 +52,7 @@
     this.feeds = null;
     this.audioChannels = {};
     this.ambientCycleKeys = (window.HomeYvrBroadcasterConfig && HomeYvrBroadcasterConfig.daveAmbientCycle) || [];
-    this.dataChannelPins = {};
+    this.dataChannelPins = (window.HomeYvrBroadcasterConfig && HomeYvrBroadcasterConfig.dataChannelPins) || {};
     this.activeKey = null;
     this.activePinKey = null;
     this.activeAudioKey = null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause

`wp_localize_script` ran twice on the same global `HomeYvrBroadcasterConfig`. The broadcaster script’s inline config replaced the hero-map config and **wiped `metroMap`** before Leaflet initialized — so the radar showed the green overlay but no tiles or pins.

## Fix

- Single `se_home_yvr_broadcaster_client_config()` with `metroMap`, `dataChannelPins`, `daveAmbientCycle`, `feedsUrl`
- Hero map `ensureBoot()` with REST fallback if config is missing
- Leaflet from jsDelivr; repeated `invalidateSize` for mobile circular viewport
- Explicit min-height on CRT ring / map wrap for mobile

## Test

- [ ] Hard refresh homepage — map tiles + pins visible inside radar circle
- [ ] Mobile: drag works, pins tappable
- [ ] Console: no missing metroMap
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8847567f-6559-4baa-822d-02ae416215a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8847567f-6559-4baa-822d-02ae416215a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

