### PR TITLE
SEO + SEM readiness for consulting pages

### DIFF
--- a/__tests__/seo-sem-readiness.test.js
+++ b/__tests__/seo-sem-readiness.test.js
@@ -1,0 +1,61 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const header = fs.readFileSync('header.php', 'utf8');
+const seo = fs.readFileSync('inc/seo.php', 'utf8');
+const shop = fs.readFileSync('inc/shop.php', 'utf8');
+const workWithSuzy = fs.readFileSync('page-work-with-suzy.php', 'utf8');
+const hireStrip = fs.readFileSync('parts/home-hire-strip.php', 'utf8');
+const analytics = fs.readFileSync('assets/js/seo-analytics.js', 'utf8');
+const contactModal = fs.readFileSync('assets/js/header-contact-modal.js', 'utf8');
+const functions = fs.readFileSync('functions.php', 'utf8');
+
+test('header delegates meta and structured data to inc/seo.php', () => {
+  assert.match(header, /se_page_meta\(\)/);
+  assert.match(header, /se_page_structured_data\(\)/);
+  assert.doesNotMatch(header, /<title>.*AI Strategist, Musician/s);
+});
+
+test('commercial pages have dedicated SEO titles and descriptions', () => {
+  assert.match(seo, /Suzy Easton \| AI, Automation & Creative Technology Consultant in Vancouver/);
+  assert.match(seo, /Hire Suzy Easton \| AI & Automation Consultant in Vancouver, BC/);
+  assert.match(shop, /Technical Consulting Sessions in Vancouver \| Suzy Easton/);
+});
+
+test('structured data includes Person and WebSite without street address', () => {
+  assert.match(seo, /'@type'\s*=>\s*'Person'/);
+  assert.match(seo, /'@type'\s*=>\s*'WebSite'/);
+  assert.match(seo, /homeLocation/);
+  assert.match(seo, /East Vancouver/);
+  assert.doesNotMatch(seo, /streetAddress/);
+  assert.doesNotMatch(seo, /LocalBusiness/);
+});
+
+test('work with suzy page surfaces Vancouver location and availability', () => {
+  assert.match(workWithSuzy, /East Vancouver/);
+  assert.match(workWithSuzy, /available/i);
+  assert.match(workWithSuzy, /<h1[^>]*id="work-with-suzy-title"/);
+  assert.match(hireStrip, /Based in East Vancouver/);
+});
+
+test('conversion analytics events are wired', () => {
+  assert.match(analytics, /hire_cta_click/);
+  assert.match(shop, /shop_view/);
+  assert.match(shop, /consulting_product_view/);
+  assert.match(shop, /checkout_click/);
+  assert.match(seo, /work_with_suzy_view/);
+  assert.match(contactModal, /contact_open/);
+  assert.match(contactModal, /contact_submit/);
+});
+
+test('stale outages feed autodiscovery hook is removed', () => {
+  assert.doesNotMatch(functions, /\/outages\/feed/);
+  assert.match(functions, /lousy_outages_feed_autodiscovery/);
+});
+
+test('header emits a single title and canonical block', () => {
+  assert.equal((header.match(/<title>/g) || []).length, 1);
+  assert.equal((header.match(/rel="canonical"/g) || []).length, 1);
+  assert.equal((header.match(/name="description"/g) || []).length, 1);
+});

--- a/assets/css/shop-console.css
+++ b/assets/css/shop-console.css
@@ -359,6 +359,14 @@
 	display: none;
 }
 
+.home-hire-strip__location {
+    margin: 0 0 0.65rem;
+    color: rgba(244, 247, 255, 0.82);
+    font-size: clamp(0.58rem, 1.2vw, 0.68rem);
+    letter-spacing: 0.08em;
+    text-transform: lowercase;
+}
+
 .home-hire-strip__title {
 	margin: 0 0 0.3rem;
 	font-family: ui-monospace, "SFMono-Regular", "JetBrains Mono", Menlo, Consolas, monospace;

--- a/assets/js/header-contact-modal.js
+++ b/assets/js/header-contact-modal.js
@@ -62,6 +62,12 @@
     modal.hidden = false;
     document.body.classList.add('se-modal-open');
 
+    if (typeof window.seTrackEvent === 'function') {
+      window.seTrackEvent('contact_open', {
+        trigger: event && event.currentTarget ? (event.currentTarget.getAttribute('data-hire-cta-label') || 'contact_trigger') : 'programmatic',
+      });
+    }
+
     if (formBody) {
       formBody.scrollTop = 0;
     }
@@ -131,6 +137,10 @@
       setStatus(data.data && data.data.message ? data.data.message : 'Message sent.', false);
       form.hidden = true;
       if (successEl) successEl.hidden = false;
+
+      if (typeof window.seTrackEvent === 'function') {
+        window.seTrackEvent('contact_submit', { surface: 'contact_modal' });
+      }
     } catch (error) {
       setStatus(error.message || 'Could not send message right now.', true);
     }

--- a/assets/js/seo-analytics.js
+++ b/assets/js/seo-analytics.js
@@ -1,0 +1,87 @@
+(function () {
+	'use strict';
+
+	function getUtmParams() {
+		var params = new URLSearchParams(window.location.search);
+		var utm = {};
+		params.forEach(function (value, key) {
+			if (key.indexOf('utm_') === 0) {
+				utm[key] = value;
+			}
+		});
+		return utm;
+	}
+
+	function appendUtmToUrl(url, utm) {
+		if (!url || !utm || !Object.keys(utm).length) {
+			return url;
+		}
+
+		try {
+			var parsed = new URL(url, window.location.origin);
+			Object.keys(utm).forEach(function (key) {
+				parsed.searchParams.set(key, utm[key]);
+			});
+			return parsed.toString();
+		} catch (error) {
+			return url;
+		}
+	}
+
+	function preserveUtmOnLinks() {
+		var utm = getUtmParams();
+		if (!Object.keys(utm).length) {
+			return;
+		}
+
+		document.querySelectorAll('[data-preserve-utm], [data-hire-cta]').forEach(function (link) {
+			var href = link.getAttribute('href');
+			if (!href || href.indexOf('mailto:') === 0 || href.indexOf('tel:') === 0) {
+				return;
+			}
+
+			var next = appendUtmToUrl(href, utm);
+			if (next !== href) {
+				link.setAttribute('href', next);
+			}
+		});
+
+		document.querySelectorAll('[data-shop-checkout]').forEach(function (link) {
+			var href = link.getAttribute('href');
+			if (!href) {
+				return;
+			}
+			var next = appendUtmToUrl(href, utm);
+			if (next !== href) {
+				link.setAttribute('href', next);
+			}
+		});
+	}
+
+	function trackHireCtas() {
+		document.querySelectorAll('[data-hire-cta]').forEach(function (cta) {
+			cta.addEventListener('click', function () {
+				if (typeof window.seTrackEvent !== 'function') {
+					return;
+				}
+
+				window.seTrackEvent('hire_cta_click', {
+					label: cta.getAttribute('data-hire-cta-label') || '',
+					href: cta.getAttribute('href') || '',
+					text: (cta.textContent || '').trim(),
+				});
+			});
+		});
+	}
+
+	function init() {
+		preserveUtmOnLinks();
+		trackHireCtas();
+	}
+
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', init);
+	} else {
+		init();
+	}
+})();

--- a/functions.php
+++ b/functions.php
@@ -35,6 +35,7 @@ require_once get_template_directory() . '/inc/home-translink-alerts.php';
 require_once get_template_directory() . '/inc/home-yvr-audio-channels.php';
 require_once get_template_directory() . '/inc/home-yvr-broadcaster.php';
 require_once get_template_directory() . '/inc/shop.php';
+require_once get_template_directory() . '/inc/seo.php';
 /**
  * Functions file for Suzy’s Music Theme
  *   - Canucks App Integration (News + Betting)
@@ -3563,14 +3564,6 @@ add_action('template_redirect', function() {
     if ( is_author() ) {
         wp_redirect(home_url(), 301);
         exit;
-    }
-});
-
-// Advertise Lousy Outages RSS feed for readers (auto-discovery)
-add_action('wp_head', function () {
-    if (function_exists('home_url')) {
-        $href = esc_url( home_url('/outages/feed') );
-        echo "<link rel=\"alternate\" type=\"application/rss+xml\" title=\"Lousy Outages Alerts\" href=\"{$href}\" />\n";
     }
 });
 

--- a/header.php
+++ b/header.php
@@ -14,127 +14,13 @@
   <link rel="profile" href="http://gmpg.org/xfn/11">
 
   <?php
-    global $wp;
-    $site_name   = 'Suzy Easton';
-    $default_img = 'https://suzyeaston.ca/arcade/og-image.png';
-
-    $meta_keywords = 'Suzy Easton, musician, creative technologist';
-
-    if ( is_front_page() ) {
-      $meta_title = 'Suzy Easton | AI Strategist, Musician & Creative Technologist — Vancouver';
-      $meta_desc  = 'Suzy Easton is a Vancouver musician, AI strategist, and creative technologist building practical AI tools, outage dashboards, music experiments, and strange useful web projects.';
-      $meta_keywords = 'Suzy Easton, AI Strategist, Vancouver creative technologist, musician, Quercus IT, creative tools, music tech, retro tools';
-      $meta_img   = $default_img;
-    } elseif ( is_page_template( 'page-asmr-lab.php' ) ) {
-      $meta_title = 'ASMR Lab – experimental predecessor now under major redevelopment';
-      $meta_desc  = 'ASMR Lab is Suzy\'s earlier audio/visual prototype that inspired the Gastown simulator and is now being rebuilt in public.';
-      $meta_keywords = 'ASMR Lab, Gastown simulator predecessor, creative tech prototype, Suzy Easton';
-      $meta_img   = $default_img;
-    } elseif ( is_page_template( 'page-lousy-outages.php' ) ) {
-      $meta_title = 'Lousy Outages | Status dashboard for modern chaos';
-      $meta_desc  = 'A retro status dashboard for provider incidents, SaaS weirdness, community reports, and alerts when things go sideways.';
-      $meta_keywords = 'lousy outages status dashboard, outage tracker, retro status board';
-      $meta_img   = $default_img;
-    } elseif ( is_page_template( 'page-track-analyzer.php' ) ) {
-      $meta_title = "Suzy’s Track Analyzer | AI-assisted song feedback";
-      $meta_desc  = 'Upload an MP3 and get direct AI-assisted notes on lyrics, structure, feel, and production direction.';
-      $meta_keywords = 'track analyzer, music AI tool, Suzy Easton, mix feedback';
-      $meta_img   = $default_img;
-    } elseif ( is_page_template( 'page-arcade.php' ) ) {
-      $meta_title = 'Canucks Puck Bash - Retro Hockey Arcade';
-      $meta_desc  = "Shoot, score, and hear 'Don't You Forget About Me' in this 80s-style hockey arcade game.";
-      $meta_keywords = 'Canucks arcade game, retro hockey game, Suzy Easton arcade';
-      $meta_img   = $default_img;
-    } elseif ( is_page_template( 'page-coffee-for-builders.php' ) ) {
-      $meta_title = 'Coffee for Builders in Vancouver | Suzy Easton';
-      $meta_desc  = 'Coffee chats in Vancouver for people building things—tech, music, civic projects, and sports takes. Low-key, public, and intentional.';
-      $meta_keywords = 'coffee chats Vancouver, builders, Suzy Easton, tech, music, civic projects, sports takes';
-      $meta_img   = $default_img;
-    } elseif ( is_page_template( 'page-shop.php' ) || is_page( 'shop' ) ) {
-      $shop_meta  = function_exists( 'se_shop_meta' ) ? se_shop_meta() : [];
-      $meta_title = (string) ( $shop_meta['title'] ?? 'Shop Suzy | Hire Suzy Easton' );
-      $meta_desc  = (string) ( $shop_meta['description'] ?? 'Book focused consulting time with Suzy Easton.' );
-      $meta_keywords = (string) ( $shop_meta['keywords'] ?? 'hire Suzy Easton, tech consulting Vancouver' );
-      $meta_img   = $default_img;
-    } else {
-      $meta_title = wp_title( '|', false, 'right' ) . $site_name;
-      $meta_desc  = get_bloginfo( 'description' );
-      $meta_keywords = 'Suzy Easton, musician, creative technologist, Vancouver artist';
-      $meta_img   = $default_img;
-    }
-    if ( is_singular() ) {
-      $meta_url = get_permalink();
-    } else {
-      $meta_url = home_url( add_query_arg( [], $wp->request ) );
-    }
-    $home_profile_graph = [];
-    if ( is_front_page() ) {
-      $home_profile_graph[] = [
-        '@type' => 'ProfilePage',
-        'name' => 'Suzy Easton',
-        'url' => home_url( '/' ),
-        'description' => $meta_desc,
-        'mainEntity' => [
-          '@type' => 'Person',
-          'name' => 'Suzy Easton',
-          'jobTitle' => 'AI Strategist & Creative Technologist',
-          'address' => [
-            '@type' => 'PostalAddress',
-            'addressLocality' => 'Vancouver',
-            'addressCountry' => 'CA',
-          ],
-          'sameAs' => [
-            'https://suzyeaston.bandcamp.com',
-            'https://soundcloud.com/suzyeaston',
-            'https://instagram.com/suzyeaston',
-            'https://youtube.com/@suzyeaston',
-          ],
-        ],
-      ];
-    }
-
-    $structured_data = [
-      '@context' => 'https://schema.org',
-      '@graph'   => [
-        [
-          '@type' => 'WebSite',
-          'name' => $site_name,
-          'url'  => home_url( '/' ),
-          'description' => $meta_desc,
-          'inLanguage'  => get_bloginfo( 'language' ),
-          'potentialAction' => [
-            '@type' => 'SearchAction',
-            'target' => home_url( '/?s={search_term_string}' ),
-            'query-input' => 'required name=search_term_string',
-          ],
-        ],
-        [
-          '@type' => 'Person',
-          'name' => 'Suzy Easton',
-          'url'  => 'https://www.suzyeaston.ca',
-          'jobTitle' => 'AI Strategist & Creative Technologist',
-          'address' => [
-            '@type' => 'PostalAddress',
-            'addressLocality' => 'Vancouver',
-            'addressCountry'  => 'CA',
-          ],
-          'sameAs' => [
-            'https://suzyeaston.bandcamp.com',
-            'https://soundcloud.com/suzyeaston',
-            'https://instagram.com/suzyeaston',
-            'https://youtube.com/@suzyeaston',
-          ],
-        ],
-      ],
-    ];
-
-    if ( ! empty( $home_profile_graph ) ) {
-      $structured_data['@graph'] = array_merge( $structured_data['@graph'], $home_profile_graph );
-    }
-
-    if ( ( is_page_template( 'page-shop.php' ) || is_page( 'shop' ) ) && function_exists( 'se_shop_structured_data' ) ) {
-      $structured_data = se_shop_structured_data();
-    }
+    $page_meta       = se_page_meta();
+    $meta_title      = $page_meta['title'];
+    $meta_desc       = $page_meta['description'];
+    $meta_keywords   = $page_meta['keywords'];
+    $meta_img        = $page_meta['image'];
+    $meta_url        = $page_meta['url'];
+    $structured_data = se_page_structured_data();
   ?>
   <title><?php echo esc_html( $meta_title ); ?></title>
   <meta name="description" content="<?php echo esc_attr( $meta_desc ); ?>">
@@ -181,8 +67,8 @@
   </div>
   <div class="header-actions">
     <nav class="se-header-nav" aria-label="Site actions">
-      <a class="se-header-nav__link se-header-nav__link--shop" href="<?php echo esc_url( home_url( '/shop/' ) ); ?>">SHOP</a>
-      <a class="se-header-nav__link" href="<?php echo esc_url( home_url( '/shop/' ) ); ?>">HIRE SUZY</a>
+      <a class="se-header-nav__link se-header-nav__link--shop" href="<?php echo esc_url( se_preserve_utm_url( home_url( '/shop/' ) ) ); ?>" data-hire-cta data-hire-cta-label="header_shop">SHOP</a>
+      <a class="se-header-nav__link" href="<?php echo esc_url( se_preserve_utm_url( home_url( '/work-with-suzy/' ) ) ); ?>" data-hire-cta data-hire-cta-label="header_hire">HIRE SUZY</a>
     </nav>
     <button class="pixel-button header-contact-trigger"
             type="button"

--- a/inc/seo.php
+++ b/inc/seo.php
@@ -1,0 +1,472 @@
+<?php
+/**
+ * SEO, structured data, and conversion analytics helpers.
+ *
+ * Single source of truth for page meta and JSON-LD. header.php consumes this;
+ * do not add a parallel SEO plugin layer without removing the manual tags first.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @return string
+ */
+function se_default_og_image() {
+	return 'https://suzyeaston.ca/arcade/og-image.png';
+}
+
+/**
+ * @return array<int, string>
+ */
+function se_person_same_as() {
+	return [
+		'https://www.linkedin.com/in/suzyeaston/',
+		'https://github.com/suzyeaston',
+		'https://suzyeaston.bandcamp.com',
+		'https://soundcloud.com/suzyeaston',
+		'https://instagram.com/suzyeaston',
+		'https://youtube.com/@suzyeaston',
+	];
+}
+
+/**
+ * @return array<int, string>
+ */
+function se_person_knows_about() {
+	return [
+		'Artificial intelligence consulting',
+		'Workflow automation',
+		'Systems integration',
+		'Technical consulting',
+		'API integration',
+		'WordPress development',
+		'Software debugging',
+		'Creative technology',
+		'QA automation',
+	];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function se_person_schema() {
+	return [
+		'@type'       => 'Person',
+		'name'        => 'Suzy Easton',
+		'url'         => home_url( '/' ),
+		'jobTitle'    => 'AI, Automation & Creative Technology Consultant',
+		'description' => 'Vancouver-based AI strategist, solutions engineer and creative technologist helping teams debug systems, automate workflows, integrate tools and build useful technology.',
+		'knowsAbout'  => se_person_knows_about(),
+		'homeLocation' => [
+			'@type' => 'Place',
+			'name'  => 'East Vancouver',
+			'address' => [
+				'@type'           => 'PostalAddress',
+				'addressLocality' => 'Vancouver',
+				'addressRegion'   => 'BC',
+				'addressCountry'  => 'CA',
+			],
+		],
+		'sameAs' => se_person_same_as(),
+	];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function se_website_schema( $description = '' ) {
+	$graph = [
+		'@type'       => 'WebSite',
+		'name'        => 'Suzy Easton',
+		'alternateName' => 'suzyeaston.ca',
+		'url'         => home_url( '/' ),
+		'description' => $description ?: get_bloginfo( 'description' ),
+		'inLanguage'  => get_bloginfo( 'language' ),
+		'publisher'   => [
+			'@type' => 'Person',
+			'name'  => 'Suzy Easton',
+			'url'   => home_url( '/' ),
+		],
+		'potentialAction' => [
+			'@type'       => 'SearchAction',
+			'target'      => home_url( '/?s={search_term_string}' ),
+			'query-input' => 'required name=search_term_string',
+		],
+	];
+
+	return $graph;
+}
+
+/**
+ * @return array<string, string>
+ */
+function se_home_meta() {
+	return [
+		'title'       => 'Suzy Easton | AI, Automation & Creative Technology Consultant in Vancouver',
+		'description' => 'Vancouver-based AI strategist, solutions engineer and creative technologist helping teams debug systems, automate workflows, integrate tools and build useful technology. Based in East Vancouver and available now.',
+		'keywords'    => 'Suzy Easton, AI consultant Vancouver, automation consultant Vancouver, creative technologist Vancouver, technical consulting Vancouver, workflow automation',
+	];
+}
+
+/**
+ * @return array<string, string>
+ */
+function se_work_with_suzy_meta() {
+	return [
+		'title'       => 'Hire Suzy Easton | AI & Automation Consultant in Vancouver, BC',
+		'description' => 'Hire Suzy Easton for AI strategy, workflow automation, integrations, debugging and technical consulting in Vancouver or remotely. Based in East Vancouver and available for projects now.',
+		'keywords'    => 'hire Suzy Easton, AI consultant Vancouver, automation consultant Vancouver, technical consultant Vancouver, workflow automation Vancouver, East Vancouver consultant',
+	];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function se_work_with_suzy_structured_data() {
+	$meta     = se_work_with_suzy_meta();
+	$services = [];
+
+	foreach ( se_get_shop_products() as $product ) {
+		$services[] = [
+			'@type'       => 'Service',
+			'name'        => (string) ( $product['title'] ?? '' ) . ' — ' . (string) ( $product['subtitle'] ?? '' ),
+			'description' => (string) ( $product['description'] ?? '' ),
+			'provider'    => [
+				'@type' => 'Person',
+				'name'  => 'Suzy Easton',
+				'url'   => home_url( '/' ),
+			],
+			'serviceType' => (string) ( $product['subtitle'] ?? 'Technical consulting' ),
+			'areaServed'  => se_service_area_served(),
+			'offers'      => [
+				'@type'         => 'Offer',
+				'price'         => (string) ( $product['price'] ?? 0 ),
+				'priceCurrency' => (string) ( $product['currency'] ?? 'CAD' ),
+				'availability'  => 'https://schema.org/InStock',
+				'url'           => home_url( '/shop/#' . (string) ( $product['slug'] ?? '' ) ),
+			],
+		];
+	}
+
+	return [
+		'@context' => 'https://schema.org',
+		'@graph'   => array_merge(
+			[
+				se_website_schema( $meta['description'] ),
+				se_person_schema(),
+				[
+					'@type'       => 'WebPage',
+					'name'        => $meta['title'],
+					'url'         => home_url( '/work-with-suzy/' ),
+					'description' => $meta['description'],
+				],
+				[
+					'@type'       => 'Service',
+					'name'        => 'AI, Automation & Technical Consulting',
+					'description' => $meta['description'],
+					'provider'    => [
+						'@type' => 'Person',
+						'name'  => 'Suzy Easton',
+						'url'   => home_url( '/' ),
+					],
+					'serviceType' => [
+						'AI consulting',
+						'workflow automation',
+						'technical consulting',
+						'systems integration',
+						'debugging',
+						'creative technology',
+					],
+					'areaServed' => se_service_area_served(),
+					'url'        => home_url( '/work-with-suzy/' ),
+				],
+			],
+			$services
+		),
+	];
+}
+
+/**
+ * @return array<int, array<string, mixed>>
+ */
+function se_service_area_served() {
+	return [
+		[
+			'@type' => 'City',
+			'name'  => 'Vancouver',
+			'containedInPlace' => [
+				'@type' => 'AdministrativeArea',
+				'name'  => 'British Columbia',
+				'containedInPlace' => [
+					'@type' => 'Country',
+					'name'  => 'Canada',
+				],
+			],
+		],
+		[
+			'@type' => 'Country',
+			'name'  => 'Canada',
+		],
+	];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function se_home_structured_data( $description ) {
+	$graph = [
+		se_website_schema( $description ),
+		se_person_schema(),
+		[
+			'@type'       => 'ProfilePage',
+			'name'        => 'Suzy Easton',
+			'url'         => home_url( '/' ),
+			'description' => $description,
+			'mainEntity'  => se_person_schema(),
+		],
+	];
+
+	return [
+		'@context' => 'https://schema.org',
+		'@graph'   => $graph,
+	];
+}
+
+/**
+ * Resolve page meta for the current request.
+ *
+ * @return array{title: string, description: string, keywords: string, image: string, url: string}
+ */
+function se_page_meta() {
+	global $wp;
+
+	$site_name   = 'Suzy Easton';
+	$default_img = se_default_og_image();
+	$keywords    = 'Suzy Easton, musician, creative technologist';
+
+	if ( is_front_page() ) {
+		$home       = se_home_meta();
+		$meta_title = $home['title'];
+		$meta_desc  = $home['description'];
+		$keywords   = $home['keywords'];
+	} elseif ( is_page_template( 'page-work-with-suzy.php' ) || is_page( 'work-with-suzy' ) ) {
+		$wws        = se_work_with_suzy_meta();
+		$meta_title = $wws['title'];
+		$meta_desc  = $wws['description'];
+		$keywords   = $wws['keywords'];
+	} elseif ( is_page_template( 'page-asmr-lab.php' ) ) {
+		$meta_title = 'ASMR Lab – experimental predecessor now under major redevelopment';
+		$meta_desc  = 'ASMR Lab is Suzy\'s earlier audio/visual prototype that inspired the Gastown simulator and is now being rebuilt in public.';
+		$keywords   = 'ASMR Lab, Gastown simulator predecessor, creative tech prototype, Suzy Easton';
+	} elseif ( is_page_template( 'page-lousy-outages.php' ) ) {
+		$meta_title = 'Lousy Outages | Status dashboard for modern chaos';
+		$meta_desc  = 'A retro status dashboard for provider incidents, SaaS weirdness, community reports, and alerts when things go sideways.';
+		$keywords   = 'lousy outages status dashboard, outage tracker, retro status board';
+	} elseif ( is_page_template( 'page-track-analyzer.php' ) ) {
+		$meta_title = "Suzy's Track Analyzer | AI-assisted song feedback";
+		$meta_desc  = 'Upload an MP3 and get direct AI-assisted notes on lyrics, structure, feel, and production direction.';
+		$keywords   = 'track analyzer, music AI tool, Suzy Easton, mix feedback';
+	} elseif ( is_page_template( 'page-arcade.php' ) ) {
+		$meta_title = 'Canucks Puck Bash - Retro Hockey Arcade';
+		$meta_desc  = "Shoot, score, and hear 'Don't You Forget About Me' in this 80s-style hockey arcade game.";
+		$keywords   = 'Canucks arcade game, retro hockey game, Suzy Easton arcade';
+	} elseif ( is_page_template( 'page-coffee-for-builders.php' ) ) {
+		$meta_title = 'Coffee for Builders in Vancouver | Suzy Easton';
+		$meta_desc  = 'Coffee chats in Vancouver for people building things—tech, music, civic projects, and sports takes. Low-key, public, and intentional.';
+		$keywords   = 'coffee chats Vancouver, builders, Suzy Easton, tech, music, civic projects, sports takes';
+	} elseif ( is_page_template( 'page-shop.php' ) || is_page( 'shop' ) ) {
+		$shop_meta  = function_exists( 'se_shop_meta' ) ? se_shop_meta() : [];
+		$meta_title = (string) ( $shop_meta['title'] ?? 'Shop Suzy | Hire Suzy Easton' );
+		$meta_desc  = (string) ( $shop_meta['description'] ?? 'Book focused consulting time with Suzy Easton.' );
+		$keywords   = (string) ( $shop_meta['keywords'] ?? 'hire Suzy Easton, tech consulting Vancouver' );
+	} else {
+		$meta_title = wp_title( '|', false, 'right' ) . $site_name;
+		$meta_desc  = get_bloginfo( 'description' );
+		$keywords   = 'Suzy Easton, musician, creative technologist, Vancouver artist';
+	}
+
+	if ( is_singular() ) {
+		$meta_url = get_permalink();
+	} else {
+		$meta_url = home_url( add_query_arg( [], $wp->request ) );
+	}
+
+	return [
+		'title'       => $meta_title,
+		'description' => $meta_desc,
+		'keywords'    => $keywords,
+		'image'       => $default_img,
+		'url'         => $meta_url,
+	];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function se_page_structured_data() {
+	$meta = se_page_meta();
+
+	if ( is_front_page() ) {
+		return se_home_structured_data( $meta['description'] );
+	}
+
+	if ( is_page_template( 'page-work-with-suzy.php' ) || is_page( 'work-with-suzy' ) ) {
+		return se_work_with_suzy_structured_data();
+	}
+
+	if ( ( is_page_template( 'page-shop.php' ) || is_page( 'shop' ) ) && function_exists( 'se_shop_structured_data' ) ) {
+		return se_shop_structured_data();
+	}
+
+	return [
+		'@context' => 'https://schema.org',
+		'@graph'   => [
+			se_website_schema( $meta['description'] ),
+			se_person_schema(),
+		],
+	];
+}
+
+/**
+ * @return array<string, string>
+ */
+function se_get_utm_query_args() {
+	$utm = [];
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	foreach ( $_GET as $key => $value ) {
+		if ( preg_match( '/^utm_/', (string) $key ) && is_scalar( $value ) ) {
+			$utm[ (string) $key ] = sanitize_text_field( wp_unslash( (string) $value ) );
+		}
+	}
+
+	return $utm;
+}
+
+/**
+ * Append current-request UTM params to an internal URL.
+ *
+ * @param string $url
+ */
+function se_preserve_utm_url( $url ) {
+	$utm = se_get_utm_query_args();
+
+	if ( empty( $utm ) ) {
+		return $url;
+	}
+
+	return add_query_arg( $utm, $url );
+}
+
+/**
+ * @param string               $event_name
+ * @param array<string, mixed> $payload
+ */
+function se_seo_track_event( $event_name, $payload = [] ) {
+	$payload = array_merge(
+		[
+			'surface' => se_seo_current_surface(),
+		],
+		is_array( $payload ) ? $payload : []
+	);
+
+	/**
+	 * Site-wide conversion analytics hook.
+	 *
+	 * @param string               $event_name
+	 * @param array<string, mixed> $payload
+	 */
+	do_action( 'se_seo_event', $event_name, $payload );
+}
+
+/**
+ * @return string
+ */
+function se_seo_current_surface() {
+	if ( is_page_template( 'page-work-with-suzy.php' ) || is_page( 'work-with-suzy' ) ) {
+		return 'work_with_suzy';
+	}
+
+	if ( is_page_template( 'page-shop.php' ) || is_page( 'shop' ) ) {
+		return 'shop';
+	}
+
+	if ( is_front_page() ) {
+		return 'home';
+	}
+
+	return 'site';
+}
+
+function se_enqueue_seo_analytics_assets() {
+	if ( is_admin() ) {
+		return;
+	}
+
+	$dir = get_template_directory();
+	$uri = get_template_directory_uri();
+	$js  = '/assets/js/seo-analytics.js';
+
+	if ( ! file_exists( $dir . $js ) ) {
+		return;
+	}
+
+	wp_enqueue_script(
+		'se-seo-analytics',
+		$uri . $js,
+		[],
+		filemtime( $dir . $js ),
+		true
+	);
+
+	wp_localize_script(
+		'se-seo-analytics',
+		'SeSeoConfig',
+		[
+			'surface' => se_seo_current_surface(),
+			'paths'   => [
+				'shop'           => home_url( '/shop/' ),
+				'workWithSuzy'   => home_url( '/work-with-suzy/' ),
+			],
+		]
+	);
+}
+add_action( 'wp_enqueue_scripts', 'se_enqueue_seo_analytics_assets', 20 );
+
+function se_seo_analytics_bootstrap() {
+	if ( is_admin() ) {
+		return;
+	}
+
+	$surface = se_seo_current_surface();
+	?>
+	<script>
+	(function () {
+		function seTrackEvent(name, data) {
+			var payload = Object.assign({ event: name, surface: <?php echo wp_json_encode( $surface ); ?> }, data || {});
+			window.dispatchEvent(new CustomEvent('se-seo:event', { detail: payload }));
+			if (window.dataLayer) {
+				window.dataLayer.push(payload);
+			}
+		}
+		window.seTrackEvent = seTrackEvent;
+
+		<?php if ( 'work_with_suzy' === $surface ) : ?>
+		seTrackEvent('work_with_suzy_view', { page: 'work_with_suzy' });
+		<?php endif; ?>
+	})();
+	</script>
+	<?php
+}
+add_action( 'wp_head', 'se_seo_analytics_bootstrap', 98 );
+
+function se_work_with_suzy_page_view() {
+	if ( ! is_page_template( 'page-work-with-suzy.php' ) && ! is_page( 'work-with-suzy' ) ) {
+		return;
+	}
+
+	se_seo_track_event( 'work_with_suzy_view', [ 'page' => 'work_with_suzy' ] );
+}
+add_action( 'wp', 'se_work_with_suzy_page_view' );

--- a/inc/shop.php
+++ b/inc/shop.php
@@ -100,9 +100,9 @@ add_action( 'wp_enqueue_scripts', 'se_enqueue_shop_assets', 25 );
  */
 function se_shop_meta() {
 	return [
-		'title'       => 'Shop Suzy | Hire Suzy Easton — Debug, Automate, Deep Dive',
-		'description' => 'Book focused consulting time with Suzy Easton: 30-minute tech rescue, AI + workflow sessions, and 90-minute deep dives. Vancouver-built, no corporate brochureware.',
-		'keywords'    => 'hire Suzy Easton, tech consulting Vancouver, WordPress debugging, workflow automation, AI strategy session',
+		'title'       => 'Technical Consulting Sessions in Vancouver | Suzy Easton',
+		'description' => 'Book focused technical help with Suzy Easton in Vancouver: debugging, AI workflows, automation, integrations and deep technical problem-solving. Remote sessions available.',
+		'keywords'    => 'technical consulting Vancouver, hire Suzy Easton, WordPress debugging Vancouver, workflow automation, AI consulting session, East Vancouver consultant',
 	];
 }
 
@@ -112,16 +112,39 @@ function se_shop_meta() {
  * @return array<string, mixed>
  */
 function se_shop_structured_data() {
+	$meta  = se_shop_meta();
 	$items = [];
 
 	foreach ( se_get_shop_products() as $product ) {
+		$product_name = (string) ( $product['title'] ?? '' ) . ' · ' . (string) ( $product['subtitle'] ?? '' );
+
 		$items[] = [
-			'@type'           => 'Product',
-			'name'            => (string) ( $product['title'] ?? '' ) . ' · ' . (string) ( $product['subtitle'] ?? '' ),
-			'description'     => (string) ( $product['description'] ?? '' ),
-			'sku'             => (string) ( $product['sku'] ?? '' ),
-			'url'             => home_url( '/shop/#' . (string) ( $product['slug'] ?? '' ) ),
-			'offers'          => [
+			'@type'       => 'Product',
+			'name'        => $product_name,
+			'description' => (string) ( $product['description'] ?? '' ),
+			'sku'         => (string) ( $product['sku'] ?? '' ),
+			'url'         => home_url( '/shop/#' . (string) ( $product['slug'] ?? '' ) ),
+			'offers'      => [
+				'@type'         => 'Offer',
+				'price'         => (string) ( $product['price'] ?? 0 ),
+				'priceCurrency' => (string) ( $product['currency'] ?? 'CAD' ),
+				'availability'  => 'https://schema.org/InStock',
+				'url'           => se_shop_product_checkout_url( $product ),
+			],
+		];
+
+		$items[] = [
+			'@type'       => 'Service',
+			'name'        => $product_name,
+			'description' => (string) ( $product['description'] ?? '' ),
+			'provider'    => [
+				'@type' => 'Person',
+				'name'  => 'Suzy Easton',
+				'url'   => home_url( '/' ),
+			],
+			'serviceType' => (string) ( $product['subtitle'] ?? 'Technical consulting' ),
+			'areaServed'  => se_service_area_served(),
+			'offers'      => [
 				'@type'         => 'Offer',
 				'price'         => (string) ( $product['price'] ?? 0 ),
 				'priceCurrency' => (string) ( $product['currency'] ?? 'CAD' ),
@@ -135,11 +158,13 @@ function se_shop_structured_data() {
 		'@context' => 'https://schema.org',
 		'@graph'   => array_merge(
 			[
+				se_website_schema( $meta['description'] ),
+				se_person_schema(),
 				[
 					'@type'       => 'WebPage',
-					'name'        => 'Shop Suzy',
+					'name'        => $meta['title'],
 					'url'         => home_url( '/shop/' ),
-					'description' => se_shop_meta()['description'],
+					'description' => $meta['description'],
 				],
 			],
 			$items
@@ -154,11 +179,20 @@ function se_shop_analytics_bootstrap() {
 	?>
 	<script>
 	(function () {
+		var conversionMap = {
+			page_view: 'shop_view',
+			product_view: 'consulting_product_view',
+			checkout_click: 'checkout_click'
+		};
+
 		function seShopEvent(name, data) {
 			var detail = Object.assign({ event: name }, data || {});
 			window.dispatchEvent(new CustomEvent('se-shop:event', { detail: detail }));
 			if (window.dataLayer) {
 				window.dataLayer.push(Object.assign({ event: 'shop_' + name }, data || {}));
+			}
+			if (typeof window.seTrackEvent === 'function' && conversionMap[name]) {
+				window.seTrackEvent(conversionMap[name], Object.assign({ page: 'shop' }, data || {}));
 			}
 		}
 		window.seShopEvent = seShopEvent;

--- a/page-shop.php
+++ b/page-shop.php
@@ -5,14 +5,15 @@ Template Name: Shop
 get_header();
 
 $products = se_get_shop_products();
+$work_url = se_preserve_utm_url( home_url( '/work-with-suzy/' ) );
 ?>
 <main id="main-content" class="shop-page">
 	<article class="page-content shop-content">
 		<section class="shop-hero" aria-labelledby="shop-title">
-			<p class="shop-kicker shop-eyebrow"><?php echo esc_html( 'consulting // vancouver // remote' ); ?></p>
-			<h1 id="shop-title" class="retro-title glow-lite"><?php echo esc_html( 'Hire Suzy' ); ?></h1>
+			<p class="shop-kicker shop-eyebrow"><?php echo esc_html( 'East Vancouver // available' ); ?></p>
+			<h1 id="shop-title" class="retro-title glow-lite"><?php echo esc_html( 'Technical consulting sessions' ); ?></h1>
 			<p class="shop-lead"><?php echo esc_html( 'Focused technical help without turning every problem into a six-week engagement.' ); ?></p>
-			<p class="shop-hero-subcopy"><?php echo esc_html( 'Debug something broken, map an AI or automation workflow, or go deep on the complicated system problem.' ); ?></p>
+			<p class="shop-hero-subcopy"><?php echo esc_html( 'Debugging, AI workflows, automation, integrations and deep technical problem-solving. Vancouver-based, remote sessions available.' ); ?></p>
 			<div class="shop-hero-terminal" aria-hidden="true">
 				<p class="shop-hero-terminal__line"><span class="shop-hero-terminal__sigil">&gt;</span> <?php echo esc_html( 'AVAILABLE · 3 FIXED-PRICE SESSIONS' ); ?></p>
 				<p class="shop-hero-terminal__line shop-hero-terminal__line--muted"><?php echo esc_html( '30 min debug · 45 min workflow · 90 min deep dive · CAD' ); ?></p>
@@ -39,7 +40,7 @@ $products = se_get_shop_products();
 			<h2 id="shop-custom-title"><?php echo esc_html( 'Need more than a session?' ); ?></h2>
 			<p><?php echo esc_html( 'For larger builds, consulting, technical roles, creative technology, or work that needs a real scope first, use the bigger-project door.' ); ?></p>
 			<div class="shop-custom-work__actions">
-				<a class="pixel-button shop-custom-work__cta" href="<?php echo esc_url( home_url( '/work-with-suzy/' ) ); ?>"><?php echo esc_html( 'Work with Suzy' ); ?></a>
+				<a class="pixel-button shop-custom-work__cta" href="<?php echo esc_url( $work_url ); ?>" data-hire-cta data-hire-cta-label="shop_work_with_suzy"><?php echo esc_html( 'Work with Suzy' ); ?></a>
 				<button class="pixel-button shop-custom-work__contact" type="button" data-contact-trigger aria-haspopup="dialog" aria-controls="contact-suzy-modal"><?php echo esc_html( 'Send a note' ); ?></button>
 			</div>
 		</section>

--- a/page-work-with-suzy.php
+++ b/page-work-with-suzy.php
@@ -3,26 +3,40 @@
 Template Name: Work With Suzy
 */
 get_header();
+
+$shop_url = se_preserve_utm_url( home_url( '/shop/' ) );
 ?>
 
 <main id="main-content" class="work-with-suzy-page">
     <article class="page-content work-with-suzy-content">
         <section class="crt-block wws-hero" aria-labelledby="work-with-suzy-title">
-            <p class="wws-kicker pixel-font wws-eyebrow">Senior technical work • custom WordPress • QA automation • practical AI • weird bug triage</p>
+            <p class="wws-kicker pixel-font wws-eyebrow">East Vancouver // available</p>
+            <p class="wws-location pixel-font">AI · automation · systems · creative technology</p>
             <h1 id="work-with-suzy-title" class="retro-title glow-lite">Work With Suzy</h1>
-            <p class="wws-lead">I help teams make messy systems understandable, testable, and shippable.</p>
-            <p class="wws-hero-subcopy">I work across custom WordPress, JavaScript/PHP, QA automation, IT operations, API/integration debugging, dashboards, workflow automation, and AI-assisted prototypes with reviewable outputs.</p>
-            <p class="wws-hero-subcopy">My strongest work happens where product, support, QA, ops, and real users collide. I can find the failure path, explain it clearly, and help build the fix.</p>
+            <p class="wws-lead">Bring me the broken thing, repetitive workflow, integration mess or ambitious idea.</p>
+            <p class="wws-hero-subcopy">I help teams make messy systems understandable, testable, and shippable — across custom WordPress, JavaScript/PHP, QA automation, IT operations, API/integration debugging, dashboards, workflow automation, and AI-assisted prototypes with reviewable outputs.</p>
+            <p class="wws-hero-subcopy">Based in East Vancouver. I work locally across Vancouver and remotely. Available for consulting, technical roles, projects and collaborations now.</p>
             <div class="wws-actions" role="group" aria-label="Work With Suzy contact links">
-                <a class="pixel-button wws-hero-cta" href="<?php echo esc_url( home_url( '/shop/' ) ); ?>">Book a session</a>
-                <a class="pixel-button wws-secondary-button" href="mailto:suzyeaston@icloud.com?subject=Work%20With%20Suzy">Email Suzy</a>
+                <a class="pixel-button wws-hero-cta" href="<?php echo esc_url( $shop_url ); ?>" data-hire-cta data-hire-cta-label="wws_book_session">Book a session</a>
+                <a class="pixel-button wws-secondary-button" href="mailto:suzyeaston@icloud.com?subject=Work%20With%20Suzy" data-hire-cta data-hire-cta-label="wws_email">Email Suzy</a>
                 <a class="pixel-button wws-secondary-button" href="https://www.linkedin.com/in/suzyeaston/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
                 <a class="pixel-button wws-secondary-button" href="https://github.com/suzyeaston" target="_blank" rel="noopener noreferrer">View GitHub</a>
             </div>
         </section>
 
+        <section class="crt-block wws-section" aria-labelledby="who-this-is-for">
+            <h2 id="who-this-is-for" class="pixel-font">Who this is for</h2>
+            <p>Founders, small businesses, creative teams, and operators who need a senior technical generalist — not another slide deck. Also a fit if you are hiring for a contract sprint or the right full-time senior role.</p>
+            <ul class="wws-fit-list">
+                <li>Teams stuck between product, support, QA, ops, and engineering with nobody who speaks all of them.</li>
+                <li>WordPress or custom web builds that need careful hands, not plugin chaos.</li>
+                <li>Workflows drowning in copy-paste rituals, spreadsheet archaeology, or manual checks.</li>
+                <li>Integrations, identity, or API behaviour that works in staging and lies in production.</li>
+            </ul>
+        </section>
+
         <section class="crt-block wws-section" aria-labelledby="what-i-help-with">
-            <h2 id="what-i-help-with" class="pixel-font">How I can help</h2>
+            <h2 id="what-i-help-with" class="pixel-font">What I solve</h2>
             <div class="wws-grid">
                 <article class="wws-card wws-card--featured">
                     <h3>Web development and custom builds</h3>
@@ -49,6 +63,12 @@ get_header();
                     <p>I use AI as leverage, not theatre: focused prototypes, summarizers, internal helpers, content workflows, dashboards, and code acceleration where the output is reviewable and useful.</p>
                 </article>
             </div>
+        </section>
+
+        <section class="crt-block wws-section" aria-labelledby="how-to-start">
+            <h2 id="how-to-start" class="pixel-font">How to start</h2>
+            <p>Fastest path: book a fixed-price session in the <a class="wws-highlight-link" href="<?php echo esc_url( $shop_url ); ?>" data-hire-cta data-hire-cta-label="wws_shop_link">Shop</a> — 30-minute debug rescue, 45-minute AI + workflow session, or 90-minute deep dive. Larger builds, roles, or scoped consulting: email me with what is broken, what &ldquo;done&rdquo; looks like, and your timeline.</p>
+            <p>I usually reply within one business day. Vancouver time.</p>
         </section>
 
         <section class="crt-block wws-section" aria-labelledby="current-focus">
@@ -126,7 +146,7 @@ get_header();
 
         <section class="crt-block wws-section" aria-labelledby="ways-to-work">
             <h2 id="ways-to-work" class="pixel-font">Ways we can work together</h2>
-            <p>Need a fixed-price session first? <a class="wws-highlight-link" href="<?php echo esc_url( home_url( '/shop/' ) ); ?>">Shop Suzy</a> — debug rescue, automation session, or deep dive.</p>
+            <p>Need a fixed-price session first? <a class="wws-highlight-link" href="<?php echo esc_url( $shop_url ); ?>" data-hire-cta data-hire-cta-label="wws_shop_sessions">Shop Suzy</a> — debug rescue, automation session, or deep dive.</p>
             <div class="wws-work-modes">
                 <div class="wws-mode"><strong>Senior role conversations</strong><span>For teams hiring someone who can bridge IT operations, QA, support engineering, automation, and practical product thinking.</span></div>
                 <div class="wws-mode"><strong>Contract QA / automation sprint</strong><span>A focused engagement to reproduce issues, improve test coverage, validate workflows, and reduce release panic.</span></div>
@@ -141,7 +161,7 @@ get_header();
             <h2 id="work-with-suzy-contact" class="pixel-font">Let&rsquo;s make the messy thing make sense</h2>
             <p>Email me with the role, project, bug, workflow, or idea. Tell me what is broken, what &ldquo;done&rdquo; looks like, and any timeline or budget constraints. I&rsquo;ll tell you honestly whether I&rsquo;m a fit.</p>
             <p>Email: <a href="mailto:suzyeaston@icloud.com?subject=Work%20With%20Suzy%20%E2%80%94%20%5Brole%2Fproject%5D">suzyeaston@icloud.com</a></p>
-            <a class="pixel-button wws-final-button" href="mailto:suzyeaston@icloud.com?subject=Work%20With%20Suzy%20%E2%80%94%20%5Brole%2Fproject%5D">Email Suzy</a>
+            <a class="pixel-button wws-final-button" href="mailto:suzyeaston@icloud.com?subject=Work%20With%20Suzy%20%E2%80%94%20%5Brole%2Fproject%5D" data-hire-cta data-hire-cta-label="wws_final_email">Email Suzy</a>
             <div class="wws-subject-list">
                 <p><strong>Suggested subject lines:</strong></p>
                 <ul>

--- a/parts/home-hire-strip.php
+++ b/parts/home-hire-strip.php
@@ -1,15 +1,16 @@
 <?php
-$shop_url = home_url( '/shop/' );
+$shop_url = se_preserve_utm_url( home_url( '/shop/' ) );
 $work_url = home_url( '/work-with-suzy/' );
 $projects = home_url( '/projects/' );
 ?>
 <section class="home-hire-strip" aria-label="<?php echo esc_attr( 'Hire Suzy and book consulting' ); ?>">
 	<p class="home-section-kicker pixel-font"><?php echo esc_html( 'available // consulting' ); ?></p>
+	<p class="home-hire-strip__location pixel-font"><?php echo esc_html( 'Based in East Vancouver · working across Vancouver and remotely' ); ?></p>
 	<h2 class="home-hire-strip__title"><?php echo esc_html( 'Need another brain on it?' ); ?></h2>
-	<p class="home-hire-strip__lede"><?php echo esc_html( 'Debug something broken, map an automation, or dig into the complicated system problem. Fixed-price technical sessions, remote from Vancouver.' ); ?></p>
+	<p class="home-hire-strip__lede"><?php echo esc_html( 'AI, automation, systems and creative technology consulting. Debug something broken, map a workflow, or dig into the complicated system problem. Available for Vancouver projects and remote work now.' ); ?></p>
 	<nav class="home-hire-strip__actions" aria-label="<?php echo esc_attr( 'Consulting links' ); ?>">
-		<a class="pixel-button home-hire-strip__cta home-hire-strip__cta--primary" href="<?php echo esc_url( $shop_url ); ?>"><?php echo esc_html( 'View sessions' ); ?></a>
-		<a class="pixel-button home-hire-strip__cta" href="<?php echo esc_url( $work_url ); ?>"><?php echo esc_html( 'Bigger project' ); ?></a>
+		<a class="pixel-button home-hire-strip__cta home-hire-strip__cta--primary" href="<?php echo esc_url( $shop_url ); ?>" data-hire-cta data-hire-cta-label="home_view_sessions"><?php echo esc_html( 'View sessions' ); ?></a>
+		<a class="pixel-button home-hire-strip__cta" href="<?php echo esc_url( $work_url ); ?>" data-hire-cta data-hire-cta-label="home_bigger_project"><?php echo esc_html( 'Bigger project' ); ?></a>
 		<a class="pixel-button home-hire-strip__cta" href="<?php echo esc_url( $projects ); ?>"><?php echo esc_html( 'Enter the lab' ); ?></a>
 	</nav>
 	<p class="home-hire-strip__footnote">

--- a/parts/shop-product-card.php
+++ b/parts/shop-product-card.php
@@ -43,7 +43,7 @@ $detail_id = 'shop-detail-' . $slug;
 	<div class="shop-product-card__actions">
 		<a
 			class="pixel-button shop-product-card__detail-link"
-			href="<?php echo esc_url( home_url( '/shop/#' . $slug ) ); ?>"
+			href="<?php echo esc_url( se_preserve_utm_url( home_url( '/shop/#' . $slug ) ) ); ?>"
 			data-shop-detail-trigger
 			data-shop-slug="<?php echo esc_attr( $slug ); ?>"
 			aria-controls="<?php echo esc_attr( $detail_id ); ?>"

--- a/style.css
+++ b/style.css
@@ -3866,6 +3866,14 @@ body.page-template-page-bio-php .bio-content {
     font-size: clamp(0.72rem, 1.5vw, 0.86rem);
 }
 
+.page-template-page-work-with-suzy .wws-location {
+    margin: 0 0 1rem;
+    color: var(--wws-muted);
+    font-size: clamp(0.62rem, 1.4vw, 0.72rem);
+    letter-spacing: 0.08em;
+    text-transform: lowercase;
+}
+
 .page-template-page-work-with-suzy .wws-hero,
 .page-template-page-work-with-suzy .wws-section,
 .page-template-page-work-with-suzy .wws-final-cta {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes suzyeaston.ca measurably stronger for organic search and Google Ads landing around Vancouver AI/automation/technical consulting — without adding a parallel SEO plugin layer or thin doorway pages.

### Meta + structured data
- New `inc/seo.php` centralizes page meta, canonical/OG/Twitter tags, and JSON-LD
- Homepage, `/work-with-suzy/`, and `/shop/` get dedicated titles + descriptions
- `Person`, `WebSite`, and `Service` schema with East Vancouver locality (no street address, no LocalBusiness)
- Shop products retain `Product` + `Offer` schema and gain matching `Service` nodes

### Visible copy (commercial pages)
- Homepage hire strip: East Vancouver location + availability signals
- Work With Suzy: SEM landing structure — who it's for, what gets solved, how to start, Vancouver/remote availability
- Shop: technical consulting positioning with Vancouver + remote session copy

### SEM / analytics
- Standardized conversion events via `seTrackEvent()` + `dataLayer`: `hire_cta_click`, `shop_view`, `consulting_product_view`, `checkout_click`, `contact_open`, `contact_submit`, `work_with_suzy_view`
- Existing `shop_*` events preserved for backward compatibility
- UTM params preserved on consulting navigation links (PHP + JS)

### Cleanup
- Removed stale global `/outages/feed` RSS autodiscovery hook (canonical feed remains `/?feed=lousy_outages_status`)
- Header `HIRE SUZY` nav now points to `/work-with-suzy/` (was `/shop/`)

### Tests
- `__tests__/seo-sem-readiness.test.js` — static checks for meta, schema, analytics wiring, single title/canonical

## Pages affected
- `/` (homepage hire strip + meta)
- `/work-with-suzy/` (primary consulting landing)
- `/shop/` (fixed-price sessions)

## Post-deploy checklist
- [ ] Google Search Console: submit `https://www.suzyeaston.ca/wp-sitemap.xml`, inspect the three commercial URLs
- [ ] GA4/GTM: map new conversion events to Ads conversions
- [ ] Validate JSON-LD in Rich Results Test for homepage, work-with-suzy, shop
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ef23cee-544b-466f-b132-1621e06ecb1a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ef23cee-544b-466f-b132-1621e06ecb1a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

