### PR TITLE
Sharpen homepage live signal console

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -43,6 +43,7 @@ jobs:
               - 'assets/css/shop-console.css'
               - 'assets/js/shop.js'
               - 'parts/**'
+              - 'assets/css/home-commercial-strip.css'
               - 'assets/css/home-hero-cabinet.css'
               - 'assets/css/home-yvr-radar-deck.css'
               - 'assets/audio/yvr/**'

--- a/assets/css/home-commercial-strip.css
+++ b/assets/css/home-commercial-strip.css
@@ -1,132 +1,248 @@
-/* Compact commercial strip — above radar, below mast */
+/* Homepage live-signal console — restrained sibling of the consulting panel. */
 
 .home-signal-strip {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 0.35rem 0.55rem;
-  width: 100%;
-  max-width: min(92vw, 900px);
+  --signal-green: #4ade80;
+  --signal-cyan: #58c7ff;
+  --signal-magenta: #df77ff;
+  --signal-yellow: #ffb300;
+  --signal-red: #ff6b6b;
+  --signal-text: #d7e8df;
+  --signal-muted: #8eaa9b;
+  --signal-border: rgba(94, 234, 160, 0.24);
+
+  width: min(92vw, 900px);
   margin: 0 auto;
-  padding: 0.45rem 0.65rem;
-  border: 2px solid rgba(87, 243, 255, 0.28);
-  border-radius: 8px;
-  background: rgba(2, 8, 18, 0.72);
-  font-size: clamp(0.38rem, 0.78vw, 0.48rem);
-  letter-spacing: 0.06em;
+  padding: 0.72rem 0.8rem 0.78rem;
+  border: 1px solid var(--signal-border);
+  border-left: 3px solid var(--signal-green);
+  border-radius: 6px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.01), transparent),
+    rgba(6, 13, 10, 0.9);
+  box-shadow: none;
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  color: var(--signal-text);
 }
 
 .home-signal-strip--warn,
-.home-signal-strip--degraded {
-  border-color: rgba(255, 179, 71, 0.45);
+.home-signal-strip--degraded,
+.home-signal-strip--advisory {
+  border-left-color: var(--signal-yellow);
 }
 
 .home-signal-strip--bad,
 .home-signal-strip--down {
-  border-color: rgba(255, 79, 79, 0.5);
+  border-left-color: var(--signal-red);
 }
 
-.home-signal-strip--hot {
-  border-color: rgba(255, 79, 79, 0.65);
-  box-shadow: 0 0 18px rgba(255, 79, 79, 0.15);
+.home-signal-strip__mast {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.48rem;
 }
 
-.home-signal-strip--hot.home-signal-strip--warn,
-.home-signal-strip--hot.home-signal-strip--degraded {
-  border-color: rgba(255, 179, 71, 0.65);
-  box-shadow: 0 0 16px rgba(255, 179, 71, 0.14);
+.home-signal-strip__eyebrow {
+  color: var(--signal-green);
+  font-size: clamp(0.38rem, 0.72vw, 0.46rem);
+  letter-spacing: 0.08em;
 }
 
-.home-signal-strip--hot .home-signal-strip__label {
-  color: #ff6b6b;
-  text-shadow: 0 0 8px rgba(255, 107, 107, 0.45);
+.home-signal-strip--warn .home-signal-strip__eyebrow,
+.home-signal-strip--degraded .home-signal-strip__eyebrow,
+.home-signal-strip--advisory .home-signal-strip__eyebrow {
+  color: var(--signal-yellow);
 }
 
-.home-signal-strip--hot.home-signal-strip--warn .home-signal-strip__label,
-.home-signal-strip--hot.home-signal-strip--degraded .home-signal-strip__label {
-  color: #ffb347;
-  text-shadow: 0 0 8px rgba(255, 179, 71, 0.4);
+.home-signal-strip--bad .home-signal-strip__eyebrow,
+.home-signal-strip--down .home-signal-strip__eyebrow {
+  color: var(--signal-red);
 }
 
-.home-signal-strip__product {
+.home-signal-strip__state {
+  color: #6f8f7e;
+  font-size: clamp(0.64rem, 1vw, 0.74rem);
+  letter-spacing: 0.03em;
+  text-transform: lowercase;
+}
+
+.home-signal-strip__primary {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.65rem;
+  min-width: 0;
+  padding: 0.58rem 0.66rem;
+  border: 1px solid rgba(94, 234, 160, 0.12);
+  background: rgba(0, 0, 0, 0.28);
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.16s ease, background 0.16s ease;
+}
+
+.home-signal-strip__primary:hover,
+.home-signal-strip__primary:focus-visible {
+  border-color: rgba(88, 199, 255, 0.34);
+  background: rgba(5, 14, 11, 0.98);
+  outline: none;
+}
+
+.home-signal-strip__prompt {
+  color: var(--signal-green);
+  font-size: 1rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.home-signal-strip--warn .home-signal-strip__prompt,
+.home-signal-strip--degraded .home-signal-strip__prompt,
+.home-signal-strip--advisory .home-signal-strip__prompt {
+  color: var(--signal-yellow);
+}
+
+.home-signal-strip--bad .home-signal-strip__prompt,
+.home-signal-strip--down .home-signal-strip__prompt {
+  color: var(--signal-red);
+}
+
+.home-signal-strip__primary-copy {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.22rem 0.55rem;
+  min-width: 0;
+}
+
+.home-signal-strip__label {
+  color: #f1f7f4;
+  font-size: clamp(0.78rem, 1.35vw, 0.95rem);
+  font-weight: 800;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+}
+
+.home-signal-strip__verdict {
+  min-width: 0;
+  color: #a9c1b5;
+  font-size: clamp(0.72rem, 1.18vw, 0.86rem);
+  line-height: 1.35;
+  text-transform: none;
+}
+
+.home-signal-strip__metrics {
   display: inline-flex;
   align-items: center;
+  gap: 0.3rem;
   flex-wrap: wrap;
-  gap: 0.28rem 0.4rem;
+  justify-content: flex-end;
+}
+
+.home-signal-strip__badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.35rem;
+  padding: 0.14rem 0.38rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 3px;
+  font-size: clamp(0.6rem, 0.95vw, 0.7rem);
+  font-weight: 800;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+
+.home-signal-strip__badge--down {
+  border-color: rgba(255, 107, 107, 0.28);
+  background: rgba(255, 107, 107, 0.08);
+  color: var(--signal-red);
+}
+
+.home-signal-strip__badge--degraded {
+  border-color: rgba(255, 179, 0, 0.28);
+  background: rgba(255, 179, 0, 0.08);
+  color: var(--signal-yellow);
+}
+
+.home-signal-strip__action {
+  color: #74d9c4;
+  font-size: clamp(0.62rem, 0.95vw, 0.72rem);
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.home-signal-strip__primary:hover .home-signal-strip__action,
+.home-signal-strip__primary:focus-visible .home-signal-strip__action {
+  color: var(--signal-cyan);
+}
+
+.home-signal-strip__utility {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
+  align-items: stretch;
+  margin-top: 0.5rem;
+  border-top: 1px dashed rgba(94, 234, 160, 0.12);
+}
+
+.home-signal-strip__utility-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.12rem;
+  min-width: 0;
+  padding: 0.48rem 0.58rem 0.12rem 0;
   color: inherit;
   text-decoration: none;
 }
 
-.home-signal-strip__product:hover,
-.home-signal-strip__product:focus-visible {
-  color: #57f3ff;
+.home-signal-strip__utility-item + .home-signal-strip__utility-item {
+  padding-left: 0.58rem;
+  border-left: 1px solid rgba(94, 234, 160, 0.08);
 }
 
-.home-signal-strip__label {
-  color: #ffe66d;
-  letter-spacing: 0.08em;
-  text-transform: lowercase;
+.home-signal-strip__utility-item[href]:hover .home-signal-strip__utility-key,
+.home-signal-strip__utility-item[href]:focus-visible .home-signal-strip__utility-key {
+  color: var(--signal-cyan);
 }
 
-.home-signal-strip__verdict {
-  color: rgba(210, 240, 230, 0.88);
-  font-family: "IBM Plex Mono", "Courier New", monospace;
-  text-transform: lowercase;
+.home-signal-strip__utility-key {
+  color: #7fd8b1;
+  font-size: clamp(0.58rem, 0.92vw, 0.68rem);
+  font-weight: 800;
+  letter-spacing: 0.07em;
 }
 
-.home-signal-strip__badge {
-  padding: 0.12rem 0.35rem;
-  border-radius: 3px;
-  background: rgba(255, 79, 79, 0.18);
-  color: #ff6b6b;
-  letter-spacing: 0.06em;
-  text-transform: lowercase;
+.home-signal-strip__utility-value {
+  overflow: hidden;
+  color: #789487;
+  font-size: clamp(0.62rem, 0.95vw, 0.72rem);
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.home-signal-strip--warn .home-signal-strip__badge,
-.home-signal-strip--degraded .home-signal-strip__badge {
-  background: rgba(255, 179, 71, 0.18);
-  color: #ffb347;
-}
-
-.home-signal-strip__link {
-  color: rgba(180, 230, 220, 0.85);
-  text-decoration: none;
-  text-transform: lowercase;
-}
-
-.home-signal-strip__link:hover,
-.home-signal-strip__link:focus-visible {
-  color: #39ff14;
-}
-
-.home-signal-strip__pipe {
-  color: rgba(120, 160, 150, 0.45);
-}
-
-.home-signal-strip__future {
-  color: rgba(150, 190, 180, 0.62);
-  text-transform: lowercase;
+.home-signal-strip__utility-item--future .home-signal-strip__utility-key {
+  color: #997db2;
 }
 
 .home-signal-strip__contact {
-  margin-left: auto;
-  padding: 0.22rem 0.45rem;
-  border: 2px solid rgba(57, 255, 20, 0.45);
-  border-radius: 4px;
-  background: rgba(57, 255, 20, 0.1);
-  color: #39ff14;
-  font-family: "Press Start 2P", monospace;
-  font-size: clamp(0.34rem, 0.72vw, 0.42rem);
-  letter-spacing: 0.06em;
-  text-transform: lowercase;
+  align-self: center;
+  margin: 0.35rem 0 0.05rem 0.65rem;
+  padding: 0.48rem 0.62rem;
+  border: 1px solid rgba(74, 222, 128, 0.48);
+  border-radius: 2px;
+  background: rgba(7, 15, 12, 0.76);
+  color: var(--signal-green);
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  font-size: clamp(0.62rem, 0.95vw, 0.72rem);
+  font-weight: 800;
+  letter-spacing: 0.04em;
   cursor: pointer;
 }
 
 .home-signal-strip__contact:hover,
 .home-signal-strip__contact:focus-visible {
-  background: rgba(57, 255, 20, 0.2);
+  background: var(--signal-green);
+  color: #041008;
+  outline: none;
 }
 
 .home-mission-card--featured {
@@ -138,23 +254,77 @@
   color: #ffb347;
 }
 
-@media (max-width: 720px) {
-  .home-signal-strip {
-    flex-direction: column;
-    align-items: stretch;
-    text-align: center;
+@media (max-width: 860px) {
+  .home-signal-strip__primary {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+  }
+
+  .home-signal-strip__action {
+    grid-column: 2 / -1;
+    justify-self: start;
+  }
+
+  .home-signal-strip__utility {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .home-signal-strip__utility-item:nth-child(3) {
+    padding-left: 0;
+    border-left: 0;
   }
 
   .home-signal-strip__contact {
-    margin-left: 0;
+    margin-left: 0.58rem;
+  }
+}
+
+@media (max-width: 620px) {
+  .home-signal-strip {
+    width: calc(100% - 1rem);
+    padding: 0.65rem;
+  }
+
+  .home-signal-strip__mast {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+
+  .home-signal-strip__primary {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .home-signal-strip__metrics,
+  .home-signal-strip__action {
+    grid-column: 2;
+    justify-content: flex-start;
+  }
+
+  .home-signal-strip__primary-copy {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  .home-signal-strip__utility {
+    grid-template-columns: 1fr;
+  }
+
+  .home-signal-strip__utility-item,
+  .home-signal-strip__utility-item + .home-signal-strip__utility-item,
+  .home-signal-strip__utility-item:nth-child(3) {
+    padding: 0.42rem 0;
+    border-left: 0;
+    border-bottom: 1px solid rgba(94, 234, 160, 0.08);
+  }
+
+  .home-signal-strip__utility-value {
+    white-space: normal;
+  }
+
+  .home-signal-strip__contact {
     width: 100%;
-  }
-
-  .home-signal-strip__pipe {
-    display: none;
-  }
-
-  .home-signal-strip__future {
-    font-size: clamp(0.34rem, 0.72vw, 0.42rem);
+    margin: 0.5rem 0 0;
   }
 }

--- a/parts/home-commercial-strip.php
+++ b/parts/home-commercial-strip.php
@@ -10,29 +10,41 @@ $degraded   = (int) ( $counts['degraded'] ?? 0 );
 $highlight  = $down > 0 || $degraded > 0 || in_array( $tone, [ 'down', 'warn', 'advisory', 'degraded', 'bad' ], true );
 ?>
 <nav class="home-signal-strip home-signal-strip--<?php echo esc_attr( $tone ); ?><?php echo $highlight ? ' home-signal-strip--hot' : ''; ?>" aria-label="<?php echo esc_attr( 'Products and live signals' ); ?>">
-    <a class="home-signal-strip__product home-signal-strip__product--lo" href="<?php echo esc_url( $lo_url ); ?>">
-        <span class="home-signal-strip__label pixel-font"><?php echo esc_html( 'lousy outages' ); ?></span>
-        <span class="home-signal-strip__verdict" data-signal-lo-verdict><?php echo esc_html( $verdict ); ?></span>
-        <?php if ( $down > 0 || $degraded > 0 ) : ?>
-            <span class="home-signal-strip__badge pixel-font">
-                <?php
-                if ( $down > 0 ) {
-                    echo esc_html( str_pad( (string) $down, 2, '0', STR_PAD_LEFT ) . ' down' );
-                } elseif ( $degraded > 0 ) {
-                    echo esc_html( str_pad( (string) $degraded, 2, '0', STR_PAD_LEFT ) . ' degraded' );
-                }
-                ?>
-            </span>
-        <?php endif; ?>
+    <div class="home-signal-strip__mast">
+        <span class="home-signal-strip__eyebrow pixel-font"><?php echo esc_html( 'LIVE // SUZY OS' ); ?></span>
+        <span class="home-signal-strip__state"><?php echo esc_html( $highlight ? 'signal detected' : 'systems nominal' ); ?></span>
+    </div>
+
+    <a class="home-signal-strip__primary home-signal-strip__product--lo" href="<?php echo esc_url( $lo_url ); ?>">
+        <span class="home-signal-strip__prompt" aria-hidden="true">&gt;</span>
+        <span class="home-signal-strip__primary-copy">
+            <span class="home-signal-strip__label"><?php echo esc_html( 'Lousy Outages' ); ?></span>
+            <span class="home-signal-strip__verdict" data-signal-lo-verdict><?php echo esc_html( $verdict ); ?></span>
+        </span>
+        <span class="home-signal-strip__metrics" aria-label="<?php echo esc_attr( 'Current outage counts' ); ?>">
+            <?php if ( $down > 0 ) : ?>
+                <span class="home-signal-strip__badge home-signal-strip__badge--down"><?php echo esc_html( str_pad( (string) $down, 2, '0', STR_PAD_LEFT ) . ' down' ); ?></span>
+            <?php endif; ?>
+            <?php if ( $degraded > 0 ) : ?>
+                <span class="home-signal-strip__badge home-signal-strip__badge--degraded"><?php echo esc_html( str_pad( (string) $degraded, 2, '0', STR_PAD_LEFT ) . ' degraded' ); ?></span>
+            <?php endif; ?>
+        </span>
+        <span class="home-signal-strip__action"><?php echo esc_html( 'open status ↗' ); ?></span>
     </a>
-    <span class="home-signal-strip__pipe" aria-hidden="true">·</span>
-    <a class="home-signal-strip__link pixel-font" href="<?php echo esc_url( $pricing ); ?>"><?php echo esc_html( 'watchlists' ); ?></a>
-    <span class="home-signal-strip__pipe" aria-hidden="true">·</span>
-    <a class="home-signal-strip__product home-signal-strip__product--shop" href="<?php echo esc_url( home_url( '/shop/' ) ); ?>">
-        <span class="home-signal-strip__label pixel-font"><?php echo esc_html( 'hire suzy' ); ?></span>
-        <span class="home-signal-strip__verdict"><?php echo esc_html( 'debug · automate · deep dive' ); ?></span>
-    </a>
-    <span class="home-signal-strip__pipe" aria-hidden="true">·</span>
-    <span class="home-signal-strip__future pixel-font"><?php echo esc_html( 'yvr data layer — api + mcp soon' ); ?></span>
-    <button type="button" class="home-signal-strip__contact pixel-font" data-contact-trigger aria-haspopup="dialog" aria-controls="contact-suzy-modal"><?php echo esc_html( 'contact' ); ?></button>
+
+    <div class="home-signal-strip__utility">
+        <a class="home-signal-strip__utility-item" href="<?php echo esc_url( $pricing ); ?>">
+            <span class="home-signal-strip__utility-key"><?php echo esc_html( 'WATCHLISTS' ); ?></span>
+            <span class="home-signal-strip__utility-value"><?php echo esc_html( 'provider monitoring' ); ?></span>
+        </a>
+        <a class="home-signal-strip__utility-item" href="<?php echo esc_url( home_url( '/shop/' ) ); ?>">
+            <span class="home-signal-strip__utility-key"><?php echo esc_html( 'CONSULTING' ); ?></span>
+            <span class="home-signal-strip__utility-value"><?php echo esc_html( 'debug · automate · deep dive' ); ?></span>
+        </a>
+        <span class="home-signal-strip__utility-item home-signal-strip__utility-item--future">
+            <span class="home-signal-strip__utility-key"><?php echo esc_html( 'YVR DATA' ); ?></span>
+            <span class="home-signal-strip__utility-value"><?php echo esc_html( 'api + mcp soon' ); ?></span>
+        </span>
+        <button type="button" class="home-signal-strip__contact" data-contact-trigger aria-haspopup="dialog" aria-controls="contact-suzy-modal"><?php echo esc_html( 'CONTACT' ); ?></button>
+    </div>
 </nav>

--- a/scripts/deploy-lousy-outages-ssh.py
+++ b/scripts/deploy-lousy-outages-ssh.py
@@ -54,6 +54,7 @@ THEME_FILES = [
     "parts/shop-product-detail.php",
     "parts/lousy-outages-teaser.php",
     "parts/home-yvr-channel-buttons.php",
+    "assets/css/home-commercial-strip.css",
     "assets/css/shop.css",
     "assets/css/shop-console.css",
     "assets/js/shop.js",


### PR DESCRIPTION
## What changed

- Rebuilds the crowded homepage signal strip into the same restrained console language as the new consulting panel
- Gives Lousy Outages a clear primary status row with separate down/degraded badges and a clean `open status` action
- Moves Watchlists, Consulting, YVR Data and Contact into a compact utility row instead of one long neon sentence
- Uses thinner borders, darker surfaces, monospace hierarchy and much less glow
- Preserves the live `data-signal-lo-verdict` hook
- Adds `home-commercial-strip.css` to the production upload list and deploy trigger so future style edits actually ship

The goal is to make the area under the hero title feel like part of the same console system as `Need another brain on it?`, while keeping the live outage signal useful.