### PR TITLE
Homepage UX: visible audio loading + commercial layout declutter

### DIFF
--- a/assets/css/home-commercial-strip.css
+++ b/assets/css/home-commercial-strip.css
@@ -1,0 +1,138 @@
+/* Compact commercial strip — above radar, below mast */
+
+.home-signal-strip {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.55rem;
+  width: 100%;
+  max-width: min(92vw, 900px);
+  margin: 0 auto;
+  padding: 0.45rem 0.65rem;
+  border: 2px solid rgba(87, 243, 255, 0.28);
+  border-radius: 8px;
+  background: rgba(2, 8, 18, 0.72);
+  font-size: clamp(0.38rem, 0.78vw, 0.48rem);
+  letter-spacing: 0.06em;
+}
+
+.home-signal-strip--warn,
+.home-signal-strip--degraded {
+  border-color: rgba(255, 179, 71, 0.45);
+}
+
+.home-signal-strip--bad,
+.home-signal-strip--down {
+  border-color: rgba(255, 79, 79, 0.5);
+}
+
+.home-signal-strip__product {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.28rem 0.4rem;
+  color: inherit;
+  text-decoration: none;
+}
+
+.home-signal-strip__product:hover,
+.home-signal-strip__product:focus-visible {
+  color: #57f3ff;
+}
+
+.home-signal-strip__label {
+  color: #ffe66d;
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+}
+
+.home-signal-strip__verdict {
+  color: rgba(210, 240, 230, 0.88);
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  text-transform: lowercase;
+}
+
+.home-signal-strip__badge {
+  padding: 0.12rem 0.35rem;
+  border-radius: 3px;
+  background: rgba(255, 79, 79, 0.18);
+  color: #ff6b6b;
+  letter-spacing: 0.06em;
+  text-transform: lowercase;
+}
+
+.home-signal-strip--warn .home-signal-strip__badge,
+.home-signal-strip--degraded .home-signal-strip__badge {
+  background: rgba(255, 179, 71, 0.18);
+  color: #ffb347;
+}
+
+.home-signal-strip__link {
+  color: rgba(180, 230, 220, 0.85);
+  text-decoration: none;
+  text-transform: lowercase;
+}
+
+.home-signal-strip__link:hover,
+.home-signal-strip__link:focus-visible {
+  color: #39ff14;
+}
+
+.home-signal-strip__pipe {
+  color: rgba(120, 160, 150, 0.45);
+}
+
+.home-signal-strip__future {
+  color: rgba(150, 190, 180, 0.62);
+  text-transform: lowercase;
+}
+
+.home-signal-strip__contact {
+  margin-left: auto;
+  padding: 0.22rem 0.45rem;
+  border: 2px solid rgba(57, 255, 20, 0.45);
+  border-radius: 4px;
+  background: rgba(57, 255, 20, 0.1);
+  color: #39ff14;
+  font-family: "Press Start 2P", monospace;
+  font-size: clamp(0.34rem, 0.72vw, 0.42rem);
+  letter-spacing: 0.06em;
+  text-transform: lowercase;
+  cursor: pointer;
+}
+
+.home-signal-strip__contact:hover,
+.home-signal-strip__contact:focus-visible {
+  background: rgba(57, 255, 20, 0.2);
+}
+
+.home-mission-card--featured {
+  border-color: rgba(255, 179, 71, 0.65);
+  box-shadow: 0 0 20px rgba(255, 179, 71, 0.12);
+}
+
+.home-mission-card--featured .home-mission-card__label {
+  color: #ffb347;
+}
+
+@media (max-width: 720px) {
+  .home-signal-strip {
+    flex-direction: column;
+    align-items: stretch;
+    text-align: center;
+  }
+
+  .home-signal-strip__contact {
+    margin-left: 0;
+    width: 100%;
+  }
+
+  .home-signal-strip__pipe {
+    display: none;
+  }
+
+  .home-signal-strip__future {
+    font-size: clamp(0.34rem, 0.72vw, 0.42rem);
+  }
+}

--- a/assets/css/home-hero-cabinet.css
+++ b/assets/css/home-hero-cabinet.css
@@ -453,6 +453,145 @@
   animation: none;
 }
 
+.home-yvr-broadcaster.is-loading .home-yvr-broadcaster__led {
+  background: #ffb347;
+  box-shadow: 0 0 12px rgba(255, 179, 71, 0.85);
+  animation: homeYvrLoadPulse 0.85s ease-in-out infinite;
+}
+
+.home-yvr-broadcaster.is-loading .home-yvr-broadcaster__channel {
+  color: #ffb347;
+}
+
+.home-yvr-broadcaster__load-tag {
+  padding: 0.08rem 0.28rem;
+  border: 1px solid rgba(255, 179, 71, 0.55);
+  border-radius: 3px;
+  color: #ffb347;
+  font-size: clamp(0.32rem, 0.68vw, 0.4rem);
+  letter-spacing: 0.08em;
+  animation: homeYvrLoadPulse 0.85s ease-in-out infinite;
+}
+
+.home-yvr-broadcaster__load-bar {
+  position: relative;
+  height: 4px;
+  margin: 0.2rem 0 0.15rem;
+  border-radius: 3px;
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.65);
+  border: 1px solid rgba(255, 179, 71, 0.35);
+}
+
+.home-yvr-broadcaster__load-bar-fill {
+  display: block;
+  width: 42%;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(255, 179, 71, 0.2), #ffb347, rgba(255, 179, 71, 0.2));
+  animation: homeYvrLoadBar 1.1s ease-in-out infinite;
+}
+
+.home-yvr-broadcaster__load-status {
+  margin: 0.18rem 0 0;
+  color: rgba(255, 236, 179, 0.95);
+  font-size: clamp(0.42rem, 0.85vw, 0.52rem);
+  letter-spacing: 0.06em;
+  text-transform: lowercase;
+}
+
+.home-yvr-broadcaster__crt[data-broadcaster-teleprompt].is-loading .home-yvr-teleprompt__script {
+  color: rgba(255, 236, 179, 0.92);
+  border-color: rgba(255, 179, 71, 0.45);
+}
+
+.home-yvr-broadcaster__ch.is-loading {
+  position: relative;
+  border-color: rgba(255, 179, 71, 0.75) !important;
+  animation: homeYvrLoadPulse 0.85s ease-in-out infinite;
+}
+
+.home-yvr-broadcaster__ch.is-loading::after {
+  content: "…";
+  position: absolute;
+  top: 0.18rem;
+  right: 0.22rem;
+  color: #ffb347;
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  font-size: 0.65em;
+}
+
+.home-yvr-broadcaster__feeds-panel {
+  margin-top: 0.15rem;
+}
+
+.home-yvr-broadcaster__feeds-summary {
+  cursor: pointer;
+  list-style: none;
+  color: rgba(255, 179, 71, 0.85);
+  font-size: clamp(0.38rem, 0.78vw, 0.48rem);
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+  padding: 0.22rem 0;
+}
+
+.home-yvr-broadcaster__feeds-summary::-webkit-details-marker {
+  display: none;
+}
+
+.home-yvr-broadcaster__feeds-summary::before {
+  content: "▸ ";
+  color: #57f3ff;
+}
+
+.home-yvr-broadcaster__feeds-panel[open] .home-yvr-broadcaster__feeds-summary::before {
+  content: "▾ ";
+}
+
+.home-yvr-broadcaster__speed-panel {
+  grid-column: 1 / -1;
+}
+
+.home-yvr-broadcaster__speed-summary {
+  cursor: pointer;
+  list-style: none;
+  text-align: center;
+  color: rgba(180, 230, 220, 0.75);
+  font-size: clamp(0.34rem, 0.72vw, 0.42rem);
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+  padding: 0.15rem 0;
+}
+
+.home-yvr-broadcaster__speed-summary::-webkit-details-marker {
+  display: none;
+}
+
+.home-yvr-broadcaster__speed-panel .home-yvr-broadcaster__speed {
+  margin-top: 0.2rem;
+}
+
+.home-yvr-broadcaster__native {
+  display: none;
+}
+
+.home-yvr-broadcaster.is-loading .home-yvr-broadcaster__native,
+.home-yvr-broadcaster.is-listening .home-yvr-broadcaster__native,
+.home-yvr-broadcaster.is-armed .home-yvr-broadcaster__native {
+  display: block;
+}
+
+@keyframes homeYvrLoadPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.45; }
+}
+
+@keyframes homeYvrLoadBar {
+  0% { transform: translateX(-120%); }
+  100% { transform: translateX(280%); }
+}
+
+
 .home-yvr-broadcaster.is-listening .home-yvr-broadcaster__led {
   background: #39ff14;
   box-shadow: 0 0 10px rgba(57, 255, 20, 0.9);

--- a/assets/css/home-yvr-radar-deck.css
+++ b/assets/css/home-yvr-radar-deck.css
@@ -352,6 +352,17 @@
   animation: homeYvrPinDiscover 1.6s ease-in-out infinite;
 }
 
+.home-yvr-radar-deck__map-wrap.is-loading .home-yvr-radar-deck__ring-label {
+  color: #ffb347;
+  text-shadow: 0 0 10px rgba(255, 179, 71, 0.65);
+  animation: homeYvrRingLive 0.85s ease-in-out infinite;
+}
+
+.home-yvr-radar-deck__map-wrap.is-loading .home-yvr-radar-deck__sweep {
+  opacity: 0.45;
+  animation-duration: 2.2s;
+}
+
 .home-yvr-radar-deck__map-wrap.is-listening .home-yvr-radar-deck__ring-label {
   color: #39ff14;
   text-shadow: 0 0 10px rgba(57, 255, 20, 0.65);

--- a/assets/css/lousy-outages-teaser.css
+++ b/assets/css/lousy-outages-teaser.css
@@ -57,6 +57,15 @@
 #lousy-outages-teaser .lo-home-delayed{grid-column:1/-1;margin:0;padding:.45rem .6rem;border:1px dashed rgba(255,230,109,.5);border-radius:10px;color:var(--lo-yellow);font-size:.82rem}
 #lousy-outages-teaser .lo-home-upgrade{margin:.65rem 0 0}
 #lousy-outages-teaser [hidden]{display:none!important}
+#lousy-outages-teaser.lo-home-teaser-panel{margin:1rem auto}
+#lousy-outages-teaser .lo-home-teaser__details{border:0}
+#lousy-outages-teaser .lo-home-teaser__summary{display:flex;align-items:center;flex-wrap:wrap;gap:.35rem .65rem;cursor:pointer;list-style:none;padding:.15rem 0 .45rem;font-family:'Press Start 2P',monospace;font-size:clamp(.48rem,.95vw,.62rem);letter-spacing:.06em;text-transform:lowercase;color:var(--lo-yellow)}
+#lousy-outages-teaser .lo-home-teaser__summary::-webkit-details-marker{display:none}
+#lousy-outages-teaser .lo-home-teaser__summary::before{content:"▸ ";color:var(--lo-cyan)}
+#lousy-outages-teaser .lo-home-teaser__details[open] .lo-home-teaser__summary::before{content:"▾ "}
+#lousy-outages-teaser .lo-home-teaser__summary-verdict{font-family:"IBM Plex Mono","Courier New",monospace;color:#c8e8ff;font-size:clamp(.42rem,.85vw,.55rem);text-transform:lowercase;flex:1 1 12rem}
+#lousy-outages-teaser .lo-home-teaser__summary-action{color:var(--lo-cyan);font-size:clamp(.4rem,.8vw,.52rem);opacity:.85}
+#lousy-outages-teaser .lo-home-teaser__body{padding-top:.15rem}
 @media (max-width:760px){
   #lousy-outages-teaser.lo-home-teaser{width:min(100% - 1rem,980px)}
   #lousy-outages-teaser .lo-home-teaser__titlebar{align-items:flex-start;flex-direction:column}

--- a/assets/js/lousy-outages-teaser.js
+++ b/assets/js/lousy-outages-teaser.js
@@ -48,6 +48,12 @@
 
     setText(container, '[data-lo-verdict-line]', teaser.verdict_line || '');
     setText(container, '[data-lo-verdict-sub]', teaser.verdict_sub || '');
+    setText(container, '[data-lo-summary-verdict]', teaser.verdict_line || '');
+
+    var signalVerdict = document.querySelector('[data-signal-lo-verdict]');
+    if (signalVerdict && teaser.verdict_line) {
+      signalVerdict.textContent = teaser.verdict_line;
+    }
 
     setText(container, '[data-lo-stat="down"] strong', padCount(counts.down));
     setText(container, '[data-lo-stat="degraded"] strong', padCount(counts.degraded));

--- a/functions.php
+++ b/functions.php
@@ -92,6 +92,16 @@ function retro_game_music_theme_scripts() {
             );
         }
 
+        $signal_css = get_template_directory() . '/assets/css/home-commercial-strip.css';
+        if ( file_exists( $signal_css ) ) {
+            wp_enqueue_style(
+                'home-commercial-strip',
+                get_template_directory_uri() . '/assets/css/home-commercial-strip.css',
+                array( 'main-styles' ),
+                filemtime( $signal_css )
+            );
+        }
+
         wp_enqueue_script(
             'home-arcade-start',
             get_template_directory_uri() . '/js/home-arcade-start.js',

--- a/js/home-yvr-broadcaster.js
+++ b/js/home-yvr-broadcaster.js
@@ -1182,6 +1182,7 @@
         this.playBroadcastifyChain(channel, this.packFromAudioChannel(channel), pinKey, {
           chainTail: keys.slice(i + 1),
           onStatus: function (msg) {
+            self.setLoadingUi(true, msg);
             self.appendBulletinAudioNote(msg);
           }
         });

--- a/js/home-yvr-broadcaster.js
+++ b/js/home-yvr-broadcaster.js
@@ -75,6 +75,9 @@
     this.detailBodyEl = root.querySelector('[data-broadcaster-detail-body]');
     this.detailNoteEl = root.querySelector('[data-broadcaster-detail-note]');
     this.feedsNoteEl = root.querySelector('[data-broadcaster-feeds-note]');
+    this.loadStatusEl = root.querySelector('[data-broadcaster-load-status]');
+    this.loadBarEl = root.querySelector('[data-broadcaster-load-bar]');
+    this.loadTagEl = root.querySelector('[data-broadcaster-load-tag]');
     this.mouthEl = root.querySelector('[data-broadcaster-mouth]');
     this.faceEl = root.querySelector('[data-broadcaster-face]');
     this.heroMap = window.HomeHeroMap || null;
@@ -330,6 +333,20 @@
       this.audio.addEventListener('pause', function () {
         self.updatePlayButton();
       });
+      this.audio.addEventListener('playing', function () {
+        self.setLoadingUi(false);
+        self.updatePlayButton();
+      });
+      this.audio.addEventListener('waiting', function () {
+        if (!self.audio.paused) {
+          self.setLoadingUi(true, 'buffering…');
+        }
+      });
+      this.audio.addEventListener('canplay', function () {
+        if (!self.audio.paused) {
+          self.setLoadingUi(false);
+        }
+      });
       this.audio.addEventListener('volumechange', function () {
         if (self.audio.muted) self.audio.muted = false;
       });
@@ -370,6 +387,56 @@
     if (this.ringLabelEl) {
       this.ringLabelEl.textContent = on ? 'live audio on deck' : 'drag · tap pins';
     }
+    if (on) {
+      this.setLoadingUi(false);
+    }
+  };
+
+  HomeYvrBroadcaster.prototype.setLoadingUi = function (on, message) {
+    var label = message || 'loading audio…';
+    this.root.classList.toggle('is-loading', on);
+    if (this.mapWrapEl) {
+      this.mapWrapEl.classList.toggle('is-loading', on);
+    }
+    if (this.telepromptRoot) {
+      this.telepromptRoot.classList.toggle('is-loading', on);
+    }
+    if (this.loadStatusEl) {
+      if (on) {
+        this.loadStatusEl.textContent = label;
+        this.loadStatusEl.hidden = false;
+      } else {
+        this.loadStatusEl.hidden = true;
+        this.loadStatusEl.textContent = '';
+      }
+    }
+    if (this.loadBarEl) {
+      this.loadBarEl.hidden = !on;
+    }
+    if (this.loadTagEl) {
+      this.loadTagEl.hidden = !on;
+    }
+    if (this.ringLabelEl && on) {
+      this.ringLabelEl.textContent = label;
+    } else if (this.ringLabelEl && !on && !this.isAudioPlaying()) {
+      this.ringLabelEl.textContent = 'drag · tap pins';
+    }
+    if (this.activeAudioKey) {
+      this.highlightChannelLoading(this.activeAudioKey, on);
+    }
+  };
+
+  HomeYvrBroadcaster.prototype.highlightChannelLoading = function (key, on) {
+    this.channelBtns.forEach(function (btn) {
+      var match = btn.getAttribute('data-broadcaster-channel-btn') === key;
+      if (match) {
+        btn.classList.toggle('is-loading', on);
+        btn.setAttribute('aria-busy', on ? 'true' : 'false');
+      } else if (on) {
+        btn.classList.remove('is-loading');
+        btn.setAttribute('aria-busy', 'false');
+      }
+    });
   };
 
   HomeYvrBroadcaster.prototype.clearAutoMuteTimer = function () {
@@ -810,6 +877,7 @@
   };
 
   HomeYvrBroadcaster.prototype.stopRadio = function () {
+    this.setLoadingUi(false);
     this.clearAutoMuteTimer();
     this.stopMeter();
     this.stopUnmuteWatchdog();
@@ -861,6 +929,8 @@
     if (!this.audio || !channel.stream_url) return false;
 
     this.stopRadio();
+    this.activeAudioKey = channel.key;
+    this.setLoadingUi(true, 'loading ' + (channel.label || channel.key).toLowerCase() + '…');
     this.renderAttribution(channel);
     this.root.classList.add('is-radio');
     this.root.classList.remove('is-bulletin-only');
@@ -875,8 +945,11 @@
     this.primeAudioElement();
 
     var afterArm = function (ok) {
-      if (!ok) {
-        self.appendBulletinAudioNote('Hit PLAY below — live audio is armed.');
+      if (ok) {
+        self.setLoadingUi(false);
+      } else {
+        self.setLoadingUi(false);
+        self.appendBulletinAudioNote('Tap PLAY below if audio didn\'t start.');
       }
     };
 
@@ -943,6 +1016,7 @@
 
     this.root.classList.add('is-bulletin-only');
     this.setBars(true);
+    this.setLoadingUi(false);
     this.appendBulletinAudioNote(
       'Scanners offline (' + tried.join(', ') + ') — bulletin text is still current. Hit PLAY to retry or pick another channel.'
     );
@@ -1030,6 +1104,7 @@
 
     this.setBars(true);
     this.setMouthTalking();
+    this.setLoadingUi(true, 'pulling bulletin…');
 
     var feeds = this.feeds;
     var feedKey = config.feed_key || pinKey;
@@ -1039,7 +1114,8 @@
       this.renderBulletin(pack, config, pinKey);
       this.renderMeta(this.packFromFeedPack(pack));
     } else {
-      this.renderScript('Pulling bulletin… hit PLAY for live audio.');
+      this.setLoadingUi(true, 'pulling bulletin…');
+      this.renderScript('Pulling bulletin… scanning for live audio.');
     }
     this.renderAttribution(null);
 
@@ -1067,6 +1143,8 @@
     if (!this.audio || !channel.stream_url) return;
 
     this.stopRadio();
+    this.activeAudioKey = channel.key;
+    this.setLoadingUi(true, 'loading ' + (channel.label || channel.key).toLowerCase() + '…');
     var display = pinKey ? this.getDisplayChannel(pinKey) : this.getDisplayChannel(channel.key);
     if (display) this.updateDisplay(display);
     this.highlightChannel(channel.key);
@@ -1092,8 +1170,11 @@
     this.primeAudioElement();
 
     var afterArm = function (ok) {
-      if (!ok) {
-        self.renderScript('Hit PLAY below — channel is armed on deck.');
+      if (ok) {
+        self.setLoadingUi(false);
+      } else {
+        self.setLoadingUi(false);
+        self.renderScript('Tap PLAY below if audio didn\'t start.');
         self.setBars(false);
         self.setMouthIdle();
       }
@@ -1155,6 +1236,7 @@
       if (this.heroMap && pinKey) this.heroMap.setActiveChannel(pinKey);
       this.playLinkOut(channel, pack, pinKey);
       this.root.classList.add('is-armed');
+      this.setLoadingUi(false);
       this.renderScript('Scanner offline — hit PLAY to retry. Tries the next feed in the marine chain automatically.');
       this.updatePlayButton();
       return;
@@ -1162,6 +1244,7 @@
 
     if (channel.mode === 'stream' || channel.mode === 'soundscape') {
       if (!channel.stream_ok || !channel.stream_url) {
+        this.setLoadingUi(false);
         this.renderScript('Live feed not available right now — try another channel.');
         this.setBars(false);
         return;
@@ -1215,6 +1298,7 @@
 
     var display = this.getDisplayChannel(key);
     if (display) this.updateDisplay(display);
+    this.setLoadingUi(true, 'tuning live audio…');
     this.renderScript('Tuning live audio…');
     var chPreview = this.audioChannels[key];
     if (chPreview) this.renderListenChannelDetail(chPreview);
@@ -1244,6 +1328,7 @@
 
       var freshChannel = self.audioChannels[key];
       if (!freshChannel) {
+        self.setLoadingUi(false);
         self.renderScript('Live feed still loading — try again in a moment.');
         self.setBars(false);
         self.setMouthIdle();

--- a/page-home.php
+++ b/page-home.php
@@ -11,6 +11,8 @@ get_header();
             <h1 id="home-hero-title" class="home-yvr-radar-deck__title pixel-font"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>
         </header>
 
+        <?php get_template_part( 'parts/home-commercial-strip' ); ?>
+
         <div class="home-yvr-radar-deck__radar-unit">
             <div class="home-yvr-radar-deck__unit-head pixel-font">
                 <span class="home-yvr-radar-deck__unit-badge"><?php echo esc_html( 'YVR RADAR' ); ?></span>
@@ -64,6 +66,7 @@ get_header();
                                 <span class="home-yvr-broadcaster__badge pixel-font"><?php echo esc_html( 'YVR BCAST' ); ?></span>
                                 <span class="home-yvr-broadcaster__on-air" role="status" aria-live="polite">
                                     <span class="home-yvr-broadcaster__led" aria-hidden="true"></span>
+                                    <span class="home-yvr-broadcaster__load-tag pixel-font" data-broadcaster-load-tag hidden><?php echo esc_html( 'LOADING' ); ?></span>
                                     <span class="home-yvr-broadcaster__channel pixel-font" data-broadcaster-channel><?php echo esc_html( 'STANDBY' ); ?></span>
                                 </span>
                                 <span class="home-yvr-broadcaster__freq pixel-font" data-broadcaster-freq>000.000</span>
@@ -84,7 +87,11 @@ get_header();
                             <p class="home-yvr-broadcaster__channel-detail-note pixel-font" data-broadcaster-detail-note></p>
                         </div>
                         <p class="home-yvr-broadcaster__attribution pixel-font" data-broadcaster-attribution hidden></p>
-                        <p class="home-yvr-teleprompt__script" data-broadcaster-script><?php echo esc_html( 'tap a pin — bulletin lands here. PLAY for live audio.' ); ?></p>
+                        <div class="home-yvr-broadcaster__load-bar" data-broadcaster-load-bar hidden aria-hidden="true">
+                            <span class="home-yvr-broadcaster__load-bar-fill"></span>
+                        </div>
+                        <p class="home-yvr-broadcaster__load-status pixel-font" data-broadcaster-load-status hidden aria-live="polite"></p>
+                        <p class="home-yvr-teleprompt__script" data-broadcaster-script><?php echo esc_html( 'tap a pin — bulletin lands here. live audio starts on its own.' ); ?></p>
                         <ul class="home-yvr-teleprompt__meta" data-broadcaster-meta hidden></ul>
                         <div class="home-yvr-broadcaster__crt-scan" aria-hidden="true"></div>
                     </div>
@@ -98,22 +105,24 @@ get_header();
                             <span class="home-yvr-broadcaster__stop-label"><?php echo esc_html( 'STOP' ); ?></span>
                             <span class="home-yvr-broadcaster__stop-hint"><?php echo esc_html( 'silence deck' ); ?></span>
                         </button>
-                        <div class="home-yvr-broadcaster__speed pixel-font" aria-label="<?php echo esc_attr( 'Playback speed' ); ?>">
-                            <span class="home-yvr-broadcaster__speed-label"><?php echo esc_html( 'speed' ); ?></span>
-                            <button type="button" class="home-yvr-broadcaster__speed-btn" data-broadcaster-speed="0.75" aria-label="<?php echo esc_attr( 'Slower' ); ?>">−</button>
-                            <span class="home-yvr-broadcaster__speed-readout" data-broadcaster-speed-label>1×</span>
-                            <button type="button" class="home-yvr-broadcaster__speed-btn" data-broadcaster-speed="1" aria-label="<?php echo esc_attr( 'Normal speed' ); ?>">1×</button>
-                            <button type="button" class="home-yvr-broadcaster__speed-btn" data-broadcaster-speed="1.25" aria-label="<?php echo esc_attr( 'Faster' ); ?>">+</button>
-                            <button type="button" class="home-yvr-broadcaster__speed-btn" data-broadcaster-speed="1.5" aria-label="<?php echo esc_attr( 'Fast' ); ?>">++</button>
-                        </div>
+                        <details class="home-yvr-broadcaster__speed-panel">
+                            <summary class="home-yvr-broadcaster__speed-summary pixel-font"><?php echo esc_html( 'speed' ); ?></summary>
+                            <div class="home-yvr-broadcaster__speed pixel-font" aria-label="<?php echo esc_attr( 'Playback speed' ); ?>">
+                                <button type="button" class="home-yvr-broadcaster__speed-btn" data-broadcaster-speed="0.75" aria-label="<?php echo esc_attr( 'Slower' ); ?>">−</button>
+                                <span class="home-yvr-broadcaster__speed-readout" data-broadcaster-speed-label>1×</span>
+                                <button type="button" class="home-yvr-broadcaster__speed-btn" data-broadcaster-speed="1" aria-label="<?php echo esc_attr( 'Normal speed' ); ?>">1×</button>
+                                <button type="button" class="home-yvr-broadcaster__speed-btn" data-broadcaster-speed="1.25" aria-label="<?php echo esc_attr( 'Faster' ); ?>">+</button>
+                                <button type="button" class="home-yvr-broadcaster__speed-btn" data-broadcaster-speed="1.5" aria-label="<?php echo esc_attr( 'Fast' ); ?>">++</button>
+                            </div>
+                        </details>
                     </div>
                     <audio class="home-yvr-broadcaster__native" data-broadcaster-audio controls preload="none" playsinline webkit-playsinline controlslist="nodownload noplaybackrate"></audio>
                 </div>
                 </div>
             </div>
             <div class="home-yvr-radar-deck__cta">
-                <p class="home-yvr-radar-deck__subtitle pixel-font"><?php echo esc_html( 'AI strategy // systems integration // creative technology' ); ?></p>
-                <p class="home-yvr-radar-deck__positioning"><?php echo esc_html( 'Punk bassist brain. Builds infra, creative tech, browser tools and applications that are practical and cool.' ); ?></p>
+                <p class="home-yvr-radar-deck__subtitle pixel-font"><?php echo esc_html( 'AI strategy // systems integration // civic data products' ); ?></p>
+                <p class="home-yvr-radar-deck__positioning"><?php echo esc_html( 'Builds infra, browser tools, and live data layers for Vancouver — outage intel today, API + MCP next.' ); ?></p>
                 <div class="home-amp-console">
                     <div class="home-title-screen-prompt pixel-font" role="status" aria-live="polite" data-arcade-status><?php echo esc_html( 'INSERT COIN' ); ?></div>
                     <button type="button" class="pixel-button home-press-start" data-home-start data-start-label="PRESS START // VIEW WORK"><?php echo esc_html( 'PRESS START // VIEW WORK' ); ?></button>
@@ -128,14 +137,12 @@ get_header();
         </div>
     </section>
 
-    <?php get_template_part( 'parts/lousy-outages-teaser' ); ?>
-
     <section id="mission-select" class="home-project-grid home-mission-select crt-block" aria-labelledby="selected-projects-title">
         <p class="home-section-kicker pixel-font"><?php echo esc_html( 'LEVEL SELECT' ); ?></p>
         <h2 id="selected-projects-title" class="pixel-font"><?php echo esc_html( 'CHOOSE YOUR SYSTEM' ); ?></h2>
         <div class="selected-work__grid home-mission-grid">
+            <article class="home-project-card selected-work__card home-mission-card home-mission-card--featured"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'status weather' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Lousy Outages' ); ?></h3><p><?php echo esc_html( 'Independent outage intelligence for AI, cloud and creative tools, translated from status-page language into something humans can use.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/lousy-outages/' ) ); ?>"><?php echo esc_html( 'Check status' ); ?></a></article>
             <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'hockey arcade' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Pacific Power Play' ); ?></h3><p><?php echo esc_html( 'Choose your line, drop the puck, and survive the rain city static in a Vancouver hockey cabinet.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/pacific-power-play/' ) ); ?>"><?php echo esc_html( 'Play game' ); ?></a></article>
-            <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'status weather' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Lousy Outages' ); ?></h3><p><?php echo esc_html( 'Independent outage intelligence for AI, cloud and creative tools, translated from status-page language into something humans can use.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/lousy-outages/' ) ); ?>"><?php echo esc_html( 'Check status' ); ?></a></article>
             <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'civic arcade world' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Gastown Simulator' ); ?></h3><p><?php echo esc_html( 'A playable Vancouver corridor built from civic data, route logic, street mood, and arcade-map obsession.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/gastown-sim/' ) ); ?>"><?php echo esc_html( 'Walk Gastown' ); ?></a></article>
             <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'audio notes' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Track Analyzer' ); ?></h3><p><?php echo esc_html( 'Upload an MP3 and get clear notes on feel, lyrics, structure, and what might actually help the track.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/suzys-track-analyzer/' ) ); ?>"><?php echo esc_html( 'Analyze track' ); ?></a></article>
             <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'early music tool' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Loop Lab' ); ?></h3><p><?php echo esc_html( 'A browser tape deck for playing first, looping fast, and stacking little mistakes on purpose.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/loop-lab/' ) ); ?>"><?php echo esc_html( 'Make noise' ); ?></a></article>
@@ -144,6 +151,8 @@ get_header();
             <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'discography' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Music / Records' ); ?></h3><p><?php echo esc_html( 'Solo releases, past bands, touring history, and the music side of the machine.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/music-releases/' ) ); ?>"><?php echo esc_html( 'Listen' ); ?></a></article>
         </div>
     </section>
+
+    <?php get_template_part( 'parts/lousy-outages-teaser' ); ?>
 
     <section id="music" class="music-world home-unlocks crt-block" aria-labelledby="music-world-title">
         <p class="home-section-kicker pixel-font"><?php echo esc_html( 'UNLOCKS' ); ?></p>

--- a/parts/home-commercial-strip.php
+++ b/parts/home-commercial-strip.php
@@ -1,0 +1,32 @@
+<?php
+$teaser     = function_exists( 'get_lousy_outages_home_teaser_data' ) ? get_lousy_outages_home_teaser_data() : [];
+$lo_url     = home_url( '/lousy-outages/' );
+$pricing    = home_url( '/lousy-outages/pricing/' );
+$verdict    = (string) ( $teaser['verdict_line'] ?? 'Independent outage intel for AI + creative stacks' );
+$tone       = sanitize_html_class( (string) ( $teaser['tone'] ?? 'ok' ) );
+$counts     = is_array( $teaser['counts'] ?? null ) ? $teaser['counts'] : [];
+$down       = (int) ( $counts['down'] ?? 0 );
+$degraded   = (int) ( $counts['degraded'] ?? 0 );
+?>
+<nav class="home-signal-strip home-signal-strip--<?php echo esc_attr( $tone ); ?>" aria-label="<?php echo esc_attr( 'Products and live signals' ); ?>">
+    <a class="home-signal-strip__product home-signal-strip__product--lo" href="<?php echo esc_url( $lo_url ); ?>">
+        <span class="home-signal-strip__label pixel-font"><?php echo esc_html( 'lousy outages' ); ?></span>
+        <span class="home-signal-strip__verdict" data-signal-lo-verdict><?php echo esc_html( $verdict ); ?></span>
+        <?php if ( $down > 0 || $degraded > 0 ) : ?>
+            <span class="home-signal-strip__badge pixel-font">
+                <?php
+                if ( $down > 0 ) {
+                    echo esc_html( str_pad( (string) $down, 2, '0', STR_PAD_LEFT ) . ' down' );
+                } elseif ( $degraded > 0 ) {
+                    echo esc_html( str_pad( (string) $degraded, 2, '0', STR_PAD_LEFT ) . ' degraded' );
+                }
+                ?>
+            </span>
+        <?php endif; ?>
+    </a>
+    <span class="home-signal-strip__pipe" aria-hidden="true">·</span>
+    <a class="home-signal-strip__link pixel-font" href="<?php echo esc_url( $pricing ); ?>"><?php echo esc_html( 'watchlists' ); ?></a>
+    <span class="home-signal-strip__pipe" aria-hidden="true">·</span>
+    <span class="home-signal-strip__future pixel-font"><?php echo esc_html( 'yvr data layer — api + mcp soon' ); ?></span>
+    <button type="button" class="home-signal-strip__contact pixel-font" data-contact-trigger aria-haspopup="dialog" aria-controls="contact-suzy-modal"><?php echo esc_html( 'contact' ); ?></button>
+</nav>

--- a/parts/home-yvr-channel-buttons.php
+++ b/parts/home-yvr-channel-buttons.php
@@ -1,5 +1,6 @@
+                    <details class="home-yvr-broadcaster__feeds-panel">
+                        <summary class="home-yvr-broadcaster__feeds-summary pixel-font"><?php echo esc_html( 'listen // live feeds' ); ?></summary>
                     <div class="home-yvr-broadcaster__feeds">
-                        <p class="home-yvr-broadcaster__feeds-label pixel-font"><?php echo esc_html( 'listen // live only' ); ?></p>
                         <div class="home-yvr-broadcaster__channels home-yvr-broadcaster__channels--listen">
                             <?php foreach ( se_broadcaster_audio_channel_catalog() as $audio_ch ) : ?>
                                 <?php if ( ! empty( $audio_ch['pin_only'] ) ) {
@@ -26,3 +27,4 @@
                         </div>
                         <p class="home-yvr-broadcaster__feeds-note pixel-font" data-broadcaster-feeds-note><?php echo esc_html( 'big pins = territory bulletins · listen row = direct live feeds' ); ?></p>
                     </div>
+                    </details>

--- a/parts/lousy-outages-teaser.php
+++ b/parts/lousy-outages-teaser.php
@@ -14,7 +14,14 @@ $advisory = (int) ( $counts['advisory'] ?? 0 );
 $up = (int) ( $counts['up'] ?? 0 );
 $tracked = (int) ( $counts['tracked'] ?? 0 );
 ?>
-<section id="lousy-outages-teaser" class="lo-home-teaser lo-home-teaser--<?php echo esc_attr( $tone ); ?>" aria-labelledby="lo-home-heading" data-lo-endpoint="<?php echo esc_url( $teaser_endpoint ); ?>" data-lo-dashboard-url="<?php echo esc_url( $dashboard_url ); ?>" data-lo-refresh-interval="<?php echo esc_attr( (string) $teaser_interval ); ?>">
+<section id="lousy-outages-teaser" class="lo-home-teaser lo-home-teaser--<?php echo esc_attr( $tone ); ?> lo-home-teaser-panel" aria-labelledby="lo-home-heading" data-lo-endpoint="<?php echo esc_url( $teaser_endpoint ); ?>" data-lo-dashboard-url="<?php echo esc_url( $dashboard_url ); ?>" data-lo-refresh-interval="<?php echo esc_attr( (string) $teaser_interval ); ?>">
+    <details class="lo-home-teaser__details">
+        <summary class="lo-home-teaser__summary pixel-font">
+            <span class="lo-home-teaser__summary-label"><?php echo esc_html( 'lousy outages' ); ?></span>
+            <span class="lo-home-teaser__summary-verdict" data-lo-summary-verdict><?php echo esc_html( (string) ( $teaser['verdict_line'] ?? '' ) ); ?></span>
+            <span class="lo-home-teaser__summary-action"><?php echo esc_html( 'expand live board' ); ?></span>
+        </summary>
+    <div class="lo-home-teaser__body">
     <div class="lo-home-teaser__titlebar">
         <div>
             <p class="lo-home-kicker"><?php echo esc_html( 'live outage signal' ); ?></p>
@@ -90,4 +97,6 @@ $tracked = (int) ( $counts['tracked'] ?? 0 );
     </div>
 
     <p class="lo-home-upgrade"><a class="lo-home-dashboard-link" data-lo-upgrade href="<?php echo esc_url( home_url( '/lousy-outages/pricing/' ) ); ?>"><?php echo esc_html( 'Save your watchlist' ); ?> <span aria-hidden="true">→</span></a></p>
+    </div>
+    </details>
 </section>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

1. **No visible loading state** — when audio was tuning/buffering, the main page looked idle (STANDBY LED, no feedback).
2. **Homepage clutter** — YVR Radar + full Dave UI + LO board + 8 project cards competed above the fold before a visitor understood the commercial products.

## Changes

### Audio loading (visible on main page)
- Amber **LOADING** tag on Dave header
- Animated load bar + status line in CRT
- Ring label updates ("loading marine vhf…", "buffering…")
- Active channel button pulses while loading
- Map ring gets loading tint during tune

### Commercial layout declutter
- **Signal strip** under mast: live LO verdict, watchlists link, "yvr data layer — api + mcp soon", contact
- **Listen feeds** collapsed behind `<details>` (pins stay primary)
- **Speed controls** collapsed behind `<details>`
- **Native `<audio>` bar** hidden until loading/listening/armed
- **Full LO board** moved below LEVEL SELECT; collapsed summary by default
- **Lousy Outages** featured first in project grid

### Copy
- Hero positioning reframed toward civic data products + future API/MCP layer

## Files
- `js/home-yvr-broadcaster.js` — `setLoadingUi()`, audio events
- `page-home.php`, `parts/home-commercial-strip.php`
- CSS across cabinet, radar deck, LO teaser, commercial strip

## Next (not in this PR)
- Merge auto-failover PR (#611) so marine loading resolves to live audio
- Dedicated `/api` or MCP landing when ready to commercialize Vancouver data layer
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8847567f-6559-4baa-822d-02ae416215a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8847567f-6559-4baa-822d-02ae416215a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

