### PR TITLE
Marine VHF fallbacks + channel detail copy + no auto tabs

### DIFF
--- a/assets/css/home-hero-cabinet.css
+++ b/assets/css/home-hero-cabinet.css
@@ -511,6 +511,40 @@
   animation: homeScannerBar 0.9s steps(4, end) infinite;
 }
 
+.home-yvr-broadcaster__channel-detail {
+  margin-bottom: 0.35rem;
+  padding-bottom: 0.28rem;
+  border-bottom: 1px solid rgba(87, 243, 255, 0.18);
+}
+
+.home-yvr-broadcaster__channel-detail[hidden] {
+  display: none;
+}
+
+.home-yvr-broadcaster__channel-detail-kicker {
+  margin: 0 0 0.2rem;
+  color: #ffe66d;
+  font-size: clamp(0.38rem, 0.78vw, 0.48rem);
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+}
+
+.home-yvr-broadcaster__channel-detail-body {
+  margin: 0 0 0.22rem;
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  font-size: clamp(0.42rem, 0.85vw, 0.52rem);
+  line-height: 1.45;
+  color: rgba(223, 255, 234, 0.92);
+}
+
+.home-yvr-broadcaster__channel-detail-note {
+  margin: 0;
+  font-size: clamp(0.34rem, 0.72vw, 0.44rem);
+  letter-spacing: 0.06em;
+  line-height: 1.4;
+  color: rgba(180, 230, 220, 0.72);
+}
+
 .home-yvr-broadcaster__crt {
   position: relative;
   border-radius: 6px;

--- a/functions.php
+++ b/functions.php
@@ -32,8 +32,8 @@ require_once get_template_directory() . '/inc/ai-guardrails.php';
 require_once get_template_directory() . '/inc/openai.php';
 require_once get_template_directory() . '/inc/vancouver-tech-events.php';
 require_once get_template_directory() . '/inc/home-translink-alerts.php';
-require_once get_template_directory() . '/inc/home-yvr-broadcaster.php';
 require_once get_template_directory() . '/inc/home-yvr-audio-channels.php';
+require_once get_template_directory() . '/inc/home-yvr-broadcaster.php';
 /**
  * Functions file for Suzy’s Music Theme
  *   - Canucks App Integration (News + Betting)

--- a/inc/home-yvr-audio-channels.php
+++ b/inc/home-yvr-audio-channels.php
@@ -163,7 +163,91 @@ function se_broadcaster_broadcastify_stream_url( int $feed_id ): ?string {
 }
 
 function se_broadcaster_marine_broadcastify_feed_ids(): array {
-    return array( 47189 );
+    // 47189 = Vancouver port ch 11/12/16 (often offline). Fallbacks: Comox, Sointula, EC marine WX.
+    return array( 47189, 32393, 32901, 44288 );
+}
+
+function se_broadcaster_channel_deck_notes(): array {
+    return array(
+        'cknw'           => array(
+            'deck_copy' => 'CKNW 980 — Vancouver news talk. Traffic, politics, local chaos. LeanStream relay.',
+            'deck_note' => 'In-page stream. No new tabs.',
+        ),
+        'cbc'            => array(
+            'deck_copy' => 'CBC Radio One Vancouver — national + local news on the HLS feed.',
+            'deck_note' => 'In-page stream. No new tabs.',
+        ),
+        'yvr_tower'      => array(
+            'deck_copy' => 'YVR approach — planes lining up over the Fraser. LiveATC embed.',
+            'deck_note' => 'In-page stream. Attribution on screen.',
+        ),
+        'yvr_ground'     => array(
+            'deck_copy' => 'YVR ground and tower mix from LiveATC. Taxi, takeoff, tower handoffs.',
+            'deck_note' => 'In-page stream.',
+        ),
+        'yvr_combo'      => array(
+            'deck_copy' => 'YVR combo — clearance, ground, tower, approach on one mount. Busy hours only.',
+            'deck_note' => 'Hidden gem. LiveATC mash feed.',
+        ),
+        'yvr_dep2'       => array(
+            'deck_copy' => 'YVR departure lane two — second approach/dep frequency when it splits.',
+            'deck_note' => 'LiveATC. Quieter than the combo mount.',
+        ),
+        'vzvr_acc'       => array(
+            'deck_copy' => 'Vancouver area control — high-altitude handoffs around YVR airspace.',
+            'deck_note' => 'LiveATC ACC feed.',
+        ),
+        'burnaby_fire'   => array(
+            'deck_copy' => 'Burnaby Fire dispatch — municipal fire/EMS scanner. Often the liveliest public-safety feed near YVR.',
+            'deck_note' => 'Broadcastify scanner. Footer link opens source only if you tap it.',
+        ),
+        'marine_vhf'     => array(
+            'deck_copy' => 'Marine VHF — port traffic, Coast Guard, distress. Tries Vancouver ch 11/12/16 first, then Comox, Sointula, EC marine weather WX.',
+            'deck_note' => 'Broadcastify chain. Stays on Dave — footer link is optional.',
+        ),
+        'hydro_bush'     => array(
+            'deck_copy' => 'Orcasound hydrophone at Bush Point — Salish Sea live. Whales, ships, weird water noise.',
+            'deck_note' => 'HLS from Orcasound. Field mic, not radio.',
+        ),
+        'hydro_mast'     => array(
+            'deck_copy' => 'Orcasound MaST Center hydrophone — Puget-side listen. Same vibe, different inlet.',
+            'deck_note' => 'HLS from Orcasound.',
+        ),
+        'sound_skytrain' => array(
+            'deck_copy' => 'SkyTrain rumble loop — field bed, not live airwaves.',
+            'deck_note' => 'Soundscape only. Dave ambient cycle.',
+        ),
+        'sound_rain'     => array(
+            'deck_copy' => 'West coast rain bed — looped field recording.',
+            'deck_note' => 'Soundscape only.',
+        ),
+        'sound_ferry'    => array(
+            'deck_copy' => 'Ferry horn bed — terminal whistle loop when marine scanners are quiet.',
+            'deck_note' => 'Soundscape fallback for ferries pin.',
+        ),
+    );
+}
+
+function se_broadcaster_pin_deck_copy( string $pin_key ): string {
+    $copy = array(
+        'translink' => 'TransLink alerts on screen. Audio tries CKNW, then marine VHF, then skytrain bed.',
+        'drivers'   => 'DriveBC incidents on the map dots and bulletin. CKNW for road/traffic radio.',
+        'ferries'   => 'BC Ferries sailings + capacity bulletin. Live marine VHF first, ferry horn bed if scanners are down.',
+        'weather'   => 'Environment Canada weather alerts bulletin. CBC Radio One for live forecast chatter.',
+        'wildfire'  => 'BC wildfire incidents bulletin. Burnaby FD + BCWS repeater chain underneath.',
+        'air'       => 'Metro Vancouver AQHI bulletin. Salish hydrophones when you want ambience with the data.',
+    );
+    return $copy[ $pin_key ] ?? '';
+}
+
+function se_broadcaster_apply_channel_deck_notes( array $channel ): array {
+    $notes = se_broadcaster_channel_deck_notes();
+    $key   = (string) ( $channel['key'] ?? '' );
+    if ( isset( $notes[ $key ] ) ) {
+        $channel['deck_copy'] = $notes[ $key ]['deck_copy'];
+        $channel['deck_note'] = $notes[ $key ]['deck_note'];
+    }
+    return $channel;
 }
 
 function se_broadcaster_audio_channel_catalog(): array {
@@ -374,17 +458,17 @@ function se_broadcaster_audio_channel_catalog(): array {
         'marine_vhf'     => array(
             'key'               => 'marine_vhf',
             'label'             => 'MARINE VHF',
-            'hint'              => 'Port traffic scan',
+            'hint'              => 'Port + coast VHF',
             'freq'              => '156.800',
             'mode'              => 'broadcastify',
             'broadcastify_id'   => 47189,
             'broadcastify_ids'  => se_broadcaster_marine_broadcastify_feed_ids(),
             'link_url'          => 'https://www.broadcastify.com/listen/feed/47189',
-            'link_label'        => 'Broadcastify marine feed',
+            'link_label'        => 'Vancouver marine feed (Broadcastify)',
             'map_lat'           => 49.2700,
             'map_lon'           => -123.1500,
-            'source'            => 'Broadcastify',
-            'source_url'        => 'https://www.broadcastify.com/listen/feed/47189',
+            'source'            => 'Broadcastify — BC marine VHF chain',
+            'source_url'        => 'https://www.broadcastify.com/listen/stid/102/marine',
             'pin_tier'          => 'marine',
         ),
         'hydro_bush'     => array(
@@ -532,6 +616,7 @@ function se_broadcaster_audio_channels_for_client(): array {
     $out     = array();
 
     foreach ( $catalog as $key => $channel ) {
+        $channel  = se_broadcaster_apply_channel_deck_notes( $channel );
         $resolved = se_broadcaster_resolve_audio_channel( $channel );
         $out[ $key ] = array(
             'key'        => $key,
@@ -551,6 +636,8 @@ function se_broadcaster_audio_channels_for_client(): array {
             'attribution' => $channel['attribution'] ?? '',
             'attribution_url' => $channel['attribution_url'] ?? '',
             'pin_tier'   => $channel['pin_tier'] ?? 'radio',
+            'deck_copy'  => $channel['deck_copy'] ?? '',
+            'deck_note'  => $channel['deck_note'] ?? '',
             'map_lat'    => (float) ( $channel['map_lat'] ?? 0 ),
             'map_lon'    => (float) ( $channel['map_lon'] ?? 0 ),
         );

--- a/inc/home-yvr-broadcaster.php
+++ b/inc/home-yvr-broadcaster.php
@@ -250,7 +250,7 @@ function se_broadcaster_metro_map_anchors(): array {
 }
 
 function se_broadcaster_data_channel_pin_config(): array {
-    return array(
+    $pins = array(
         'translink' => array(
             'feed_key'       => 'translink',
             'audio_keys'     => array( 'cknw', 'marine_vhf', 'sound_skytrain' ),
@@ -293,6 +293,13 @@ function se_broadcaster_data_channel_pin_config(): array {
             'tier'           => 'air',
         ),
     );
+
+    foreach ( $pins as $key => $pin ) {
+        $pins[ $key ]['deck_copy'] = se_broadcaster_pin_deck_copy( $key );
+        $pins[ $key ]['deck_note'] = 'Territory pin — bulletin on CRT, live audio on Dave. Small map dots are incidents; they land here too, not in a new tab.';
+    }
+
+    return $pins;
 }
 
 function se_broadcaster_metro_map_static(): array {

--- a/js/home-hero-map.js
+++ b/js/home-hero-map.js
@@ -170,8 +170,14 @@
       });
       om.bindTooltip((m.name || '') + (m.detail ? ' — ' + m.detail : ''));
       if (m.url) {
-        om.on('click', function () {
-          window.open(m.url, '_blank', 'noopener,noreferrer');
+        om.on('click', function (e) {
+          if (window.L && window.L.DomEvent) {
+            window.L.DomEvent.stopPropagation(e);
+            window.L.DomEvent.preventDefault(e);
+          }
+          if (window.HomeYvrBroadcaster && window.HomeYvrBroadcaster.showMapOverlay) {
+            window.HomeYvrBroadcaster.showMapOverlay(m);
+          }
         });
       }
       om.addTo(self.layer);

--- a/js/home-yvr-broadcaster.js
+++ b/js/home-yvr-broadcaster.js
@@ -66,6 +66,11 @@
     this.telepromptRoot = root.querySelector('[data-broadcaster-teleprompt]');
     this.scriptEl = root.querySelector('[data-broadcaster-script]');
     this.metaEl = root.querySelector('[data-broadcaster-meta]');
+    this.detailRoot = root.querySelector('[data-broadcaster-channel-detail]');
+    this.detailKickerEl = root.querySelector('[data-broadcaster-detail-kicker]');
+    this.detailBodyEl = root.querySelector('[data-broadcaster-detail-body]');
+    this.detailNoteEl = root.querySelector('[data-broadcaster-detail-note]');
+    this.feedsNoteEl = root.querySelector('[data-broadcaster-feeds-note]');
     this.mouthEl = root.querySelector('[data-broadcaster-mouth]');
     this.faceEl = root.querySelector('[data-broadcaster-face]');
     this.heroMap = window.HomeHeroMap || null;
@@ -404,6 +409,72 @@
     }, delay);
   };
 
+  HomeYvrBroadcaster.prototype.renderChannelDetail = function (opts) {
+    if (!this.detailRoot) return;
+
+    var copy = (opts && opts.deck_copy) ? opts.deck_copy : '';
+    var note = (opts && opts.deck_note) ? opts.deck_note : '';
+    var kicker = (opts && opts.kicker) ? opts.kicker : 'channel';
+
+    if (!copy && !note) {
+      this.detailRoot.hidden = true;
+      if (this.detailBodyEl) this.detailBodyEl.textContent = '';
+      if (this.detailNoteEl) this.detailNoteEl.textContent = '';
+      return;
+    }
+
+    if (this.detailKickerEl) this.detailKickerEl.textContent = kicker;
+    if (this.detailBodyEl) this.detailBodyEl.textContent = copy;
+    if (this.detailNoteEl) this.detailNoteEl.textContent = note;
+    this.detailRoot.hidden = false;
+  };
+
+  HomeYvrBroadcaster.prototype.showMapOverlay = function (marker) {
+    if (!marker) return;
+
+    this.stopAll(false);
+    this.focusDavePlayer();
+
+    var name = marker.name || 'Map incident';
+    var detail = marker.detail || '';
+    var html = '<div class="home-yvr-bulletin home-yvr-bulletin--overlay">';
+    html += '<p class="home-yvr-bulletin__kicker pixel-font">map incident</p>';
+    html += '<p class="home-yvr-bulletin__title">' + escapeHtml(name) + '</p>';
+    if (detail) {
+      html += '<p class="home-yvr-bulletin__text">' + escapeHtml(detail) + '</p>';
+    }
+    html += '<p class="home-yvr-bulletin__text">Incident dot from the active territory layer. Audio unchanged — pick a listen-row channel or territory pin for live sound.</p>';
+    html += '</div>';
+
+    if (this.scriptEl) {
+      this.scriptEl.innerHTML = html;
+      this.scriptEl.scrollTop = 0;
+    }
+
+    this.renderChannelDetail({
+      kicker: 'map dot',
+      deck_copy: name + (detail ? ' — ' + detail : ''),
+      deck_note: 'Stays on Dave. Footer link opens the official source only if you tap it — no auto pop-ups.'
+    });
+
+    var items = [];
+    if (marker.url) {
+      items.push({
+        url: marker.url,
+        link_label: 'Open official source (new tab)'
+      });
+    }
+    this.renderMeta({
+      fetched_label: 'Map overlay',
+      items: items
+    });
+
+    this.root.classList.add('is-live', 'is-bulletin');
+    if (this.telepromptRoot) {
+      this.telepromptRoot.classList.add('is-live', 'is-bulletin');
+    }
+  };
+
   HomeYvrBroadcaster.prototype.renderAttribution = function (channel) {
     if (!this.attributionEl) return;
 
@@ -577,6 +648,7 @@
 
   HomeYvrBroadcaster.prototype.setTelepromptStandby = function () {
     this.renderMeta(null);
+    this.renderChannelDetail(null);
     if (this.scriptEl) {
       this.scriptEl.innerHTML = '';
       this.scriptEl.textContent = 'tap a pin — bulletin lands here. PLAY for live audio.';
@@ -868,8 +940,22 @@
     this.root.classList.add('is-bulletin-only');
     this.setBars(true);
     this.appendBulletinAudioNote(
-      'Scanners offline (' + tried.join(', ') + ') — bulletin text is still current.'
+      'Scanners offline (' + tried.join(', ') + ') — bulletin text is still current. Hit PLAY to retry or pick another channel.'
     );
+  };
+
+  HomeYvrBroadcaster.prototype.renderListenChannelDetail = function (channel) {
+    if (!channel) {
+      this.renderChannelDetail(null);
+      return;
+    }
+    this.renderChannelDetail({
+      kicker: channel.label || channel.key,
+      deck_copy: channel.deck_copy || channel.hint || '',
+      deck_note: channel.deck_note || (channel.mode === 'broadcastify'
+        ? 'Broadcastify scanner — audio stays on Dave. Footer link is optional.'
+        : 'In-page live audio.')
+    });
   };
 
   HomeYvrBroadcaster.prototype.mergeFeeds = function (data) {
@@ -920,6 +1006,12 @@
     var display = this.getDisplayChannel(pinKey);
     if (display) this.updateDisplay(display);
     this.highlightChannel(null);
+
+    this.renderChannelDetail({
+      kicker: (config && config.bulletin_label) || pinKey,
+      deck_copy: (config && config.deck_copy) || '',
+      deck_note: (config && config.deck_note) || ''
+    });
 
     this.root.classList.add('is-live', 'is-bulletin', 'is-armed');
     this.root.classList.remove('is-bulletin-only', 'is-radio');
@@ -974,6 +1066,7 @@
     var display = pinKey ? this.getDisplayChannel(pinKey) : this.getDisplayChannel(channel.key);
     if (display) this.updateDisplay(display);
     this.highlightChannel(channel.key);
+    if (!pinKey) this.renderListenChannelDetail(channel);
     this.renderMeta(pack);
     this.renderAttribution(channel);
     this.renderScript(
@@ -1025,9 +1118,10 @@
     var display = pinKey ? this.getDisplayChannel(pinKey) : this.getDisplayChannel(channel.key);
     if (display) this.updateDisplay(display);
     this.highlightChannel(channel.key);
+    if (!pinKey) this.renderListenChannelDetail(channel);
     this.renderMeta(pack);
     this.renderAttribution(channel);
-    this.renderScript('Live feed opens off-site — no robot voice on this deck.');
+    this.renderScript('Off-site source — use the footer link if you need their player.');
     if (this.telepromptRoot) {
       this.telepromptRoot.classList.add('is-live');
       this.telepromptRoot.classList.remove('is-radio');
@@ -1057,7 +1151,7 @@
       if (this.heroMap && pinKey) this.heroMap.setActiveChannel(pinKey);
       this.playLinkOut(channel, pack, pinKey);
       this.root.classList.add('is-armed');
-      this.renderScript('Scanner offline right now — hit PLAY to retry or use the footer link.');
+      this.renderScript('Scanner offline — hit PLAY to retry. Tries the next feed in the marine chain automatically.');
       this.updatePlayButton();
       return;
     }
@@ -1118,6 +1212,8 @@
     var display = this.getDisplayChannel(key);
     if (display) this.updateDisplay(display);
     this.renderScript('Tuning live audio…');
+    var chPreview = this.audioChannels[key];
+    if (chPreview) this.renderListenChannelDetail(chPreview);
     this.root.classList.add('is-live', 'is-armed');
     this.setBars(true);
     this.setMouthTalking();

--- a/page-home.php
+++ b/page-home.php
@@ -27,7 +27,7 @@ get_header();
                     <p class="home-yvr-radar-deck__ring-label pixel-font" data-yvr-ring-label><?php echo esc_html( 'drag · tap pins' ); ?></p>
                     <div class="home-yvr-radar-deck__wander pixel-font" data-yvr-wander-hint hidden>
                         <p class="home-yvr-radar-deck__wander-kicker"><?php echo esc_html( 'you wandered in.' ); ?></p>
-                        <p class="home-yvr-radar-deck__wander-body"><?php echo esc_html( 'drag the scope. tap a pin — bulletin text plus matched live scanner.' ); ?></p>
+                        <p class="home-yvr-radar-deck__wander-body"><?php echo esc_html( 'big pins = territory channels. listen row = direct live feeds. small dots = incidents — they land on Dave, not a new tab.' ); ?></p>
                         <button type="button" class="home-yvr-radar-deck__wander-dismiss pixel-font" data-yvr-wander-dismiss><?php echo esc_html( 'got it' ); ?></button>
                     </div>
                 </div>
@@ -78,6 +78,11 @@ get_header();
                         </div>
                     </div>
                     <div class="home-yvr-broadcaster__crt" data-broadcaster-teleprompt>
+                        <div class="home-yvr-broadcaster__channel-detail" data-broadcaster-channel-detail hidden>
+                            <p class="home-yvr-broadcaster__channel-detail-kicker pixel-font" data-broadcaster-detail-kicker><?php echo esc_html( 'channel' ); ?></p>
+                            <p class="home-yvr-broadcaster__channel-detail-body" data-broadcaster-detail-body></p>
+                            <p class="home-yvr-broadcaster__channel-detail-note pixel-font" data-broadcaster-detail-note></p>
+                        </div>
                         <p class="home-yvr-broadcaster__attribution pixel-font" data-broadcaster-attribution hidden></p>
                         <p class="home-yvr-teleprompt__script" data-broadcaster-script><?php echo esc_html( 'tap a pin — bulletin lands here. PLAY for live audio.' ); ?></p>
                         <ul class="home-yvr-teleprompt__meta" data-broadcaster-meta hidden></ul>

--- a/parts/home-yvr-channel-buttons.php
+++ b/parts/home-yvr-channel-buttons.php
@@ -24,5 +24,5 @@
                                 </button>
                             <?php endforeach; ?>
                         </div>
-                        <p class="home-yvr-broadcaster__feeds-note pixel-font"><?php echo esc_html( 'map pins show bulletins + tune matched live scanners' ); ?></p>
+                        <p class="home-yvr-broadcaster__feeds-note pixel-font" data-broadcaster-feeds-note><?php echo esc_html( 'big pins = territory bulletins · listen row = direct live feeds' ); ?></p>
                     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Marine VHF
Primary Vancouver port feed (47189) has been offline on Broadcastify. Marine now tries a chain:
47189 → Comox (32393) → Sointula (32901) → EC marine weather WX (44288).

## Channel detail panel
CRT shows what each channel is, how audio works, and when footer links open a new tab (only if you tap them).

## Map dots
Small incident overlay markers no longer auto-open DriveBC / AQ pages — they scroll to Dave and show the incident with an optional footer link.

## Copy
Territory pins and listen row both get deck copy in Suzy voice.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8847567f-6559-4baa-822d-02ae416215a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8847567f-6559-4baa-822d-02ae416215a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

