### PR TITLE
Auto-failover for dead marine scanners — no more "hit PLAY to retry"

### DIFF
--- a/assets/css/home-hero-cabinet.css
+++ b/assets/css/home-hero-cabinet.css
@@ -584,6 +584,13 @@
 .home-yvr-broadcaster__crt[data-broadcaster-teleprompt].is-radio .home-yvr-teleprompt__script {
   border-color: rgba(255, 230, 109, 0.5);
   box-shadow: inset 0 0 16px rgba(255, 230, 109, 0.12);
+  color: rgba(223, 255, 234, 0.92);
+}
+
+.home-yvr-broadcaster__crt[data-broadcaster-teleprompt].is-status .home-yvr-teleprompt__script {
+  border-color: rgba(255, 179, 71, 0.55);
+  box-shadow: inset 0 0 16px rgba(255, 179, 71, 0.14);
+  color: rgba(255, 236, 179, 0.95);
 }
 
 .home-yvr-map__anchor {

--- a/inc/home-yvr-audio-channels.php
+++ b/inc/home-yvr-audio-channels.php
@@ -254,8 +254,8 @@ function se_broadcaster_channel_deck_notes(): array {
             'deck_note' => 'Broadcastify scanner. Footer link opens source only if you tap it.',
         ),
         'marine_vhf'     => array(
-            'deck_copy' => 'Marine VHF — port traffic, Coast Guard, distress. Tries Vancouver ch 11/12/16 first, then Comox, Sointula, EC marine weather WX.',
-            'deck_note' => 'Broadcastify chain. Stays on Dave — footer link is optional.',
+            'deck_copy' => 'Marine VHF — port traffic, Coast Guard, distress. Walks Vancouver → Comox → Sointula → EC marine WX automatically. Coast dead? Dave jumps to YVR combo.',
+            'deck_note' => 'Broadcastify chain. No retry button — Dave finds a live feed or switches.',
         ),
         'hydro_bush'     => array(
             'deck_copy' => 'Orcasound hydrophone at Bush Point — Salish Sea live. Whales, ships, weird water noise.',
@@ -284,7 +284,7 @@ function se_broadcaster_pin_deck_copy( string $pin_key ): string {
     $copy = array(
         'translink' => 'TransLink alerts on screen. Audio tries CKNW, then marine VHF, then skytrain bed.',
         'drivers'   => 'DriveBC incidents on the map dots and bulletin. CKNW for road/traffic radio.',
-        'ferries'   => 'BC Ferries sailings + capacity bulletin. Live marine VHF first, ferry horn bed if scanners are down.',
+        'ferries'   => 'BC Ferries sailings + capacity bulletin. Marine VHF auto-scans the coast; ferry horn bed if everything\'s dead.',
         'weather'   => 'Environment Canada weather alerts bulletin. CBC Radio One for live forecast chatter.',
         'wildfire'  => 'BC wildfire incidents bulletin. Burnaby FD + BCWS repeater chain underneath.',
         'air'       => 'Metro Vancouver AQHI bulletin. Salish hydrophones when you want ambience with the data.',

--- a/js/home-yvr-broadcaster.js
+++ b/js/home-yvr-broadcaster.js
@@ -55,6 +55,37 @@
     return 'https://hls-o1.broadcastify.com/s2/feed/' + feedId + '/playlist.m3u8';
   }
 
+  var BROADCASTIFY_FEED_LABELS = {
+    47189: 'Vancouver port',
+    32393: 'Comox coast',
+    32901: 'Sointula',
+    44288: 'EC marine WX',
+    38213: 'Burnaby Fire',
+    47303: 'BCWS south',
+    47304: 'BCWS north',
+    47305: 'BCWS central'
+  };
+
+  /** When every scanner in a chain is dead, jump here before giving up. */
+  var CHANNEL_AUDIO_FALLBACKS = {
+    marine_vhf: 'yvr_combo',
+    burnaby_fire: 'yvr_combo'
+  };
+
+  function broadcastifyFeedLabel(feedId) {
+    return BROADCASTIFY_FEED_LABELS[feedId] || ('feed ' + feedId);
+  }
+
+  function probeHlsLive(url) {
+    return fetch(url, { credentials: 'omit', mode: 'cors' })
+      .then(function (r) { return r.ok ? r.text() : ''; })
+      .then(function (body) {
+        if (!body) return false;
+        return /\.ts(?:\?|$)/m.test(body) || body.indexOf('#EXTINF:') !== -1;
+      })
+      .catch(function () { return false; });
+  }
+
   function HomeYvrBroadcaster(root) {
     this.root = root;
     this.audio = root.querySelector('[data-broadcaster-audio]');
@@ -104,6 +135,7 @@
     this.focusTimer = null;
     this.pendingMapSelectKey = null;
     this.unmuteWatchdog = null;
+    this.broadcastifyChainGen = 0;
   }
 
   HomeYvrBroadcaster.prototype.isKnownChannel = function (key) {
@@ -577,6 +609,34 @@
   HomeYvrBroadcaster.prototype.renderScript = function (text) {
     if (!this.scriptEl) return;
     this.scriptEl.textContent = text || '';
+    if (this.telepromptRoot) {
+      this.telepromptRoot.classList.remove('is-status');
+    }
+  };
+
+  HomeYvrBroadcaster.prototype.renderStatusScript = function (text) {
+    if (!this.scriptEl) return;
+    this.scriptEl.textContent = text || '';
+    if (this.telepromptRoot) {
+      this.telepromptRoot.classList.add('is-live', 'is-status');
+      this.telepromptRoot.classList.remove('is-radio');
+    }
+  };
+
+  HomeYvrBroadcaster.prototype.getBroadcastifyFeedIds = function (channel) {
+    if (!channel) return [];
+    var ids = channel.broadcastify_ids;
+    if (ids && ids.length) {
+      return ids.map(function (id) { return parseInt(id, 10); }).filter(function (id) { return id > 0; });
+    }
+    if (channel.broadcastify_id) {
+      return [parseInt(channel.broadcastify_id, 10)];
+    }
+    return [];
+  };
+
+  HomeYvrBroadcaster.prototype.cancelBroadcastifyChain = function () {
+    this.broadcastifyChainGen += 1;
   };
 
   HomeYvrBroadcaster.prototype.packFromFeedPack = function (pack) {
@@ -655,11 +715,11 @@
     this.renderChannelDetail(null);
     if (this.scriptEl) {
       this.scriptEl.innerHTML = '';
-      this.scriptEl.textContent = 'tap a pin — bulletin lands here. PLAY for live audio.';
+      this.scriptEl.textContent = 'tap a pin — bulletin lands here. live audio starts on its own.';
     }
     this.renderAttribution(null);
     if (this.telepromptRoot) {
-      this.telepromptRoot.classList.remove('is-live', 'is-radio', 'is-bulletin');
+      this.telepromptRoot.classList.remove('is-live', 'is-radio', 'is-bulletin', 'is-status');
     }
     if (this.heroMap) {
       this.heroMap.setActiveChannel(null);
@@ -810,6 +870,7 @@
   };
 
   HomeYvrBroadcaster.prototype.stopRadio = function () {
+    this.cancelBroadcastifyChain();
     this.clearAutoMuteTimer();
     this.stopMeter();
     this.stopUnmuteWatchdog();
@@ -856,6 +917,122 @@
     if (this.channelEl) this.channelEl.textContent = channel.label;
   };
 
+  HomeYvrBroadcaster.prototype.handleBroadcastifyChainFailed = function (channel, pack, pinKey, chainTail) {
+    var self = this;
+    var fallbackKey = CHANNEL_AUDIO_FALLBACKS[channel.key];
+
+    if (fallbackKey) {
+      var fallback = this.audioChannels[fallbackKey];
+      if (fallback && fallback.mode !== 'link_out') {
+        var status = channel.key === 'marine_vhf'
+          ? 'Coast scanners dead — YVR combo instead.'
+          : 'Scanner quiet — YVR combo instead.';
+        if (pinKey) {
+          this.appendBulletinAudioNote(status);
+        } else {
+          this.renderStatusScript(status);
+        }
+        this.activeAudioKey = fallbackKey;
+        this.highlightChannel(fallbackKey);
+        var fbPack = this.packFromAudioChannel(fallback);
+        if (fallback.stream_ok && fallback.stream_url) {
+          this.playStream(fallback, fbPack, pinKey);
+          return;
+        }
+        this.activateAudioChannel(fallback, pinKey);
+        return;
+      }
+    }
+
+    if (chainTail && chainTail.length) {
+      this.tryPlayAudioChain(chainTail, pinKey);
+      return;
+    }
+
+    this.root.classList.add('is-bulletin-only');
+    var deadCopy = channel.key === 'marine_vhf'
+      ? 'All coast feeds quiet. Bulletin still live — YVR MIX usually has traffic.'
+      : 'Scanner offline. Bulletin still live — pick another channel.';
+    if (pinKey) {
+      this.appendBulletinAudioNote(deadCopy);
+    } else {
+      this.renderStatusScript(deadCopy);
+    }
+    this.setBars(true);
+    this.updatePlayButton();
+  };
+
+  HomeYvrBroadcaster.prototype.playBroadcastifyChain = function (channel, pack, pinKey, opts) {
+    var self = this;
+    opts = opts || {};
+    var chainTail = opts.chainTail || [];
+    var pinMode = !!pinKey;
+    var onStatus = opts.onStatus || function (msg) {
+      self.renderStatusScript(msg);
+    };
+
+    var feedIds = this.getBroadcastifyFeedIds(channel);
+    if (!feedIds.length) {
+      this.handleBroadcastifyChainFailed(channel, pack, pinKey, chainTail);
+      return;
+    }
+
+    var gen = ++this.broadcastifyChainGen;
+
+    this.activeAudioKey = channel.key;
+    this.highlightChannel(channel.key);
+    if (this.heroMap && pinKey) this.heroMap.setActiveChannel(pinKey);
+    if (!pinKey) this.renderListenChannelDetail(channel);
+    this.renderMeta(pack);
+    this.renderAttribution(channel);
+    onStatus('Scanning scanner chain…');
+    this.root.classList.add('is-live', 'is-armed');
+    this.root.classList.remove('is-bulletin-only');
+    if (this.telepromptRoot) {
+      this.telepromptRoot.classList.add('is-live', 'is-status');
+      this.telepromptRoot.classList.remove('is-radio');
+    }
+    this.setBars(true);
+    this.setMouthTalking();
+    this.unlockAudio();
+
+    var idx = 0;
+
+    function tryNext() {
+      if (gen !== self.broadcastifyChainGen) return;
+      if (idx >= feedIds.length) {
+        self.handleBroadcastifyChainFailed(channel, pack, pinKey, chainTail);
+        return;
+      }
+
+      var feedId = feedIds[idx];
+      var label = broadcastifyFeedLabel(feedId);
+      idx += 1;
+      onStatus(idx === 1 ? 'Checking ' + label + '…' : label + ' quiet — trying next…');
+
+      probeHlsLive(broadcastifyHlsUrl(feedId)).then(function (live) {
+        if (gen !== self.broadcastifyChainGen) return;
+        if (!live) {
+          tryNext();
+          return;
+        }
+
+        var liveChannel = Object.assign({}, channel, {
+          stream_url: broadcastifyHlsUrl(feedId),
+          stream_ok: true,
+          format: 'hls'
+        });
+        var statusMsg = feedId === feedIds[0]
+          ? 'Live on ' + label + '.'
+          : broadcastifyFeedLabel(feedIds[0]) + ' quiet — on ' + label + ' now.';
+        onStatus(statusMsg);
+        self.playStream(liveChannel, pack, pinKey);
+      });
+    }
+
+    tryNext();
+  };
+
   HomeYvrBroadcaster.prototype.startBulletinAudio = function (channel) {
     var self = this;
     if (!this.audio || !channel.stream_url) return false;
@@ -876,7 +1053,7 @@
 
     var afterArm = function (ok) {
       if (!ok) {
-        self.appendBulletinAudioNote('Hit PLAY below — live audio is armed.');
+        self.appendBulletinAudioNote('Tap PLAY below if audio didn\'t start.');
       }
     };
 
@@ -929,7 +1106,13 @@
           this.appendBulletinAudioNote('Live scan: ' + (channel.label || audioKey) + '.');
           return;
         }
-        continue;
+        this.playBroadcastifyChain(channel, this.packFromAudioChannel(channel), pinKey, {
+          chainTail: keys.slice(i + 1),
+          onStatus: function (msg) {
+            self.appendBulletinAudioNote(msg);
+          }
+        });
+        return;
       }
 
       if ((channel.mode === 'stream' || channel.mode === 'soundscape') && channel.stream_ok && channel.stream_url) {
@@ -944,7 +1127,7 @@
     this.root.classList.add('is-bulletin-only');
     this.setBars(true);
     this.appendBulletinAudioNote(
-      'Scanners offline (' + tried.join(', ') + ') — bulletin text is still current. Hit PLAY to retry or pick another channel.'
+      'Scanners quiet (' + tried.join(', ') + ') — bulletin still current. YVR MIX usually has traffic.'
     );
   };
 
@@ -957,7 +1140,7 @@
       kicker: channel.label || channel.key,
       deck_copy: channel.deck_copy || channel.hint || '',
       deck_note: channel.deck_note || (channel.mode === 'broadcastify'
-        ? 'Broadcastify scanner — audio stays on Dave. Footer link is optional.'
+        ? 'Broadcastify chain — Dave walks feeds until something\'s live.'
         : 'In-page live audio.')
     });
   };
@@ -1039,7 +1222,7 @@
       this.renderBulletin(pack, config, pinKey);
       this.renderMeta(this.packFromFeedPack(pack));
     } else {
-      this.renderScript('Pulling bulletin… hit PLAY for live audio.');
+      this.renderScript('Pulling bulletin… scanning for live audio.');
     }
     this.renderAttribution(null);
 
@@ -1082,6 +1265,7 @@
     );
     if (this.telepromptRoot) {
       this.telepromptRoot.classList.add('is-live', 'is-radio');
+      this.telepromptRoot.classList.remove('is-status');
     }
     this.root.classList.add('is-live', 'is-radio');
     this.setMouthTalking();
@@ -1093,7 +1277,7 @@
 
     var afterArm = function (ok) {
       if (!ok) {
-        self.renderScript('Hit PLAY below — channel is armed on deck.');
+        self.renderStatusScript('Tap PLAY below if audio didn\'t start.');
         self.setBars(false);
         self.setMouthIdle();
       }
@@ -1153,9 +1337,7 @@
         return;
       }
       if (this.heroMap && pinKey) this.heroMap.setActiveChannel(pinKey);
-      this.playLinkOut(channel, pack, pinKey);
-      this.root.classList.add('is-armed');
-      this.renderScript('Scanner offline — hit PLAY to retry. Tries the next feed in the marine chain automatically.');
+      this.playBroadcastifyChain(channel, pack, pinKey, { chainTail: [] });
       this.updatePlayButton();
       return;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

First-time users tapping **MARINE VHF** saw "Scanner offline — hit PLAY to retry" — a dead end. Nobody retries. Vancouver port feed (47189) is often offline even when Comox (32393) has live segments.

## Solution

Dave now **auto-walks the Broadcastify HLS chain** on channel select:

1. Probes each feed ID client-side (`47189 → 32393 → 32901 → 44288`)
2. Auto-plays the first live source — no manual retry
3. Shows human status copy: "Checking Vancouver port…" → "Vancouver quiet — on Comox coast now."
4. If **all coast feeds are dead**, auto-switches to **YVR combo** (LiveATC) with clear messaging
5. Pin audio chains (ferries, translink) inherit the same behavior; soundscape beds still kick in as last resort

## UX polish

- Removed all "hit PLAY to retry" dead-end copy
- Brighter CRT status text (`.is-status` / `.is-radio`) for mobile readability
- Updated marine channel detail copy to explain auto-chain + YVR fallback

## Files

- `js/home-yvr-broadcaster.js` — `probeHlsLive`, `playBroadcastifyChain`, smart fallbacks
- `assets/css/home-hero-cabinet.css` — status/radio script contrast
- `inc/home-yvr-audio-channels.php` — deck copy updates
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8847567f-6559-4baa-822d-02ae416215a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8847567f-6559-4baa-822d-02ae416215a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

