### PR TITLE
Stop auto-opening Broadcastify on offline scanner taps

### DIFF
--- a/js/home-hero-map.js
+++ b/js/home-hero-map.js
@@ -148,6 +148,7 @@
         marker.on('click', function (e) {
           if (window.L && window.L.DomEvent) {
             window.L.DomEvent.stopPropagation(e);
+            window.L.DomEvent.preventDefault(e);
           }
           if (window.HomeYvrBroadcaster && window.HomeYvrBroadcaster.handleMapSelect) {
             window.HomeYvrBroadcaster.handleMapSelect(key);

--- a/js/home-yvr-broadcaster.js
+++ b/js/home-yvr-broadcaster.js
@@ -1002,9 +1002,9 @@
     if (channel.mode === 'link_out') {
       if (this.heroMap && pinKey) this.heroMap.setActiveChannel(pinKey);
       this.playLinkOut(channel, pack, pinKey);
-      if (channel.link_url) {
-        window.open(channel.link_url, '_blank', 'noopener,noreferrer');
-      }
+      this.root.classList.add('is-armed');
+      this.renderScript('Off-site feed — link in footer. Or pick another pin.');
+      this.updatePlayButton();
       return;
     }
 
@@ -1016,10 +1016,9 @@
       }
       if (this.heroMap && pinKey) this.heroMap.setActiveChannel(pinKey);
       this.playLinkOut(channel, pack, pinKey);
-      this.renderScript('Scanner offline — opening Broadcastify in a new tab.');
-      if (channel.link_url) {
-        window.open(channel.link_url, '_blank', 'noopener,noreferrer');
-      }
+      this.root.classList.add('is-armed');
+      this.renderScript('Scanner offline right now — hit PLAY to retry or use the footer link.');
+      this.updatePlayButton();
       return;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When Broadcastify scanners are offline, pin/listen taps were opening new tabs — felt broken on desktop and mobile.

Now the deck arms on Dave, shows offline copy, and PLAY retries in-page. Footer link still opens Broadcastify manually.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8847567f-6559-4baa-822d-02ae416215a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8847567f-6559-4baa-822d-02ae416215a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

