### PR TITLE
Pin tap → Dave player with PLAY/STOP and speed controls

### DIFF
--- a/assets/css/home-hero-cabinet.css
+++ b/assets/css/home-hero-cabinet.css
@@ -1259,8 +1259,110 @@ body.home-yvr-map-modal-open {
   border-radius: 4px;
 }
 
+.home-yvr-broadcaster__transport {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.35rem;
+  margin-top: 0.12rem;
+}
+
+.home-yvr-broadcaster__transport .home-yvr-broadcaster__btn {
+  width: auto;
+  flex: 1;
+}
+
+.home-yvr-broadcaster__play {
+  background: linear-gradient(180deg, #39ff14 0%, #1faa0a 100%);
+  color: #020308;
+  box-shadow: 2px 2px 0 #020308;
+}
+
+.home-yvr-broadcaster__play:hover,
+.home-yvr-broadcaster__play:focus-visible {
+  background: linear-gradient(180deg, #57ff3a 0%, #39ff14 100%);
+}
+
+.home-yvr-broadcaster__play.is-playing {
+  background: linear-gradient(180deg, #ffe66d 0%, #d4a800 100%);
+  color: #020308;
+}
+
+.home-yvr-broadcaster__play-hint,
+.home-yvr-broadcaster__stop-hint {
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  font-size: clamp(0.36rem, 0.78vw, 0.44rem);
+  letter-spacing: 0.03em;
+  opacity: 0.88;
+  text-transform: lowercase;
+}
+
+.home-yvr-broadcaster__speed {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.28rem 0.35rem;
+  padding: 0.28rem 0.35rem;
+  border: 2px solid rgba(87, 243, 255, 0.22);
+  border-radius: 4px;
+  background: rgba(2, 8, 18, 0.55);
+}
+
+.home-yvr-broadcaster__speed-label {
+  font-size: clamp(0.34rem, 0.72vw, 0.42rem);
+  letter-spacing: 0.08em;
+  color: rgba(180, 230, 220, 0.75);
+  text-transform: lowercase;
+}
+
+.home-yvr-broadcaster__speed-readout {
+  min-width: 2.2rem;
+  text-align: center;
+  color: #ffe66d;
+  font-size: clamp(0.38rem, 0.82vw, 0.48rem);
+}
+
+.home-yvr-broadcaster__speed-btn {
+  min-width: 1.65rem;
+  min-height: 1.45rem;
+  padding: 0.2rem 0.35rem;
+  border: 2px solid #020308;
+  border-radius: 3px;
+  background: rgba(87, 243, 255, 0.12);
+  color: #57f3ff;
+  font-family: "Press Start 2P", monospace;
+  font-size: clamp(0.34rem, 0.72vw, 0.42rem);
+  cursor: pointer;
+}
+
+.home-yvr-broadcaster__speed-btn:hover,
+.home-yvr-broadcaster__speed-btn:focus-visible {
+  background: rgba(87, 243, 255, 0.22);
+}
+
+.home-yvr-broadcaster__speed-btn.is-active {
+  background: #39ff14;
+  color: #020308;
+}
+
+.home-yvr-broadcaster.is-armed .home-yvr-broadcaster__play {
+  animation: homeYvrPlayPulse 1.1s ease-in-out infinite;
+}
+
+.home-yvr-broadcaster.is-focused {
+  outline: 2px solid rgba(57, 255, 20, 0.75);
+  outline-offset: 4px;
+  box-shadow: 0 0 24px rgba(57, 255, 20, 0.35);
+}
+
+@keyframes homeYvrPlayPulse {
+  0%, 100% { box-shadow: 2px 2px 0 #020308, 0 0 0 rgba(57, 255, 20, 0); }
+  50% { box-shadow: 2px 2px 0 #020308, 0 0 14px rgba(57, 255, 20, 0.65); }
+}
+
 .home-yvr-broadcaster__stop {
-  margin-top: 0.08rem;
+  margin-top: 0;
   background: linear-gradient(180deg, #ff5c5c 0%, #e03a3a 100%);
   color: #fff;
   box-shadow: 2px 2px 0 #020308;
@@ -1273,14 +1375,6 @@ body.home-yvr-map-modal-open {
 
 .home-yvr-broadcaster__stop-label {
   flex-shrink: 0;
-}
-
-.home-yvr-broadcaster__stop-hint {
-  font-family: "IBM Plex Mono", "Courier New", monospace;
-  font-size: clamp(0.36rem, 0.78vw, 0.44rem);
-  letter-spacing: 0.03em;
-  opacity: 0.88;
-  text-transform: lowercase;
 }
 
 .home-yvr-broadcaster.is-speaking .home-yvr-broadcaster__channel {

--- a/js/home-hero-map.js
+++ b/js/home-hero-map.js
@@ -145,8 +145,15 @@
       });
       marker.bindTooltip(anchor.label + ' — ' + anchor.hint, { direction: 'top' });
       if (key !== 'dave') {
-        marker.on('click', function () {
-          if (self.onChannelSelect) self.onChannelSelect(key);
+        marker.on('click', function (e) {
+          if (window.L && window.L.DomEvent) {
+            window.L.DomEvent.stopPropagation(e);
+          }
+          if (window.HomeYvrBroadcaster && window.HomeYvrBroadcaster.handleMapSelect) {
+            window.HomeYvrBroadcaster.handleMapSelect(key);
+          } else if (self.onChannelSelect) {
+            self.onChannelSelect(key);
+          }
         });
       }
       marker.addTo(self.layer);

--- a/js/home-yvr-broadcaster.js
+++ b/js/home-yvr-broadcaster.js
@@ -39,6 +39,9 @@
     this.freqEl = root.querySelector('[data-broadcaster-freq]');
     this.channelEl = root.querySelector('[data-broadcaster-channel]');
     this.stopBtn = root.querySelector('[data-broadcaster-stop]');
+    this.playBtn = root.querySelector('[data-broadcaster-play]');
+    this.speedLabelEl = root.querySelector('[data-broadcaster-speed-label]');
+    this.speedBtns = root.querySelectorAll('[data-broadcaster-speed]');
     this.bars = root.querySelectorAll('[data-broadcaster-bar]');
     this.channelBtns = root.querySelectorAll('[data-broadcaster-channel-btn]');
     this.telepromptRoot = root.querySelector('[data-broadcaster-teleprompt]');
@@ -68,6 +71,10 @@
     this.meterActive = false;
     this.meterRaf = null;
     this.audioSourceNode = null;
+    this.meterWired = false;
+    this.playbackRate = 1;
+    this.focusTimer = null;
+    this.pendingMapSelectKey = null;
   }
 
   HomeYvrBroadcaster.prototype.isKnownChannel = function (key) {
@@ -89,17 +96,133 @@
     return this.audioChannels[key] || null;
   };
 
+  HomeYvrBroadcaster.prototype.wireHeroMap = function () {
+    var self = this;
+    this.heroMap = window.HomeHeroMap || null;
+    if (!this.heroMap) return;
+
+    this.heroMap.onChannelSelect = function (key) {
+      self.handleMapSelect(key);
+    };
+
+    if (this.pendingMapSelectKey) {
+      var pending = this.pendingMapSelectKey;
+      this.pendingMapSelectKey = null;
+      self.handleMapSelect(pending);
+    }
+  };
+
+  HomeYvrBroadcaster.prototype.handleMapSelect = function (key) {
+    if (!this.isKnownChannel(key)) return;
+    this.unlockAudio();
+    this.focusDavePlayer();
+    this.activate(key);
+    this.updatePlayButton();
+  };
+
+  HomeYvrBroadcaster.prototype.focusDavePlayer = function () {
+    var self = this;
+    this.root.classList.add('is-focused');
+    if (this.focusTimer) clearTimeout(this.focusTimer);
+    this.focusTimer = setTimeout(function () {
+      self.root.classList.remove('is-focused');
+    }, 2600);
+
+    try {
+      this.root.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    } catch (e) {
+      this.root.scrollIntoView(true);
+    }
+
+    if (this.faceEl) {
+      try {
+        this.faceEl.focus({ preventScroll: true });
+      } catch (err) {
+        this.faceEl.focus();
+      }
+    }
+  };
+
+  HomeYvrBroadcaster.prototype.resumeAudioContext = function () {
+    if (this.audioCtx && this.audioCtx.state === 'suspended') {
+      return this.audioCtx.resume();
+    }
+    return Promise.resolve();
+  };
+
+  HomeYvrBroadcaster.prototype.updatePlayButton = function () {
+    if (!this.playBtn) return;
+    var playing = this.isAudioPlaying();
+    this.playBtn.classList.toggle('is-playing', playing);
+    this.playBtn.setAttribute('aria-pressed', playing ? 'true' : 'false');
+    var label = this.playBtn.querySelector('[data-broadcaster-play-label]');
+    if (label) {
+      label.textContent = playing ? 'PAUSE' : 'PLAY';
+    }
+    var hint = this.playBtn.querySelector('[data-broadcaster-play-hint]');
+    if (hint) {
+      hint.textContent = playing ? 'live on deck' : 'start live audio';
+    }
+  };
+
+  HomeYvrBroadcaster.prototype.setPlaybackRate = function (rate) {
+    this.playbackRate = rate;
+    if (this.audio) {
+      this.audio.playbackRate = rate;
+    }
+    if (this.speedLabelEl) {
+      this.speedLabelEl.textContent = rate === 1 ? '1×' : rate.toFixed(2).replace(/\.?0+$/, '') + '×';
+    }
+    this.speedBtns.forEach(function (btn) {
+      var step = parseFloat(btn.getAttribute('data-broadcaster-speed') || '1');
+      btn.classList.toggle('is-active', Math.abs(step - rate) < 0.01);
+    });
+  };
+
+  HomeYvrBroadcaster.prototype.startPlayback = function () {
+    var self = this;
+    this.unlockAudio();
+
+    if (this.activePinKey) {
+      var config = this.getPinConfig(this.activePinKey);
+      if (config) {
+        this.tryPlayAudioChain(config.audio_keys || [], this.activePinKey);
+        if (!this.isAudioPlaying()) {
+          this.refreshFeedsInBackground(this.activePinKey, config);
+        }
+        return;
+      }
+    }
+
+    var audioKey = this.activeAudioKey || this.activeKey;
+    if (!audioKey) return;
+
+    var channel = this.audioChannels[audioKey];
+    if (channel) {
+      this.activateAudioChannel(channel, this.activePinKey);
+      return;
+    }
+
+    this.fetchFeeds(true).then(function (feeds) {
+      if (!feeds) return;
+      self.mergeFeeds(feeds);
+      var fresh = self.audioChannels[audioKey];
+      if (fresh) self.activateAudioChannel(fresh, self.activePinKey);
+    });
+  };
+
   HomeYvrBroadcaster.prototype.init = function () {
     var self = this;
 
-    this.heroMap = window.HomeHeroMap || null;
-    if (this.heroMap) {
-      this.heroMap.onChannelSelect = function (key) {
-        if (self.isKnownChannel(key)) {
-          self.unlockAudio();
-          self.activate(key);
-        }
-      };
+    this.wireHeroMap();
+    if (!this.heroMap) {
+      this.pendingMapSelectKey = null;
+      var mapRetries = 0;
+      var mapRetryTimer = setInterval(function () {
+        mapRetries += 1;
+        self.wireHeroMap();
+        if (self.heroMap || mapRetries > 40) clearInterval(mapRetryTimer);
+      }, 100);
     }
 
     this.channelBtns.forEach(function (btn) {
@@ -107,9 +230,27 @@
         var key = btn.getAttribute('data-broadcaster-channel-btn');
         if (!key || !self.isKnownChannel(key)) return;
         self.unlockAudio();
+        self.focusDavePlayer();
         self.activate(key);
+        self.updatePlayButton();
       });
     });
+
+    if (this.playBtn) {
+      this.playBtn.addEventListener('click', function () {
+        self.unlockAudio();
+        if (self.isAudioPlaying()) {
+          self.audio.pause();
+          self.setBars(false);
+          self.stopMeter();
+          self.setListeningUi(false);
+          self.setMouthIdle();
+          self.updatePlayButton();
+          return;
+        }
+        self.startPlayback();
+      });
+    }
 
     if (this.stopBtn) {
       this.stopBtn.addEventListener('click', function () {
@@ -125,14 +266,33 @@
       });
     }
 
+    this.setPlaybackRate(1);
+
+    if (this.speedBtns.length) {
+      this.speedBtns.forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          var step = parseFloat(btn.getAttribute('data-broadcaster-speed') || '1');
+          if (!step || step < 0.5 || step > 2) return;
+          self.setPlaybackRate(step);
+        });
+      });
+    }
+
     this.loadFeeds();
     this.setStandby();
+    this.updatePlayButton();
 
     if (this.audio) {
       this.audio.addEventListener('playing', function () {
+        self.setupAudioMeter();
         self.setListeningUi(true);
         self.setBars(true);
         self.startMeter();
+        self.updatePlayButton();
+        self.root.classList.remove('is-armed');
+      });
+      this.audio.addEventListener('pause', function () {
+        self.updatePlayButton();
       });
     }
 
@@ -144,12 +304,8 @@
   HomeYvrBroadcaster.prototype.unlockAudio = function () {
     if (!this.audio) return;
 
-    this.setupAudioMeter();
-
     if (this.audioUnlocked) {
-      if (this.audioCtx && this.audioCtx.state === 'suspended') {
-        this.audioCtx.resume();
-      }
+      this.resumeAudioContext();
       return;
     }
 
@@ -161,6 +317,7 @@
         this.audio.pause();
         this.audio.muted = false;
         this.audioUnlocked = true;
+        this.resumeAudioContext();
       }.bind(this);
 
       if (playPromise && typeof playPromise.then === 'function') {
@@ -172,10 +329,6 @@
       }
     } catch (e) {
       this.audioUnlocked = true;
-    }
-
-    if (this.audioCtx && this.audioCtx.state === 'suspended') {
-      this.audioCtx.resume();
     }
   };
 
@@ -409,7 +562,7 @@
     this.renderMeta(null);
     if (this.scriptEl) {
       this.scriptEl.innerHTML = '';
-      this.scriptEl.textContent = 'tap a pin — bulletin on screen, matched live scanner underneath.';
+      this.scriptEl.textContent = 'tap a pin — bulletin lands here. PLAY for live audio.';
     }
     this.renderAttribution(null);
     if (this.telepromptRoot) {
@@ -426,9 +579,10 @@
     this.setTelepromptStandby();
     this.setMouthIdle();
     this.clearAutoMuteTimer();
-    this.root.classList.remove('is-live', 'is-speaking', 'is-radio', 'is-bulletin', 'is-bulletin-only');
+    this.root.classList.remove('is-live', 'is-speaking', 'is-radio', 'is-bulletin', 'is-bulletin-only', 'is-armed');
     this.setBars(false);
     this.highlightChannel(null);
+    this.updatePlayButton();
   };
 
   HomeYvrBroadcaster.prototype.highlightChannel = function (key) {
@@ -515,7 +669,7 @@
   };
 
   HomeYvrBroadcaster.prototype.setupAudioMeter = function () {
-    if (!this.audio) return;
+    if (!this.audio || this.meterWired) return;
     try {
       if (!this.audioCtx) {
         this.audioCtx = new (window.AudioContext || window.webkitAudioContext)();
@@ -524,12 +678,11 @@
         this.audioSourceNode = this.audioCtx.createMediaElementSource(this.audio);
         this.audioSourceNode.connect(this.analyser);
         this.analyser.connect(this.audioCtx.destination);
+        this.meterWired = true;
       }
-      if (this.audioCtx.state === 'suspended') {
-        this.audioCtx.resume();
-      }
+      this.resumeAudioContext();
     } catch (e) {
-      /* meter optional */
+      /* meter optional — keep native element output */
     }
   };
 
@@ -593,6 +746,7 @@
 
     this.audio.loop = !!channel.loop;
     this.audio.volume = channel.mode === 'soundscape' ? 0.35 : 0.5;
+    this.audio.playbackRate = this.playbackRate;
 
     if (channel.format === 'hls') {
       this.hls = attachHls(this.audio, channel.stream_url);
@@ -600,7 +754,8 @@
       this.audio.src = channel.stream_url;
     }
 
-    this.setupAudioMeter();
+    var self = this;
+    this.resumeAudioContext();
 
     var playPromise = this.audio.play();
     if (playPromise && typeof playPromise.then === 'function') {
@@ -612,7 +767,9 @@
         })
         .catch(function () {
           self.setListeningUi(false);
-          self.appendBulletinAudioNote('Tap STOP then tap the pin again if audio stays blocked.');
+          self.root.classList.add('is-armed');
+          self.appendBulletinAudioNote('Hit PLAY below — live audio is armed.');
+          self.updatePlayButton();
         });
     } else {
       this.setBars(true);
@@ -720,7 +877,7 @@
     if (display) this.updateDisplay(display);
     this.highlightChannel(null);
 
-    this.root.classList.add('is-live', 'is-bulletin');
+    this.root.classList.add('is-live', 'is-bulletin', 'is-armed');
     this.root.classList.remove('is-bulletin-only', 'is-radio');
     if (this.telepromptRoot) {
       this.telepromptRoot.classList.add('is-live', 'is-bulletin');
@@ -742,12 +899,13 @@
       this.renderBulletin(pack, config, pinKey);
       this.renderMeta(this.packFromFeedPack(pack));
     } else {
-      this.renderScript('Pulling bulletin… live audio tuning now.');
+      this.renderScript('Pulling bulletin… hit PLAY for live audio.');
     }
     this.renderAttribution(null);
 
     var audioKeys = config.audio_keys || [];
     this.tryPlayAudioChain(audioKeys, pinKey);
+    this.updatePlayButton();
 
     if (!this.isAudioPlaying()) {
       this.refreshFeedsInBackground(pinKey, config);
@@ -789,6 +947,7 @@
 
     this.audio.loop = !!channel.loop;
     this.audio.volume = channel.mode === 'soundscape' ? 0.42 : 0.55;
+    this.audio.playbackRate = this.playbackRate;
 
     if (channel.format === 'hls') {
       this.hls = attachHls(this.audio, channel.stream_url);
@@ -796,7 +955,7 @@
       this.audio.src = channel.stream_url;
     }
 
-    this.setupAudioMeter();
+    this.resumeAudioContext();
 
     var playPromise = this.audio.play();
     if (playPromise && typeof playPromise.then === 'function') {
@@ -807,10 +966,12 @@
           self.setListeningUi(true);
         })
         .catch(function () {
-          self.renderScript('Audio blocked — tap STOP then tap again.');
+          self.renderScript('Hit PLAY below — channel is armed on deck.');
           self.setBars(false);
           self.setMouthIdle();
           self.setListeningUi(false);
+          self.root.classList.add('is-armed');
+          self.updatePlayButton();
         });
     } else {
       this.setBars(true);
@@ -918,7 +1079,7 @@
     var display = this.getDisplayChannel(key);
     if (display) this.updateDisplay(display);
     this.renderScript('Tuning live audio…');
-    this.root.classList.add('is-live');
+    this.root.classList.add('is-live', 'is-armed');
     this.setBars(true);
     this.setMouthTalking();
 

--- a/page-home.php
+++ b/page-home.php
@@ -41,7 +41,7 @@ get_header();
         <div class="home-yvr-radar-deck__console">
             <div class="home-yvr-radar-deck__rack">
                 <div class="home-yvr-rack">
-                <div class="home-yvr-broadcaster" data-yvr-broadcaster aria-label="<?php echo esc_attr( 'YVR broadcaster — live feeds and radio' ); ?>">
+                <div class="home-yvr-broadcaster" data-yvr-broadcaster tabindex="-1" aria-label="<?php echo esc_attr( 'YVR broadcaster — live feeds and radio' ); ?>">
                     <div class="home-yvr-broadcaster__mast">
                         <div class="home-yvr-broadcaster__avatar" data-broadcaster-face data-broadcaster-dave-cycle title="<?php echo esc_attr( 'Tap Dave to cycle ambient beds' ); ?>" aria-label="<?php echo esc_attr( 'Dave — tap to cycle ambient sound' ); ?>">
                             <div class="home-yvr-broadcaster__avatar-frame home-yvr-broadcaster__pigeon">
@@ -79,15 +79,29 @@ get_header();
                     </div>
                     <div class="home-yvr-broadcaster__crt" data-broadcaster-teleprompt>
                         <p class="home-yvr-broadcaster__attribution pixel-font" data-broadcaster-attribution hidden></p>
-                        <p class="home-yvr-teleprompt__script" data-broadcaster-script><?php echo esc_html( 'tap a pin — bulletin on screen, live scanner underneath.' ); ?></p>
+                        <p class="home-yvr-teleprompt__script" data-broadcaster-script><?php echo esc_html( 'tap a pin — bulletin lands here. PLAY for live audio.' ); ?></p>
                         <ul class="home-yvr-teleprompt__meta" data-broadcaster-meta hidden></ul>
                         <div class="home-yvr-broadcaster__crt-scan" aria-hidden="true"></div>
                     </div>
                     <?php get_template_part( 'parts/home-yvr-channel-buttons' ); ?>
-                    <button type="button" class="home-yvr-broadcaster__btn home-yvr-broadcaster__stop pixel-font" data-broadcaster-stop aria-label="<?php echo esc_attr( 'Stop audio' ); ?>">
-                        <span class="home-yvr-broadcaster__stop-label"><?php echo esc_html( 'STOP' ); ?></span>
-                        <span class="home-yvr-broadcaster__stop-hint"><?php echo esc_html( 'silence deck' ); ?></span>
-                    </button>
+                    <div class="home-yvr-broadcaster__transport">
+                        <button type="button" class="home-yvr-broadcaster__btn home-yvr-broadcaster__play pixel-font" data-broadcaster-play aria-pressed="false" aria-label="<?php echo esc_attr( 'Play or pause live audio' ); ?>">
+                            <span class="home-yvr-broadcaster__play-label" data-broadcaster-play-label><?php echo esc_html( 'PLAY' ); ?></span>
+                            <span class="home-yvr-broadcaster__play-hint" data-broadcaster-play-hint><?php echo esc_html( 'start live audio' ); ?></span>
+                        </button>
+                        <button type="button" class="home-yvr-broadcaster__btn home-yvr-broadcaster__stop pixel-font" data-broadcaster-stop aria-label="<?php echo esc_attr( 'Stop audio' ); ?>">
+                            <span class="home-yvr-broadcaster__stop-label"><?php echo esc_html( 'STOP' ); ?></span>
+                            <span class="home-yvr-broadcaster__stop-hint"><?php echo esc_html( 'silence deck' ); ?></span>
+                        </button>
+                        <div class="home-yvr-broadcaster__speed pixel-font" aria-label="<?php echo esc_attr( 'Playback speed' ); ?>">
+                            <span class="home-yvr-broadcaster__speed-label"><?php echo esc_html( 'speed' ); ?></span>
+                            <button type="button" class="home-yvr-broadcaster__speed-btn" data-broadcaster-speed="0.75" aria-label="<?php echo esc_attr( 'Slower' ); ?>">−</button>
+                            <span class="home-yvr-broadcaster__speed-readout" data-broadcaster-speed-label>1×</span>
+                            <button type="button" class="home-yvr-broadcaster__speed-btn" data-broadcaster-speed="1" aria-label="<?php echo esc_attr( 'Normal speed' ); ?>">1×</button>
+                            <button type="button" class="home-yvr-broadcaster__speed-btn" data-broadcaster-speed="1.25" aria-label="<?php echo esc_attr( 'Faster' ); ?>">+</button>
+                            <button type="button" class="home-yvr-broadcaster__speed-btn" data-broadcaster-speed="1.5" aria-label="<?php echo esc_attr( 'Fast' ); ?>">++</button>
+                        </div>
+                    </div>
                     <audio data-broadcaster-audio preload="none" crossorigin="anonymous"></audio>
                 </div>
                 </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #603 — pin taps still felt broken on desktop because Web Audio hijacked the `<audio>` element before playback, and Dave sat below the map with no obvious controls.

## Changes

- **Scroll to Dave** on map pin tap — smooth scroll + focus ring on the broadcaster rack
- **PLAY / PAUSE / STOP** transport row with pulsing PLAY when a channel is armed
- **Speed control** — 0.75×, 1×, 1.25×, 1.5× via `playbackRate`
- **Bulletin text stays on CRT** while audio plays underneath (pin flow unchanged)
- **Audio fix** — defer `MediaElementSource` meter wiring until `playing`; resume `AudioContext` before play; no meter setup during unlock
- **Map wiring** — pins call `HomeYvrBroadcaster.handleMapSelect` directly + retry hookup if scripts race

## Test plan

- [ ] Desktop: tap weather pin → scrolls to Dave, bulletin visible, PLAY pulses, audio starts (auto or on PLAY)
- [ ] Desktop: CBC listen button → same flow
- [ ] Speed buttons change playback rate while live
- [ ] STOP returns to standby
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8847567f-6559-4baa-822d-02ae416215a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8847567f-6559-4baa-822d-02ae416215a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

