### PR TITLE
Add resume deploy pipeline and download URL

### DIFF
--- a/.github/workflows/deploy-resume.yml
+++ b/.github/workflows/deploy-resume.yml
@@ -1,0 +1,64 @@
+name: Deploy Resume
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      LOUSY_SSH_HOST: ${{ secrets.LOUSY_SSH_HOST }}
+      LOUSY_SSH_PORT: ${{ secrets.LOUSY_SSH_PORT }}
+      LOUSY_SSH_USER: ${{ secrets.LOUSY_SSH_USER }}
+      LOUSY_SSH_PASSWORD: ${{ secrets.LOUSY_SSH_PASSWORD }}
+      RESUME_DATA_PHP: ${{ secrets.RESUME_DATA_PHP }}
+      RESUME_HTML: ${{ secrets.RESUME_HTML }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify deploy secrets are configured
+        run: |
+          missing=()
+          [ -z "$LOUSY_SSH_HOST" ] && missing+=("LOUSY_SSH_HOST")
+          [ -z "$LOUSY_SSH_USER" ] && missing+=("LOUSY_SSH_USER")
+          [ -z "$LOUSY_SSH_PASSWORD" ] && missing+=("LOUSY_SSH_PASSWORD")
+          [ -z "$RESUME_DATA_PHP" ] && missing+=("RESUME_DATA_PHP")
+          [ -z "$RESUME_HTML" ] && missing+=("RESUME_HTML")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error title=Missing secrets::Add repository secrets: ${missing[*]}"
+            echo "SSH: see docs/deploy-production.md"
+            echo "Resume: run ./scripts/setup-github-resume-secrets.sh on your machine"
+            exit 1
+          fi
+          if [ -z "$LOUSY_SSH_PORT" ]; then
+            echo "LOUSY_SSH_PORT=22" >> "$GITHUB_ENV"
+          fi
+
+      - name: Write private resume files
+        run: |
+          mkdir -p inc assets/resume
+          printf '%s' "$RESUME_DATA_PHP" > inc/resume-data.php
+          printf '%s' "$RESUME_HTML" > assets/resume/suzy-easton-bsa-resume.html
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Build resume PDF
+        run: |
+          npm ci
+          npx playwright install chromium
+          npm run build:resume-pdf
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Deploy resume assets
+        run: |
+          pip install paramiko
+          python3 scripts/deploy-resume-ssh.py

--- a/assets/resume/README.md
+++ b/assets/resume/README.md
@@ -13,4 +13,22 @@ Regenerate the PDF after editing the HTML:
 npm run build:resume-pdf
 ```
 
+Deploy everything to production (theme files + private resume assets):
+
+```bash
+python3 scripts/deploy-resume-ssh.py
+```
+
+Or via GitHub Actions after storing resume secrets once:
+
+```bash
+./scripts/setup-github-resume-secrets.sh
+gh workflow run deploy-resume.yml
+```
+
+## Live URLs (after deploy)
+
+- **PDF download:** https://suzyeaston.ca/resume/download/
+- **Resume page:** https://suzyeaston.ca/resume/ (create WP page + assign Resume template)
+
 The `/resume/` WordPress page renders from `inc/resume-data.php` and links to these files when present.

--- a/functions.php
+++ b/functions.php
@@ -3515,6 +3515,32 @@ add_action('wp_head', function () {
 });
 
 // =========================================
+// 9d) RESUME DOWNLOAD ROUTE
+// =========================================
+add_action('init', function () {
+    add_rewrite_rule('^resume/download/?$', 'index.php?se_resume_download=1', 'top');
+    add_rewrite_tag('%se_resume_download%', '([0-9]+)');
+});
+
+add_action('template_redirect', function () {
+    if (!get_query_var('se_resume_download')) {
+        return;
+    }
+
+    $pdf = get_template_directory() . '/assets/resume/Suzy_Easton_BSA_Resume.pdf';
+    if (!is_readable($pdf)) {
+        wp_die('Resume PDF is not available yet.', 'Resume unavailable', array('response' => 404));
+    }
+
+    nocache_headers();
+    header('Content-Type: application/pdf');
+    header('Content-Disposition: attachment; filename="Suzy_Easton_BSA_Resume.pdf"');
+    header('Content-Length: ' . filesize($pdf));
+    readfile($pdf);
+    exit;
+});
+
+// =========================================
 // 10. CRAWLABILITY / INDEXING CONTROLS
 // =========================================
 function se_get_utility_page_templates(): array {

--- a/page-resume.php
+++ b/page-resume.php
@@ -10,7 +10,7 @@ $resume           = file_exists( $resume_data_path ) ? require $resume_data_path
 $resume_dir      = get_template_directory() . '/assets/resume';
 $resume_uri      = get_template_directory_uri() . '/assets/resume';
 $download_html   = $resume_uri . '/suzy-easton-bsa-resume.html';
-$download_pdf    = $resume_uri . '/Suzy_Easton_BSA_Resume.pdf';
+$download_pdf    = home_url( '/resume/download/' );
 $has_html        = file_exists( $resume_dir . '/suzy-easton-bsa-resume.html' );
 $has_pdf         = file_exists( $resume_dir . '/Suzy_Easton_BSA_Resume.pdf' );
 ?>
@@ -28,7 +28,7 @@ $has_pdf         = file_exists( $resume_dir . '/Suzy_Easton_BSA_Resume.pdf' );
         <span class="resume-toolbar__label"><?php echo esc_html( $resume['name'] ); ?> // BSA Resume</span>
         <div class="resume-toolbar__actions">
             <?php if ( $has_pdf ) : ?>
-                <a class="resume-btn resume-btn--primary" href="<?php echo esc_url( $download_pdf ); ?>" download="Suzy_Easton_BSA_Resume.pdf">Download PDF</a>
+                <a class="resume-btn resume-btn--primary" href="<?php echo esc_url( $download_pdf ); ?>">Download PDF</a>
             <?php endif; ?>
             <button type="button" class="resume-btn<?php echo $has_pdf ? '' : ' resume-btn--primary'; ?>" data-resume-print>Print<?php echo $has_pdf ? '' : ' / Save PDF'; ?></button>
             <?php if ( $has_html ) : ?>

--- a/scripts/deploy-resume-ssh.py
+++ b/scripts/deploy-resume-ssh.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Deploy resume theme files and private resume assets over SFTP.
+
+Reads credentials from /workspace/.env.deploy.local or LOUSY_SSH_* env vars
+(same as scripts/deploy-lousy-outages-ssh.py).
+
+Usage:
+    python3 scripts/deploy-resume-ssh.py
+"""
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import paramiko
+
+ROOT = Path(__file__).resolve().parent.parent
+ENV = ROOT / ".env.deploy.local"
+THEME_DIR = "/home/uquklkik/public_html/wp-content/themes/suzyeastonca-main"
+
+RESUME_FILES = [
+    "page-resume.php",
+    "assets/css/resume.css",
+    "js/resume.js",
+    "functions.php",
+    "header.php",
+    "inc/resume-data.php",
+    "assets/resume/suzy-easton-bsa-resume.html",
+    "assets/resume/Suzy_Easton_BSA_Resume.pdf",
+]
+
+DEPLOY_ENV_KEYS = (
+    "LOUSY_SSH_HOST",
+    "LOUSY_SSH_PORT",
+    "LOUSY_SSH_USER",
+    "LOUSY_SSH_PASSWORD",
+)
+
+
+def load_env(path: Path) -> dict:
+    data = {}
+    for key in DEPLOY_ENV_KEYS:
+        value = os.environ.get(key)
+        if value:
+            data[key] = value
+    if path.is_file():
+        for line in path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            data.setdefault(key.strip(), value.strip())
+    if not data.get("LOUSY_SSH_HOST") or not data.get("LOUSY_SSH_USER") or not data.get("LOUSY_SSH_PASSWORD"):
+        raise SystemExit(
+            "Missing deploy credentials. Set LOUSY_SSH_* in the environment or .env.deploy.local "
+            "(see docs/deploy-production.md)."
+        )
+    return data
+
+
+def run(client, cmd: str, timeout: int = 300) -> int:
+    _, stdout, stderr = client.exec_command(cmd, timeout=timeout)
+    code = stdout.channel.recv_exit_status()
+    out = stdout.read().decode(errors="replace")
+    err = stderr.read().decode(errors="replace")
+    if out.strip():
+        print(out.rstrip())
+    if err.strip():
+        print("stderr:", err.rstrip())
+    if code != 0:
+        print(f"WARNING: exit {code}")
+    return code
+
+
+def main() -> None:
+    missing = [relative for relative in RESUME_FILES if not (ROOT / relative).is_file()]
+    if missing:
+        raise SystemExit(
+            "Missing resume files:\n  - " + "\n  - ".join(missing) + "\n"
+            "Ensure inc/resume-data.php exists and run: npm run build:resume-pdf"
+        )
+
+    env = load_env(ENV)
+    stamp = time.strftime("%Y%m%d-%H%M%S")
+    backup = f"/home/uquklkik/theme-backups/resume-{stamp}"
+
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    client.connect(
+        env.get("LOUSY_SSH_HOST", ""),
+        port=int(env.get("LOUSY_SSH_PORT", "22")),
+        username=env.get("LOUSY_SSH_USER", ""),
+        password=env.get("LOUSY_SSH_PASSWORD", ""),
+        timeout=60,
+    )
+    sftp = paramiko.SFTPClient.from_transport(client.get_transport())
+
+    try:
+        run(client, f"mkdir -p {backup}")
+        for relative in RESUME_FILES:
+            local = ROOT / relative
+            remote = f"{THEME_DIR}/{relative}"
+            run(client, f"mkdir -p $(dirname {remote})")
+            run(client, f"test -f {remote} && cp -a {remote} {backup}/ 2>/dev/null || true")
+            print(f"Uploading {relative}...")
+            sftp.put(str(local), remote)
+
+        run(
+            client,
+            "cd /home/uquklkik/public_html && php -r \"require 'wp-load.php'; "
+            "flush_rewrite_rules(false); echo 'rewrite rules flushed';\" 2>&1 | tail -1",
+        )
+        print(f"Backup: {backup}")
+        print("Resume download URL: https://suzyeaston.ca/resume/download/")
+        print("Resume page: https://suzyeaston.ca/resume/ (assign Resume template in WP if needed)")
+    finally:
+        sftp.close()
+        client.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup-github-resume-secrets.sh
+++ b/scripts/setup-github-resume-secrets.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "Install GitHub CLI (gh) and run: gh auth login"
+  exit 1
+fi
+
+for file in inc/resume-data.php assets/resume/suzy-easton-bsa-resume.html; do
+  if [[ ! -f "$file" ]]; then
+    echo "Missing $file"
+    echo "Copy inc/resume-data.example.php to inc/resume-data.php and fill it in, then run: npm run build:resume-pdf"
+    exit 1
+  fi
+done
+
+gh secret set RESUME_DATA_PHP < inc/resume-data.php
+gh secret set RESUME_HTML < assets/resume/suzy-easton-bsa-resume.html
+
+echo "Stored RESUME_DATA_PHP and RESUME_HTML in GitHub Actions secrets."
+echo "Deploy with: gh workflow run deploy-resume.yml"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes the resume accessible at a real URL after deploy.

- **`https://suzyeaston.ca/resume/download/`** — clean PDF download route
- **`scripts/deploy-resume-ssh.py`** — uploads theme + private resume files to production
- **`deploy-resume.yml`** workflow — builds PDF and deploys via GitHub Actions secrets
- **`setup-github-resume-secrets.sh`** — one-time local script to store private resume content in GitHub secrets

Private resume files stay out of git. Deploy puts them on the server only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6195a4d7-3a4c-4a4b-b87e-b0a22c9bd8f8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6195a4d7-3a4c-4a4b-b87e-b0a22c9bd8f8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

