### PR TITLE
Harden local-only gitignore path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,8 @@ screenshots/
 playwright-report/
 test-results/
 
-# Local-only folders
-private-resume/
+# Local-only folders (never commit)
+.local-only/
 /build/*.zip
 
 # Generated release binaries are shared as artifacts, not committed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Final privacy hardening after history rewrite.

- Rename gitignored path from `private-resume/` to neutral `.local-only/`
- Removes the last resume-specific string from the public tree

Git history on `main` is already clean. Orphaned PR pages (#617–#623) may still be visible on GitHub's web UI until GitHub garbage-collects dangling commits — delete `RESUME_DATA_PHP` and `RESUME_HTML` in repo Settings → Secrets if present.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7238db0a-a02b-413b-9ca6-167c5fbc5399?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7238db0a-a02b-413b-9ca6-167c5fbc5399&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

