### PR TITLE
Ignore local resume files and uploads folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ test-results/
 
 # Local-only folders (never commit)
 .local-only/
+**/uploads/
+*Resume*.pdf
+*resume*.pdf
 /build/*.zip
 
 # Generated release binaries are shared as artifacts, not committed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds explicit `.gitignore` rules so personal resume PDFs and upload scratch files never get committed to the repo.

- `**/uploads/`
- `*Resume*.pdf` / `*resume*.pdf`

The actual resume lives in `.local-only/resume/` (already ignored).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e6e4db7-50ea-4e6c-8be3-d50db3099f73?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e6e4db7-50ea-4e6c-8be3-d50db3099f73&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

