### PR TITLE
Redesign homepage Lousy Outages flyover as signal whale scene

### DIFF
--- a/__tests__/lousy-outages-teaser.test.js
+++ b/__tests__/lousy-outages-teaser.test.js
@@ -219,9 +219,9 @@ test('renderFlyover updates homepage flyover module', () => {
   banner.setAttribute('data-lo-flyover-banner', '');
   const report = new El('p');
   report.setAttribute('data-lo-flyover-report', '');
-  const mast = new El('span');
-  mast.className = 'home-lo-flyover__mast-state';
-  flyover.append(banner, report, mast);
+  const cta = new El('a');
+  cta.className = 'home-lo-flyover__cta';
+  flyover.append(banner, report, cta);
   teaser.renderFlyover(flyover, sampleTeaser());
   assert.match(banner.textContent, /open status/);
   assert.match(report.textContent, /degraded service/);

--- a/assets/css/home-commercial-strip.css
+++ b/assets/css/home-commercial-strip.css
@@ -1,4 +1,4 @@
-/* Homepage Lousy Outages flyover — live transmission above the hero deck. */
+/* Homepage Lousy Outages signal whale — cinematic live transmission above the hero deck. */
 
 .home-lo-flyover {
   --fly-green: #4ade80;
@@ -8,30 +8,39 @@
   --fly-red: #ff6b6b;
   --fly-text: #d7e8df;
   --fly-muted: #8eaa9b;
-  --fly-border: rgba(94, 234, 160, 0.24);
-  --fly-scene-h: clamp(5.5rem, 14vw, 7.5rem);
+  --fly-border: rgba(94, 234, 160, 0.18);
+  --fly-scene-h: clamp(6.75rem, 17vw, 9.25rem);
 
   position: relative;
-  width: min(92vw, 900px);
+  width: min(92vw, 920px);
   margin: 0 auto;
   font-family: "IBM Plex Mono", "Courier New", monospace;
   color: var(--fly-text);
 }
 
+.home-lo-flyover__module {
+  overflow: hidden;
+  border: 1px solid var(--fly-border);
+  border-radius: 10px;
+  background:
+    radial-gradient(ellipse 130% 90% at 50% 115%, rgba(88, 199, 255, 0.07), transparent 58%),
+    radial-gradient(circle at 14% 18%, rgba(223, 119, 255, 0.05), transparent 40%),
+    linear-gradient(180deg, rgba(6, 12, 18, 0.96) 0%, rgba(3, 6, 12, 0.98) 100%);
+  box-shadow:
+    0 12px 40px rgba(0, 0, 0, 0.35),
+    inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
 .home-lo-flyover__scene {
   position: relative;
   height: var(--fly-scene-h);
-  margin-bottom: 0.55rem;
   overflow: hidden;
-  border: 1px solid var(--fly-border);
-  border-radius: 8px 8px 2px 2px;
+  border-bottom: 1px solid rgba(88, 199, 255, 0.08);
   background:
-    radial-gradient(ellipse 120% 80% at 50% 110%, rgba(88, 199, 255, 0.08), transparent 55%),
+    radial-gradient(ellipse 120% 80% at 50% 110%, rgba(88, 199, 255, 0.1), transparent 55%),
     radial-gradient(circle at 18% 22%, rgba(223, 119, 255, 0.06), transparent 38%),
-    linear-gradient(180deg, #03060d 0%, #050b14 42%, #020408 100%);
-  box-shadow:
-    inset 0 0 32px rgba(0, 0, 0, 0.55),
-    inset 0 -18px 28px rgba(88, 199, 255, 0.04);
+    linear-gradient(180deg, #020408 0%, #050b14 46%, #03060d 100%);
+  box-shadow: inset 0 -24px 36px rgba(88, 199, 255, 0.04);
 }
 
 .home-lo-flyover__sky {
@@ -51,26 +60,27 @@
   width: 2px;
   height: 2px;
   color: #c8e8ff;
-  animation: homeLoFlyStarTwinkle 4.8s ease-in-out infinite;
+  animation: homeLoWhaleStarTwinkle 5.2s ease-in-out infinite;
 }
 
-.home-lo-flyover__star--1 { top: 14%; left: 12%; animation-delay: 0s; }
-.home-lo-flyover__star--2 { top: 22%; left: 34%; animation-delay: 0.8s; opacity: 0.35; }
-.home-lo-flyover__star--3 { top: 10%; left: 58%; animation-delay: 1.4s; }
-.home-lo-flyover__star--4 { top: 28%; left: 76%; animation-delay: 2.1s; opacity: 0.4; }
-.home-lo-flyover__star--5 { top: 18%; left: 88%; animation-delay: 0.3s; }
+.home-lo-flyover__star--1 { top: 12%; left: 10%; animation-delay: 0s; }
+.home-lo-flyover__star--2 { top: 20%; left: 28%; animation-delay: 0.7s; opacity: 0.35; }
+.home-lo-flyover__star--3 { top: 8%; left: 52%; animation-delay: 1.3s; }
+.home-lo-flyover__star--4 { top: 26%; left: 68%; animation-delay: 2s; opacity: 0.4; }
+.home-lo-flyover__star--5 { top: 14%; left: 84%; animation-delay: 0.4s; }
+.home-lo-flyover__star--6 { top: 34%; left: 42%; animation-delay: 2.6s; opacity: 0.3; width: 1px; height: 1px; }
 
 .home-lo-flyover__signal {
   width: 3px;
   height: 3px;
   color: var(--fly-green);
   box-shadow: 0 0 6px rgba(74, 222, 128, 0.55);
-  animation: homeLoFlySignalPulse 2.6s ease-in-out infinite;
+  animation: homeLoWhaleSignalPulse 2.8s ease-in-out infinite;
 }
 
-.home-lo-flyover__signal--1 { top: 36%; left: 22%; animation-delay: 0.2s; }
-.home-lo-flyover__signal--2 { top: 44%; left: 48%; animation-delay: 1.1s; opacity: 0.7; }
-.home-lo-flyover__signal--3 { top: 32%; left: 71%; animation-delay: 1.8s; }
+.home-lo-flyover__signal--1 { top: 38%; left: 18%; animation-delay: 0.2s; }
+.home-lo-flyover__signal--2 { top: 48%; left: 46%; animation-delay: 1.1s; opacity: 0.7; }
+.home-lo-flyover__signal--3 { top: 34%; left: 74%; animation-delay: 1.9s; }
 
 .home-lo-flyover--hot .home-lo-flyover__signal {
   color: var(--fly-yellow);
@@ -88,7 +98,7 @@
   right: 0;
   bottom: 0;
   left: 0;
-  height: 42%;
+  height: 44%;
 }
 
 .home-lo-flyover__mountains {
@@ -98,10 +108,10 @@
   left: 0;
   height: 100%;
   background:
-    linear-gradient(165deg, transparent 42%, rgba(8, 18, 28, 0.92) 42%),
-    linear-gradient(148deg, transparent 52%, rgba(12, 24, 36, 0.88) 52%),
-    linear-gradient(172deg, transparent 36%, rgba(6, 14, 22, 0.95) 36%);
-  opacity: 0.9;
+    linear-gradient(158deg, transparent 40%, rgba(8, 18, 28, 0.94) 40%),
+    linear-gradient(145deg, transparent 50%, rgba(12, 24, 36, 0.9) 50%),
+    linear-gradient(170deg, transparent 34%, rgba(6, 14, 22, 0.96) 34%);
+  opacity: 0.92;
 }
 
 .home-lo-flyover__skyline {
@@ -113,391 +123,370 @@
   background:
     linear-gradient(90deg,
       transparent 0%,
-      rgba(88, 199, 255, 0.12) 18%,
-      rgba(88, 199, 255, 0.22) 22%,
-      rgba(88, 199, 255, 0.08) 24%,
-      transparent 28%,
-      rgba(223, 119, 255, 0.1) 42%,
-      rgba(223, 119, 255, 0.18) 44%,
-      transparent 48%,
-      rgba(88, 199, 255, 0.14) 62%,
-      rgba(88, 199, 255, 0.24) 65%,
-      transparent 70%,
-      rgba(74, 222, 128, 0.1) 84%,
-      rgba(74, 222, 128, 0.16) 86%,
-      transparent 92%
+      rgba(88, 199, 255, 0.1) 16%,
+      rgba(88, 199, 255, 0.2) 20%,
+      rgba(88, 199, 255, 0.07) 23%,
+      transparent 27%,
+      rgba(223, 119, 255, 0.08) 40%,
+      rgba(223, 119, 255, 0.16) 43%,
+      transparent 47%,
+      rgba(88, 199, 255, 0.12) 60%,
+      rgba(88, 199, 255, 0.22) 64%,
+      transparent 69%,
+      rgba(74, 222, 128, 0.08) 82%,
+      rgba(74, 222, 128, 0.14) 85%,
+      transparent 91%
     );
   mask-image: linear-gradient(180deg, transparent 0%, #000 72%);
-  opacity: 0.75;
+  opacity: 0.72;
 }
 
 .home-lo-flyover__track {
   position: absolute;
   inset: 0;
-  pointer-events: none;
 }
 
+/* Banner trails behind the orca: banner → tether → whale (whale leads rightward). */
 .home-lo-flyover__craft {
   position: absolute;
-  top: 28%;
-  left: -18%;
+  top: 24%;
+  left: -28%;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 0;
   width: max-content;
   color: inherit;
   text-decoration: none;
   pointer-events: auto;
-  animation: homeLoFlyPass 18s linear infinite;
+  animation: homeLoWhalePass 20s linear infinite;
   will-change: transform, left;
-}
-
-.home-lo-flyover__plane {
-  position: relative;
-  flex: 0 0 auto;
-  width: 22px;
-  height: 14px;
-  margin-top: 2px;
-  filter: drop-shadow(0 0 4px rgba(88, 199, 255, 0.35));
-}
-
-.home-lo-flyover__plane-body,
-.home-lo-flyover__plane-wing,
-.home-lo-flyover__plane-tail,
-.home-lo-flyover__plane-prop {
-  position: absolute;
-  background: #e8f4ff;
-  image-rendering: pixelated;
-}
-
-.home-lo-flyover__plane-body {
-  top: 5px;
-  left: 6px;
-  width: 12px;
-  height: 4px;
-  background: #d7ecff;
-  box-shadow:
-    1px 0 0 #8ec8ff,
-    2px 0 0 #8ec8ff,
-    3px 0 0 #8ec8ff;
-}
-
-.home-lo-flyover__plane-wing {
-  top: 7px;
-  left: 9px;
-  width: 8px;
-  height: 2px;
-  background: #58c7ff;
-}
-
-.home-lo-flyover__plane-tail {
-  top: 4px;
-  left: 4px;
-  width: 3px;
-  height: 3px;
-  background: #9ed8ff;
-}
-
-.home-lo-flyover__plane-prop {
-  top: 5px;
-  left: 18px;
-  width: 2px;
-  height: 4px;
-  background: #fff;
-  animation: homeLoFlyProp 0.18s steps(2) infinite;
-}
-
-.home-lo-flyover__tether {
-  align-self: center;
-  width: 14px;
-  height: 1px;
-  margin-top: 8px;
-  background: linear-gradient(90deg, rgba(88, 199, 255, 0.15), rgba(88, 199, 255, 0.55));
 }
 
 .home-lo-flyover__banner-skin {
   display: inline-flex;
   align-items: center;
-  min-height: 1.65rem;
-  max-width: min(58vw, 26rem);
-  padding: 0.28rem 0.55rem;
-  border: 1px solid rgba(88, 199, 255, 0.28);
+  min-height: 1.85rem;
+  padding: 0.32rem 0.62rem;
+  border: 1px solid rgba(88, 199, 255, 0.26);
   border-radius: 2px;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.04), transparent),
-    rgba(4, 12, 18, 0.88);
+    linear-gradient(180deg, rgba(255, 255, 255, 0.05), transparent),
+    rgba(4, 12, 18, 0.9);
   box-shadow:
-    0 0 12px rgba(88, 199, 255, 0.12),
-    inset 0 0 0 1px rgba(74, 222, 128, 0.08);
+    0 0 14px rgba(88, 199, 255, 0.1),
+    inset 0 0 0 1px rgba(74, 222, 128, 0.07);
 }
 
 .home-lo-flyover__banner-text {
-  overflow: hidden;
   color: #f1f7f4;
-  font-size: clamp(0.58rem, 1.05vw, 0.72rem);
+  font-size: clamp(0.62rem, 1.15vw, 0.78rem);
   font-weight: 800;
-  letter-spacing: 0.03em;
-  line-height: 1.25;
-  text-overflow: ellipsis;
+  letter-spacing: 0.025em;
+  line-height: 1.3;
   white-space: nowrap;
 }
 
 .home-lo-flyover--hot .home-lo-flyover__banner-skin {
-  border-color: rgba(255, 179, 0, 0.35);
+  border-color: rgba(255, 179, 0, 0.34);
   box-shadow:
-    0 0 14px rgba(255, 179, 0, 0.14),
+    0 0 16px rgba(255, 179, 0, 0.12),
     inset 0 0 0 1px rgba(255, 107, 107, 0.08);
 }
 
 .home-lo-flyover--down .home-lo-flyover__banner-skin,
 .home-lo-flyover--bad .home-lo-flyover__banner-skin {
-  border-color: rgba(255, 107, 107, 0.38);
-  box-shadow: 0 0 16px rgba(255, 107, 107, 0.16);
+  border-color: rgba(255, 107, 107, 0.36);
+  box-shadow: 0 0 18px rgba(255, 107, 107, 0.14);
 }
 
-.home-lo-flyover__panel {
-  padding: 0.72rem 0.8rem 0.78rem;
-  border: 1px solid var(--fly-border);
-  border-left: 3px solid var(--fly-green);
-  border-radius: 6px;
+.home-lo-flyover__tether {
+  flex: 0 0 auto;
+  width: clamp(1.25rem, 3vw, 2rem);
+  height: 1px;
+  background: linear-gradient(90deg, rgba(88, 199, 255, 0.12), rgba(88, 199, 255, 0.55));
+  box-shadow: 0 0 6px rgba(88, 199, 255, 0.2);
+}
+
+/* Pixel-inspired signal whale — side profile facing right. */
+.home-lo-flyover__orca {
+  position: relative;
+  flex: 0 0 auto;
+  width: 58px;
+  height: 34px;
+  filter: drop-shadow(0 0 8px rgba(88, 199, 255, 0.28));
+  animation: homeLoWhaleBob 3.6s ease-in-out infinite;
+}
+
+.home-lo-flyover__orca-fluke,
+.home-lo-flyover__orca-body,
+.home-lo-flyover__orca-belly,
+.home-lo-flyover__orca-patch,
+.home-lo-flyover__orca-dorsal,
+.home-lo-flyover__orca-head,
+.home-lo-flyover__orca-eye,
+.home-lo-flyover__orca-spray {
+  position: absolute;
+  image-rendering: pixelated;
+}
+
+.home-lo-flyover__orca-fluke {
+  bottom: 8px;
+  left: 0;
+  width: 12px;
+  height: 14px;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.01), transparent),
-    rgba(6, 13, 10, 0.9);
+    linear-gradient(135deg, #0a1018 0%, #0a1018 48%, transparent 48%),
+    linear-gradient(225deg, #0a1018 0%, #0a1018 48%, transparent 48%);
+  transform: rotate(-8deg);
 }
 
-.home-lo-flyover--warn .home-lo-flyover__panel,
-.home-lo-flyover--degraded .home-lo-flyover__panel,
-.home-lo-flyover--advisory .home-lo-flyover__panel {
-  border-left-color: var(--fly-yellow);
+.home-lo-flyover__orca-body {
+  bottom: 10px;
+  left: 8px;
+  width: 34px;
+  height: 16px;
+  border-radius: 2px 10px 8px 4px;
+  background: linear-gradient(180deg, #121820 0%, #060a10 100%);
+  box-shadow:
+    inset 0 -3px 0 rgba(255, 255, 255, 0.06),
+    inset 0 2px 0 rgba(255, 255, 255, 0.04);
 }
 
-.home-lo-flyover--down .home-lo-flyover__panel,
-.home-lo-flyover--bad .home-lo-flyover__panel {
-  border-left-color: var(--fly-red);
+.home-lo-flyover__orca-belly {
+  bottom: 10px;
+  left: 14px;
+  width: 22px;
+  height: 6px;
+  border-radius: 0 0 8px 8px;
+  background: linear-gradient(180deg, rgba(220, 232, 244, 0.18), rgba(220, 232, 244, 0.06));
 }
 
-.home-lo-flyover__mast {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  margin: 0 0 0.48rem;
+.home-lo-flyover__orca-patch {
+  top: 12px;
+  left: 34px;
+  width: 10px;
+  height: 7px;
+  border-radius: 50% 40% 40% 50%;
+  background: linear-gradient(180deg, #eef4fb 0%, #c8d8ea 100%);
+  box-shadow: 0 0 6px rgba(200, 220, 240, 0.35);
 }
 
-.home-lo-flyover__mast-label {
-  color: var(--fly-green);
-  font-size: clamp(0.38rem, 0.72vw, 0.46rem);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+.home-lo-flyover__orca-dorsal {
+  top: 2px;
+  left: 22px;
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-bottom: 12px solid #0a1018;
+  filter: drop-shadow(0 0 4px rgba(88, 199, 255, 0.15));
 }
 
-.home-lo-flyover--warn .home-lo-flyover__mast-label,
-.home-lo-flyover--degraded .home-lo-flyover__mast-label,
-.home-lo-flyover--advisory .home-lo-flyover__mast-label {
-  color: var(--fly-yellow);
+.home-lo-flyover__orca-head {
+  top: 10px;
+  right: 0;
+  width: 18px;
+  height: 14px;
+  border-radius: 0 50% 45% 0;
+  background: linear-gradient(180deg, #141c26 0%, #060a10 100%);
+  box-shadow: inset -2px 0 0 rgba(255, 255, 255, 0.05);
 }
 
-.home-lo-flyover--down .home-lo-flyover__mast-label,
-.home-lo-flyover--bad .home-lo-flyover__mast-label {
-  color: var(--fly-red);
+.home-lo-flyover__orca-eye {
+  top: 14px;
+  right: 4px;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: #57f3ff;
+  box-shadow:
+    0 0 6px rgba(87, 243, 255, 0.75),
+    0 0 12px rgba(87, 243, 255, 0.35);
+  animation: homeLoWhaleEyePulse 2.4s ease-in-out infinite;
 }
 
-.home-lo-flyover__mast-state {
-  color: #6f8f7e;
-  font-family: "IBM Plex Mono", "Courier New", monospace;
-  font-size: clamp(0.64rem, 1vw, 0.74rem);
-  letter-spacing: 0.03em;
-  text-transform: lowercase;
+.home-lo-flyover__orca-spray {
+  top: 6px;
+  right: -2px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(88, 199, 255, 0.35) 0%, transparent 70%);
+  opacity: 0.55;
+  animation: homeLoWhaleSpray 2.8s ease-in-out infinite;
 }
 
-.home-lo-flyover__primary {
+.home-lo-flyover--hot .home-lo-flyover__orca-eye {
+  background: var(--fly-yellow);
+  box-shadow: 0 0 8px rgba(255, 179, 0, 0.65);
+}
+
+.home-lo-flyover--down .home-lo-flyover__orca-eye,
+.home-lo-flyover--bad .home-lo-flyover__orca-eye {
+  background: var(--fly-red);
+  box-shadow: 0 0 8px rgba(255, 107, 107, 0.55);
+}
+
+.home-lo-flyover__readout {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 0.65rem;
-  min-width: 0;
-  padding: 0.58rem 0.66rem;
-  border: 1px solid rgba(94, 234, 160, 0.12);
-  background: rgba(0, 0, 0, 0.28);
-  color: inherit;
-  text-decoration: none;
-  transition: border-color 0.16s ease, background 0.16s ease;
+  gap: 0.42rem;
+  padding: 0.82rem 0.92rem 0.88rem;
 }
 
-.home-lo-flyover__primary:hover,
-.home-lo-flyover__primary:focus-visible {
-  border-color: rgba(88, 199, 255, 0.34);
-  background: rgba(5, 14, 11, 0.98);
-  outline: none;
-}
-
-.home-lo-flyover__prompt {
-  color: var(--fly-green);
-  font-size: 1rem;
-  font-weight: 800;
-  line-height: 1;
-}
-
-.home-lo-flyover--warn .home-lo-flyover__prompt,
-.home-lo-flyover--degraded .home-lo-flyover__prompt,
-.home-lo-flyover--advisory .home-lo-flyover__prompt {
-  color: var(--fly-yellow);
-}
-
-.home-lo-flyover--down .home-lo-flyover__prompt,
-.home-lo-flyover--bad .home-lo-flyover__prompt {
-  color: var(--fly-red);
-}
-
-.home-lo-flyover__banner-line {
-  display: block;
-  min-width: 0;
+.home-lo-flyover__summary {
+  margin: 0;
   color: #f1f7f4;
-  font-size: clamp(0.74rem, 1.28vw, 0.92rem);
-  font-weight: 800;
-  letter-spacing: 0.02em;
-  line-height: 1.35;
+  font-size: clamp(0.46rem, 0.82vw, 0.54rem);
+  letter-spacing: 0.06em;
+  line-height: 1.55;
+  text-transform: uppercase;
+  word-break: break-word;
 }
 
-.home-lo-flyover__cta {
-  color: #74d9c4;
-  font-size: clamp(0.62rem, 0.95vw, 0.72rem);
-  font-weight: 700;
-  white-space: nowrap;
+.home-lo-flyover--warn .home-lo-flyover__summary,
+.home-lo-flyover--degraded .home-lo-flyover__summary,
+.home-lo-flyover--advisory .home-lo-flyover__summary {
+  color: #ffe9a8;
+  text-shadow: 0 0 10px rgba(255, 179, 0, 0.12);
 }
 
-.home-lo-flyover__primary:hover .home-lo-flyover__cta,
-.home-lo-flyover__primary:focus-visible .home-lo-flyover__cta {
-  color: var(--fly-cyan);
+.home-lo-flyover--down .home-lo-flyover__summary,
+.home-lo-flyover--bad .home-lo-flyover__summary {
+  color: #ffc9c9;
+  text-shadow: 0 0 10px rgba(255, 107, 107, 0.12);
 }
 
 .home-lo-flyover__report {
-  margin: 0.45rem 0 0;
-  padding-left: 1.35rem;
-  color: #a9c1b5;
+  margin: 0;
+  color: var(--fly-muted);
   font-size: clamp(0.68rem, 1.05vw, 0.8rem);
-  line-height: 1.4;
+  line-height: 1.45;
 }
 
-.home-lo-flyover__secondary {
-  display: inline-block;
-  margin: 0.35rem 0 0 1.35rem;
+.home-lo-flyover__cta {
+  justify-self: start;
+  margin-top: 0.12rem;
   color: #74d9c4;
-  font-size: clamp(0.6rem, 0.92vw, 0.7rem);
+  font-size: clamp(0.64rem, 0.98vw, 0.74rem);
   font-weight: 700;
+  letter-spacing: 0.02em;
   text-decoration: none;
+  transition: color 0.16s ease;
 }
 
-.home-lo-flyover__secondary:hover,
-.home-lo-flyover__secondary:focus-visible {
+.home-lo-flyover__cta:hover,
+.home-lo-flyover__cta:focus-visible {
   color: var(--fly-cyan);
   outline: none;
 }
 
-@keyframes homeLoFlyPass {
+@keyframes homeLoWhalePass {
   0% {
-    left: -18%;
+    left: -28%;
     transform: translateY(0);
   }
-  12% {
-    transform: translateY(-3px);
+  10% {
+    transform: translateY(-4px);
   }
-  28% {
+  24% {
     transform: translateY(2px);
   }
-  50% {
-    left: 108%;
-    transform: translateY(-2px);
+  48% {
+    left: 112%;
+    transform: translateY(-3px);
   }
-  50.01% {
-    left: -18%;
+  48.01% {
+    left: -28%;
     transform: translateY(0);
   }
   100% {
-    left: -18%;
+    left: -28%;
     transform: translateY(0);
   }
 }
 
-@keyframes homeLoFlyProp {
-  0% { opacity: 1; transform: scaleX(1); }
-  50% { opacity: 0.35; transform: scaleX(0.4); }
-  100% { opacity: 1; transform: scaleX(1); }
+@keyframes homeLoWhaleBob {
+  0%, 100% { transform: translateY(0) rotate(-2deg); }
+  50% { transform: translateY(-3px) rotate(1deg); }
 }
 
-@keyframes homeLoFlyStarTwinkle {
-  0%, 100% { opacity: 0.25; }
-  50% { opacity: 0.75; }
+@keyframes homeLoWhaleStarTwinkle {
+  0%, 100% { opacity: 0.22; }
+  50% { opacity: 0.78; }
 }
 
-@keyframes homeLoFlySignalPulse {
-  0%, 100% { transform: scale(1); opacity: 0.45; }
-  50% { transform: scale(1.35); opacity: 0.95; }
+@keyframes homeLoWhaleSignalPulse {
+  0%, 100% { transform: scale(1); opacity: 0.4; }
+  50% { transform: scale(1.4); opacity: 0.95; }
+}
+
+@keyframes homeLoWhaleEyePulse {
+  0%, 100% { opacity: 0.85; }
+  50% { opacity: 1; transform: scale(1.15); }
+}
+
+@keyframes homeLoWhaleSpray {
+  0%, 100% { opacity: 0.25; transform: scale(0.85); }
+  50% { opacity: 0.7; transform: scale(1.1); }
 }
 
 @media (max-width: 720px) {
   .home-lo-flyover {
-    --fly-scene-h: 4.25rem;
-  }
-
-  .home-lo-flyover__scene {
-    margin-bottom: 0.42rem;
+    --fly-scene-h: 5.25rem;
   }
 
   .home-lo-flyover__craft {
-    top: 24%;
-    animation-duration: 22s;
+    top: 20%;
+    animation-duration: 24s;
   }
 
-  .home-lo-flyover__banner-skin {
-    max-width: min(70vw, 18rem);
-    padding: 0.22rem 0.42rem;
+  .home-lo-flyover__orca {
+    width: 48px;
+    height: 28px;
+  }
+
+  .home-lo-flyover__orca-body {
+    width: 28px;
+    height: 14px;
   }
 
   .home-lo-flyover__banner-text {
-    font-size: 0.56rem;
+    font-size: 0.58rem;
   }
 
-  .home-lo-flyover__primary {
-    grid-template-columns: auto minmax(0, 1fr);
-  }
-
-  .home-lo-flyover__cta {
-    grid-column: 2;
-    justify-self: start;
-  }
-
-  .home-lo-flyover__report,
-  .home-lo-flyover__secondary {
-    padding-left: 0;
-    margin-left: 0;
+  .home-lo-flyover__readout {
+    padding: 0.68rem 0.72rem 0.74rem;
   }
 }
 
 @media (max-width: 520px) {
-  .home-lo-flyover__scene {
-    display: none;
+  .home-lo-flyover {
+    --fly-scene-h: 4.75rem;
   }
 
-  .home-lo-flyover__panel {
-    position: relative;
-    overflow: hidden;
+  .home-lo-flyover__craft {
+    animation-duration: 28s;
   }
 
-  .home-lo-flyover__panel::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background:
-      radial-gradient(circle at 82% 18%, rgba(88, 199, 255, 0.08), transparent 42%),
-      radial-gradient(circle at 12% 88%, rgba(74, 222, 128, 0.06), transparent 38%);
-    pointer-events: none;
+  .home-lo-flyover__banner-text {
+    font-size: 0.54rem;
+  }
+
+  .home-lo-flyover__orca {
+    width: 42px;
+    height: 24px;
+  }
+
+  .home-lo-flyover__summary {
+    font-size: 0.42rem;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .home-lo-flyover__craft,
-  .home-lo-flyover__plane-prop,
+  .home-lo-flyover__orca,
+  .home-lo-flyover__orca-eye,
+  .home-lo-flyover__orca-spray,
   .home-lo-flyover__star,
   .home-lo-flyover__signal {
     animation: none !important;
@@ -505,7 +494,7 @@
 
   .home-lo-flyover__craft {
     left: 50%;
-    transform: translateX(-50%);
+    transform: translateX(-42%);
   }
 
   .home-lo-flyover__scene {

--- a/assets/js/lousy-outages-teaser.js
+++ b/assets/js/lousy-outages-teaser.js
@@ -74,7 +74,7 @@
       if (kind === 'down') {
         report = provider
           ? 'latest report: ' + provider + ' status page indicates service disruption'
-          : 'latest report: status page indicates service disruption';
+          : 'latest report: service disruption is being reported';
       } else if (kind === 'warn') {
         report = provider
           ? 'latest report: ' + provider + ' status page shows degraded service'
@@ -114,10 +114,10 @@
     });
     var reportEl = flyover.querySelector('[data-lo-flyover-report]');
     if (reportEl) reportEl.textContent = copy.report;
-    var primary = flyover.querySelector('.home-lo-flyover__primary');
-    if (primary) primary.setAttribute('aria-label', copy.banner + ' — view Lousy Outages status');
-    var mastState = flyover.querySelector('.home-lo-flyover__mast-state');
-    if (mastState) mastState.textContent = copy.highlight ? 'signal detected' : 'monitoring';
+    var cta = flyover.querySelector('.home-lo-flyover__cta');
+    if (cta) cta.setAttribute('aria-label', copy.banner + ' — view Lousy Outages status');
+    var craft = flyover.querySelector('.home-lo-flyover__craft');
+    if (craft && teaser.dashboard_url) craft.setAttribute('href', teaser.dashboard_url);
   }
 
   function render(container, payload, config) {

--- a/functions.php
+++ b/functions.php
@@ -715,7 +715,7 @@ function se_home_lo_flyover_copy( array $teaser ): array {
     } elseif ( 'down' === $kind ) {
         $report = '' !== $provider
             ? "latest report: {$provider} status page indicates service disruption"
-            : 'latest report: status page indicates service disruption';
+            : 'latest report: service disruption is being reported';
     } elseif ( 'warn' === $kind ) {
         $report = '' !== $provider
             ? "latest report: {$provider} status page shows degraded service"

--- a/parts/home-commercial-strip.php
+++ b/parts/home-commercial-strip.php
@@ -19,60 +19,57 @@ $report    = (string) ( $copy['report'] ?? 'latest report: no major active incid
     data-lo-endpoint="<?php echo esc_url( rest_url( 'lousy-outages/v1/summary' ) ); ?>"
     data-lo-dashboard-url="<?php echo esc_url( $lo_url ); ?>"
 >
-    <div class="home-lo-flyover__scene" aria-hidden="true">
-        <div class="home-lo-flyover__sky">
-            <span class="home-lo-flyover__star home-lo-flyover__star--1"></span>
-            <span class="home-lo-flyover__star home-lo-flyover__star--2"></span>
-            <span class="home-lo-flyover__star home-lo-flyover__star--3"></span>
-            <span class="home-lo-flyover__star home-lo-flyover__star--4"></span>
-            <span class="home-lo-flyover__star home-lo-flyover__star--5"></span>
-            <span class="home-lo-flyover__signal home-lo-flyover__signal--1"></span>
-            <span class="home-lo-flyover__signal home-lo-flyover__signal--2"></span>
-            <span class="home-lo-flyover__signal home-lo-flyover__signal--3"></span>
-            <div class="home-lo-flyover__horizon">
-                <div class="home-lo-flyover__mountains"></div>
-                <div class="home-lo-flyover__skyline"></div>
+    <div class="home-lo-flyover__module">
+        <div class="home-lo-flyover__scene" aria-hidden="true">
+            <div class="home-lo-flyover__sky">
+                <span class="home-lo-flyover__star home-lo-flyover__star--1"></span>
+                <span class="home-lo-flyover__star home-lo-flyover__star--2"></span>
+                <span class="home-lo-flyover__star home-lo-flyover__star--3"></span>
+                <span class="home-lo-flyover__star home-lo-flyover__star--4"></span>
+                <span class="home-lo-flyover__star home-lo-flyover__star--5"></span>
+                <span class="home-lo-flyover__star home-lo-flyover__star--6"></span>
+                <span class="home-lo-flyover__signal home-lo-flyover__signal--1"></span>
+                <span class="home-lo-flyover__signal home-lo-flyover__signal--2"></span>
+                <span class="home-lo-flyover__signal home-lo-flyover__signal--3"></span>
+                <div class="home-lo-flyover__horizon">
+                    <div class="home-lo-flyover__mountains"></div>
+                    <div class="home-lo-flyover__skyline"></div>
+                </div>
+            </div>
+
+            <div class="home-lo-flyover__track">
+                <a
+                    class="home-lo-flyover__craft"
+                    href="<?php echo esc_url( $lo_url ); ?>"
+                    tabindex="-1"
+                    aria-hidden="true"
+                >
+                    <span class="home-lo-flyover__banner-skin">
+                        <span class="home-lo-flyover__banner-text" data-lo-flyover-banner><?php echo esc_html( $banner ); ?></span>
+                    </span>
+                    <span class="home-lo-flyover__tether" aria-hidden="true"></span>
+                    <span class="home-lo-flyover__orca" aria-hidden="true">
+                        <span class="home-lo-flyover__orca-fluke"></span>
+                        <span class="home-lo-flyover__orca-body"></span>
+                        <span class="home-lo-flyover__orca-belly"></span>
+                        <span class="home-lo-flyover__orca-patch"></span>
+                        <span class="home-lo-flyover__orca-dorsal"></span>
+                        <span class="home-lo-flyover__orca-head"></span>
+                        <span class="home-lo-flyover__orca-eye"></span>
+                        <span class="home-lo-flyover__orca-spray"></span>
+                    </span>
+                </a>
             </div>
         </div>
 
-        <div class="home-lo-flyover__track">
+        <div class="home-lo-flyover__readout">
+            <p class="home-lo-flyover__summary pixel-font" data-lo-flyover-banner><?php echo esc_html( $banner ); ?></p>
+            <p class="home-lo-flyover__report" data-lo-flyover-report><?php echo esc_html( $report ); ?></p>
             <a
-                class="home-lo-flyover__craft"
+                class="home-lo-flyover__cta"
                 href="<?php echo esc_url( $lo_url ); ?>"
-                tabindex="-1"
-                aria-hidden="true"
-            >
-                <span class="home-lo-flyover__plane" aria-hidden="true">
-                    <span class="home-lo-flyover__plane-body"></span>
-                    <span class="home-lo-flyover__plane-wing"></span>
-                    <span class="home-lo-flyover__plane-tail"></span>
-                    <span class="home-lo-flyover__plane-prop"></span>
-                </span>
-                <span class="home-lo-flyover__tether" aria-hidden="true"></span>
-                <span class="home-lo-flyover__banner-skin">
-                    <span class="home-lo-flyover__banner-text" data-lo-flyover-banner><?php echo esc_html( $banner ); ?></span>
-                </span>
-            </a>
+                aria-label="<?php echo esc_attr( $banner . ' — view Lousy Outages status' ); ?>"
+            ><?php echo esc_html( 'open status ↗' ); ?></a>
         </div>
-    </div>
-
-    <div class="home-lo-flyover__panel">
-        <p class="home-lo-flyover__mast pixel-font">
-            <span class="home-lo-flyover__mast-label"><?php echo esc_html( 'live transmission' ); ?></span>
-            <span class="home-lo-flyover__mast-state"><?php echo esc_html( $highlight ? 'signal detected' : 'monitoring' ); ?></span>
-        </p>
-        <a
-            class="home-lo-flyover__primary"
-            href="<?php echo esc_url( $lo_url ); ?>"
-            aria-label="<?php echo esc_attr( $banner . ' — view Lousy Outages status' ); ?>"
-        >
-            <span class="home-lo-flyover__prompt" aria-hidden="true">&gt;</span>
-            <span class="home-lo-flyover__primary-copy">
-                <span class="home-lo-flyover__banner-line" data-lo-flyover-banner><?php echo esc_html( $banner ); ?></span>
-            </span>
-            <span class="home-lo-flyover__cta"><?php echo esc_html( 'open status ↗' ); ?></span>
-        </a>
-        <p class="home-lo-flyover__report" data-lo-flyover-report><?php echo esc_html( $report ); ?></p>
-        <a class="home-lo-flyover__secondary" href="<?php echo esc_url( $lo_url ); ?>"><?php echo esc_html( 'view outage intel ↗' ); ?></a>
     </div>
 </aside>

--- a/tests/HomeLoFlyoverTest.php
+++ b/tests/HomeLoFlyoverTest.php
@@ -37,7 +37,9 @@ assert_true($hot['highlight'] === true, 'hot state is highlighted');
 
 $part = file_get_contents(__DIR__ . '/../parts/home-commercial-strip.php');
 assert_true(str_contains($part, 'home-lo-flyover'), 'homepage strip replaced with flyover module');
+assert_true(str_contains($part, 'home-lo-flyover__orca'), 'signal whale orca in flyover');
 assert_true(str_contains($part, 'data-lo-flyover-banner'), 'flyover banner is data-driven');
+assert_true(!str_contains($part, 'home-lo-flyover__plane'), 'legacy plane removed');
 assert_true(!str_contains($part, 'home-signal-strip'), 'legacy signal strip markup removed');
 
 echo "OK\n";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the broken plane flyover with a surreal **signal whale** hero moment: a pixel-inspired killer whale towing a readable status banner across a night-sky scene, with a minimal readout below.

## What changed

### Motion & layout
- **Banner now trails behind the whale** (DOM order: banner → tether → orca). Previously the banner sat ahead of the plane, so it looked pushed in front during the pass animation.
- **Larger, clearer orca** (~58px) with dorsal fin, eye patch, neon eye, and subtle spray/bob animation.
- **Single unified card** instead of stacked status boxes: cinematic scene + concise readout (summary, report, one CTA).

### Copy & data
- Live text still comes from the existing Lousy Outages teaser pipeline (`get_lousy_outages_home_teaser_data()` / `/wp-json/lousy-outages/v1/summary`).
- Conservative banner/report language unchanged in spirit; generic down fallback now reads `service disruption is being reported`.
- No hardcoded provider names unless present in teaser `lead.provider`.

### Accessibility & responsive
- Scene is decorative (`aria-hidden`); primary link is `open status ↗` in the readout.
- Flying craft remains clickable (links to `/lousy-outages/`).
- `prefers-reduced-motion`: static centered whale + banner, no pass animation.
- Mobile keeps a simplified scene (no longer hidden at 520px).

## Files changed

- `parts/home-commercial-strip.php` — markup refactor (orca scene + readout)
- `assets/css/home-commercial-strip.css` — full visual redesign
- `assets/js/lousy-outages-teaser.js` — `renderFlyover()` updated for new DOM
- `functions.php` — minor report fallback tweak
- `tests/HomeLoFlyoverTest.php`, `__tests__/lousy-outages-teaser.test.js` — updated assertions

## Live summary generation

Banner and report are built by `se_home_lo_flyover_copy()` (PHP SSR) and `flyoverCopy()` (JS refresh), both reading the teaser payload:

| Field | Source |
|-------|--------|
| **Banner** | `counts.down`, `counts.degraded`, `counts.advisory` — e.g. `LOUSY OUTAGES → 1 degraded · 1 advisory · open status`, or `monitoring provider signals` when clear |
| **Report** | `lead.kind` + `lead.provider` — templated cautious language (degraded/disruption/advisory/unknown) |
| **Tone / hot** | `teaser.tone` + count/kind thresholds drive `--warn`, `--down`, `--hot` modifier classes |

Data flows: WP snapshot → `HomeTeaser::build()` → REST `/summary` → client poll every 5 min.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75ca4278-771b-41e2-b1a9-9630f3957563?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75ca4278-771b-41e2-b1a9-9630f3957563&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

