### PR TITLE
Hero pitch at top, night-watch intro, motion-safe defaults

### DIFF
--- a/assets/css/home-hero-cabinet.css
+++ b/assets/css/home-hero-cabinet.css
@@ -1936,7 +1936,14 @@ body.home-yvr-map-modal-open {
   .home-yvr-broadcaster__crt-scan,
   .home-yvr-broadcaster__eye,
   .home-yvr-broadcaster__mouth.is-flap,
-  .home-yvr-broadcaster.is-live .home-yvr-broadcaster__led {
+  .home-yvr-broadcaster.is-live .home-yvr-broadcaster__led,
+  .home-yvr-broadcaster.is-loading .home-yvr-broadcaster__led,
+  .home-yvr-broadcaster.is-loading .home-yvr-broadcaster__load-tag,
+  .home-yvr-broadcaster.is-loading .home-yvr-broadcaster__load-bar-fill,
+  .home-yvr-broadcaster.is-loading .home-yvr-broadcaster__ch.is-loading,
+  .home-yvr-broadcaster.is-listening .home-yvr-broadcaster__led,
+  .home-yvr-broadcaster.is-armed .home-yvr-broadcaster__play,
+  .home-yvr-broadcaster__ch--scan.is-active {
     animation: none !important;
   }
 }

--- a/assets/css/home-yvr-radar-deck.css
+++ b/assets/css/home-yvr-radar-deck.css
@@ -48,6 +48,74 @@
     0 0 18px rgba(255, 255, 102, 0.35);
 }
 
+.home-yvr-radar-deck__pitch {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.45rem;
+  width: min(100%, 920px);
+  margin: 0 auto;
+  padding: clamp(0.55rem, 1.2vw, 0.85rem) clamp(0.65rem, 1.5vw, 1rem);
+  text-align: center;
+  border: 2px solid rgba(255, 79, 216, 0.35);
+  border-radius: 10px;
+  background:
+    linear-gradient(135deg, rgba(255, 79, 216, 0.08), rgba(87, 243, 255, 0.06)),
+    rgba(2, 8, 18, 0.78);
+  box-shadow:
+    inset 0 0 24px rgba(87, 243, 255, 0.06),
+    0 0 20px rgba(255, 79, 216, 0.08);
+}
+
+.home-yvr-radar-deck__pitch-tags {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem 0.45rem;
+  margin: 0;
+}
+
+.home-yvr-radar-deck__pitch-tag {
+  padding: 0.2rem 0.42rem;
+  border: 1px solid rgba(87, 243, 255, 0.35);
+  border-radius: 4px;
+  background: rgba(0, 8, 16, 0.55);
+  color: rgba(210, 240, 255, 0.92);
+  font-size: clamp(0.42rem, 0.88vw, 0.58rem);
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+}
+
+.home-yvr-radar-deck__pitch-tag--accent {
+  color: #ffe66d;
+  border-color: rgba(255, 230, 109, 0.45);
+  background: rgba(255, 230, 109, 0.08);
+  box-shadow: 0 0 12px rgba(255, 230, 109, 0.12);
+}
+
+.home-yvr-radar-deck__pitch-sep {
+  color: rgba(255, 79, 216, 0.65);
+  font-size: clamp(0.4rem, 0.82vw, 0.52rem);
+}
+
+.home-yvr-radar-deck__pitch-lead {
+  margin: 0;
+  max-width: 42rem;
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  font-size: clamp(0.72rem, 1.15vw, 0.92rem);
+  line-height: 1.5;
+  color: rgba(232, 247, 255, 0.92);
+}
+
+.home-yvr-radar-deck__pitch-sub {
+  margin: 0;
+  color: rgba(150, 190, 180, 0.72);
+  font-size: clamp(0.38rem, 0.78vw, 0.48rem);
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+}
+
 /* —— Radar unit (the map IS the hero) —— */
 .home-yvr-radar-deck__radar-unit {
   display: flex;
@@ -548,11 +616,16 @@
   .home-yvr-radar-deck__unit-status::before,
   .home-yvr-radar-deck.is-starting,
   .home-yvr-radar-deck__cta .home-title-screen-prompt,
-  .home-yvr-radar-deck__cta .home-press-start {
+  .home-yvr-radar-deck__cta .home-press-start,
+  .home-yvr-radar-deck__map-wrap.is-discover .home-yvr-leaflet-pin span,
+  .home-yvr-radar-deck__map-wrap.is-listening .home-yvr-radar-deck__ring-label,
+  .home-yvr-radar-deck__map-wrap.is-loading .home-yvr-radar-deck__ring-label,
+  .home-yvr-radar-deck__map-wrap.is-listening .home-yvr-radar-deck__sweep {
     animation: none !important;
   }
 
-  .home-yvr-radar-deck__map-wrap.is-discover .home-yvr-leaflet-pin span {
-    animation: none !important;
+  .home-yvr-radar-deck__sweep,
+  .home-yvr-radar-deck__scan {
+    opacity: 0.22;
   }
 }

--- a/header.php
+++ b/header.php
@@ -229,7 +229,7 @@
 
 <!-- Hero banner lives in page templates (e.g., homepage hero); this header stays compact above it -->
 <!-- Full‑screen moving starfield background -->
-<canvas id="starfield" role="img" aria-label="Animated starfield background"></canvas>
+<canvas id="starfield" role="img" aria-label="Starfield background"></canvas>
 
 <?php
   // You can drop in your site header/branding or navigation here if you like,

--- a/js/home-hero-map.js
+++ b/js/home-hero-map.js
@@ -339,8 +339,10 @@
     var mapWrap = document.querySelector('.home-yvr-radar-deck__map-wrap');
     if (!hint) return;
 
+    var reduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
     hint.hidden = false;
-    if (mapWrap) mapWrap.classList.add('is-discover');
+    if (mapWrap && !reduceMotion) mapWrap.classList.add('is-discover');
 
     var dismiss = hint.querySelector('[data-yvr-wander-dismiss]');
     if (dismiss) {

--- a/js/starfield.js
+++ b/js/starfield.js
@@ -1,27 +1,34 @@
-(function() {
-  const canvas = document.getElementById('starfield');
+(function () {
+  'use strict';
+
+  var canvas = document.getElementById('starfield');
   if (!canvas) return;
 
-  const ctx = canvas.getContext('2d');
-  let stars = [];
-  let width = 0;
-  let height = 0;
-  let parallaxRange = 50;
-  let starSpeed = 2;
-  let offsetX = 0;
-  let offsetY = 0;
-  let maxDepth = 0;
+  var ctx = canvas.getContext('2d');
+  var stars = [];
+  var width = 0;
+  var height = 0;
+  var parallaxRange = 50;
+  var starSpeed = 2;
+  var offsetX = 0;
+  var offsetY = 0;
+  var maxDepth = 0;
+  var reduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-  const mediaQuery = window.matchMedia('(max-width: 720px)');
+  var mediaQuery = window.matchMedia('(max-width: 720px)');
 
   function init() {
     resize();
     seedStars();
+    if (reduceMotion) {
+      drawStatic();
+      return;
+    }
     requestAnimationFrame(update);
   }
 
   function seedStars() {
-    const target = getStarCount();
+    var target = getStarCount();
     if (stars.length > target) {
       stars = stars.slice(0, target);
     }
@@ -34,13 +41,13 @@
     return {
       x: Math.random() * width,
       y: Math.random() * height,
-      z: Math.random() * maxDepth,
-      o: 0.45 + Math.random() * 0.55 // opacity variation for softer glow
+      z: reduceMotion ? maxDepth * 0.5 : Math.random() * maxDepth,
+      o: 0.45 + Math.random() * 0.55
     };
   }
 
   function resize() {
-    const ratio = Math.min(window.devicePixelRatio || 1, 2);
+    var ratio = Math.min(window.devicePixelRatio || 1, 2);
     width = canvas.clientWidth || window.innerWidth;
     height = canvas.clientHeight || window.innerHeight;
     maxDepth = Math.max(width, height);
@@ -51,46 +58,58 @@
     canvas.height = Math.round(height * ratio);
     ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
     seedStars();
+    if (reduceMotion) drawStatic();
   }
 
   function getStarCount() {
-    const density = mediaQuery.matches ? 0.5 : 1;
-    const area = Math.max(width * height, 1);
-    const scaled = Math.round((area / 9000) * density);
+    var density = mediaQuery.matches ? 0.5 : 1;
+    var area = Math.max(width * height, 1);
+    var scaled = Math.round((area / 9000) * density);
     return Math.min(Math.max(scaled, 160), 380);
+  }
+
+  function drawStarAt(s) {
+    var k = 120 / Math.max(s.z, 0.2);
+    var px = (s.x - width / 2 + offsetX) * k + width / 2;
+    var py = (s.y - height / 2 + offsetY) * k + height / 2;
+    var size = Math.max((1 - s.z / maxDepth) * 3.2, 0.75);
+
+    ctx.beginPath();
+    ctx.fillStyle = 'rgba(255,255,255,' + s.o.toFixed(2) + ')';
+    ctx.arc(px, py, size, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  function drawStatic() {
+    ctx.clearRect(0, 0, width, height);
+    stars.forEach(drawStarAt);
   }
 
   function update() {
     ctx.clearRect(0, 0, width, height);
-    for (const s of stars) {
+    for (var i = 0; i < stars.length; i++) {
+      var s = stars[i];
       s.z -= starSpeed;
       if (s.z <= 0.2) {
         Object.assign(s, randomStar());
         s.z = maxDepth;
       }
-
-      const k = 120 / s.z;
-      const px = (s.x - width / 2 + offsetX) * k + width / 2;
-      const py = (s.y - height / 2 + offsetY) * k + height / 2;
-      const size = Math.max((1 - s.z / maxDepth) * 3.2, 0.75);
-
-      ctx.beginPath();
-      ctx.fillStyle = `rgba(255,255,255,${s.o.toFixed(2)})`;
-      ctx.arc(px, py, size, 0, Math.PI * 2);
-      ctx.fill();
+      drawStarAt(s);
     }
     requestAnimationFrame(update);
   }
 
   function onMove(e) {
-    const rect = canvas.getBoundingClientRect();
-    const x = (e.clientX - rect.left) / rect.width;
-    const y = (e.clientY - rect.top) / rect.height;
+    if (reduceMotion) return;
+    var rect = canvas.getBoundingClientRect();
+    var x = (e.clientX - rect.left) / rect.width;
+    var y = (e.clientY - rect.top) / rect.height;
     offsetX = (x - 0.5) * parallaxRange;
     offsetY = (y - 0.5) * parallaxRange;
   }
 
   function onTilt(e) {
+    if (reduceMotion) return;
     if (e.beta == null || e.gamma == null) return;
     offsetX = (e.gamma / 45) * (parallaxRange * 0.55);
     offsetY = (e.beta / 45) * (parallaxRange * 0.55);

--- a/page-home.php
+++ b/page-home.php
@@ -11,6 +11,8 @@ get_header();
             <h1 id="home-hero-title" class="home-yvr-radar-deck__title pixel-font"><?php echo esc_html( 'SUZY EASTON' ); ?></h1>
         </header>
 
+        <?php get_template_part( 'parts/home-hero-pitch' ); ?>
+
         <?php get_template_part( 'parts/home-commercial-strip' ); ?>
 
         <div class="home-yvr-radar-deck__radar-unit">
@@ -28,9 +30,9 @@ get_header();
                     <div class="home-yvr-radar-deck__scan" aria-hidden="true"></div>
                     <p class="home-yvr-radar-deck__ring-label pixel-font" data-yvr-ring-label><?php echo esc_html( 'drag · tap pins' ); ?></p>
                     <div class="home-yvr-radar-deck__wander pixel-font" data-yvr-wander-hint hidden>
-                        <p class="home-yvr-radar-deck__wander-kicker"><?php echo esc_html( 'you wandered in.' ); ?></p>
-                        <p class="home-yvr-radar-deck__wander-body"><?php echo esc_html( 'big pins = territory channels. listen row = direct live feeds. small dots = incidents — they land on Dave, not a new tab.' ); ?></p>
-                        <button type="button" class="home-yvr-radar-deck__wander-dismiss pixel-font" data-yvr-wander-dismiss><?php echo esc_html( 'got it' ); ?></button>
+                        <p class="home-yvr-radar-deck__wander-kicker"><?php echo esc_html( 'night watch online.' ); ?></p>
+                        <p class="home-yvr-radar-deck__wander-body"><?php echo esc_html( 'Ham-radio view of the lower mainland. Big pins tune live territory feeds — coast guard, wildfire, skytrain, towers. Dave keeps audio on deck.' ); ?></p>
+                        <button type="button" class="home-yvr-radar-deck__wander-dismiss pixel-font" data-yvr-wander-dismiss><?php echo esc_html( 'on band' ); ?></button>
                     </div>
                 </div>
                 <div class="home-yvr-radar-deck__knobs" aria-hidden="true">
@@ -121,8 +123,6 @@ get_header();
                 </div>
             </div>
             <div class="home-yvr-radar-deck__cta">
-                <p class="home-yvr-radar-deck__subtitle pixel-font"><?php echo esc_html( 'AI strategy // systems integration // civic data products' ); ?></p>
-                <p class="home-yvr-radar-deck__positioning"><?php echo esc_html( 'Builds infra, browser tools, and live data layers for Vancouver — outage intel today, API + MCP next.' ); ?></p>
                 <div class="home-amp-console">
                     <div class="home-title-screen-prompt pixel-font" role="status" aria-live="polite" data-arcade-status><?php echo esc_html( 'INSERT COIN' ); ?></div>
                     <button type="button" class="pixel-button home-press-start" data-home-start data-start-label="PRESS START // VIEW WORK"><?php echo esc_html( 'PRESS START // VIEW WORK' ); ?></button>

--- a/parts/home-hero-pitch.php
+++ b/parts/home-hero-pitch.php
@@ -1,0 +1,11 @@
+        <div class="home-yvr-radar-deck__pitch" aria-label="<?php echo esc_attr( 'Practice overview' ); ?>">
+            <p class="home-yvr-radar-deck__pitch-tags pixel-font">
+                <span class="home-yvr-radar-deck__pitch-tag"><?php echo esc_html( 'AI strategy' ); ?></span>
+                <span class="home-yvr-radar-deck__pitch-sep" aria-hidden="true">//</span>
+                <span class="home-yvr-radar-deck__pitch-tag"><?php echo esc_html( 'systems integration' ); ?></span>
+                <span class="home-yvr-radar-deck__pitch-sep" aria-hidden="true">//</span>
+                <span class="home-yvr-radar-deck__pitch-tag home-yvr-radar-deck__pitch-tag--accent"><?php echo esc_html( 'civic data products' ); ?></span>
+            </p>
+            <p class="home-yvr-radar-deck__pitch-lead"><?php echo esc_html( 'Live scanner deck for greater Vancouver — coast guard, wildfire, towers, outage intel. Late-night radio brain on a civic data spine.' ); ?></p>
+            <p class="home-yvr-radar-deck__pitch-sub pixel-font"><?php echo esc_html( 'outage intel today · yvr data layer + mcp next' ); ?></p>
+        </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes

### Pitch at top
- **AI strategy // systems integration // civic data products** now sits directly under the name in a styled pitch block — tag chips, lead line, MCP teaser
- Removed duplicate copy from the right console column (PRESS START stays)

### Wander intro copy
- **"you wandered in."** → **"night watch online."**
- Ham-radio explainer for the Vancouver scanner map
- Dismiss button: **"on band"**

### Motion sensitivity (`prefers-reduced-motion`)
- Starfield renders **static** — no drift, no parallax
- First-visit pin pulse disabled when reduced motion is on
- Radar sweep, loading pulses, ring labels, Dave LEDs respect reduced motion

## Files
- `parts/home-hero-pitch.php`, `page-home.php`
- `assets/css/home-yvr-radar-deck.css`, `home-hero-cabinet.css`
- `js/starfield.js`, `js/home-hero-map.js`
- `header.php` (starfield aria label)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8847567f-6559-4baa-822d-02ae416215a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8847567f-6559-4baa-822d-02ae416215a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

