### PR TITLE
Beulah the beluga + Lousy Outages homepage highlights

### DIFF
--- a/assets/css/home-commercial-strip.css
+++ b/assets/css/home-commercial-strip.css
@@ -27,6 +27,28 @@
   border-color: rgba(255, 79, 79, 0.5);
 }
 
+.home-signal-strip--hot {
+  border-color: rgba(255, 79, 79, 0.65);
+  box-shadow: 0 0 18px rgba(255, 79, 79, 0.15);
+}
+
+.home-signal-strip--hot.home-signal-strip--warn,
+.home-signal-strip--hot.home-signal-strip--degraded {
+  border-color: rgba(255, 179, 71, 0.65);
+  box-shadow: 0 0 16px rgba(255, 179, 71, 0.14);
+}
+
+.home-signal-strip--hot .home-signal-strip__label {
+  color: #ff6b6b;
+  text-shadow: 0 0 8px rgba(255, 107, 107, 0.45);
+}
+
+.home-signal-strip--hot.home-signal-strip--warn .home-signal-strip__label,
+.home-signal-strip--hot.home-signal-strip--degraded .home-signal-strip__label {
+  color: #ffb347;
+  text-shadow: 0 0 8px rgba(255, 179, 71, 0.4);
+}
+
 .home-signal-strip__product {
   display: inline-flex;
   align-items: center;

--- a/assets/css/home-hero-cabinet.css
+++ b/assets/css/home-hero-cabinet.css
@@ -203,7 +203,7 @@
 .home-yvr-rack::before { left: 0; }
 .home-yvr-rack::after { right: 0; }
 
-/* YVR broadcaster — Dave the pigeon + rack */
+/* YVR broadcaster — Beulah the beluga + rack */
 .home-yvr-broadcaster {
   position: relative;
   z-index: 1;
@@ -260,103 +260,101 @@
   height: 60px;
 }
 
-.home-yvr-broadcaster__pigeon-tail {
+.home-yvr-broadcaster__beluga-fluke {
+  position: absolute;
+  bottom: 6px;
+  left: 8px;
+  width: 16px;
+  height: 10px;
+  border-radius: 2px 2px 8px 8px;
+  background: linear-gradient(180deg, #d8e4ef 0%, #a8b8c8 100%);
+  border: 2px solid #0a0c10;
+  transform: rotate(-12deg);
+}
+
+.home-yvr-broadcaster__beluga-body {
   position: absolute;
   bottom: 10px;
-  left: 4px;
-  width: 14px;
-  height: 10px;
-  border-radius: 2px 0 8px 8px;
-  background: linear-gradient(135deg, #6a7588, #4a5568);
+  left: 14px;
+  width: 34px;
+  height: 28px;
+  border-radius: 45% 50% 40% 40%;
+  background: linear-gradient(160deg, #f4f8fc 0%, #d0dce8 55%, #b0c0d0 100%);
   border: 2px solid #0a0c10;
-  transform: rotate(-18deg);
+  box-shadow: inset 0 -6px 10px rgba(0, 0, 0, 0.12);
 }
 
-.home-yvr-broadcaster__pigeon-body {
+.home-yvr-broadcaster__beluga-fin {
   position: absolute;
-  bottom: 8px;
-  left: 12px;
-  width: 30px;
-  height: 26px;
-  border-radius: 50% 50% 45% 45%;
-  background: linear-gradient(160deg, #9aa5b8 0%, #6a7588 55%, #505a68 100%);
-  border: 2px solid #0a0c10;
-  box-shadow: inset 0 -6px 10px rgba(0, 0, 0, 0.25);
-}
-
-.home-yvr-broadcaster__pigeon-wing {
-  position: absolute;
-  bottom: 12px;
-  left: 18px;
-  width: 18px;
-  height: 14px;
+  bottom: 16px;
+  width: 10px;
+  height: 8px;
   border-radius: 0 60% 40% 60%;
-  background: linear-gradient(180deg, #7a8598, #525c6e);
+  background: linear-gradient(180deg, #c8d8e8, #98a8b8);
   border: 2px solid #0a0c10;
-  transform: rotate(-8deg);
-  box-shadow: inset 0 -3px 6px rgba(0, 0, 0, 0.2);
+  box-shadow: inset 0 -2px 4px rgba(0, 0, 0, 0.15);
 }
 
-.home-yvr-broadcaster__pigeon-head {
-  position: absolute;
-  top: 8px;
-  left: 22px;
-  width: 24px;
-  height: 22px;
-  border-radius: 55% 55% 45% 45%;
-  background: linear-gradient(180deg, #b8c0d0 0%, #8a94a8 100%);
-  border: 2px solid #0a0c10;
-  box-shadow: inset 0 -3px 6px rgba(0, 0, 0, 0.15);
+.home-yvr-broadcaster__beluga-fin--left {
+  left: 16px;
+  transform: rotate(18deg);
 }
 
-.home-yvr-broadcaster__pigeon-head .home-yvr-broadcaster__eye {
+.home-yvr-broadcaster__beluga-fin--right {
+  left: 28px;
+  transform: rotate(-8deg) scaleX(0.85);
+}
+
+.home-yvr-broadcaster__beluga-head {
   position: absolute;
-  top: 7px;
-  left: 6px;
+  top: 4px;
+  left: 18px;
+  width: 30px;
+  height: 28px;
+  border-radius: 50% 50% 42% 42%;
+  background: linear-gradient(180deg, #ffffff 0%, #e0eaf2 70%, #c0d0e0 100%);
+  border: 2px solid #0a0c10;
+  box-shadow: inset 0 -4px 8px rgba(0, 0, 0, 0.08);
+}
+
+.home-yvr-broadcaster__beluga-head .home-yvr-broadcaster__eye {
+  position: absolute;
+  top: 10px;
+  left: 8px;
   width: 6px;
   height: 6px;
   border-radius: 50%;
   background: #0a0c10;
-  box-shadow: inset -1px -1px 0 #39ff14, 0 0 6px rgba(57, 255, 20, 0.55);
+  box-shadow: inset -1px -1px 0 #57f3ff, 0 0 6px rgba(87, 243, 255, 0.55);
   animation: homeBcastBlink 5s steps(2, end) infinite;
 }
 
-.home-yvr-broadcaster__pigeon-beak {
+.home-yvr-broadcaster__beluga-smile {
   position: absolute;
-  top: 10px;
-  right: -2px;
-  width: 14px;
-  height: 12px;
+  bottom: 5px;
+  left: 6px;
+  width: 18px;
+  height: 10px;
 }
 
-.home-yvr-broadcaster__pigeon-beak-top {
-  display: block;
-  width: 14px;
-  height: 5px;
-  border-radius: 0 6px 2px 2px;
-  background: linear-gradient(180deg, #ffb347, #e8922a);
-  border: 2px solid #0a0c10;
-  border-bottom: none;
-}
-
-.home-yvr-broadcaster__pigeon-beak .home-yvr-broadcaster__mouth {
+.home-yvr-broadcaster__beluga-smile .home-yvr-broadcaster__mouth {
   position: relative;
   display: block;
-  width: 12px;
+  width: 14px;
   height: 4px;
-  margin-top: -1px;
-  border-radius: 0 0 6px 6px;
-  background: linear-gradient(180deg, #e8922a, #c9781a);
+  margin: 0 auto;
+  border-radius: 0 0 10px 10px;
   border: 2px solid #0a0c10;
   border-top: none;
+  background: linear-gradient(180deg, #98a8b8, #708090);
   transform-origin: center top;
-  transition: height 0.07s ease-out;
+  transition: height 0.07s ease-out, border-radius 0.07s ease-out;
 }
 
-.home-yvr-broadcaster__pigeon-mic {
+.home-yvr-broadcaster__beluga-mic {
   position: absolute;
-  bottom: 14px;
-  right: 6px;
+  bottom: 16px;
+  right: 4px;
   width: 5px;
   height: 8px;
   border-radius: 2px;
@@ -378,22 +376,22 @@
   animation: homeBcastBlinkFast 1.2s steps(2, end) infinite;
 }
 
-.home-yvr-broadcaster__avatar.is-talking .home-yvr-broadcaster__pigeon-head,
-.home-yvr-broadcaster__face.is-talking .home-yvr-broadcaster__pigeon-head {
-  box-shadow: inset 0 -3px 6px rgba(0, 0, 0, 0.15), 0 0 10px rgba(255, 230, 109, 0.25);
+.home-yvr-broadcaster__avatar.is-talking .home-yvr-broadcaster__beluga-head,
+.home-yvr-broadcaster__face.is-talking .home-yvr-broadcaster__beluga-head {
+  box-shadow: inset 0 -4px 8px rgba(0, 0, 0, 0.08), 0 0 12px rgba(87, 243, 255, 0.35);
 }
 
-.home-yvr-broadcaster__pigeon-beak .home-yvr-broadcaster__mouth.is-open {
+.home-yvr-broadcaster__beluga-smile .home-yvr-broadcaster__mouth.is-open {
   height: 9px;
-  background: linear-gradient(180deg, #ff4fd8 0%, #e8922a 80%);
-  box-shadow: 0 0 8px rgba(255, 79, 216, 0.4);
+  background: linear-gradient(180deg, #ff4fd8 0%, #708090 80%);
+  box-shadow: 0 0 8px rgba(255, 79, 216, 0.35);
 }
 
-.home-yvr-broadcaster__pigeon-beak .home-yvr-broadcaster__mouth.is-flap {
-  animation: homeDaveBeakFlap 0.26s steps(3, end) infinite;
+.home-yvr-broadcaster__beluga-smile .home-yvr-broadcaster__mouth.is-flap {
+  animation: homeBeulahSmileFlap 0.26s steps(3, end) infinite;
 }
 
-@keyframes homeDaveBeakFlap {
+@keyframes homeBeulahSmileFlap {
   0%, 100% { height: 4px; }
   50% { height: 10px; }
 }
@@ -1349,8 +1347,8 @@ body.home-yvr-map-modal-open {
   cursor: pointer;
 }
 
-.home-yvr-broadcaster__avatar[data-broadcaster-dave-cycle]:hover .home-yvr-broadcaster__pigeon-head {
-  box-shadow: inset 0 -3px 6px rgba(0, 0, 0, 0.15), 0 0 12px rgba(255, 230, 109, 0.35);
+.home-yvr-broadcaster__avatar[data-broadcaster-dave-cycle]:hover .home-yvr-broadcaster__beluga-head {
+  box-shadow: inset 0 -4px 8px rgba(0, 0, 0, 0.08), 0 0 14px rgba(87, 243, 255, 0.4);
 }
 
 .home-yvr-broadcaster__channels {

--- a/assets/css/lousy-outages-teaser.css
+++ b/assets/css/lousy-outages-teaser.css
@@ -17,6 +17,17 @@
   color:#f7fbff;
 }
 #lousy-outages-teaser *{box-sizing:border-box;min-width:0}
+#lousy-outages-teaser.lo-home-teaser--hot{border-color:rgba(255,75,75,.85);box-shadow:0 0 28px rgba(255,75,75,.22),inset 0 0 0 1px rgba(255,230,109,.18);animation:loHomeTeaserHotPulse 2.4s ease-in-out infinite}
+#lousy-outages-teaser.lo-home-teaser--hot.lo-home-teaser--warn{border-color:rgba(255,230,109,.75);box-shadow:0 0 24px rgba(255,230,109,.18),inset 0 0 0 1px rgba(255,79,216,.12)}
+@keyframes loHomeTeaserHotPulse{0%,100%{box-shadow:0 0 28px rgba(255,75,75,.22),inset 0 0 0 1px rgba(255,230,109,.18)}50%{box-shadow:0 0 36px rgba(255,75,75,.34),inset 0 0 0 1px rgba(255,230,109,.28)}}
+#lousy-outages-teaser .lo-home-alert{grid-column:1/-1;display:grid;grid-template-columns:minmax(5.5rem,auto) minmax(0,1fr) auto;gap:.35rem .65rem;align-items:center;padding:.7rem .85rem;border:1px solid rgba(255,230,109,.45);border-radius:12px;background:linear-gradient(90deg,rgba(255,230,109,.14),rgba(255,79,216,.08)),rgba(0,0,0,.35)}
+#lousy-outages-teaser .lo-home-alert--outage{border-color:rgba(255,75,75,.55);background:linear-gradient(90deg,rgba(255,75,75,.16),rgba(255,79,216,.06)),rgba(0,0,0,.35)}
+#lousy-outages-teaser .lo-home-alert__label{font-family:'Press Start 2P',monospace;font-size:.48rem;text-transform:uppercase;letter-spacing:.06em;color:var(--lo-yellow)}
+#lousy-outages-teaser .lo-home-alert--outage .lo-home-alert__label{color:var(--lo-red)}
+#lousy-outages-teaser .lo-home-alert__body{color:#fff;text-decoration:none;min-width:0}
+#lousy-outages-teaser .lo-home-alert__body strong{display:block;font-size:.88rem;line-height:1.3}
+#lousy-outages-teaser .lo-home-alert__body span{display:block;color:#c8e8ff;font-size:.78rem;line-height:1.35}
+#lousy-outages-teaser .lo-home-alert__time{font-family:"IBM Plex Mono","Courier New",monospace;font-size:.72rem;color:var(--lo-yellow);white-space:nowrap}
 #lousy-outages-teaser.lo-home-teaser--down{border-color:rgba(255,75,75,.75)}
 #lousy-outages-teaser.lo-home-teaser--warn{border-color:rgba(255,230,109,.65)}
 #lousy-outages-teaser.lo-home-teaser--advisory{border-color:rgba(255,79,216,.55)}

--- a/assets/js/lousy-outages-teaser.js
+++ b/assets/js/lousy-outages-teaser.js
@@ -44,15 +44,41 @@
     var urls = teaser.urls || {};
 
     container.className = container.className.replace(/lo-home-teaser--\w+/g, '').trim();
-    container.classList.add('lo-home-teaser', 'lo-home-teaser--' + tone);
+    container.classList.add('lo-home-teaser');
+    container.classList.add('lo-home-teaser--' + tone);
+
+    var downCount = parseInt(counts.down, 10) || 0;
+    var degradedCount = parseInt(counts.degraded, 10) || 0;
+    var isHot = downCount > 0 || degradedCount > 0 || tone === 'down' || tone === 'warn' || tone === 'advisory' || tone === 'degraded' || tone === 'bad';
+    if (isHot) {
+      container.classList.add('lo-home-teaser--hot');
+    } else {
+      container.classList.remove('lo-home-teaser--hot');
+    }
+
+    var details = container.querySelector('.lo-home-teaser__details');
+    if (details) {
+      if (isHot) {
+        details.setAttribute('open', 'open');
+      } else {
+        details.removeAttribute('open');
+      }
+    }
+
+    var summaryAction = container.querySelector('.lo-home-teaser__summary-action');
+    if (summaryAction) {
+      summaryAction.textContent = isHot ? 'live board open' : 'expand live board';
+    }
 
     setText(container, '[data-lo-verdict-line]', teaser.verdict_line || '');
     setText(container, '[data-lo-verdict-sub]', teaser.verdict_sub || '');
     setText(container, '[data-lo-summary-verdict]', teaser.verdict_line || '');
 
-    var signalVerdict = document.querySelector('[data-signal-lo-verdict]');
-    if (signalVerdict && teaser.verdict_line) {
-      signalVerdict.textContent = teaser.verdict_line;
+    if (typeof document !== 'undefined' && typeof document.querySelector === 'function') {
+      var signalVerdict = document.querySelector('[data-signal-lo-verdict]');
+      if (signalVerdict && teaser.verdict_line) {
+        signalVerdict.textContent = teaser.verdict_line;
+      }
     }
 
     setText(container, '[data-lo-stat="down"] strong', padCount(counts.down));
@@ -120,6 +146,22 @@
     if (teaser.fetched_label) syncParts.push('Last sync ' + teaser.fetched_label);
     if (counts.tracked) syncParts.push(padCount(counts.tracked) + ' tracked');
     setText(container, '[data-lo-sync]', syncParts.join(' · '));
+
+    var lastAlert = teaser.last_alert || null;
+    var alertEl = container.querySelector('[data-lo-last-alert]');
+    if (alertEl) {
+      if (lastAlert && (lastAlert.title || lastAlert.provider)) {
+        alertEl.removeAttribute('hidden');
+        alertEl.className = 'lo-home-alert lo-home-alert--' + (lastAlert.tone || 'signal');
+        setText(alertEl, '[data-lo-last-alert-label]', lastAlert.label || 'LAST EMAIL');
+        setText(alertEl, '[data-lo-last-alert-title]', lastAlert.title || lastAlert.provider || '');
+        setText(alertEl, '[data-lo-last-alert-provider]', lastAlert.provider || '');
+        setText(alertEl, '[data-lo-last-alert-time]', lastAlert.time_label || '');
+        updateLink(alertEl, '[data-lo-last-alert-link]', lastAlert.url || config.dashboardUrl + '#active');
+      } else {
+        alertEl.setAttribute('hidden', 'hidden');
+      }
+    }
 
     if (teaser.delayed) {
       markDelayed(container);

--- a/inc/home-yvr-audio-channels.php
+++ b/inc/home-yvr-audio-channels.php
@@ -254,8 +254,8 @@ function se_broadcaster_channel_deck_notes(): array {
             'deck_note' => 'Broadcastify scanner. Footer link opens source only if you tap it.',
         ),
         'marine_vhf'     => array(
-            'deck_copy' => 'Marine VHF — port traffic, Coast Guard, distress. Walks Vancouver → Comox → Sointula → EC marine WX automatically. Coast dead? Dave jumps to YVR combo.',
-            'deck_note' => 'Broadcastify chain. No retry button — Dave finds a live feed or switches.',
+            'deck_copy' => 'Marine VHF — port traffic, Coast Guard, distress. Walks Vancouver → Comox → Sointula → EC marine WX automatically. Coast dead? Beulah jumps to YVR combo.',
+            'deck_note' => 'Broadcastify chain. No retry button — Beulah finds a live feed or switches.',
         ),
         'hydro_bush'     => array(
             'deck_copy' => 'Orcasound hydrophone at Bush Point — Salish Sea live. Whales, ships, weird water noise.',
@@ -267,7 +267,7 @@ function se_broadcaster_channel_deck_notes(): array {
         ),
         'sound_skytrain' => array(
             'deck_copy' => 'SkyTrain rumble loop — field bed, not live airwaves.',
-            'deck_note' => 'Soundscape only. Dave ambient cycle.',
+            'deck_note' => 'Soundscape only. Beulah ambient cycle.',
         ),
         'sound_rain'     => array(
             'deck_copy' => 'West coast rain bed — looped field recording.',

--- a/inc/home-yvr-broadcaster.php
+++ b/inc/home-yvr-broadcaster.php
@@ -193,7 +193,7 @@ function se_broadcaster_metro_map_anchors(): array {
     $anchors = array(
         array(
             'key'   => 'dave',
-            'label' => 'DAVE',
+            'label' => 'BEULAH',
             'hint'  => 'YVR rack',
             'lat'   => 49.1967,
             'lon'   => -123.1815,
@@ -296,7 +296,7 @@ function se_broadcaster_data_channel_pin_config(): array {
 
     foreach ( $pins as $key => $pin ) {
         $pins[ $key ]['deck_copy'] = se_broadcaster_pin_deck_copy( $key );
-        $pins[ $key ]['deck_note'] = 'Territory pin — bulletin on CRT, live audio on Dave. Small map dots are incidents; they land here too, not in a new tab.';
+        $pins[ $key ]['deck_note'] = 'Territory pin — bulletin on CRT, live audio on Beulah. Small map dots are incidents; they land here too, not in a new tab.';
     }
 
     return $pins;

--- a/js/home-yvr-broadcaster.js
+++ b/js/home-yvr-broadcaster.js
@@ -557,7 +557,7 @@
     this.renderChannelDetail({
       kicker: 'map dot',
       deck_copy: name + (detail ? ' — ' + detail : ''),
-      deck_note: 'Stays on Dave. Footer link opens the official source only if you tap it — no auto pop-ups.'
+      deck_note: 'Stays on Beulah. Footer link opens the official source only if you tap it — no auto pop-ups.'
     });
 
     var items = [];
@@ -1215,7 +1215,7 @@
       kicker: channel.label || channel.key,
       deck_copy: channel.deck_copy || channel.hint || '',
       deck_note: channel.deck_note || (channel.mode === 'broadcastify'
-        ? 'Broadcastify chain — Dave walks feeds until something\'s live.'
+        ? 'Broadcastify chain — Beulah walks feeds until something\'s live.'
         : 'In-page live audio.')
     });
   };

--- a/lousy-outages/includes/HomeTeaser.php
+++ b/lousy-outages/includes/HomeTeaser.php
@@ -53,6 +53,7 @@ final class HomeTeaser
             'counts'          => $counts,
             'lead'            => $lead,
             'also'            => $also,
+            'last_alert'      => self::last_alert_view($dashboard),
             'fetched_at'      => $fetched_raw,
             'fetched_label'   => $fetched_ts > 0 ? Board\relative_time($fetched_ts) : '',
             'urls'            => [
@@ -63,6 +64,48 @@ final class HomeTeaser
                 'full'       => $dashboard,
             ],
             'delayed'         => !empty($state['errors']) && $counts['down'] === 0 && $counts['degraded'] === 0,
+        ];
+    }
+
+    /**
+     * @return array<string, string>|null
+     */
+    private static function last_alert_view(string $dashboard): ?array
+    {
+        $raw = get_option('lousy_outages_last_alert_success', []);
+        if (!is_array($raw) || empty($raw['timestamp'])) {
+            return null;
+        }
+
+        if (!empty($raw['synthetic'])) {
+            return null;
+        }
+
+        $provider = Board\tidy((string) ($raw['provider'] ?? ''), 80);
+        $title = Board\tidy((string) ($raw['title'] ?? ''), 140);
+        if ('' === $provider && '' === $title) {
+            return null;
+        }
+
+        $status = strtolower((string) ($raw['status'] ?? ''));
+        $tone = 'signal';
+        if (in_array($status, ['major_outage', 'major', 'outage', 'critical'], true)) {
+            $tone = 'outage';
+        } elseif (in_array($status, ['degraded', 'partial_outage', 'partial', 'minor', 'maintenance'], true)) {
+            $tone = 'signal';
+        } elseif ('' !== $status) {
+            $tone = 'unknown';
+        }
+
+        $ts = Board\timestamp_from((string) $raw['timestamp']);
+
+        return [
+            'label'        => 'LAST EMAIL',
+            'provider'     => $provider,
+            'title'        => $title ?: $provider,
+            'tone'         => $tone,
+            'time_label'   => $ts > 0 ? Board\relative_time($ts) : '',
+            'url'          => $dashboard . '#active',
         ];
     }
 

--- a/page-home.php
+++ b/page-home.php
@@ -51,21 +51,21 @@ get_header();
                 <div class="home-yvr-rack">
                 <div class="home-yvr-broadcaster" data-yvr-broadcaster tabindex="-1" aria-label="<?php echo esc_attr( 'YVR radar deck — bulletins and live audio from map pins' ); ?>">
                     <div class="home-yvr-broadcaster__mast">
-                        <div class="home-yvr-broadcaster__avatar" data-broadcaster-face data-broadcaster-dave-cycle title="<?php echo esc_attr( 'Tap Dave to cycle ambient beds' ); ?>" aria-label="<?php echo esc_attr( 'Dave — tap to cycle ambient sound' ); ?>">
-                            <div class="home-yvr-broadcaster__avatar-frame home-yvr-broadcaster__pigeon">
-                                <div class="home-yvr-broadcaster__pigeon-tail"></div>
-                                <div class="home-yvr-broadcaster__pigeon-body"></div>
-                                <div class="home-yvr-broadcaster__pigeon-wing"></div>
-                                <div class="home-yvr-broadcaster__pigeon-head">
+                        <div class="home-yvr-broadcaster__avatar" data-broadcaster-face data-broadcaster-dave-cycle title="<?php echo esc_attr( 'Tap Beulah to cycle ambient beds' ); ?>" aria-label="<?php echo esc_attr( 'Beulah — tap to cycle ambient sound' ); ?>">
+                            <div class="home-yvr-broadcaster__avatar-frame home-yvr-broadcaster__beluga">
+                                <div class="home-yvr-broadcaster__beluga-fluke"></div>
+                                <div class="home-yvr-broadcaster__beluga-body"></div>
+                                <div class="home-yvr-broadcaster__beluga-fin home-yvr-broadcaster__beluga-fin--left"></div>
+                                <div class="home-yvr-broadcaster__beluga-fin home-yvr-broadcaster__beluga-fin--right"></div>
+                                <div class="home-yvr-broadcaster__beluga-head">
                                     <span class="home-yvr-broadcaster__eye"></span>
-                                    <div class="home-yvr-broadcaster__pigeon-beak">
-                                        <span class="home-yvr-broadcaster__pigeon-beak-top"></span>
+                                    <div class="home-yvr-broadcaster__beluga-smile">
                                         <span class="home-yvr-broadcaster__mouth" data-broadcaster-mouth></span>
                                     </div>
                                 </div>
-                                <div class="home-yvr-broadcaster__pigeon-mic" aria-hidden="true"></div>
+                                <div class="home-yvr-broadcaster__beluga-mic" aria-hidden="true"></div>
                             </div>
-                            <p class="home-yvr-broadcaster__avatar-name pixel-font"><?php echo esc_html( 'DAVE' ); ?></p>
+                            <p class="home-yvr-broadcaster__avatar-name pixel-font"><?php echo esc_html( 'BEULAH' ); ?></p>
                         </div>
                         <div class="home-yvr-broadcaster__mast-info">
                             <div class="home-yvr-broadcaster__header">

--- a/parts/home-commercial-strip.php
+++ b/parts/home-commercial-strip.php
@@ -7,8 +7,9 @@ $tone       = sanitize_html_class( (string) ( $teaser['tone'] ?? 'ok' ) );
 $counts     = is_array( $teaser['counts'] ?? null ) ? $teaser['counts'] : [];
 $down       = (int) ( $counts['down'] ?? 0 );
 $degraded   = (int) ( $counts['degraded'] ?? 0 );
+$highlight  = $down > 0 || $degraded > 0 || in_array( $tone, [ 'down', 'warn', 'advisory', 'degraded', 'bad' ], true );
 ?>
-<nav class="home-signal-strip home-signal-strip--<?php echo esc_attr( $tone ); ?>" aria-label="<?php echo esc_attr( 'Products and live signals' ); ?>">
+<nav class="home-signal-strip home-signal-strip--<?php echo esc_attr( $tone ); ?><?php echo $highlight ? ' home-signal-strip--hot' : ''; ?>" aria-label="<?php echo esc_attr( 'Products and live signals' ); ?>">
     <a class="home-signal-strip__product home-signal-strip__product--lo" href="<?php echo esc_url( $lo_url ); ?>">
         <span class="home-signal-strip__label pixel-font"><?php echo esc_html( 'lousy outages' ); ?></span>
         <span class="home-signal-strip__verdict" data-signal-lo-verdict><?php echo esc_html( $verdict ); ?></span>

--- a/parts/lousy-outages-teaser.php
+++ b/parts/lousy-outages-teaser.php
@@ -7,19 +7,22 @@ $counts = is_array( $teaser['counts'] ?? null ) ? $teaser['counts'] : [];
 $lead = is_array( $teaser['lead'] ?? null ) ? $teaser['lead'] : [];
 $also = is_array( $teaser['also'] ?? null ) ? $teaser['also'] : [];
 $urls = is_array( $teaser['urls'] ?? null ) ? $teaser['urls'] : [];
+$last_alert = is_array( $teaser['last_alert'] ?? null ) ? $teaser['last_alert'] : null;
 $tone = sanitize_html_class( (string) ( $teaser['tone'] ?? 'ok' ) );
 $down = (int) ( $counts['down'] ?? 0 );
 $degraded = (int) ( $counts['degraded'] ?? 0 );
 $advisory = (int) ( $counts['advisory'] ?? 0 );
 $up = (int) ( $counts['up'] ?? 0 );
 $tracked = (int) ( $counts['tracked'] ?? 0 );
+$highlight = $down > 0 || $degraded > 0 || in_array( $tone, [ 'down', 'warn', 'advisory', 'degraded', 'bad' ], true );
+$alert_tone = sanitize_html_class( (string) ( $last_alert['tone'] ?? 'signal' ) );
 ?>
-<section id="lousy-outages-teaser" class="lo-home-teaser lo-home-teaser--<?php echo esc_attr( $tone ); ?> lo-home-teaser-panel" aria-labelledby="lo-home-heading" data-lo-endpoint="<?php echo esc_url( $teaser_endpoint ); ?>" data-lo-dashboard-url="<?php echo esc_url( $dashboard_url ); ?>" data-lo-refresh-interval="<?php echo esc_attr( (string) $teaser_interval ); ?>">
-    <details class="lo-home-teaser__details">
+<section id="lousy-outages-teaser" class="lo-home-teaser lo-home-teaser--<?php echo esc_attr( $tone ); ?> lo-home-teaser-panel<?php echo $highlight ? ' lo-home-teaser--hot' : ''; ?>" aria-labelledby="lo-home-heading" data-lo-endpoint="<?php echo esc_url( $teaser_endpoint ); ?>" data-lo-dashboard-url="<?php echo esc_url( $dashboard_url ); ?>" data-lo-refresh-interval="<?php echo esc_attr( (string) $teaser_interval ); ?>">
+    <details class="lo-home-teaser__details"<?php echo $highlight ? ' open' : ''; ?>>
         <summary class="lo-home-teaser__summary pixel-font">
             <span class="lo-home-teaser__summary-label"><?php echo esc_html( 'lousy outages' ); ?></span>
             <span class="lo-home-teaser__summary-verdict" data-lo-summary-verdict><?php echo esc_html( (string) ( $teaser['verdict_line'] ?? '' ) ); ?></span>
-            <span class="lo-home-teaser__summary-action"><?php echo esc_html( 'expand live board' ); ?></span>
+            <span class="lo-home-teaser__summary-action"><?php echo esc_html( $highlight ? 'live board open' : 'expand live board' ); ?></span>
         </summary>
     <div class="lo-home-teaser__body">
     <div class="lo-home-teaser__titlebar">
@@ -50,6 +53,15 @@ $tracked = (int) ( $counts['tracked'] ?? 0 );
             <strong><?php echo esc_html( str_pad( (string) $up, 2, '0', STR_PAD_LEFT ) ); ?></strong>
             <span><?php echo esc_html( 'UP' ); ?></span>
         </a>
+
+        <div class="lo-home-alert lo-home-alert--<?php echo esc_attr( $alert_tone ); ?>" data-lo-last-alert<?php echo $last_alert ? '' : ' hidden'; ?>>
+            <span class="lo-home-alert__label" data-lo-last-alert-label><?php echo esc_html( (string) ( $last_alert['label'] ?? 'LAST EMAIL' ) ); ?></span>
+            <a class="lo-home-alert__body" data-lo-last-alert-link href="<?php echo esc_url( (string) ( $last_alert['url'] ?? $dashboard_url . '#active' ) ); ?>">
+                <strong data-lo-last-alert-title><?php echo esc_html( (string) ( $last_alert['title'] ?? '' ) ); ?></strong>
+                <span data-lo-last-alert-provider><?php echo esc_html( (string) ( $last_alert['provider'] ?? '' ) ); ?></span>
+            </a>
+            <time class="lo-home-alert__time" data-lo-last-alert-time><?php echo esc_html( (string) ( $last_alert['time_label'] ?? '' ) ); ?></time>
+        </div>
 
         <div class="lo-home-lead" data-lo-lead>
             <span class="lo-home-chip lo-home-chip--<?php echo esc_attr( sanitize_html_class( (string) ( $lead['kind'] ?? $tone ) ) ); ?>" data-lo-lead-label><?php echo esc_html( (string) ( $lead['label'] ?? '' ) ); ?></span>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Replaces Dave the pigeon with **Beulah**, a CSS beluga whale on the YVR radar deck (avatar, nameplate, map pin label, and deck copy).
- Makes **Lousy Outages** harder to miss on the homepage:
  - Signal strip and teaser get a hot-state glow when providers are down or degraded
  - Teaser auto-expands when something is on fire
- Surfaces the **last real email alert** in the homepage teaser (provider, incident title, relative send time) using `lousy_outages_last_alert_success`.

## Test plan

- [x] `node --test __tests__/lousy-outages-teaser.test.js`
- [ ] Load homepage — confirm Beulah renders on the deck and map pin reads BEULAH
- [ ] With active outages, confirm Lousy Outages strip/teaser pulse and teaser opens expanded
- [ ] After a real alert fires, confirm LAST EMAIL row appears in the teaser
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd7f6-b758-77ab-abe0-074dfb8637e1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd7f6-b758-77ab-abe0-074dfb8637e1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

