### PR TITLE
Add local resume export command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ test-results/
 inc/resume-data.php
 assets/resume/*.pdf
 assets/resume/suzy-easton-bsa-resume.html
+downloads/*
+!downloads/README.md
 /build/*.zip
 
 # Generated release binaries are shared as artifacts, not committed.

--- a/assets/resume/README.md
+++ b/assets/resume/README.md
@@ -13,6 +13,12 @@ Regenerate the PDF after editing the HTML:
 npm run build:resume-pdf
 ```
 
+Export copies to your computer (repo `downloads/resume/` + Mac `~/Downloads/`):
+
+```bash
+npm run resume:export
+```
+
 Deploy everything to production (theme files + private resume assets):
 
 ```bash

--- a/downloads/README.md
+++ b/downloads/README.md
@@ -1,0 +1,20 @@
+# Local resume exports
+
+This folder is gitignored. Nothing here is committed to GitHub.
+
+Generate your resume files on your computer:
+
+```bash
+npm run resume:export
+```
+
+That builds the PDF (if needed) and copies it to:
+
+- `downloads/resume/` in this repo
+- `~/Downloads/` on your Mac
+
+Private source files stay in:
+
+- `inc/resume-data.php`
+- `assets/resume/Suzy_Easton_BSA_Resume.pdf`
+- `assets/resume/suzy-easton-bsa-resume.html`

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "node --test \"./__tests__/**/*.test.js\"",
     "build:gastown-world": "npm run sync:cov && node scripts/build-gastown-world.js",
     "build:resume-pdf": "node scripts/generate-resume-pdf.js",
+    "resume:export": "node scripts/export-resume-local.js",
     "sync:cov": "node scripts/sync-cov-open-data.js",
     "local:start": "docker compose up -d",
     "local:setup": "./scripts/setup-local-wp.sh",

--- a/scripts/export-resume-local.js
+++ b/scripts/export-resume-local.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '..');
+const SOURCE_DIR = path.join(ROOT, 'assets', 'resume');
+const LOCAL_DIR = path.join(ROOT, 'downloads', 'resume');
+const FILES = [
+  {
+    source: path.join(SOURCE_DIR, 'Suzy_Easton_BSA_Resume.pdf'),
+    name: 'Suzy_Easton_BSA_Resume.pdf',
+  },
+  {
+    source: path.join(SOURCE_DIR, 'suzy-easton-bsa-resume.html'),
+    name: 'suzy-easton-bsa-resume.html',
+  },
+];
+
+function ensureResumeAssets() {
+  const resumeData = path.join(ROOT, 'inc', 'resume-data.php');
+  if (!fs.existsSync(resumeData)) {
+    throw new Error(
+      'Missing inc/resume-data.php. Copy inc/resume-data.example.php to inc/resume-data.php and fill it in.'
+    );
+  }
+
+  const missing = FILES.filter((file) => !fs.existsSync(file.source));
+  if (missing.length === 0) {
+    return;
+  }
+
+  console.log('Building resume PDF...');
+  execSync('npm run build:resume-pdf', { cwd: ROOT, stdio: 'inherit' });
+
+  const stillMissing = FILES.filter((file) => !fs.existsSync(file.source)).map((file) => file.name);
+  if (stillMissing.length > 0) {
+    throw new Error(`Resume export failed. Missing: ${stillMissing.join(', ')}`);
+  }
+}
+
+function copyToDir(targetDir) {
+  fs.mkdirSync(targetDir, { recursive: true });
+  for (const file of FILES) {
+    const destination = path.join(targetDir, file.name);
+    fs.copyFileSync(file.source, destination);
+    console.log(`Wrote ${destination}`);
+  }
+}
+
+function copyToDownloadsFolder() {
+  const home = process.env.HOME || process.env.USERPROFILE;
+  if (!home) {
+    return;
+  }
+
+  const downloadsDir = path.join(home, 'Downloads');
+  if (!fs.existsSync(downloadsDir)) {
+    return;
+  }
+
+  copyToDir(downloadsDir);
+}
+
+function revealOnMac(targetDir) {
+  if (process.platform !== 'darwin') {
+    return;
+  }
+
+  try {
+    execSync(`open "${targetDir}"`, { stdio: 'ignore' });
+  } catch (error) {
+    // Finder reveal is optional.
+  }
+}
+
+function main() {
+  ensureResumeAssets();
+  copyToDir(LOCAL_DIR);
+  copyToDownloadsFolder();
+  revealOnMac(LOCAL_DIR);
+
+  console.log('');
+  console.log('Resume files are ready locally:');
+  console.log(`  ${LOCAL_DIR}`);
+  if (process.platform === 'darwin') {
+    console.log(`  ${path.join(process.env.HOME, 'Downloads')}`);
+  }
+  console.log('');
+  console.log('These folders are gitignored. Your resume stays off GitHub.');
+}
+
+main();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Keeps resume content local and gitignored, while making it easy to grab on your Mac.

- `npm run resume:export` copies the PDF + HTML to `downloads/resume/` in the repo
- On Mac, also copies to `~/Downloads/` and opens the folder in Finder
- `downloads/*` is gitignored (only `downloads/README.md` is committed)
- Private source files stay in `inc/resume-data.php` and `assets/resume/`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6195a4d7-3a4c-4a4b-b87e-b0a22c9bd8f8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6195a4d7-3a4c-4a4b-b87e-b0a22c9bd8f8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

