### PR TITLE
Force-unmute watchdog + native audio controls on Dave

### DIFF
--- a/assets/css/home-hero-cabinet.css
+++ b/assets/css/home-hero-cabinet.css
@@ -1266,6 +1266,16 @@ body.home-yvr-map-modal-open {
   margin-top: 0.12rem;
 }
 
+.home-yvr-broadcaster__native {
+  display: block;
+  width: 100%;
+  height: 36px;
+  margin-top: 0.35rem;
+  border-radius: 4px;
+  background: #020308;
+  accent-color: #39ff14;
+}
+
 .home-yvr-broadcaster__transport .home-yvr-broadcaster__btn {
   width: auto;
   flex: 1;

--- a/js/home-yvr-broadcaster.js
+++ b/js/home-yvr-broadcaster.js
@@ -94,6 +94,7 @@
     this.playbackRate = 1;
     this.focusTimer = null;
     this.pendingMapSelectKey = null;
+    this.unmuteWatchdog = null;
   }
 
   HomeYvrBroadcaster.prototype.isKnownChannel = function (key) {
@@ -257,6 +258,7 @@
     if (this.playBtn) {
       this.playBtn.addEventListener('click', function () {
         self.unlockAudio();
+        self.primeAudioElement();
         if (self.isAudioPlaying()) {
           self.audio.pause();
           self.setBars(false);
@@ -264,6 +266,10 @@
           self.setListeningUi(false);
           self.setMouthIdle();
           self.updatePlayButton();
+          return;
+        }
+        if (self.audio && self.audio.src && !self.audio.error) {
+          self.playAudioElement();
           return;
         }
         self.startPlayback();
@@ -666,13 +672,41 @@
 
   HomeYvrBroadcaster.prototype.primeAudioElement = function () {
     if (!this.audio) return;
+    try {
+      this.audio.defaultMuted = false;
+      this.audio.removeAttribute('muted');
+    } catch (e) {
+      /* ignore */
+    }
     this.audio.muted = false;
-    if (this.audio.volume < 0.2) this.audio.volume = 0.9;
+    if (!(this.audio.volume > 0.2)) this.audio.volume = 0.95;
+    if (this.audio.volume < 0.85 && this.activeAudioKey) {
+      var ch = this.audioChannels[this.activeAudioKey];
+      if (!ch || ch.mode !== 'soundscape') this.audio.volume = 0.95;
+    }
+  };
+
+  HomeYvrBroadcaster.prototype.startUnmuteWatchdog = function () {
+    var self = this;
+    this.stopUnmuteWatchdog();
+    this.unmuteWatchdog = setInterval(function () {
+      if (!self.audio) return;
+      if (self.audio.muted) self.audio.muted = false;
+      if (!self.audio.paused && self.audio.volume < 0.2) self.audio.volume = 0.95;
+    }, 400);
+  };
+
+  HomeYvrBroadcaster.prototype.stopUnmuteWatchdog = function () {
+    if (this.unmuteWatchdog) {
+      clearInterval(this.unmuteWatchdog);
+      this.unmuteWatchdog = null;
+    }
   };
 
   HomeYvrBroadcaster.prototype.playAudioElement = function () {
     var self = this;
     this.primeAudioElement();
+    this.startUnmuteWatchdog();
     var playPromise = this.audio.play();
     if (playPromise && typeof playPromise.then === 'function') {
       return playPromise
@@ -684,7 +718,9 @@
           self.root.classList.remove('is-armed');
           return true;
         })
-        .catch(function (err) {
+        .catch(function () {
+          // Autoplay blocked unmuted — arm deck and keep native controls visible.
+          self.primeAudioElement();
           self.setListeningUi(false);
           self.root.classList.add('is-armed');
           self.updatePlayButton();
@@ -700,6 +736,7 @@
   HomeYvrBroadcaster.prototype.stopRadio = function () {
     this.clearAutoMuteTimer();
     this.stopMeter();
+    this.stopUnmuteWatchdog();
     if (this.hls) {
       this.hls.destroy();
       this.hls = null;

--- a/page-home.php
+++ b/page-home.php
@@ -102,7 +102,7 @@ get_header();
                             <button type="button" class="home-yvr-broadcaster__speed-btn" data-broadcaster-speed="1.5" aria-label="<?php echo esc_attr( 'Fast' ); ?>">++</button>
                         </div>
                     </div>
-                    <audio data-broadcaster-audio preload="none" playsinline webkit-playsinline></audio>
+                    <audio class="home-yvr-broadcaster__native" data-broadcaster-audio controls preload="none" playsinline webkit-playsinline controlslist="nodownload noplaybackrate"></audio>
                 </div>
                 </div>
             </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #606. Live QA still saw `audio.muted === true` while the UI said live.

- Unmute watchdog while a stream is armed/playing
- Native `<audio controls>` under the transport so you can hit browser play/unmute yourself
- PLAY reuses an already-loaded stream src instead of re-tuning
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8847567f-6559-4baa-822d-02ae416215a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8847567f-6559-4baa-822d-02ae416215a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

