### PR TITLE
Replace homepage live-signal strip with Lousy Outages flyover

### DIFF
--- a/__tests__/lousy-outages-teaser.test.js
+++ b/__tests__/lousy-outages-teaser.test.js
@@ -193,3 +193,38 @@ test('init fetches summary endpoint', async () => {
   assert.match(urls[0], /\/summary/);
   assert.match(textOf(container), /01/);
 });
+
+test('flyoverCopy uses conservative outage language from teaser data', () => {
+  const { teaser } = load();
+  const clear = teaser.flyoverCopy({
+    tone: 'ok',
+    counts: { down: 0, degraded: 0, advisory: 0 },
+    lead: { kind: 'clear' }
+  });
+  assert.equal(clear.banner, 'LOUSY OUTAGES → monitoring provider signals');
+  assert.match(clear.report, /no major active incident summary available right now/);
+
+  const hot = teaser.flyoverCopy(sampleTeaser());
+  assert.match(hot.banner, /LOUSY OUTAGES → 1 degraded · 1 advisory · open status/);
+  assert.match(hot.report, /Cloudflare status page shows degraded service/);
+  assert.equal(hot.highlight, true);
+});
+
+test('renderFlyover updates homepage flyover module', () => {
+  const { teaser } = load();
+  const flyover = new El('aside');
+  flyover.setAttribute('class', 'home-lo-flyover home-lo-flyover--ok');
+  flyover.setAttribute('data-lo-flyover', '');
+  const banner = new El('span');
+  banner.setAttribute('data-lo-flyover-banner', '');
+  const report = new El('p');
+  report.setAttribute('data-lo-flyover-report', '');
+  const mast = new El('span');
+  mast.className = 'home-lo-flyover__mast-state';
+  flyover.append(banner, report, mast);
+  teaser.renderFlyover(flyover, sampleTeaser());
+  assert.match(banner.textContent, /open status/);
+  assert.match(report.textContent, /degraded service/);
+  assert.ok(flyover.classList.contains('home-lo-flyover--warn'));
+  assert.ok(flyover.classList.contains('home-lo-flyover--hot'));
+});

--- a/assets/css/home-commercial-strip.css
+++ b/assets/css/home-commercial-strip.css
@@ -1,75 +1,318 @@
-/* Homepage live-signal console — restrained sibling of the consulting panel. */
+/* Homepage Lousy Outages flyover — live transmission above the hero deck. */
 
-.home-signal-strip {
-  --signal-green: #4ade80;
-  --signal-cyan: #58c7ff;
-  --signal-magenta: #df77ff;
-  --signal-yellow: #ffb300;
-  --signal-red: #ff6b6b;
-  --signal-text: #d7e8df;
-  --signal-muted: #8eaa9b;
-  --signal-border: rgba(94, 234, 160, 0.24);
+.home-lo-flyover {
+  --fly-green: #4ade80;
+  --fly-cyan: #58c7ff;
+  --fly-magenta: #df77ff;
+  --fly-yellow: #ffb300;
+  --fly-red: #ff6b6b;
+  --fly-text: #d7e8df;
+  --fly-muted: #8eaa9b;
+  --fly-border: rgba(94, 234, 160, 0.24);
+  --fly-scene-h: clamp(5.5rem, 14vw, 7.5rem);
 
+  position: relative;
   width: min(92vw, 900px);
   margin: 0 auto;
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  color: var(--fly-text);
+}
+
+.home-lo-flyover__scene {
+  position: relative;
+  height: var(--fly-scene-h);
+  margin-bottom: 0.55rem;
+  overflow: hidden;
+  border: 1px solid var(--fly-border);
+  border-radius: 8px 8px 2px 2px;
+  background:
+    radial-gradient(ellipse 120% 80% at 50% 110%, rgba(88, 199, 255, 0.08), transparent 55%),
+    radial-gradient(circle at 18% 22%, rgba(223, 119, 255, 0.06), transparent 38%),
+    linear-gradient(180deg, #03060d 0%, #050b14 42%, #020408 100%);
+  box-shadow:
+    inset 0 0 32px rgba(0, 0, 0, 0.55),
+    inset 0 -18px 28px rgba(88, 199, 255, 0.04);
+}
+
+.home-lo-flyover__sky {
+  position: absolute;
+  inset: 0;
+}
+
+.home-lo-flyover__star,
+.home-lo-flyover__signal {
+  position: absolute;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.55;
+}
+
+.home-lo-flyover__star {
+  width: 2px;
+  height: 2px;
+  color: #c8e8ff;
+  animation: homeLoFlyStarTwinkle 4.8s ease-in-out infinite;
+}
+
+.home-lo-flyover__star--1 { top: 14%; left: 12%; animation-delay: 0s; }
+.home-lo-flyover__star--2 { top: 22%; left: 34%; animation-delay: 0.8s; opacity: 0.35; }
+.home-lo-flyover__star--3 { top: 10%; left: 58%; animation-delay: 1.4s; }
+.home-lo-flyover__star--4 { top: 28%; left: 76%; animation-delay: 2.1s; opacity: 0.4; }
+.home-lo-flyover__star--5 { top: 18%; left: 88%; animation-delay: 0.3s; }
+
+.home-lo-flyover__signal {
+  width: 3px;
+  height: 3px;
+  color: var(--fly-green);
+  box-shadow: 0 0 6px rgba(74, 222, 128, 0.55);
+  animation: homeLoFlySignalPulse 2.6s ease-in-out infinite;
+}
+
+.home-lo-flyover__signal--1 { top: 36%; left: 22%; animation-delay: 0.2s; }
+.home-lo-flyover__signal--2 { top: 44%; left: 48%; animation-delay: 1.1s; opacity: 0.7; }
+.home-lo-flyover__signal--3 { top: 32%; left: 71%; animation-delay: 1.8s; }
+
+.home-lo-flyover--hot .home-lo-flyover__signal {
+  color: var(--fly-yellow);
+  box-shadow: 0 0 8px rgba(255, 179, 0, 0.5);
+}
+
+.home-lo-flyover--down .home-lo-flyover__signal,
+.home-lo-flyover--bad .home-lo-flyover__signal {
+  color: var(--fly-red);
+  box-shadow: 0 0 8px rgba(255, 107, 107, 0.45);
+}
+
+.home-lo-flyover__horizon {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 42%;
+}
+
+.home-lo-flyover__mountains {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 100%;
+  background:
+    linear-gradient(165deg, transparent 42%, rgba(8, 18, 28, 0.92) 42%),
+    linear-gradient(148deg, transparent 52%, rgba(12, 24, 36, 0.88) 52%),
+    linear-gradient(172deg, transparent 36%, rgba(6, 14, 22, 0.95) 36%);
+  opacity: 0.9;
+}
+
+.home-lo-flyover__skyline {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 58%;
+  background:
+    linear-gradient(90deg,
+      transparent 0%,
+      rgba(88, 199, 255, 0.12) 18%,
+      rgba(88, 199, 255, 0.22) 22%,
+      rgba(88, 199, 255, 0.08) 24%,
+      transparent 28%,
+      rgba(223, 119, 255, 0.1) 42%,
+      rgba(223, 119, 255, 0.18) 44%,
+      transparent 48%,
+      rgba(88, 199, 255, 0.14) 62%,
+      rgba(88, 199, 255, 0.24) 65%,
+      transparent 70%,
+      rgba(74, 222, 128, 0.1) 84%,
+      rgba(74, 222, 128, 0.16) 86%,
+      transparent 92%
+    );
+  mask-image: linear-gradient(180deg, transparent 0%, #000 72%);
+  opacity: 0.75;
+}
+
+.home-lo-flyover__track {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.home-lo-flyover__craft {
+  position: absolute;
+  top: 28%;
+  left: -18%;
+  display: flex;
+  align-items: flex-start;
+  gap: 0;
+  width: max-content;
+  color: inherit;
+  text-decoration: none;
+  pointer-events: auto;
+  animation: homeLoFlyPass 18s linear infinite;
+  will-change: transform, left;
+}
+
+.home-lo-flyover__plane {
+  position: relative;
+  flex: 0 0 auto;
+  width: 22px;
+  height: 14px;
+  margin-top: 2px;
+  filter: drop-shadow(0 0 4px rgba(88, 199, 255, 0.35));
+}
+
+.home-lo-flyover__plane-body,
+.home-lo-flyover__plane-wing,
+.home-lo-flyover__plane-tail,
+.home-lo-flyover__plane-prop {
+  position: absolute;
+  background: #e8f4ff;
+  image-rendering: pixelated;
+}
+
+.home-lo-flyover__plane-body {
+  top: 5px;
+  left: 6px;
+  width: 12px;
+  height: 4px;
+  background: #d7ecff;
+  box-shadow:
+    1px 0 0 #8ec8ff,
+    2px 0 0 #8ec8ff,
+    3px 0 0 #8ec8ff;
+}
+
+.home-lo-flyover__plane-wing {
+  top: 7px;
+  left: 9px;
+  width: 8px;
+  height: 2px;
+  background: #58c7ff;
+}
+
+.home-lo-flyover__plane-tail {
+  top: 4px;
+  left: 4px;
+  width: 3px;
+  height: 3px;
+  background: #9ed8ff;
+}
+
+.home-lo-flyover__plane-prop {
+  top: 5px;
+  left: 18px;
+  width: 2px;
+  height: 4px;
+  background: #fff;
+  animation: homeLoFlyProp 0.18s steps(2) infinite;
+}
+
+.home-lo-flyover__tether {
+  align-self: center;
+  width: 14px;
+  height: 1px;
+  margin-top: 8px;
+  background: linear-gradient(90deg, rgba(88, 199, 255, 0.15), rgba(88, 199, 255, 0.55));
+}
+
+.home-lo-flyover__banner-skin {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.65rem;
+  max-width: min(58vw, 26rem);
+  padding: 0.28rem 0.55rem;
+  border: 1px solid rgba(88, 199, 255, 0.28);
+  border-radius: 2px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04), transparent),
+    rgba(4, 12, 18, 0.88);
+  box-shadow:
+    0 0 12px rgba(88, 199, 255, 0.12),
+    inset 0 0 0 1px rgba(74, 222, 128, 0.08);
+}
+
+.home-lo-flyover__banner-text {
+  overflow: hidden;
+  color: #f1f7f4;
+  font-size: clamp(0.58rem, 1.05vw, 0.72rem);
+  font-weight: 800;
+  letter-spacing: 0.03em;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.home-lo-flyover--hot .home-lo-flyover__banner-skin {
+  border-color: rgba(255, 179, 0, 0.35);
+  box-shadow:
+    0 0 14px rgba(255, 179, 0, 0.14),
+    inset 0 0 0 1px rgba(255, 107, 107, 0.08);
+}
+
+.home-lo-flyover--down .home-lo-flyover__banner-skin,
+.home-lo-flyover--bad .home-lo-flyover__banner-skin {
+  border-color: rgba(255, 107, 107, 0.38);
+  box-shadow: 0 0 16px rgba(255, 107, 107, 0.16);
+}
+
+.home-lo-flyover__panel {
   padding: 0.72rem 0.8rem 0.78rem;
-  border: 1px solid var(--signal-border);
-  border-left: 3px solid var(--signal-green);
+  border: 1px solid var(--fly-border);
+  border-left: 3px solid var(--fly-green);
   border-radius: 6px;
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.01), transparent),
     rgba(6, 13, 10, 0.9);
-  box-shadow: none;
-  font-family: "IBM Plex Mono", "Courier New", monospace;
-  color: var(--signal-text);
 }
 
-.home-signal-strip--warn,
-.home-signal-strip--degraded,
-.home-signal-strip--advisory {
-  border-left-color: var(--signal-yellow);
+.home-lo-flyover--warn .home-lo-flyover__panel,
+.home-lo-flyover--degraded .home-lo-flyover__panel,
+.home-lo-flyover--advisory .home-lo-flyover__panel {
+  border-left-color: var(--fly-yellow);
 }
 
-.home-signal-strip--bad,
-.home-signal-strip--down {
-  border-left-color: var(--signal-red);
+.home-lo-flyover--down .home-lo-flyover__panel,
+.home-lo-flyover--bad .home-lo-flyover__panel {
+  border-left-color: var(--fly-red);
 }
 
-.home-signal-strip__mast {
+.home-lo-flyover__mast {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
-  margin-bottom: 0.48rem;
+  margin: 0 0 0.48rem;
 }
 
-.home-signal-strip__eyebrow {
-  color: var(--signal-green);
+.home-lo-flyover__mast-label {
+  color: var(--fly-green);
   font-size: clamp(0.38rem, 0.72vw, 0.46rem);
   letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
-.home-signal-strip--warn .home-signal-strip__eyebrow,
-.home-signal-strip--degraded .home-signal-strip__eyebrow,
-.home-signal-strip--advisory .home-signal-strip__eyebrow {
-  color: var(--signal-yellow);
+.home-lo-flyover--warn .home-lo-flyover__mast-label,
+.home-lo-flyover--degraded .home-lo-flyover__mast-label,
+.home-lo-flyover--advisory .home-lo-flyover__mast-label {
+  color: var(--fly-yellow);
 }
 
-.home-signal-strip--bad .home-signal-strip__eyebrow,
-.home-signal-strip--down .home-signal-strip__eyebrow {
-  color: var(--signal-red);
+.home-lo-flyover--down .home-lo-flyover__mast-label,
+.home-lo-flyover--bad .home-lo-flyover__mast-label {
+  color: var(--fly-red);
 }
 
-.home-signal-strip__state {
+.home-lo-flyover__mast-state {
   color: #6f8f7e;
+  font-family: "IBM Plex Mono", "Courier New", monospace;
   font-size: clamp(0.64rem, 1vw, 0.74rem);
   letter-spacing: 0.03em;
   text-transform: lowercase;
 }
 
-.home-signal-strip__primary {
+.home-lo-flyover__primary {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
   gap: 0.65rem;
   min-width: 0;
@@ -81,250 +324,191 @@
   transition: border-color 0.16s ease, background 0.16s ease;
 }
 
-.home-signal-strip__primary:hover,
-.home-signal-strip__primary:focus-visible {
+.home-lo-flyover__primary:hover,
+.home-lo-flyover__primary:focus-visible {
   border-color: rgba(88, 199, 255, 0.34);
   background: rgba(5, 14, 11, 0.98);
   outline: none;
 }
 
-.home-signal-strip__prompt {
-  color: var(--signal-green);
+.home-lo-flyover__prompt {
+  color: var(--fly-green);
   font-size: 1rem;
   font-weight: 800;
   line-height: 1;
 }
 
-.home-signal-strip--warn .home-signal-strip__prompt,
-.home-signal-strip--degraded .home-signal-strip__prompt,
-.home-signal-strip--advisory .home-signal-strip__prompt {
-  color: var(--signal-yellow);
+.home-lo-flyover--warn .home-lo-flyover__prompt,
+.home-lo-flyover--degraded .home-lo-flyover__prompt,
+.home-lo-flyover--advisory .home-lo-flyover__prompt {
+  color: var(--fly-yellow);
 }
 
-.home-signal-strip--bad .home-signal-strip__prompt,
-.home-signal-strip--down .home-signal-strip__prompt {
-  color: var(--signal-red);
+.home-lo-flyover--down .home-lo-flyover__prompt,
+.home-lo-flyover--bad .home-lo-flyover__prompt {
+  color: var(--fly-red);
 }
 
-.home-signal-strip__primary-copy {
-  display: flex;
-  align-items: baseline;
-  flex-wrap: wrap;
-  gap: 0.22rem 0.55rem;
+.home-lo-flyover__banner-line {
+  display: block;
   min-width: 0;
-}
-
-.home-signal-strip__label {
   color: #f1f7f4;
-  font-size: clamp(0.78rem, 1.35vw, 0.95rem);
+  font-size: clamp(0.74rem, 1.28vw, 0.92rem);
   font-weight: 800;
-  letter-spacing: 0.01em;
-  white-space: nowrap;
-}
-
-.home-signal-strip__verdict {
-  min-width: 0;
-  color: #a9c1b5;
-  font-size: clamp(0.72rem, 1.18vw, 0.86rem);
+  letter-spacing: 0.02em;
   line-height: 1.35;
-  text-transform: none;
 }
 
-.home-signal-strip__metrics {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-}
-
-.home-signal-strip__badge {
-  display: inline-flex;
-  align-items: center;
-  min-height: 1.35rem;
-  padding: 0.14rem 0.38rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 3px;
-  font-size: clamp(0.6rem, 0.95vw, 0.7rem);
-  font-weight: 800;
-  letter-spacing: 0.03em;
-  white-space: nowrap;
-}
-
-.home-signal-strip__badge--down {
-  border-color: rgba(255, 107, 107, 0.28);
-  background: rgba(255, 107, 107, 0.08);
-  color: var(--signal-red);
-}
-
-.home-signal-strip__badge--degraded {
-  border-color: rgba(255, 179, 0, 0.28);
-  background: rgba(255, 179, 0, 0.08);
-  color: var(--signal-yellow);
-}
-
-.home-signal-strip__action {
+.home-lo-flyover__cta {
   color: #74d9c4;
   font-size: clamp(0.62rem, 0.95vw, 0.72rem);
   font-weight: 700;
   white-space: nowrap;
 }
 
-.home-signal-strip__primary:hover .home-signal-strip__action,
-.home-signal-strip__primary:focus-visible .home-signal-strip__action {
-  color: var(--signal-cyan);
+.home-lo-flyover__primary:hover .home-lo-flyover__cta,
+.home-lo-flyover__primary:focus-visible .home-lo-flyover__cta {
+  color: var(--fly-cyan);
 }
 
-.home-signal-strip__utility {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
-  align-items: stretch;
-  margin-top: 0.5rem;
-  border-top: 1px dashed rgba(94, 234, 160, 0.12);
+.home-lo-flyover__report {
+  margin: 0.45rem 0 0;
+  padding-left: 1.35rem;
+  color: #a9c1b5;
+  font-size: clamp(0.68rem, 1.05vw, 0.8rem);
+  line-height: 1.4;
 }
 
-.home-signal-strip__utility-item {
-  display: flex;
-  flex-direction: column;
-  gap: 0.12rem;
-  min-width: 0;
-  padding: 0.48rem 0.58rem 0.12rem 0;
-  color: inherit;
+.home-lo-flyover__secondary {
+  display: inline-block;
+  margin: 0.35rem 0 0 1.35rem;
+  color: #74d9c4;
+  font-size: clamp(0.6rem, 0.92vw, 0.7rem);
+  font-weight: 700;
   text-decoration: none;
 }
 
-.home-signal-strip__utility-item + .home-signal-strip__utility-item {
-  padding-left: 0.58rem;
-  border-left: 1px solid rgba(94, 234, 160, 0.08);
-}
-
-.home-signal-strip__utility-item[href]:hover .home-signal-strip__utility-key,
-.home-signal-strip__utility-item[href]:focus-visible .home-signal-strip__utility-key {
-  color: var(--signal-cyan);
-}
-
-.home-signal-strip__utility-key {
-  color: #7fd8b1;
-  font-size: clamp(0.58rem, 0.92vw, 0.68rem);
-  font-weight: 800;
-  letter-spacing: 0.07em;
-}
-
-.home-signal-strip__utility-value {
-  overflow: hidden;
-  color: #789487;
-  font-size: clamp(0.62rem, 0.95vw, 0.72rem);
-  line-height: 1.35;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.home-signal-strip__utility-item--future .home-signal-strip__utility-key {
-  color: #997db2;
-}
-
-.home-signal-strip__contact {
-  align-self: center;
-  margin: 0.35rem 0 0.05rem 0.65rem;
-  padding: 0.48rem 0.62rem;
-  border: 1px solid rgba(74, 222, 128, 0.48);
-  border-radius: 2px;
-  background: rgba(7, 15, 12, 0.76);
-  color: var(--signal-green);
-  font-family: "IBM Plex Mono", "Courier New", monospace;
-  font-size: clamp(0.62rem, 0.95vw, 0.72rem);
-  font-weight: 800;
-  letter-spacing: 0.04em;
-  cursor: pointer;
-}
-
-.home-signal-strip__contact:hover,
-.home-signal-strip__contact:focus-visible {
-  background: var(--signal-green);
-  color: #041008;
+.home-lo-flyover__secondary:hover,
+.home-lo-flyover__secondary:focus-visible {
+  color: var(--fly-cyan);
   outline: none;
 }
 
-.home-mission-card--featured {
-  border-color: rgba(255, 179, 71, 0.65);
-  box-shadow: 0 0 20px rgba(255, 179, 71, 0.12);
+@keyframes homeLoFlyPass {
+  0% {
+    left: -18%;
+    transform: translateY(0);
+  }
+  12% {
+    transform: translateY(-3px);
+  }
+  28% {
+    transform: translateY(2px);
+  }
+  50% {
+    left: 108%;
+    transform: translateY(-2px);
+  }
+  50.01% {
+    left: -18%;
+    transform: translateY(0);
+  }
+  100% {
+    left: -18%;
+    transform: translateY(0);
+  }
 }
 
-.home-mission-card--featured .home-mission-card__label {
-  color: #ffb347;
+@keyframes homeLoFlyProp {
+  0% { opacity: 1; transform: scaleX(1); }
+  50% { opacity: 0.35; transform: scaleX(0.4); }
+  100% { opacity: 1; transform: scaleX(1); }
 }
 
-@media (max-width: 860px) {
-  .home-signal-strip__primary {
-    grid-template-columns: auto minmax(0, 1fr) auto;
+@keyframes homeLoFlyStarTwinkle {
+  0%, 100% { opacity: 0.25; }
+  50% { opacity: 0.75; }
+}
+
+@keyframes homeLoFlySignalPulse {
+  0%, 100% { transform: scale(1); opacity: 0.45; }
+  50% { transform: scale(1.35); opacity: 0.95; }
+}
+
+@media (max-width: 720px) {
+  .home-lo-flyover {
+    --fly-scene-h: 4.25rem;
   }
 
-  .home-signal-strip__action {
-    grid-column: 2 / -1;
+  .home-lo-flyover__scene {
+    margin-bottom: 0.42rem;
+  }
+
+  .home-lo-flyover__craft {
+    top: 24%;
+    animation-duration: 22s;
+  }
+
+  .home-lo-flyover__banner-skin {
+    max-width: min(70vw, 18rem);
+    padding: 0.22rem 0.42rem;
+  }
+
+  .home-lo-flyover__banner-text {
+    font-size: 0.56rem;
+  }
+
+  .home-lo-flyover__primary {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .home-lo-flyover__cta {
+    grid-column: 2;
     justify-self: start;
   }
 
-  .home-signal-strip__utility {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .home-signal-strip__utility-item:nth-child(3) {
+  .home-lo-flyover__report,
+  .home-lo-flyover__secondary {
     padding-left: 0;
-    border-left: 0;
-  }
-
-  .home-signal-strip__contact {
-    margin-left: 0.58rem;
+    margin-left: 0;
   }
 }
 
-@media (max-width: 620px) {
-  .home-signal-strip {
-    width: calc(100% - 1rem);
-    padding: 0.65rem;
+@media (max-width: 520px) {
+  .home-lo-flyover__scene {
+    display: none;
   }
 
-  .home-signal-strip__mast {
-    align-items: flex-start;
-    flex-direction: column;
-    gap: 0.2rem;
+  .home-lo-flyover__panel {
+    position: relative;
+    overflow: hidden;
   }
 
-  .home-signal-strip__primary {
-    grid-template-columns: auto minmax(0, 1fr);
-    align-items: start;
+  .home-lo-flyover__panel::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background:
+      radial-gradient(circle at 82% 18%, rgba(88, 199, 255, 0.08), transparent 42%),
+      radial-gradient(circle at 12% 88%, rgba(74, 222, 128, 0.06), transparent 38%);
+    pointer-events: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-lo-flyover__craft,
+  .home-lo-flyover__plane-prop,
+  .home-lo-flyover__star,
+  .home-lo-flyover__signal {
+    animation: none !important;
   }
 
-  .home-signal-strip__metrics,
-  .home-signal-strip__action {
-    grid-column: 2;
-    justify-content: flex-start;
+  .home-lo-flyover__craft {
+    left: 50%;
+    transform: translateX(-50%);
   }
 
-  .home-signal-strip__primary-copy {
-    align-items: flex-start;
-    flex-direction: column;
-    gap: 0.15rem;
-  }
-
-  .home-signal-strip__utility {
-    grid-template-columns: 1fr;
-  }
-
-  .home-signal-strip__utility-item,
-  .home-signal-strip__utility-item + .home-signal-strip__utility-item,
-  .home-signal-strip__utility-item:nth-child(3) {
-    padding: 0.42rem 0;
-    border-left: 0;
-    border-bottom: 1px solid rgba(94, 234, 160, 0.08);
-  }
-
-  .home-signal-strip__utility-value {
-    white-space: normal;
-  }
-
-  .home-signal-strip__contact {
-    width: 100%;
-    margin: 0.5rem 0 0;
+  .home-lo-flyover__scene {
+    display: block;
   }
 }

--- a/assets/js/lousy-outages-teaser.js
+++ b/assets/js/lousy-outages-teaser.js
@@ -47,6 +47,79 @@
     }
   }
 
+  function flyoverCopy(teaser) {
+    var counts = teaser.counts || {};
+    var down = parseInt(counts.down, 10) || 0;
+    var degraded = parseInt(counts.degraded, 10) || 0;
+    var advisory = parseInt(counts.advisory, 10) || 0;
+    var lead = teaser.lead || {};
+    var kind = lead.kind || 'clear';
+    var provider = String(lead.provider || '').trim();
+    var tone = teaser.tone || 'ok';
+    var highlight = down > 0 || degraded > 0 || advisory > 0
+      || ['down', 'warn', 'advisory', 'degraded', 'bad', 'unknown'].indexOf(tone) !== -1
+      || ['down', 'warn', 'advisory', 'unknown'].indexOf(kind) !== -1;
+    var bannerParts = [];
+
+    if (down > 0) bannerParts.push(down + ' provider' + (down === 1 ? '' : 's') + ' down');
+    if (degraded > 0) bannerParts.push(degraded + ' degraded');
+    if (advisory > 0) bannerParts.push(advisory + ' advisory' + (advisory === 1 ? '' : 'ies'));
+
+    var banner = bannerParts.length
+      ? 'LOUSY OUTAGES → ' + bannerParts.join(' · ') + ' · open status'
+      : 'LOUSY OUTAGES → monitoring provider signals';
+
+    var report = 'latest report: no major active incident summary available right now';
+    if (highlight && kind !== 'clear') {
+      if (kind === 'down') {
+        report = provider
+          ? 'latest report: ' + provider + ' status page indicates service disruption'
+          : 'latest report: status page indicates service disruption';
+      } else if (kind === 'warn') {
+        report = provider
+          ? 'latest report: ' + provider + ' status page shows degraded service'
+          : 'latest report: provider status page shows degraded service';
+      } else if (kind === 'advisory') {
+        report = provider
+          ? 'latest report: ' + provider + ' open advisory still active'
+          : 'latest report: open advisory still active';
+      } else if (kind === 'unknown') {
+        report = provider
+          ? 'latest report: ' + provider + ' status could not be verified'
+          : 'latest report: status verification incomplete';
+      } else {
+        report = 'latest report: provider signals under watch';
+      }
+    }
+
+    return { banner: banner, report: report, tone: tone, highlight: highlight };
+  }
+
+  function updateFlyoverTone(flyover, tone, highlight) {
+    flyover.className = flyover.className
+      .replace(/home-lo-flyover--\w+/g, '')
+      .replace(/\bhome-lo-flyover--hot\b/g, '')
+      .trim();
+    flyover.classList.add('home-lo-flyover');
+    flyover.classList.add('home-lo-flyover--' + tone);
+    if (highlight) flyover.classList.add('home-lo-flyover--hot');
+  }
+
+  function renderFlyover(flyover, teaser) {
+    if (!flyover || !teaser) return;
+    var copy = flyoverCopy(teaser);
+    updateFlyoverTone(flyover, copy.tone, copy.highlight);
+    flyover.querySelectorAll('[data-lo-flyover-banner]').forEach(function (el) {
+      el.textContent = copy.banner;
+    });
+    var reportEl = flyover.querySelector('[data-lo-flyover-report]');
+    if (reportEl) reportEl.textContent = copy.report;
+    var primary = flyover.querySelector('.home-lo-flyover__primary');
+    if (primary) primary.setAttribute('aria-label', copy.banner + ' — view Lousy Outages status');
+    var mastState = flyover.querySelector('.home-lo-flyover__mast-state');
+    if (mastState) mastState.textContent = copy.highlight ? 'signal detected' : 'monitoring';
+  }
+
   function render(container, payload, config) {
     var teaser = payload && payload.teaser ? payload.teaser : null;
     if (!teaser) return;
@@ -114,6 +187,12 @@
       syncBits.push(padCount(counts.tracked) + ' tracked');
     }
     setText(container, '[data-lo-preview-sync]', syncBits.join(' · '));
+
+    if (typeof document !== 'undefined' && typeof document.querySelector === 'function') {
+      document.querySelectorAll('[data-lo-flyover]').forEach(function (flyover) {
+        renderFlyover(flyover, teaser);
+      });
+    }
 
     if (typeof document !== 'undefined' && typeof document.querySelector === 'function') {
       var signalVerdict = document.querySelector('[data-signal-lo-verdict]');
@@ -242,7 +321,12 @@
       url.searchParams.set('_lo_cache_bust', Date.now().toString());
       fetch(url.toString(), { cache: 'no-store', credentials: 'same-origin' })
         .then(function (r) { if (!r.ok) throw new Error('summary fetch failed'); return r.json(); })
-        .then(function (payload) { render(container, payload, config); })
+        .then(function (payload) {
+          render(container, payload, config);
+          if (container.hasAttribute('data-lo-flyover') && payload && payload.teaser) {
+            renderFlyover(container, payload.teaser);
+          }
+        })
         .catch(function () { markDelayed(container); })
         .finally(function () { inFlight = false; });
     };
@@ -252,9 +336,10 @@
     document.addEventListener('visibilitychange', function () { if (!document.hidden) refresh(); });
   }
 
-  window.LousyOutagesTeaser = { render, markDelayed, init };
+  window.LousyOutagesTeaser = { render, renderFlyover, flyoverCopy, markDelayed, init };
   document.addEventListener('DOMContentLoaded', function () {
     var containers = document.querySelectorAll('[data-lo-endpoint]');
     containers.forEach(init);
+    document.querySelectorAll('[data-lo-flyover][data-lo-endpoint]').forEach(init);
   });
 }());

--- a/functions.php
+++ b/functions.php
@@ -671,6 +671,75 @@ function get_lousy_outages_home_teaser_data(): array {
     ];
 }
 
+/**
+ * Conservative homepage flyover copy from Lousy Outages teaser data.
+ *
+ * @param array<string, mixed> $teaser
+ * @return array{banner: string, report: string, tone: string, highlight: bool}
+ */
+function se_home_lo_flyover_copy( array $teaser ): array {
+    $counts   = is_array( $teaser['counts'] ?? null ) ? $teaser['counts'] : [];
+    $down     = (int) ( $counts['down'] ?? 0 );
+    $degraded = (int) ( $counts['degraded'] ?? 0 );
+    $advisory = (int) ( $counts['advisory'] ?? 0 );
+    $lead     = is_array( $teaser['lead'] ?? null ) ? $teaser['lead'] : [];
+    $kind     = (string) ( $lead['kind'] ?? 'clear' );
+    $provider = trim( (string) ( $lead['provider'] ?? '' ) );
+    $tone     = sanitize_html_class( (string) ( $teaser['tone'] ?? 'ok' ) );
+
+    $highlight = $down > 0
+        || $degraded > 0
+        || $advisory > 0
+        || in_array( $tone, [ 'down', 'warn', 'advisory', 'degraded', 'bad', 'unknown' ], true )
+        || in_array( $kind, [ 'down', 'warn', 'advisory', 'unknown' ], true );
+
+    $banner_parts = [];
+    if ( $down > 0 ) {
+        $banner_parts[] = $down . ' provider' . ( 1 === $down ? '' : 's' ) . ' down';
+    }
+    if ( $degraded > 0 ) {
+        $banner_parts[] = $degraded . ' degraded';
+    }
+    if ( $advisory > 0 ) {
+        $banner_parts[] = $advisory . ' advisory' . ( 1 === $advisory ? '' : 'ies' );
+    }
+
+    if ( empty( $banner_parts ) ) {
+        $banner = 'LOUSY OUTAGES → monitoring provider signals';
+    } else {
+        $banner = 'LOUSY OUTAGES → ' . implode( ' · ', $banner_parts ) . ' · open status';
+    }
+
+    if ( ! $highlight || 'clear' === $kind ) {
+        $report = 'latest report: no major active incident summary available right now';
+    } elseif ( 'down' === $kind ) {
+        $report = '' !== $provider
+            ? "latest report: {$provider} status page indicates service disruption"
+            : 'latest report: status page indicates service disruption';
+    } elseif ( 'warn' === $kind ) {
+        $report = '' !== $provider
+            ? "latest report: {$provider} status page shows degraded service"
+            : 'latest report: provider status page shows degraded service';
+    } elseif ( 'advisory' === $kind ) {
+        $report = '' !== $provider
+            ? "latest report: {$provider} open advisory still active"
+            : 'latest report: open advisory still active';
+    } elseif ( 'unknown' === $kind ) {
+        $report = '' !== $provider
+            ? "latest report: {$provider} status could not be verified"
+            : 'latest report: status verification incomplete';
+    } else {
+        $report = 'latest report: provider signals under watch';
+    }
+
+    return [
+        'banner'    => $banner,
+        'report'    => $report,
+        'tone'      => $tone,
+        'highlight' => $highlight,
+    ];
+}
+
 function lousy_outages_home_format_incident_time( $value ): string {
     if ( empty( $value ) ) {
         return '';

--- a/parts/home-commercial-strip.php
+++ b/parts/home-commercial-strip.php
@@ -1,50 +1,78 @@
 <?php
-$teaser     = function_exists( 'get_lousy_outages_home_teaser_data' ) ? get_lousy_outages_home_teaser_data() : [];
-$lo_url     = home_url( '/lousy-outages/' );
-$pricing    = home_url( '/lousy-outages/pricing/' );
-$verdict    = (string) ( $teaser['verdict_line'] ?? 'Independent outage intel for AI + creative stacks' );
-$tone       = sanitize_html_class( (string) ( $teaser['tone'] ?? 'ok' ) );
-$counts     = is_array( $teaser['counts'] ?? null ) ? $teaser['counts'] : [];
-$down       = (int) ( $counts['down'] ?? 0 );
-$degraded   = (int) ( $counts['degraded'] ?? 0 );
-$highlight  = $down > 0 || $degraded > 0 || in_array( $tone, [ 'down', 'warn', 'advisory', 'degraded', 'bad' ], true );
+$teaser  = function_exists( 'get_lousy_outages_home_teaser_data' ) ? get_lousy_outages_home_teaser_data() : [];
+$lo_url  = (string) ( $teaser['dashboard_url'] ?? home_url( '/lousy-outages/' ) );
+$copy    = function_exists( 'se_home_lo_flyover_copy' ) ? se_home_lo_flyover_copy( $teaser ) : [
+    'banner'    => 'LOUSY OUTAGES → monitoring provider signals',
+    'report'    => 'latest report: no major active incident summary available right now',
+    'tone'      => 'ok',
+    'highlight' => false,
+];
+$tone      = sanitize_html_class( (string) ( $copy['tone'] ?? 'ok' ) );
+$highlight = ! empty( $copy['highlight'] );
+$banner    = (string) ( $copy['banner'] ?? 'LOUSY OUTAGES → monitoring provider signals' );
+$report    = (string) ( $copy['report'] ?? 'latest report: no major active incident summary available right now' );
 ?>
-<nav class="home-signal-strip home-signal-strip--<?php echo esc_attr( $tone ); ?><?php echo $highlight ? ' home-signal-strip--hot' : ''; ?>" aria-label="<?php echo esc_attr( 'Products and live signals' ); ?>">
-    <div class="home-signal-strip__mast">
-        <span class="home-signal-strip__eyebrow pixel-font"><?php echo esc_html( 'LIVE // SUZY OS' ); ?></span>
-        <span class="home-signal-strip__state"><?php echo esc_html( $highlight ? 'signal detected' : 'systems nominal' ); ?></span>
+<aside
+    class="home-lo-flyover home-lo-flyover--<?php echo esc_attr( $tone ); ?><?php echo $highlight ? ' home-lo-flyover--hot' : ''; ?>"
+    aria-label="<?php echo esc_attr( 'Lousy Outages live signal' ); ?>"
+    data-lo-flyover
+    data-lo-endpoint="<?php echo esc_url( rest_url( 'lousy-outages/v1/summary' ) ); ?>"
+    data-lo-dashboard-url="<?php echo esc_url( $lo_url ); ?>"
+>
+    <div class="home-lo-flyover__scene" aria-hidden="true">
+        <div class="home-lo-flyover__sky">
+            <span class="home-lo-flyover__star home-lo-flyover__star--1"></span>
+            <span class="home-lo-flyover__star home-lo-flyover__star--2"></span>
+            <span class="home-lo-flyover__star home-lo-flyover__star--3"></span>
+            <span class="home-lo-flyover__star home-lo-flyover__star--4"></span>
+            <span class="home-lo-flyover__star home-lo-flyover__star--5"></span>
+            <span class="home-lo-flyover__signal home-lo-flyover__signal--1"></span>
+            <span class="home-lo-flyover__signal home-lo-flyover__signal--2"></span>
+            <span class="home-lo-flyover__signal home-lo-flyover__signal--3"></span>
+            <div class="home-lo-flyover__horizon">
+                <div class="home-lo-flyover__mountains"></div>
+                <div class="home-lo-flyover__skyline"></div>
+            </div>
+        </div>
+
+        <div class="home-lo-flyover__track">
+            <a
+                class="home-lo-flyover__craft"
+                href="<?php echo esc_url( $lo_url ); ?>"
+                tabindex="-1"
+                aria-hidden="true"
+            >
+                <span class="home-lo-flyover__plane" aria-hidden="true">
+                    <span class="home-lo-flyover__plane-body"></span>
+                    <span class="home-lo-flyover__plane-wing"></span>
+                    <span class="home-lo-flyover__plane-tail"></span>
+                    <span class="home-lo-flyover__plane-prop"></span>
+                </span>
+                <span class="home-lo-flyover__tether" aria-hidden="true"></span>
+                <span class="home-lo-flyover__banner-skin">
+                    <span class="home-lo-flyover__banner-text" data-lo-flyover-banner><?php echo esc_html( $banner ); ?></span>
+                </span>
+            </a>
+        </div>
     </div>
 
-    <a class="home-signal-strip__primary home-signal-strip__product--lo" href="<?php echo esc_url( $lo_url ); ?>">
-        <span class="home-signal-strip__prompt" aria-hidden="true">&gt;</span>
-        <span class="home-signal-strip__primary-copy">
-            <span class="home-signal-strip__label"><?php echo esc_html( 'Lousy Outages' ); ?></span>
-            <span class="home-signal-strip__verdict" data-signal-lo-verdict><?php echo esc_html( $verdict ); ?></span>
-        </span>
-        <span class="home-signal-strip__metrics" aria-label="<?php echo esc_attr( 'Current outage counts' ); ?>">
-            <?php if ( $down > 0 ) : ?>
-                <span class="home-signal-strip__badge home-signal-strip__badge--down"><?php echo esc_html( str_pad( (string) $down, 2, '0', STR_PAD_LEFT ) . ' down' ); ?></span>
-            <?php endif; ?>
-            <?php if ( $degraded > 0 ) : ?>
-                <span class="home-signal-strip__badge home-signal-strip__badge--degraded"><?php echo esc_html( str_pad( (string) $degraded, 2, '0', STR_PAD_LEFT ) . ' degraded' ); ?></span>
-            <?php endif; ?>
-        </span>
-        <span class="home-signal-strip__action"><?php echo esc_html( 'open status ↗' ); ?></span>
-    </a>
-
-    <div class="home-signal-strip__utility">
-        <a class="home-signal-strip__utility-item" href="<?php echo esc_url( $pricing ); ?>">
-            <span class="home-signal-strip__utility-key"><?php echo esc_html( 'WATCHLISTS' ); ?></span>
-            <span class="home-signal-strip__utility-value"><?php echo esc_html( 'provider monitoring' ); ?></span>
+    <div class="home-lo-flyover__panel">
+        <p class="home-lo-flyover__mast pixel-font">
+            <span class="home-lo-flyover__mast-label"><?php echo esc_html( 'live transmission' ); ?></span>
+            <span class="home-lo-flyover__mast-state"><?php echo esc_html( $highlight ? 'signal detected' : 'monitoring' ); ?></span>
+        </p>
+        <a
+            class="home-lo-flyover__primary"
+            href="<?php echo esc_url( $lo_url ); ?>"
+            aria-label="<?php echo esc_attr( $banner . ' — view Lousy Outages status' ); ?>"
+        >
+            <span class="home-lo-flyover__prompt" aria-hidden="true">&gt;</span>
+            <span class="home-lo-flyover__primary-copy">
+                <span class="home-lo-flyover__banner-line" data-lo-flyover-banner><?php echo esc_html( $banner ); ?></span>
+            </span>
+            <span class="home-lo-flyover__cta"><?php echo esc_html( 'open status ↗' ); ?></span>
         </a>
-        <a class="home-signal-strip__utility-item" href="<?php echo esc_url( home_url( '/shop/' ) ); ?>">
-            <span class="home-signal-strip__utility-key"><?php echo esc_html( 'CONSULTING' ); ?></span>
-            <span class="home-signal-strip__utility-value"><?php echo esc_html( 'debug · automate · deep dive' ); ?></span>
-        </a>
-        <span class="home-signal-strip__utility-item home-signal-strip__utility-item--future">
-            <span class="home-signal-strip__utility-key"><?php echo esc_html( 'YVR DATA' ); ?></span>
-            <span class="home-signal-strip__utility-value"><?php echo esc_html( 'api + mcp soon' ); ?></span>
-        </span>
-        <button type="button" class="home-signal-strip__contact" data-contact-trigger aria-haspopup="dialog" aria-controls="contact-suzy-modal"><?php echo esc_html( 'CONTACT' ); ?></button>
+        <p class="home-lo-flyover__report" data-lo-flyover-report><?php echo esc_html( $report ); ?></p>
+        <a class="home-lo-flyover__secondary" href="<?php echo esc_url( $lo_url ); ?>"><?php echo esc_html( 'view outage intel ↗' ); ?></a>
     </div>
-</nav>
+</aside>

--- a/tests/HomeLoFlyoverTest.php
+++ b/tests/HomeLoFlyoverTest.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace {
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/../');
+}
+function sanitize_html_class($class) {
+    return preg_replace('/[^a-z0-9_-]/i', '', (string) $class);
+}
+require_once __DIR__ . '/../functions.php';
+
+function assert_true($cond, $msg) {
+    if (!$cond) {
+        fwrite(STDERR, "FAIL: $msg\n");
+        exit(1);
+    }
+}
+
+$clear = se_home_lo_flyover_copy([
+    'tone' => 'ok',
+    'counts' => ['down' => 0, 'degraded' => 0, 'advisory' => 0],
+    'lead' => ['kind' => 'clear', 'provider' => ''],
+]);
+assert_true($clear['banner'] === 'LOUSY OUTAGES → monitoring provider signals', 'clear banner fallback');
+assert_true(str_contains($clear['report'], 'no major active incident summary available right now'), 'clear report fallback');
+assert_true($clear['highlight'] === false, 'clear state is not hot');
+
+$hot = se_home_lo_flyover_copy([
+    'tone' => 'warn',
+    'counts' => ['down' => 1, 'degraded' => 2, 'advisory' => 0],
+    'lead' => ['kind' => 'down', 'provider' => 'ExampleCo'],
+]);
+assert_true($hot['banner'] === 'LOUSY OUTAGES → 1 provider down · 2 degraded · open status', 'hot banner counts');
+assert_true($hot['report'] === 'latest report: ExampleCo status page indicates service disruption', 'provider-specific down report');
+assert_true($hot['highlight'] === true, 'hot state is highlighted');
+
+$part = file_get_contents(__DIR__ . '/../parts/home-commercial-strip.php');
+assert_true(str_contains($part, 'home-lo-flyover'), 'homepage strip replaced with flyover module');
+assert_true(str_contains($part, 'data-lo-flyover-banner'), 'flyover banner is data-driven');
+assert_true(!str_contains($part, 'home-signal-strip'), 'legacy signal strip markup removed');
+
+echo "OK\n";
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the homepage `LIVE // SUZY OS` status strip with a cinematic Lousy Outages flyover module: a small pixel plane drags a live banner across a Vancouver-at-night scene, with a readable panel below that matches the consulting strip's console aesthetic.

## What changed

- **`parts/home-commercial-strip.php`** — new flyover markup (scene + accessible panel)
- **`assets/css/home-commercial-strip.css`** — flyover scene, plane animation, skyline, tone states, mobile + `prefers-reduced-motion` fallbacks
- **`functions.php`** — `se_home_lo_flyover_copy()` builds conservative banner/report text from teaser data
- **`assets/js/lousy-outages-teaser.js`** — `flyoverCopy()` / `renderFlyover()` for live REST refresh
- **Tests** — JS + static PHP regression coverage

## Data sourcing

Copy is driven by `get_lousy_outages_home_teaser_data()` → plugin `HomeTeaser::build()` → `lousy_outages_get_current_state()` snapshot. The flyover polls `GET /wp-json/lousy-outages/v1/summary` every 5 minutes (same as the feature preview block).

**Active incidents:** banner shows counts like `LOUSY OUTAGES → 1 provider down · 2 degraded · open status`; report line reflects `lead.kind` conservatively (e.g. `latest report: {provider} status page shows degraded service`).

**No active summary:** falls back to `LOUSY OUTAGES → monitoring provider signals` and `latest report: no major active incident summary available right now`.

Provider names only appear when present in the teaser `lead` payload — never hardcoded.

## Interaction / accessibility

- Primary link + secondary `view outage intel ↗` → `/lousy-outages/`
- Decorative plane track is `aria-hidden`; panel carries the real link + `aria-label`
- `prefers-reduced-motion`: static centered plane, no twinkle/pulse
- Mobile ≤520px: scene hidden, compact panel remains fully readable

## Testing

- `node --test __tests__/lousy-outages-teaser.test.js` (flyover copy + render)
- `php tests/HomeLoFlyoverTest.php` (static regression)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0cf6b569-c5b0-4d34-8842-af86e217738f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0cf6b569-c5b0-4d34-8842-af86e217738f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

