### PR TITLE
Broadcastify HLS client fallback + marine feed order

### DIFF
--- a/inc/home-yvr-audio-channels.php
+++ b/inc/home-yvr-audio-channels.php
@@ -186,7 +186,7 @@ function se_broadcaster_broadcastify_hls_has_segments( string $playlist_url ): b
     }
 
     $body = (string) wp_remote_retrieve_body( $response );
-    return str_contains( $body, '.ts' );
+    return strpos( $body, '.ts' ) !== false;
 }
 
 function se_broadcaster_broadcastify_stream_url( int $feed_id ): ?string {

--- a/inc/home-yvr-audio-channels.php
+++ b/inc/home-yvr-audio-channels.php
@@ -653,7 +653,7 @@ function se_broadcaster_resolve_audio_channel( array $channel ): array {
             $resolved = se_broadcaster_broadcastify_stream_url( $feed_id );
             if ( $resolved ) {
                 $out['stream_url'] = $resolved;
-                $out['format']     = str_contains( $resolved, '.m3u8' ) ? 'hls' : 'mp3';
+                $out['format']     = ( strpos( $resolved, '.m3u8' ) !== false ) ? 'hls' : 'mp3';
                 $out['stream_ok']  = true;
                 break;
             }
@@ -690,6 +690,12 @@ function se_broadcaster_audio_channels_for_client(): array {
             'pin_tier'   => $channel['pin_tier'] ?? 'radio',
             'deck_copy'  => $channel['deck_copy'] ?? '',
             'deck_note'  => $channel['deck_note'] ?? '',
+            'broadcastify_ids' => array_values(
+                array_map(
+                    'intval',
+                    $channel['broadcastify_ids'] ?? array( (int) ( $channel['broadcastify_id'] ?? 0 ) )
+                )
+            ),
             'map_lat'    => (float) ( $channel['map_lat'] ?? 0 ),
             'map_lon'    => (float) ( $channel['map_lon'] ?? 0 ),
         );

--- a/js/home-yvr-broadcaster.js
+++ b/js/home-yvr-broadcaster.js
@@ -51,6 +51,10 @@
     return null;
   }
 
+  function broadcastifyHlsUrl(feedId) {
+    return 'https://hls-o1.broadcastify.com/s2/feed/' + feedId + '/playlist.m3u8';
+  }
+
   function HomeYvrBroadcaster(root) {
     this.root = root;
     this.audio = root.querySelector('[data-broadcaster-audio]');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #609: PHP 7.4 strpos compat, client-side HLS URL fallback when server resolve fails, marine chain order (Comox first).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8847567f-6559-4baa-822d-02ae416215a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8847567f-6559-4baa-822d-02ae416215a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

