### PR TITLE
Unify radar + deck — remove orphaned PRESS START column

### DIFF
--- a/assets/css/home-yvr-radar-deck.css
+++ b/assets/css/home-yvr-radar-deck.css
@@ -455,12 +455,41 @@
   50% { transform: scale(1.35); box-shadow: 0 0 16px currentColor, 0 0 24px currentColor; }
 }
 
-/* —— Console: Dave + CTA —— */
-.home-yvr-radar-deck__console {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  gap: clamp(0.65rem, 1.5vw, 1rem);
-  align-items: start;
+/* —— Deck output (single column under radar) —— */
+.home-yvr-radar-deck__deck {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.45rem, 1vw, 0.65rem);
+  width: 100%;
+  max-width: min(100%, 680px);
+  margin: 0 auto;
+}
+
+.home-yvr-radar-deck__deck-head {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.45rem 0.65rem;
+  width: 100%;
+}
+
+.home-yvr-radar-deck__deck-badge {
+  padding: 0.24rem 0.5rem;
+  border: 2px solid rgba(57, 255, 20, 0.5);
+  border-radius: 4px;
+  background: rgba(57, 255, 20, 0.1);
+  color: #39ff14;
+  font-size: clamp(0.4rem, 0.85vw, 0.52rem);
+  letter-spacing: 0.1em;
+  text-transform: lowercase;
+}
+
+.home-yvr-radar-deck__deck-status {
+  color: rgba(180, 230, 220, 0.78);
+  font-size: clamp(0.38rem, 0.78vw, 0.48rem);
+  letter-spacing: 0.06em;
+  text-transform: lowercase;
 }
 
 .home-yvr-radar-deck__rack {
@@ -471,83 +500,31 @@
   background: rgba(2, 8, 18, 0.55);
 }
 
-.home-yvr-radar-deck__cta {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: clamp(0.4rem, 1vw, 0.65rem);
-  min-width: 0;
-  padding: clamp(0.35rem, 1vw, 0.65rem);
-}
-
-.home-yvr-radar-deck__subtitle {
+.home-yvr-radar-deck__deck-foot {
   margin: 0;
-  color: rgba(223, 255, 234, 0.88);
-  font-size: clamp(0.52rem, 1vw, 0.72rem);
-  line-height: 1.45;
-  letter-spacing: 0.08em;
+  text-align: center;
 }
 
-.home-yvr-radar-deck__positioning {
-  margin: 0;
-  font-family: "IBM Plex Mono", "Courier New", monospace;
-  font-size: clamp(0.78rem, 1.25vw, 0.94rem);
-  line-height: 1.45;
-  color: rgba(232, 247, 255, 0.9);
-}
-
-.home-yvr-radar-deck__cta .home-amp-console {
-  display: flex;
-  flex-wrap: wrap;
+.home-yvr-radar-deck__work-link {
+  display: inline-flex;
   align-items: center;
-  gap: 0.55rem 0.75rem;
-  margin-top: 0.15rem;
+  min-height: 44px;
+  padding: 0.35rem 0.65rem;
+  color: rgba(180, 230, 220, 0.82);
+  font-size: clamp(0.4rem, 0.82vw, 0.52rem);
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(87, 243, 255, 0.35);
 }
 
-.home-yvr-radar-deck__cta .home-title-screen-prompt {
-  position: relative;
-  margin: 0;
-  padding: 0.38rem 0.65rem;
-  font-size: clamp(0.48rem, 0.85vw, 0.62rem);
-  color: #020308;
-  background: #ffe66d;
-  border: 2px solid #020308;
-  box-shadow: 3px 3px 0 #ff4fd8;
+.home-yvr-radar-deck__work-link:hover,
+.home-yvr-radar-deck__work-link:focus-visible {
+  color: #57f3ff;
+  border-bottom-color: #57f3ff;
 }
 
-.home-yvr-radar-deck__cta .home-press-start {
-  min-width: 0;
-  width: auto;
-  padding: 0.65rem 1rem;
-  font-size: clamp(0.62rem, 1.1vw, 0.78rem);
-  background: #39ff14;
-  border-color: #ffff66;
-  color: #020805;
-  box-shadow: 4px 4px 0 #ff4fd8, 0 0 16px rgba(57, 255, 20, 0.28);
-}
-
-.home-yvr-radar-deck__cta .home-title-screen-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem 0.5rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.home-yvr-radar-deck__cta .home-title-screen-meta li {
-  font-family: "Press Start 2P", monospace;
-  font-size: clamp(0.42rem, 0.75vw, 0.55rem);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  padding: 0.28rem 0.45rem;
-  border: 1px solid rgba(87, 243, 255, 0.32);
-  border-radius: 999px;
-  color: rgba(200, 240, 255, 0.88);
-  background: rgba(0, 12, 20, 0.55);
-}
-
-/* Radar deck start animation (arcade-start.js) */
+/* Radar deck start animation (arcade-start.js — optional elsewhere) */
 .home-yvr-radar-deck.is-starting {
   animation: homeYvrRadarCoin 900ms steps(4, end) 1;
 }
@@ -566,23 +543,6 @@
 @media (max-width: 820px) {
   .home-yvr-radar-deck__crt-ring {
     max-height: min(46vh, 380px);
-  }
-
-  .home-yvr-radar-deck__console {
-    grid-template-columns: 1fr;
-  }
-
-  .home-yvr-radar-deck__cta {
-    text-align: center;
-    align-items: center;
-  }
-
-  .home-yvr-radar-deck__cta .home-amp-console {
-    justify-content: center;
-  }
-
-  .home-yvr-radar-deck__cta .home-title-screen-meta {
-    justify-content: center;
   }
 }
 
@@ -615,8 +575,6 @@
   .home-yvr-radar-deck__scan,
   .home-yvr-radar-deck__unit-status::before,
   .home-yvr-radar-deck.is-starting,
-  .home-yvr-radar-deck__cta .home-title-screen-prompt,
-  .home-yvr-radar-deck__cta .home-press-start,
   .home-yvr-radar-deck__map-wrap.is-discover .home-yvr-leaflet-pin span,
   .home-yvr-radar-deck__map-wrap.is-listening .home-yvr-radar-deck__ring-label,
   .home-yvr-radar-deck__map-wrap.is-loading .home-yvr-radar-deck__ring-label,

--- a/js/home-yvr-broadcaster.js
+++ b/js/home-yvr-broadcaster.js
@@ -782,7 +782,7 @@
     this.renderChannelDetail(null);
     if (this.scriptEl) {
       this.scriptEl.innerHTML = '';
-      this.scriptEl.textContent = 'tap a pin — bulletin lands here. live audio starts on its own.';
+      this.scriptEl.textContent = 'tap a pin on the map — bulletin + audio lands here.';
     }
     this.renderAttribution(null);
     if (this.telepromptRoot) {

--- a/page-home.php
+++ b/page-home.php
@@ -31,7 +31,7 @@ get_header();
                     <p class="home-yvr-radar-deck__ring-label pixel-font" data-yvr-ring-label><?php echo esc_html( 'drag · tap pins' ); ?></p>
                     <div class="home-yvr-radar-deck__wander pixel-font" data-yvr-wander-hint hidden>
                         <p class="home-yvr-radar-deck__wander-kicker"><?php echo esc_html( 'night watch online.' ); ?></p>
-                        <p class="home-yvr-radar-deck__wander-body"><?php echo esc_html( 'Ham-radio view of the lower mainland. Big pins tune live territory feeds — coast guard, wildfire, skytrain, towers. Dave keeps audio on deck.' ); ?></p>
+                        <p class="home-yvr-radar-deck__wander-body"><?php echo esc_html( 'Ham-radio view of the lower mainland. Big pins tune live territory feeds — coast guard, wildfire, skytrain, towers. Bulletins + audio land in the deck below.' ); ?></p>
                         <button type="button" class="home-yvr-radar-deck__wander-dismiss pixel-font" data-yvr-wander-dismiss><?php echo esc_html( 'on band' ); ?></button>
                     </div>
                 </div>
@@ -39,13 +39,17 @@ get_header();
                     <span></span><span></span><span></span>
                 </div>
             </div>
-            <p class="home-yvr-radar-deck__hint pixel-font"><?php echo esc_html( "pins = channels — wildfire, skytrain, marine scan, liveatc" ); ?></p>
+            <p class="home-yvr-radar-deck__hint pixel-font"><?php echo esc_html( 'tap a pin — bulletins + live audio land in the deck below' ); ?></p>
         </div>
 
-        <div class="home-yvr-radar-deck__console">
+        <div class="home-yvr-radar-deck__deck">
+            <div class="home-yvr-radar-deck__deck-head pixel-font">
+                <span class="home-yvr-radar-deck__deck-badge"><?php echo esc_html( 'deck output' ); ?></span>
+                <span class="home-yvr-radar-deck__deck-status"><?php echo esc_html( 'map pins in · bulletins + audio out' ); ?></span>
+            </div>
             <div class="home-yvr-radar-deck__rack">
                 <div class="home-yvr-rack">
-                <div class="home-yvr-broadcaster" data-yvr-broadcaster tabindex="-1" aria-label="<?php echo esc_attr( 'YVR broadcaster — live feeds and radio' ); ?>">
+                <div class="home-yvr-broadcaster" data-yvr-broadcaster tabindex="-1" aria-label="<?php echo esc_attr( 'YVR radar deck — bulletins and live audio from map pins' ); ?>">
                     <div class="home-yvr-broadcaster__mast">
                         <div class="home-yvr-broadcaster__avatar" data-broadcaster-face data-broadcaster-dave-cycle title="<?php echo esc_attr( 'Tap Dave to cycle ambient beds' ); ?>" aria-label="<?php echo esc_attr( 'Dave — tap to cycle ambient sound' ); ?>">
                             <div class="home-yvr-broadcaster__avatar-frame home-yvr-broadcaster__pigeon">
@@ -93,7 +97,7 @@ get_header();
                             <span class="home-yvr-broadcaster__load-bar-fill"></span>
                         </div>
                         <p class="home-yvr-broadcaster__load-status pixel-font" data-broadcaster-load-status hidden aria-live="polite"></p>
-                        <p class="home-yvr-teleprompt__script" data-broadcaster-script><?php echo esc_html( 'tap a pin — bulletin lands here. live audio starts on its own.' ); ?></p>
+                        <p class="home-yvr-teleprompt__script" data-broadcaster-script><?php echo esc_html( 'tap a pin on the map — bulletin + audio lands here.' ); ?></p>
                         <ul class="home-yvr-teleprompt__meta" data-broadcaster-meta hidden></ul>
                         <div class="home-yvr-broadcaster__crt-scan" aria-hidden="true"></div>
                     </div>
@@ -122,18 +126,9 @@ get_header();
                 </div>
                 </div>
             </div>
-            <div class="home-yvr-radar-deck__cta">
-                <div class="home-amp-console">
-                    <div class="home-title-screen-prompt pixel-font" role="status" aria-live="polite" data-arcade-status><?php echo esc_html( 'INSERT COIN' ); ?></div>
-                    <button type="button" class="pixel-button home-press-start" data-home-start data-start-label="PRESS START // VIEW WORK"><?php echo esc_html( 'PRESS START // VIEW WORK' ); ?></button>
-                </div>
-                <ul class="home-title-screen-meta pixel-font" aria-label="<?php echo esc_attr( 'Scene tags' ); ?>">
-                    <li><?php echo esc_html( 'Vancouver' ); ?></li>
-                    <li><?php echo esc_html( 'independent practice' ); ?></li>
-                    <li><?php echo esc_html( 'civic tech' ); ?></li>
-                    <li><?php echo esc_html( 'west coast' ); ?></li>
-                </ul>
-            </div>
+            <p class="home-yvr-radar-deck__deck-foot pixel-font">
+                <a class="home-yvr-radar-deck__work-link" href="#mission-select"><?php echo esc_html( 'view projects ↓' ); ?></a>
+            </p>
         </div>
     </section>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The hero felt like **two separate things**: the radar map up top and a weird side column with INSERT COIN / PRESS START beside Dave. Two "players," one confused first visit.

## Solution

**One unit: map → deck output**

- Radar map stays the hero (unchanged — you said you love it)
- Dave is reframed as **deck output** — `map pins in · bulletins + audio out`
- Single centered column under the map (no 2-col grid)
- Removed INSERT COIN / PRESS START / scene tag pills from hero
- Simple **view projects ↓** text link scrolls to LEVEL SELECT

## Copy
- Map hint: "tap a pin — bulletins + live audio land in the deck below"
- Wander intro: references deck below, not "Dave" as separate entity
- CRT standby: "tap a pin on the map — bulletin + audio lands here."

Dave stays — he's the face of the deck, not a second app.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8847567f-6559-4baa-822d-02ae416215a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8847567f-6559-4baa-822d-02ae416215a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

