### PR TITLE
Polish resume layout and add West Vancouver Secondary School

### DIFF
--- a/assets/css/resume.css
+++ b/assets/css/resume.css
@@ -107,6 +107,7 @@
 }
 
 .resume-sheet {
+  position: relative;
   max-width: 920px;
   margin: 0 auto;
   background: var(--resume-panel);
@@ -114,21 +115,37 @@
   box-shadow: var(--resume-shadow);
   overflow: hidden;
   display: grid;
-  grid-template-columns: 250px 1fr;
+  grid-template-columns: 262px 1fr;
+  align-items: stretch;
+}
+
+.resume-sheet::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 262px;
+  background: linear-gradient(180deg, #0c1a2e 0%, #132238 100%);
+  border-radius: 14px 0 0 14px;
+  z-index: 0;
 }
 
 .resume-sidebar {
-  background: linear-gradient(180deg, #0c1a2e 0%, #132238 100%);
+  position: relative;
+  z-index: 1;
   color: var(--resume-sidebar-text);
-  padding: 1.75rem 1.35rem;
+  padding: 1.85rem 1.45rem 1.85rem;
   display: flex;
   flex-direction: column;
-  gap: 1.35rem;
+  gap: 1.45rem;
+  min-height: 100%;
+  align-self: stretch;
 }
 
 .resume-sidebar__name {
   font-family: 'Fraunces', Georgia, serif;
-  font-size: 1.55rem;
+  font-size: 1.65rem;
   font-weight: 700;
   line-height: 1.1;
   color: #fff;
@@ -136,8 +153,8 @@
 }
 
 .resume-sidebar__title {
-  margin: 0.35rem 0 0;
-  font-size: 0.78rem;
+  margin: 0.4rem 0 0;
+  font-size: 0.84rem;
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -145,10 +162,10 @@
 }
 
 .resume-sidebar__tags {
-  margin: 0.75rem 0 0;
+  margin: 0.8rem 0 0;
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 0.58rem;
-  line-height: 1.55;
+  font-size: 0.64rem;
+  line-height: 1.6;
   letter-spacing: 0.04em;
   color: var(--resume-accent);
 }
@@ -159,10 +176,11 @@
   gap: 0.45rem;
 }
 
-.resume-contact a {
+.resume-contact a,
+.resume-contact span {
   color: #cbd5e1;
   text-decoration: none;
-  font-size: 0.8rem;
+  font-size: 0.875rem;
   word-break: break-word;
 }
 
@@ -172,11 +190,11 @@
 
 .resume-availability {
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 0.58rem;
-  line-height: 1.55;
+  font-size: 0.64rem;
+  line-height: 1.6;
   letter-spacing: 0.06em;
   color: #86efac;
-  padding: 0.55rem 0.65rem;
+  padding: 0.65rem 0.75rem;
   border: 1px solid rgba(134, 239, 172, 0.25);
   border-radius: 8px;
   background: rgba(134, 239, 172, 0.06);
@@ -184,17 +202,17 @@
 
 .resume-sidebar-block h3 {
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 0.62rem;
+  font-size: 0.68rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--resume-accent);
-  margin: 0 0 0.55rem;
+  margin: 0 0 0.65rem;
 }
 
 .resume-sidebar-block p,
 .resume-sidebar-block li {
-  font-size: 0.78rem;
-  line-height: 1.55;
+  font-size: 0.84rem;
+  line-height: 1.58;
   color: #cbd5e1;
   margin: 0;
 }
@@ -215,14 +233,20 @@
 
 .resume-sidebar-block .toolkit-group strong {
   display: block;
-  font-size: 0.72rem;
+  font-size: 0.8rem;
   font-weight: 600;
   color: #f1f5f9;
-  margin-bottom: 0.2rem;
+  margin-bottom: 0.25rem;
+}
+
+.resume-sidebar-block--toolkit {
+  flex: 1;
 }
 
 .resume-main {
-  padding: 1.75rem 1.65rem 1.5rem;
+  position: relative;
+  z-index: 1;
+  padding: 1.85rem 1.75rem 1.65rem;
 }
 
 .resume-section + .resume-section {
@@ -240,7 +264,7 @@
 
 .resume-section__num {
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 0.68rem;
+  font-size: 0.72rem;
   font-weight: 500;
   letter-spacing: 0.08em;
   color: var(--resume-accent);
@@ -248,7 +272,7 @@
 }
 
 .resume-section__title {
-  font-size: 0.72rem;
+  font-size: 0.78rem;
   font-weight: 700;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -258,8 +282,8 @@
 
 .resume-section p,
 .resume-section li {
-  font-size: 0.86rem;
-  line-height: 1.62;
+  font-size: 0.94rem;
+  line-height: 1.65;
   color: var(--resume-muted);
 }
 
@@ -294,22 +318,22 @@
 }
 
 .resume-role__company {
-  font-size: 0.92rem;
+  font-size: 0.98rem;
   font-weight: 700;
   color: var(--resume-ink);
   margin: 0;
 }
 
 .resume-role__meta {
-  font-size: 0.76rem;
+  font-size: 0.82rem;
   color: var(--resume-faint);
   white-space: nowrap;
 }
 
 .resume-role__location {
-  font-size: 0.76rem;
+  font-size: 0.82rem;
   color: var(--resume-faint);
-  margin: 0 0 0.35rem;
+  margin: 0 0 0.4rem;
 }
 
 .resume-role ul {
@@ -327,12 +351,25 @@
   font-weight: 600;
 }
 
+.resume-education__list {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.resume-education__list li + li {
+  margin-top: 0.35rem;
+}
+
+.resume-education__note {
+  margin-top: 0.75rem;
+}
+
 .resume-footer {
   margin-top: 1.25rem;
   padding-top: 0.85rem;
   border-top: 1px solid var(--resume-border);
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 0.62rem;
+  font-size: 0.68rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--resume-faint);
@@ -344,8 +381,13 @@
     grid-template-columns: 1fr;
   }
 
+  .resume-sheet::before {
+    display: none;
+  }
+
   .resume-sidebar {
-    padding: 1.35rem 1.15rem;
+    background: linear-gradient(180deg, #0c1a2e 0%, #132238 100%);
+    padding: 1.45rem 1.2rem;
   }
 
   .resume-main {
@@ -383,12 +425,19 @@
     max-width: none;
     box-shadow: none;
     border-radius: 0;
-    grid-template-columns: 210px 1fr;
+    grid-template-columns: 220px 1fr;
     page-break-inside: avoid;
   }
 
-  .resume-sidebar {
+  .resume-sheet::before {
+    width: 220px;
+    border-radius: 0;
     background: #0c1a2e !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  .resume-sidebar {
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
   }

--- a/inc/resume-data.example.php
+++ b/inc/resume-data.example.php
@@ -48,6 +48,7 @@ return array(
     'earlier_roles' => array(),
     'builds' => array(),
     'education' => array(
-        'School — Certificate',
+        'School — Certificate or Program',
+        'High School Name',
     ),
 );

--- a/page-resume.php
+++ b/page-resume.php
@@ -58,7 +58,7 @@ $has_pdf         = file_exists( $resume_dir . '/Suzy_Easton_BSA_Resume.pdf' );
                 <?php endforeach; ?>
             </nav>
 
-            <section class="resume-sidebar-block" aria-labelledby="resume-toolkit-title">
+            <section class="resume-sidebar-block resume-sidebar-block--toolkit" aria-labelledby="resume-toolkit-title">
                 <h3 id="resume-toolkit-title">03 // Core Toolkit</h3>
                 <?php foreach ( $resume['toolkit_groups'] as $group ) : ?>
                     <div class="toolkit-group">
@@ -66,16 +66,6 @@ $has_pdf         = file_exists( $resume_dir . '/Suzy_Easton_BSA_Resume.pdf' );
                         <p><?php echo esc_html( $group['items'] ); ?></p>
                     </div>
                 <?php endforeach; ?>
-            </section>
-
-            <section class="resume-sidebar-block" aria-labelledby="resume-education-title">
-                <h3 id="resume-education-title">07 // Education</h3>
-                <ul>
-                    <?php foreach ( $resume['education'] as $item ) : ?>
-                        <li><?php echo esc_html( $item ); ?></li>
-                    <?php endforeach; ?>
-                </ul>
-                <p style="margin-top:0.65rem;"><?php echo esc_html( $resume['education_note'] ); ?></p>
             </section>
         </aside>
 
@@ -169,6 +159,19 @@ $has_pdf         = file_exists( $resume_dir . '/Suzy_Easton_BSA_Resume.pdf' );
                         </li>
                     <?php endforeach; ?>
                 </ul>
+            </section>
+
+            <section class="resume-section resume-education" aria-labelledby="resume-education-title">
+                <div class="resume-section__head">
+                    <span class="resume-section__num">07 //</span>
+                    <h2 class="resume-section__title" id="resume-education-title">Education and Creative Signal</h2>
+                </div>
+                <ul class="resume-education__list">
+                    <?php foreach ( $resume['education'] as $item ) : ?>
+                        <li><?php echo esc_html( $item ); ?></li>
+                    <?php endforeach; ?>
+                </ul>
+                <p class="resume-education__note"><?php echo esc_html( $resume['education_note'] ); ?></p>
             </section>
 
             <footer class="resume-footer"><?php echo esc_html( $resume['footer'] ); ?></footer>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resume layout polish based on review feedback.

- **Sidebar gap fixed** — dark background now extends full sheet height via a pseudo-element, so no white or empty block below the sidebar content
- **Larger text** — bumped body, contact, role, and sidebar copy sizes for readability
- **Education moved** — section 07 now lives in the main column (after builds) instead of cramming the sidebar
- **West Vancouver Secondary School** added to education list (in private `inc/resume-data.php` on server)

## Server note

After merge, update your private `inc/resume-data.php` education array to include West Vancouver Secondary School if it is not there yet. Regenerate the PDF with `npm run build:resume-pdf`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6195a4d7-3a4c-4a4b-b87e-b0a22c9bd8f8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6195a4d7-3a4c-4a4b-b87e-b0a22c9bd8f8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

