### PR TITLE
Add terminal-style feature previews to homepage

### DIFF
--- a/assets/css/home-feature-previews.css
+++ b/assets/css/home-feature-previews.css
@@ -1,0 +1,288 @@
+/* Homepage feature preview cards — compact Lousy Outages terminal shell */
+
+.home-feature-previews {
+  --fp-bg: #05080a;
+  --fp-panel: rgba(9, 16, 14, 0.88);
+  --fp-line: rgba(94, 234, 160, 0.22);
+  --fp-line-soft: rgba(94, 234, 160, 0.1);
+  --fp-text: #cfe7d8;
+  --fp-dim: #7d9a8b;
+  --fp-ok: #4ade80;
+  --fp-warn: #ffb300;
+  --fp-down: #ff5468;
+  --fp-advisory: #b98bff;
+  --fp-mono: ui-monospace, "SFMono-Regular", "JetBrains Mono", Menlo, Consolas, monospace;
+
+  width: min(100% - 2rem, 1180px);
+  margin: clamp(1.25rem, 3vw, 2rem) auto;
+  padding: clamp(1rem, 2.5vw, 1.5rem);
+}
+
+.home-feature-previews__lede {
+  margin: 0 0 1.1rem;
+  max-width: 52ch;
+  color: rgba(223, 255, 234, 0.84);
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+.home-feature-previews__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: clamp(0.75rem, 2vw, 1.1rem);
+}
+
+.home-feature-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  min-width: 0;
+  padding: clamp(0.85rem, 1.8vw, 1.1rem);
+  border: 1px solid rgba(94, 234, 160, 0.28);
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(0, 18, 12, 0.82), rgba(0, 0, 0, 0.72));
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.28);
+}
+
+.home-feature-preview--live.home-feature-preview--down {
+  border-color: rgba(255, 84, 104, 0.45);
+  box-shadow: 0 0 22px rgba(255, 84, 104, 0.12), 0 12px 32px rgba(0, 0, 0, 0.28);
+}
+
+.home-feature-preview--live.home-feature-preview--warn {
+  border-color: rgba(255, 179, 0, 0.4);
+  box-shadow: 0 0 18px rgba(255, 179, 0, 0.1), 0 12px 32px rgba(0, 0, 0, 0.28);
+}
+
+.home-feature-preview__head {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.home-feature-preview__label {
+  margin: 0;
+  color: var(--fp-ok);
+  font-size: clamp(0.45rem, 0.9vw, 0.55rem);
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+}
+
+.home-feature-preview__title {
+  margin: 0;
+  color: var(--fp-ok);
+  font-size: clamp(0.72rem, 1.4vw, 0.92rem);
+  line-height: 1.35;
+  letter-spacing: 0.06em;
+  text-shadow: 0 0 12px rgba(74, 222, 128, 0.35);
+}
+
+.home-feature-preview__tagline {
+  margin: 0;
+  color: var(--fp-dim);
+  font-family: var(--fp-mono);
+  font-size: 0.72rem;
+  line-height: 1.45;
+}
+
+.home-feature-preview__terminal {
+  position: relative;
+  display: grid;
+  gap: 0.55rem;
+  isolation: isolate;
+}
+
+/* Compact radar/CRT wash — scoped to terminal only, smaller than full board */
+.home-feature-preview__scan {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  border-radius: 10px;
+  opacity: 0.45;
+  background:
+    repeating-linear-gradient(to bottom, rgba(120, 255, 190, 0.03) 0 1px, transparent 1px 3px),
+    radial-gradient(ellipse 70% 55% at 50% 15%, rgba(38, 96, 74, 0.28), transparent 72%);
+}
+
+.home-feature-preview__shell {
+  position: relative;
+  z-index: 1;
+  overflow: hidden;
+  border: 1px solid var(--fp-line);
+  border-radius: 10px;
+  background: var(--fp-panel);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35), 0 12px 28px -18px rgba(74, 222, 128, 0.35);
+}
+
+.home-feature-preview__shell-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.65rem;
+  border-bottom: 1px solid var(--fp-line-soft);
+  background: rgba(4, 10, 8, 0.92);
+  font-family: var(--fp-mono);
+  font-size: 0.58rem;
+  letter-spacing: 0.05em;
+  color: var(--fp-dim);
+}
+
+.home-feature-preview__dots {
+  display: inline-flex;
+  gap: 0.28rem;
+  flex-shrink: 0;
+}
+
+.home-feature-preview__dots i {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--fp-down);
+}
+
+.home-feature-preview__dots i:nth-child(2) { background: var(--fp-warn); }
+.home-feature-preview__dots i:nth-child(3) { background: var(--fp-ok); }
+
+.home-feature-preview__path {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.home-feature-preview__build {
+  flex-shrink: 0;
+  opacity: 0.65;
+}
+
+.home-feature-preview__shell-body {
+  padding: 0.75rem 0.7rem 0.7rem;
+  font-family: var(--fp-mono);
+}
+
+.home-feature-preview__prompt {
+  margin: 0;
+  font-size: 0.62rem;
+  color: var(--fp-dim);
+  letter-spacing: 0.02em;
+}
+
+.home-feature-preview__sigil {
+  color: var(--fp-ok);
+  margin-right: 0.3rem;
+}
+
+.home-feature-preview__caret {
+  display: inline-block;
+  width: 0.45em;
+  height: 0.85em;
+  margin-left: 0.25rem;
+  vertical-align: -0.12em;
+  background: var(--fp-ok);
+  animation: home-fp-blink 1.1s steps(1) infinite;
+}
+
+@keyframes home-fp-blink {
+  50% { opacity: 0; }
+}
+
+.home-feature-preview__verdict {
+  margin: 0.45rem 0 0;
+  font-family: var(--fp-mono);
+  font-size: clamp(0.95rem, 2.2vw, 1.25rem);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  line-height: 1.1;
+}
+
+.home-feature-preview__verdict--ok { color: var(--fp-ok); text-shadow: 0 0 14px rgba(74, 222, 128, 0.35); }
+.home-feature-preview__verdict--warn { color: var(--fp-warn); text-shadow: 0 0 14px rgba(255, 179, 0, 0.3); }
+.home-feature-preview__verdict--down { color: var(--fp-down); text-shadow: 0 0 14px rgba(255, 84, 104, 0.35); }
+.home-feature-preview__verdict--advisory { color: var(--fp-advisory); text-shadow: 0 0 14px rgba(185, 139, 255, 0.3); }
+.home-feature-preview__verdict--unknown { color: #58c7ff; text-shadow: 0 0 14px rgba(88, 199, 255, 0.3); }
+
+.home-feature-preview__verdict-sub {
+  margin: 0.2rem 0 0;
+  font-size: 0.68rem;
+  line-height: 1.4;
+  color: var(--fp-text);
+}
+
+.home-feature-preview__meta {
+  margin: 0.45rem 0 0;
+  font-size: 0.6rem;
+  color: var(--fp-dim);
+}
+
+.home-feature-preview__readout {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.35rem;
+}
+
+.home-feature-preview__cell {
+  padding: 0.45rem 0.4rem;
+  border: 1px solid var(--fp-line-soft);
+  border-radius: 7px;
+  background: var(--fp-panel);
+  text-align: center;
+}
+
+.home-feature-preview__value {
+  display: block;
+  font-family: var(--fp-mono);
+  font-size: clamp(0.85rem, 1.8vw, 1.05rem);
+  font-weight: 700;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.home-feature-preview__stat-label {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.38rem;
+  letter-spacing: 0.1em;
+  color: var(--fp-dim);
+}
+
+.home-feature-preview__cell--ok .home-feature-preview__value { color: var(--fp-ok); }
+.home-feature-preview__cell--warn .home-feature-preview__value { color: var(--fp-warn); }
+.home-feature-preview__cell--down .home-feature-preview__value { color: var(--fp-down); }
+.home-feature-preview__cell--advisory .home-feature-preview__value { color: var(--fp-advisory); }
+.home-feature-preview__cell--dim .home-feature-preview__value { color: var(--fp-text); }
+
+.home-feature-preview__cell--down { border-color: rgba(255, 84, 104, 0.28); }
+.home-feature-preview__cell--warn { border-color: rgba(255, 179, 0, 0.25); }
+
+.home-feature-preview__cta {
+  align-self: flex-start;
+  margin-top: auto;
+}
+
+.home-feature-preview--delayed .home-feature-preview__meta::after {
+  content: " · verification delayed";
+  color: var(--fp-warn);
+}
+
+@media (max-width: 1024px) {
+  .home-feature-previews__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  .home-feature-previews {
+    width: min(100% - 1rem, 1180px);
+  }
+
+  .home-feature-preview__readout {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .home-feature-preview__shell-bar {
+    font-size: 0.52rem;
+  }
+}

--- a/assets/js/lousy-outages-teaser.js
+++ b/assets/js/lousy-outages-teaser.js
@@ -34,6 +34,19 @@
     return String(n).padStart(2, '0');
   }
 
+  function updateToneClasses(container, tone) {
+    container.className = container.className
+      .replace(/lo-home-teaser--\w+/g, '')
+      .replace(/home-feature-preview--(ok|warn|down|advisory|degraded|bad|unknown|clear|dim)\b/g, '')
+      .trim();
+    if (container.classList.contains('lo-home-teaser')) {
+      container.classList.add('lo-home-teaser--' + tone);
+    }
+    if (container.classList.contains('home-feature-preview--live')) {
+      container.classList.add('home-feature-preview--' + tone);
+    }
+  }
+
   function render(container, payload, config) {
     var teaser = payload && payload.teaser ? payload.teaser : null;
     if (!teaser) return;
@@ -43,9 +56,10 @@
     var tone = teaser.tone || 'ok';
     var urls = teaser.urls || {};
 
-    container.className = container.className.replace(/lo-home-teaser--\w+/g, '').trim();
-    container.classList.add('lo-home-teaser');
-    container.classList.add('lo-home-teaser--' + tone);
+    if (container.classList.contains('lo-home-teaser')) {
+      container.classList.add('lo-home-teaser');
+    }
+    updateToneClasses(container, tone);
 
     var downCount = parseInt(counts.down, 10) || 0;
     var degradedCount = parseInt(counts.degraded, 10) || 0;
@@ -73,6 +87,33 @@
     setText(container, '[data-lo-verdict-line]', teaser.verdict_line || '');
     setText(container, '[data-lo-verdict-sub]', teaser.verdict_sub || '');
     setText(container, '[data-lo-summary-verdict]', teaser.verdict_line || '');
+    setText(container, '[data-lo-preview-verdict]', teaser.verdict_line || '');
+    setText(container, '[data-lo-preview-verdict-sub]', teaser.verdict_sub || '');
+
+    var previewVerdict = container.querySelector('[data-lo-preview-verdict]');
+    if (previewVerdict) {
+      previewVerdict.className = 'home-feature-preview__verdict home-feature-preview__verdict--' + tone;
+    }
+
+    var previewStats = container.querySelectorAll('[data-lo-preview-stat]');
+    if (previewStats.length) {
+      previewStats.forEach(function (cell) {
+        var key = cell.getAttribute('data-lo-preview-stat');
+        var valueEl = cell.querySelector('.home-feature-preview__value');
+        if (valueEl && counts[key] !== undefined) {
+          valueEl.textContent = padCount(counts[key]);
+        }
+      });
+    }
+
+    var syncBits = [];
+    if (teaser.fetched_label) {
+      syncBits.push('Last sync ' + teaser.fetched_label);
+    }
+    if (counts.tracked) {
+      syncBits.push(padCount(counts.tracked) + ' tracked');
+    }
+    setText(container, '[data-lo-preview-sync]', syncBits.join(' · '));
 
     if (typeof document !== 'undefined' && typeof document.querySelector === 'function') {
       var signalVerdict = document.querySelector('[data-signal-lo-verdict]');
@@ -169,11 +210,15 @@
       var delayed = container.querySelector('.lo-home-delayed');
       if (delayed) delayed.remove();
       container.classList.remove('lo-home-teaser--delayed');
+      container.classList.remove('home-feature-preview--delayed');
     }
   }
 
   function markDelayed(container) {
     container.classList.add('lo-home-teaser--delayed');
+    if (container.classList.contains('home-feature-preview--live')) {
+      container.classList.add('home-feature-preview--delayed');
+    }
     var screen = container.querySelector('.lo-home-teaser__screen');
     if (screen && !screen.querySelector('.lo-home-delayed')) {
       var p = document.createElement('p');
@@ -209,7 +254,7 @@
 
   window.LousyOutagesTeaser = { render, markDelayed, init };
   document.addEventListener('DOMContentLoaded', function () {
-    var c = document.getElementById('lousy-outages-teaser');
-    if (c) init(c);
+    var containers = document.querySelectorAll('[data-lo-endpoint]');
+    containers.forEach(init);
   });
 }());

--- a/functions.php
+++ b/functions.php
@@ -160,6 +160,16 @@ function retro_game_music_theme_scripts() {
             );
         }
 
+        $feature_previews_css = get_template_directory() . '/assets/css/home-feature-previews.css';
+        if ( file_exists( $feature_previews_css ) ) {
+            wp_enqueue_style(
+                'home-feature-previews',
+                get_template_directory_uri() . '/assets/css/home-feature-previews.css',
+                array( 'main-styles' ),
+                filemtime( $feature_previews_css )
+            );
+        }
+
         $teaser_js = get_template_directory() . '/assets/js/lousy-outages-teaser.js';
         if ( file_exists( $teaser_js ) ) {
             wp_enqueue_script(

--- a/page-home.php
+++ b/page-home.php
@@ -132,6 +132,8 @@ get_header();
         </div>
     </section>
 
+    <?php get_template_part( 'parts/home-feature-previews' ); ?>
+
     <section id="mission-select" class="home-project-grid home-mission-select crt-block" aria-labelledby="selected-projects-title">
         <p class="home-section-kicker pixel-font"><?php echo esc_html( 'LEVEL SELECT' ); ?></p>
         <h2 id="selected-projects-title" class="pixel-font"><?php echo esc_html( 'CHOOSE YOUR SYSTEM' ); ?></h2>
@@ -146,8 +148,6 @@ get_header();
             <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'discography' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Music / Records' ); ?></h3><p><?php echo esc_html( 'Solo releases, past bands, touring history, and the music side of the machine.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/music-releases/' ) ); ?>"><?php echo esc_html( 'Listen' ); ?></a></article>
         </div>
     </section>
-
-    <?php get_template_part( 'parts/lousy-outages-teaser' ); ?>
 
     <section id="music" class="music-world home-unlocks crt-block" aria-labelledby="music-world-title">
         <p class="home-section-kicker pixel-font"><?php echo esc_html( 'UNLOCKS' ); ?></p>

--- a/parts/home-feature-previews.php
+++ b/parts/home-feature-previews.php
@@ -1,0 +1,173 @@
+<?php
+$teaser = function_exists( 'get_lousy_outages_home_teaser_data' ) ? get_lousy_outages_home_teaser_data() : [];
+$dashboard_url = (string) ( $teaser['dashboard_url'] ?? home_url( '/lousy-outages/' ) );
+$teaser_endpoint = rest_url( 'lousy-outages/v1/summary' );
+$teaser_interval = 5 * MINUTE_IN_SECONDS * 1000;
+$counts = is_array( $teaser['counts'] ?? null ) ? $teaser['counts'] : [];
+$tone = sanitize_html_class( (string) ( $teaser['tone'] ?? 'ok' ) );
+$down = (int) ( $counts['down'] ?? 0 );
+$degraded = (int) ( $counts['degraded'] ?? 0 );
+$advisory = (int) ( $counts['advisory'] ?? 0 );
+$up = (int) ( $counts['up'] ?? 0 );
+$tracked = (int) ( $counts['tracked'] ?? 0 );
+$lo_version = defined( 'LOUSY_OUTAGES_VERSION' ) ? LOUSY_OUTAGES_VERSION : '0.5.7';
+$sync_bits = [];
+if ( ! empty( $teaser['fetched_label'] ) ) {
+    $sync_bits[] = 'Last sync ' . (string) $teaser['fetched_label'];
+}
+if ( $tracked > 0 ) {
+    $sync_bits[] = str_pad( (string) $tracked, 2, '0', STR_PAD_LEFT ) . ' tracked';
+}
+$sync_line = implode( ' · ', $sync_bits );
+?>
+<section id="feature-previews" class="home-feature-previews crt-block" aria-labelledby="feature-previews-title">
+    <p class="home-section-kicker pixel-font"><?php echo esc_html( 'live previews' ); ?></p>
+    <h2 id="feature-previews-title" class="pixel-font"><?php echo esc_html( 'FEATURE BUILDS' ); ?></h2>
+    <p class="home-feature-previews__lede"><?php echo esc_html( 'Terminal windows into the stuff that actually ships. No brochureware.' ); ?></p>
+
+    <div class="home-feature-previews__grid">
+        <article
+            class="home-feature-preview home-feature-preview--live home-feature-preview--<?php echo esc_attr( $tone ); ?>"
+            aria-labelledby="home-preview-lo-title"
+            data-lo-endpoint="<?php echo esc_url( $teaser_endpoint ); ?>"
+            data-lo-dashboard-url="<?php echo esc_url( $dashboard_url ); ?>"
+            data-lo-refresh-interval="<?php echo esc_attr( (string) $teaser_interval ); ?>"
+        >
+            <header class="home-feature-preview__head">
+                <p class="home-feature-preview__label pixel-font"><?php echo esc_html( 'status weather' ); ?></p>
+                <h3 id="home-preview-lo-title" class="home-feature-preview__title pixel-font"><?php echo esc_html( 'Lousy Outages' ); ?></h3>
+                <p class="home-feature-preview__tagline"><?php echo esc_html( 'Official status pages, read for you every 15 minutes. No spin, no vibes.' ); ?></p>
+            </header>
+
+            <div class="home-feature-preview__terminal" role="status" aria-live="polite">
+                <div class="home-feature-preview__scan" aria-hidden="true"></div>
+                <div class="home-feature-preview__shell">
+                    <div class="home-feature-preview__shell-bar pixel-font">
+                        <span class="home-feature-preview__dots" aria-hidden="true"><i></i><i></i><i></i></span>
+                        <span class="home-feature-preview__path">lousy-outages@yvr — status --all</span>
+                        <span class="home-feature-preview__build">build <?php echo esc_html( $lo_version ); ?></span>
+                    </div>
+                    <div class="home-feature-preview__shell-body">
+                        <p class="home-feature-preview__prompt pixel-font"><span class="home-feature-preview__sigil">$</span> watch --every=15m ./poll-official-status<span class="home-feature-preview__caret" aria-hidden="true"></span></p>
+                        <p class="home-feature-preview__verdict home-feature-preview__verdict--<?php echo esc_attr( $tone ); ?>" data-lo-preview-verdict><?php echo esc_html( (string) ( $teaser['verdict_line'] ?? '' ) ); ?></p>
+                        <p class="home-feature-preview__verdict-sub" data-lo-preview-verdict-sub><?php echo esc_html( (string) ( $teaser['verdict_sub'] ?? '' ) ); ?></p>
+                        <p class="home-feature-preview__meta" data-lo-preview-sync><?php echo esc_html( $sync_line ); ?></p>
+                    </div>
+                </div>
+
+                <div class="home-feature-preview__readout" aria-label="<?php echo esc_attr( 'Status totals' ); ?>">
+                    <div class="home-feature-preview__cell home-feature-preview__cell--down" data-lo-preview-stat="down">
+                        <span class="home-feature-preview__value"><?php echo esc_html( str_pad( (string) $down, 2, '0', STR_PAD_LEFT ) ); ?></span>
+                        <span class="home-feature-preview__stat-label pixel-font"><?php echo esc_html( 'DOWN' ); ?></span>
+                    </div>
+                    <div class="home-feature-preview__cell home-feature-preview__cell--warn" data-lo-preview-stat="degraded">
+                        <span class="home-feature-preview__value"><?php echo esc_html( str_pad( (string) $degraded, 2, '0', STR_PAD_LEFT ) ); ?></span>
+                        <span class="home-feature-preview__stat-label pixel-font"><?php echo esc_html( 'DEGRADED' ); ?></span>
+                    </div>
+                    <div class="home-feature-preview__cell home-feature-preview__cell--advisory" data-lo-preview-stat="advisory">
+                        <span class="home-feature-preview__value"><?php echo esc_html( str_pad( (string) $advisory, 2, '0', STR_PAD_LEFT ) ); ?></span>
+                        <span class="home-feature-preview__stat-label pixel-font"><?php echo esc_html( 'ADVISORIES' ); ?></span>
+                    </div>
+                    <div class="home-feature-preview__cell home-feature-preview__cell--ok" data-lo-preview-stat="up">
+                        <span class="home-feature-preview__value"><?php echo esc_html( str_pad( (string) $up, 2, '0', STR_PAD_LEFT ) ); ?></span>
+                        <span class="home-feature-preview__stat-label pixel-font"><?php echo esc_html( 'UP' ); ?></span>
+                    </div>
+                </div>
+            </div>
+
+            <a class="pixel-button home-feature-preview__cta" href="<?php echo esc_url( $dashboard_url ); ?>"><?php echo esc_html( 'Check status' ); ?></a>
+        </article>
+
+        <article class="home-feature-preview home-feature-preview--static" aria-labelledby="home-preview-gastown-title">
+            <header class="home-feature-preview__head">
+                <p class="home-feature-preview__label pixel-font"><?php echo esc_html( 'civic arcade world' ); ?></p>
+                <h3 id="home-preview-gastown-title" class="home-feature-preview__title pixel-font"><?php echo esc_html( 'Gastown Simulator' ); ?></h3>
+                <p class="home-feature-preview__tagline"><?php echo esc_html( 'Open data, street mood, route logic. A Vancouver corridor you can walk.' ); ?></p>
+            </header>
+
+            <div class="home-feature-preview__terminal">
+                <div class="home-feature-preview__scan" aria-hidden="true"></div>
+                <div class="home-feature-preview__shell">
+                    <div class="home-feature-preview__shell-bar pixel-font">
+                        <span class="home-feature-preview__dots" aria-hidden="true"><i></i><i></i><i></i></span>
+                        <span class="home-feature-preview__path">gastown@yvr — sim --corridor</span>
+                        <span class="home-feature-preview__build">build 0.3.1</span>
+                    </div>
+                    <div class="home-feature-preview__shell-body">
+                        <p class="home-feature-preview__prompt pixel-font"><span class="home-feature-preview__sigil">$</span> ./walk --from=water-st<span class="home-feature-preview__caret" aria-hidden="true"></span></p>
+                        <p class="home-feature-preview__verdict home-feature-preview__verdict--ok"><?php echo esc_html( 'CORRIDOR LIVE' ); ?></p>
+                        <p class="home-feature-preview__verdict-sub"><?php echo esc_html( 'Civic tiles loaded. Steam clock ticking. Pigeons hostile.' ); ?></p>
+                        <p class="home-feature-preview__meta"><?php echo esc_html( 'Open data · arcade physics · mood engine' ); ?></p>
+                    </div>
+                </div>
+
+                <div class="home-feature-preview__readout" aria-hidden="true">
+                    <div class="home-feature-preview__cell home-feature-preview__cell--ok">
+                        <span class="home-feature-preview__value">12</span>
+                        <span class="home-feature-preview__stat-label pixel-font"><?php echo esc_html( 'STOPS' ); ?></span>
+                    </div>
+                    <div class="home-feature-preview__cell home-feature-preview__cell--warn">
+                        <span class="home-feature-preview__value">03</span>
+                        <span class="home-feature-preview__stat-label pixel-font"><?php echo esc_html( 'EVENTS' ); ?></span>
+                    </div>
+                    <div class="home-feature-preview__cell home-feature-preview__cell--dim">
+                        <span class="home-feature-preview__value">47</span>
+                        <span class="home-feature-preview__stat-label pixel-font"><?php echo esc_html( 'TILES' ); ?></span>
+                    </div>
+                    <div class="home-feature-preview__cell home-feature-preview__cell--dim">
+                        <span class="home-feature-preview__value">01</span>
+                        <span class="home-feature-preview__stat-label pixel-font"><?php echo esc_html( 'MOOD' ); ?></span>
+                    </div>
+                </div>
+            </div>
+
+            <a class="pixel-button home-feature-preview__cta" href="<?php echo esc_url( home_url( '/gastown-sim/' ) ); ?>"><?php echo esc_html( 'Walk Gastown' ); ?></a>
+        </article>
+
+        <article class="home-feature-preview home-feature-preview--static" aria-labelledby="home-preview-ppp-title">
+            <header class="home-feature-preview__head">
+                <p class="home-feature-preview__label pixel-font"><?php echo esc_html( 'hockey arcade' ); ?></p>
+                <h3 id="home-preview-ppp-title" class="home-feature-preview__title pixel-font"><?php echo esc_html( 'Pacific Power Play' ); ?></h3>
+                <p class="home-feature-preview__tagline"><?php echo esc_html( 'Rain city hockey cabinet. Pick your line, drop the puck, survive the static.' ); ?></p>
+            </header>
+
+            <div class="home-feature-preview__terminal">
+                <div class="home-feature-preview__scan" aria-hidden="true"></div>
+                <div class="home-feature-preview__shell">
+                    <div class="home-feature-preview__shell-bar pixel-font">
+                        <span class="home-feature-preview__dots" aria-hidden="true"><i></i><i></i><i></i></span>
+                        <span class="home-feature-preview__path">ppp@yvr — arcade --period=1</span>
+                        <span class="home-feature-preview__build">build 1.0.0</span>
+                    </div>
+                    <div class="home-feature-preview__shell-body">
+                        <p class="home-feature-preview__prompt pixel-font"><span class="home-feature-preview__sigil">$</span> ./drop-puck --line=second<span class="home-feature-preview__caret" aria-hidden="true"></span></p>
+                        <p class="home-feature-preview__verdict home-feature-preview__verdict--warn"><?php echo esc_html( 'PUCK DROPPED' ); ?></p>
+                        <p class="home-feature-preview__verdict-sub"><?php echo esc_html( 'Second line on ice. Rain on the glass. Crowd loud.' ); ?></p>
+                        <p class="home-feature-preview__meta"><?php echo esc_html( 'Browser cabinet · 2P local · rain FX' ); ?></p>
+                    </div>
+                </div>
+
+                <div class="home-feature-preview__readout" aria-hidden="true">
+                    <div class="home-feature-preview__cell home-feature-preview__cell--ok">
+                        <span class="home-feature-preview__value">02</span>
+                        <span class="home-feature-preview__stat-label pixel-font"><?php echo esc_html( 'GOALS' ); ?></span>
+                    </div>
+                    <div class="home-feature-preview__cell home-feature-preview__cell--warn">
+                        <span class="home-feature-preview__value">14</span>
+                        <span class="home-feature-preview__stat-label pixel-font"><?php echo esc_html( 'SHOTS' ); ?></span>
+                    </div>
+                    <div class="home-feature-preview__cell home-feature-preview__cell--down">
+                        <span class="home-feature-preview__value">01</span>
+                        <span class="home-feature-preview__stat-label pixel-font"><?php echo esc_html( 'PIM' ); ?></span>
+                    </div>
+                    <div class="home-feature-preview__cell home-feature-preview__cell--dim">
+                        <span class="home-feature-preview__value">P1</span>
+                        <span class="home-feature-preview__stat-label pixel-font"><?php echo esc_html( 'PERIOD' ); ?></span>
+                    </div>
+                </div>
+            </div>
+
+            <a class="pixel-button home-feature-preview__cta" href="<?php echo esc_url( home_url( '/pacific-power-play/' ) ); ?>"><?php echo esc_html( 'Play game' ); ?></a>
+        </article>
+    </div>
+</section>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Feature Builds** section to the homepage with compact terminal preview cards — the Lousy Outages shell from `/lousy-outages/`, scaled down for the home page.

- **Lousy Outages** — live terminal preview with verdict, stat readout, and sync line (polls the same `/lousy-outages/v1/summary` endpoint)
- **Gastown Simulator** and **Pacific Power Play** — static terminal previews in the same visual language

## Changes

- New `parts/home-feature-previews.php` partial and `assets/css/home-feature-previews.css`
- Radar/CRT scan overlay scoped to the terminal block only, smaller and subtler than the full board
- Extended `lousy-outages-teaser.js` to hydrate any `[data-lo-endpoint]` container (preview card + legacy teaser if present)
- Replaced the old expandable LO teaser panel with the new preview grid (hero signal strip still updates live)

## Placement

Section sits between the YVR radar hero and the mission select grid.

## Test plan

- [ ] Homepage loads with three feature preview cards
- [ ] LO card shows live verdict and stat counts
- [ ] LO card border glows red/yellow when providers are down/degraded
- [ ] Gastown and PPP cards show static terminal content
- [ ] Mobile: cards stack vertically, readout tiles wrap to 2 columns
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-423cb7f7-d68f-476c-840f-8402d19c791d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-423cb7f7-d68f-476c-840f-8402d19c791d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

