### PR TITLE
Add provider-agnostic manual entitlements for Lousy Outages

### DIFF
--- a/lousy-outages/includes/CommerceAdmin.php
+++ b/lousy-outages/includes/CommerceAdmin.php
@@ -1,11 +1,280 @@
 <?php
 declare(strict_types=1);
+
 namespace SuzyEaston\LousyOutages;
 
 final class CommerceAdmin {
-    private const OPTIONS=['lousy_outages_stripe_publishable_key','lousy_outages_stripe_secret_key','lousy_outages_stripe_webhook_secret','lousy_outages_stripe_price_pro','lousy_outages_stripe_price_team','lousy_outages_feature_commerce','lousy_outages_feature_webhooks','lousy_outages_feature_private_boards'];
-    public static function bootstrap(): void { add_action('admin_menu',[self::class,'menu']); add_action('admin_init',[self::class,'settings']); }
-    public static function menu(): void { add_submenu_page('lousy-outages','Plans & Billing','Plans & Billing','manage_options','lousy-outages-billing',[self::class,'page']); }
-    public static function settings(): void { foreach(self::OPTIONS as $option) register_setting('lousy_outages_billing',$option,['sanitize_callback'=>str_contains($option,'feature_')?'absint':'sanitize_text_field']); }
-    public static function page(): void { if(!current_user_can('manage_options'))return; ?><div class="wrap"><h1>Plans &amp; Billing</h1><p>Stripe keys can also be supplied through deployment tooling. Secret values are stored as WordPress options and should never be committed.</p><form action="options.php" method="post"><?php settings_fields('lousy_outages_billing'); ?><table class="form-table"><?php foreach(self::OPTIONS as $option): $secret=str_contains($option,'secret'); $flag=str_contains($option,'feature_'); ?><tr><th><label for="<?php echo esc_attr($option); ?>"><?php echo esc_html(ucwords(str_replace(['lousy_outages_','_'],' ', $option))); ?></label></th><td><input id="<?php echo esc_attr($option); ?>" name="<?php echo esc_attr($option); ?>" type="<?php echo $flag?'checkbox':($secret?'password':'text'); ?>" <?php if($flag) checked((int)get_option($option,0),1); ?> value="<?php echo $flag?'1':esc_attr((string)get_option($option,'')); ?>" class="<?php echo $flag?'':'regular-text'; ?>" autocomplete="off"></td></tr><?php endforeach; ?></table><?php submit_button(); ?></form><p><strong>Webhook URL:</strong> <code><?php echo esc_html(rest_url('lousy-outages/v1/stripe/webhook')); ?></code></p></div><?php }
+    private const OPTIONS = [
+        'lousy_outages_stripe_publishable_key',
+        'lousy_outages_stripe_secret_key',
+        'lousy_outages_stripe_webhook_secret',
+        'lousy_outages_stripe_price_pro',
+        'lousy_outages_stripe_price_team',
+        'lousy_outages_feature_commerce',
+        'lousy_outages_feature_webhooks',
+        'lousy_outages_feature_private_boards',
+    ];
+
+    public static function bootstrap(): void {
+        add_action('admin_menu', [self::class, 'menu']);
+        add_action('admin_init', [self::class, 'settings']);
+        add_action('admin_post_lousy_outages_grant_manual_access', [self::class, 'handle_grant']);
+        add_action('admin_post_lousy_outages_revoke_manual_access', [self::class, 'handle_revoke']);
+    }
+
+    public static function menu(): void {
+        add_submenu_page(
+            'lousy-outages',
+            'Plans & Billing',
+            'Plans & Billing',
+            'manage_options',
+            'lousy-outages-billing',
+            [self::class, 'page']
+        );
+    }
+
+    public static function settings(): void {
+        foreach (self::OPTIONS as $option) {
+            register_setting('lousy_outages_billing', $option, [
+                'sanitize_callback' => str_contains($option, 'feature_') ? 'absint' : 'sanitize_text_field',
+            ]);
+        }
+    }
+
+    public static function page(): void {
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+
+        $notice = self::consume_notice();
+        $manual_rows = CommerceStore::list_manual_entitlements();
+        ?>
+        <div class="wrap">
+            <h1>Plans &amp; Billing</h1>
+            <?php if ($notice !== null) : ?>
+                <div class="notice notice-<?php echo esc_attr($notice['type']); ?> is-dismissible"><p><?php echo esc_html($notice['message']); ?></p></div>
+            <?php endif; ?>
+
+            <p>Stripe keys can also be supplied through deployment tooling. Secret values are stored as WordPress options and should never be committed.</p>
+            <form action="options.php" method="post">
+                <?php settings_fields('lousy_outages_billing'); ?>
+                <table class="form-table">
+                    <?php foreach (self::OPTIONS as $option) :
+                        $secret = str_contains($option, 'secret');
+                        $flag = str_contains($option, 'feature_');
+                        ?>
+                        <tr>
+                            <th><label for="<?php echo esc_attr($option); ?>"><?php echo esc_html(ucwords(str_replace(['lousy_outages_', '_'], ' ', $option))); ?></label></th>
+                            <td>
+                                <input
+                                    id="<?php echo esc_attr($option); ?>"
+                                    name="<?php echo esc_attr($option); ?>"
+                                    type="<?php echo $flag ? 'checkbox' : ($secret ? 'password' : 'text'); ?>"
+                                    <?php if ($flag) {
+                                        checked((int) get_option($option, 0), 1);
+                                    } ?>
+                                    value="<?php echo $flag ? '1' : esc_attr((string) get_option($option, '')); ?>"
+                                    class="<?php echo $flag ? '' : 'regular-text'; ?>"
+                                    autocomplete="off"
+                                >
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </table>
+                <?php submit_button(); ?>
+            </form>
+            <p><strong>Webhook URL:</strong> <code><?php echo esc_html(rest_url('lousy-outages/v1/stripe/webhook')); ?></code></p>
+
+            <hr>
+            <h2>Manual Access</h2>
+            <p>Grant Founding Pro / Team after you verify PayPal, Buy Me a Coffee, GitHub Sponsors, or complimentary access. No payment credentials or transaction payloads are stored here — only entitlement provenance.</p>
+            <p>The buyer must already have a Lousy Outages account (magic-link sign-in). This form will not invent users.</p>
+
+            <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+                <input type="hidden" name="action" value="lousy_outages_grant_manual_access">
+                <?php wp_nonce_field('lousy_outages_grant_manual_access'); ?>
+                <table class="form-table">
+                    <tr>
+                        <th><label for="lo_manual_email">WordPress user email</label></th>
+                        <td><input class="regular-text" type="email" name="lo_manual_email" id="lo_manual_email" required autocomplete="off"></td>
+                    </tr>
+                    <tr>
+                        <th><label for="lo_manual_plan">Plan</label></th>
+                        <td>
+                            <select name="lo_manual_plan" id="lo_manual_plan">
+                                <?php foreach (Entitlements::PLANS as $plan) : ?>
+                                    <option value="<?php echo esc_attr($plan); ?>" <?php selected($plan, 'pro'); ?>><?php echo esc_html(ucfirst($plan)); ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th><label for="lo_manual_source">Access source</label></th>
+                        <td>
+                            <select name="lo_manual_source" id="lo_manual_source">
+                                <?php foreach (CommerceStore::ACCESS_SOURCES as $source) : ?>
+                                    <option value="<?php echo esc_attr($source); ?>"><?php echo esc_html(self::source_label($source)); ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th><label for="lo_manual_expires">Expiry date</label></th>
+                        <td>
+                            <input type="date" name="lo_manual_expires" id="lo_manual_expires" class="regular-text">
+                            <p class="description">Optional. Leave blank for no expiry. Expired access falls back to Free.</p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th><label for="lo_manual_note">Internal note</label></th>
+                        <td>
+                            <input class="regular-text" type="text" name="lo_manual_note" id="lo_manual_note" maxlength="255" placeholder="e.g. founding pro via paypal 2026-08">
+                            <p class="description">Short provenance only. Do not paste transaction IDs with secrets, card data, or webhook credentials.</p>
+                        </td>
+                    </tr>
+                </table>
+                <?php submit_button('Grant / update access', 'primary', 'submit', false); ?>
+            </form>
+
+            <h3>Active manual entitlements</h3>
+            <?php if ($manual_rows === []) : ?>
+                <p>No active manual paid access right now.</p>
+            <?php else : ?>
+                <table class="widefat striped">
+                    <thead>
+                        <tr>
+                            <th>Email</th>
+                            <th>Plan</th>
+                            <th>Source</th>
+                            <th>Expiry</th>
+                            <th>Note</th>
+                            <th>Revoke</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($manual_rows as $row) : ?>
+                            <tr>
+                                <td><?php echo esc_html((string) ($row['email'] ?? '')); ?></td>
+                                <td><?php echo esc_html(ucfirst((string) ($row['plan'] ?? 'free'))); ?></td>
+                                <td><?php echo esc_html(self::source_label((string) ($row['access_source'] ?? ''))); ?></td>
+                                <td><?php echo esc_html(self::format_expiry((string) ($row['access_expires_at'] ?? ''))); ?></td>
+                                <td><?php echo esc_html((string) ($row['access_note'] ?? '')); ?></td>
+                                <td>
+                                    <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="display:inline">
+                                        <input type="hidden" name="action" value="lousy_outages_revoke_manual_access">
+                                        <input type="hidden" name="user_id" value="<?php echo esc_attr((string) ($row['user_id'] ?? 0)); ?>">
+                                        <?php wp_nonce_field('lousy_outages_revoke_manual_access_' . (int) ($row['user_id'] ?? 0)); ?>
+                                        <?php submit_button('Revoke', 'delete', 'submit', false); ?>
+                                    </form>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            <?php endif; ?>
+        </div>
+        <?php
+    }
+
+    public static function handle_grant(): void {
+        if (!current_user_can('manage_options')) {
+            wp_die('Insufficient permissions.');
+        }
+        check_admin_referer('lousy_outages_grant_manual_access');
+
+        $email = sanitize_email((string) ($_POST['lo_manual_email'] ?? ''));
+        $plan = Entitlements::normalize_plan((string) ($_POST['lo_manual_plan'] ?? 'free'));
+        $source = CommerceStore::normalize_access_source((string) ($_POST['lo_manual_source'] ?? ''));
+        $expires_raw = sanitize_text_field((string) ($_POST['lo_manual_expires'] ?? ''));
+        $note = sanitize_text_field((string) ($_POST['lo_manual_note'] ?? ''));
+
+        if (!is_email($email)) {
+            self::redirect_with_notice('error', 'Enter a real email address.');
+        }
+
+        $user = get_user_by('email', $email);
+        if (!$user) {
+            self::redirect_with_notice(
+                'error',
+                'No Lousy Outages account exists for that email yet. The buyer must first create/sign into their account via the magic-link flow at /lousy-outages/account/, then you can grant access.'
+            );
+        }
+
+        if ($plan !== 'free' && $source === '') {
+            self::redirect_with_notice('error', 'Choose a valid access source for paid plans.');
+        }
+
+        // Reject plans that normalize away from what was submitted (invalid → free is OK only if free was chosen).
+        $submitted_plan = strtolower(trim((string) ($_POST['lo_manual_plan'] ?? '')));
+        if ($submitted_plan !== '' && !in_array($submitted_plan, Entitlements::PLANS, true)) {
+            self::redirect_with_notice('error', 'Invalid plan. Access was not changed.');
+        }
+
+        $result = CommerceStore::grant_manual_access(
+            (int) $user->ID,
+            $plan,
+            $source,
+            $expires_raw !== '' ? $expires_raw : null,
+            $note
+        );
+        if (is_wp_error($result)) {
+            self::redirect_with_notice('error', $result->get_error_message());
+        }
+
+        $label = $plan === 'free' ? 'Free (manual paid access cleared)' : ucfirst($plan);
+        self::redirect_with_notice('success', 'Updated access for ' . $email . ' → ' . $label . '.');
+    }
+
+    public static function handle_revoke(): void {
+        if (!current_user_can('manage_options')) {
+            wp_die('Insufficient permissions.');
+        }
+        $user_id = absint($_POST['user_id'] ?? 0);
+        check_admin_referer('lousy_outages_revoke_manual_access_' . $user_id);
+        if ($user_id <= 0) {
+            self::redirect_with_notice('error', 'Missing user for revoke.');
+        }
+
+        CommerceStore::revoke_manual_access($user_id);
+        self::redirect_with_notice('success', 'Manual paid access revoked. Stripe fields were left alone.');
+    }
+
+    private static function source_label(string $source): string {
+        return match ($source) {
+            'paypal' => 'PayPal',
+            'buymeacoffee' => 'Buy Me a Coffee',
+            'github_sponsors' => 'GitHub Sponsors',
+            'complimentary' => 'Complimentary',
+            'manual' => 'Manual',
+            default => $source !== '' ? $source : '—',
+        };
+    }
+
+    private static function format_expiry(string $expires): string {
+        $expires = trim($expires);
+        if ($expires === '') {
+            return 'Never';
+        }
+        return substr($expires, 0, 10);
+    }
+
+    private static function redirect_with_notice(string $type, string $message): void {
+        set_transient('lo_billing_notice_' . get_current_user_id(), ['type' => $type, 'message' => $message], 60);
+        wp_safe_redirect(admin_url('admin.php?page=lousy-outages-billing'));
+        exit;
+    }
+
+    /** @return array{type:string,message:string}|null */
+    private static function consume_notice(): ?array {
+        $key = 'lo_billing_notice_' . get_current_user_id();
+        $notice = get_transient($key);
+        if (is_array($notice) && isset($notice['type'], $notice['message'])) {
+            delete_transient($key);
+            return [
+                'type' => sanitize_key((string) $notice['type']) === 'error' ? 'error' : 'success',
+                'message' => sanitize_text_field((string) $notice['message']),
+            ];
+        }
+        return null;
+    }
 }

--- a/lousy-outages/includes/CommerceStore.php
+++ b/lousy-outages/includes/CommerceStore.php
@@ -4,35 +4,91 @@ declare(strict_types=1);
 namespace SuzyEaston\LousyOutages;
 
 final class CommerceStore {
-    public const SCHEMA_VERSION = '1.0.0';
+    public const SCHEMA_VERSION = '1.1.0';
+
+    /** Provider-neutral entitlement provenance. Not payment credentials. */
+    public const ACCESS_SOURCES = ['paypal', 'buymeacoffee', 'github_sponsors', 'complimentary', 'manual'];
+
+    private const CUSTOMER_FIELDS = [
+        'stripe_customer_id',
+        'stripe_subscription_id',
+        'plan',
+        'subscription_status',
+        'current_period_end',
+        'team_id',
+        'access_source',
+        'access_expires_at',
+        'access_note',
+    ];
 
     public static function install(): void {
         global $wpdb;
         require_once ABSPATH . 'wp-admin/includes/upgrade.php';
         $charset = $wpdb->get_charset_collate();
         $p = $wpdb->prefix . 'lo_';
+        // dbDelta requires one field per line to add columns on upgrade.
         dbDelta("CREATE TABLE {$p}customers (
-          user_id bigint(20) unsigned NOT NULL, stripe_customer_id varchar(64) NULL, stripe_subscription_id varchar(64) NULL,
-          plan varchar(16) NOT NULL DEFAULT 'free', subscription_status varchar(32) NOT NULL DEFAULT 'none', current_period_end datetime NULL,
-          team_id bigint(20) unsigned NULL, updated_at datetime NOT NULL, PRIMARY KEY (user_id), UNIQUE KEY stripe_customer_id (stripe_customer_id)
+          user_id bigint(20) unsigned NOT NULL,
+          stripe_customer_id varchar(64) NULL,
+          stripe_subscription_id varchar(64) NULL,
+          plan varchar(16) NOT NULL DEFAULT 'free',
+          subscription_status varchar(32) NOT NULL DEFAULT 'none',
+          current_period_end datetime NULL,
+          team_id bigint(20) unsigned NULL,
+          access_source varchar(32) NULL,
+          access_expires_at datetime NULL,
+          access_note varchar(255) NULL,
+          updated_at datetime NOT NULL,
+          PRIMARY KEY  (user_id),
+          UNIQUE KEY stripe_customer_id (stripe_customer_id)
         ) {$charset};");
         dbDelta("CREATE TABLE {$p}watchlists (
-          id bigint(20) unsigned NOT NULL AUTO_INCREMENT, owner_user_id bigint(20) unsigned NOT NULL, team_id bigint(20) unsigned NULL,
-          name varchar(190) NOT NULL, providers longtext NOT NULL, filters longtext NULL, digest_preferences longtext NULL, is_shared tinyint(1) NOT NULL DEFAULT 0,
-          created_at datetime NOT NULL, updated_at datetime NOT NULL, PRIMARY KEY (id), KEY owner (owner_user_id), KEY team (team_id)
+          id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+          owner_user_id bigint(20) unsigned NOT NULL,
+          team_id bigint(20) unsigned NULL,
+          name varchar(190) NOT NULL,
+          providers longtext NOT NULL,
+          filters longtext NULL,
+          digest_preferences longtext NULL,
+          is_shared tinyint(1) NOT NULL DEFAULT 0,
+          created_at datetime NOT NULL,
+          updated_at datetime NOT NULL,
+          PRIMARY KEY  (id),
+          KEY owner (owner_user_id),
+          KEY team (team_id)
         ) {$charset};");
         dbDelta("CREATE TABLE {$p}alert_destinations (
-          id bigint(20) unsigned NOT NULL AUTO_INCREMENT, owner_user_id bigint(20) unsigned NOT NULL, team_id bigint(20) unsigned NULL,
-          type varchar(20) NOT NULL, label varchar(190) NOT NULL, endpoint_encrypted longtext NOT NULL, enabled tinyint(1) NOT NULL DEFAULT 1, created_at datetime NOT NULL,
-          PRIMARY KEY (id), KEY owner (owner_user_id), KEY team (team_id)
+          id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+          owner_user_id bigint(20) unsigned NOT NULL,
+          team_id bigint(20) unsigned NULL,
+          type varchar(20) NOT NULL,
+          label varchar(190) NOT NULL,
+          endpoint_encrypted longtext NOT NULL,
+          enabled tinyint(1) NOT NULL DEFAULT 1,
+          created_at datetime NOT NULL,
+          PRIMARY KEY  (id),
+          KEY owner (owner_user_id),
+          KEY team (team_id)
         ) {$charset};");
         dbDelta("CREATE TABLE {$p}api_tokens (
-          id bigint(20) unsigned NOT NULL AUTO_INCREMENT, owner_user_id bigint(20) unsigned NOT NULL, team_id bigint(20) unsigned NULL,
-          name varchar(190) NOT NULL, token_prefix varchar(16) NOT NULL, token_hash varchar(255) NOT NULL, last_used_at datetime NULL, created_at datetime NOT NULL, revoked_at datetime NULL,
-          PRIMARY KEY (id), KEY token_prefix (token_prefix), KEY owner (owner_user_id)
+          id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+          owner_user_id bigint(20) unsigned NOT NULL,
+          team_id bigint(20) unsigned NULL,
+          name varchar(190) NOT NULL,
+          token_prefix varchar(16) NOT NULL,
+          token_hash varchar(255) NOT NULL,
+          last_used_at datetime NULL,
+          created_at datetime NOT NULL,
+          revoked_at datetime NULL,
+          PRIMARY KEY  (id),
+          KEY token_prefix (token_prefix),
+          KEY owner (owner_user_id)
         ) {$charset};");
         dbDelta("CREATE TABLE {$p}stripe_events (
-          event_id varchar(255) NOT NULL, event_type varchar(100) NOT NULL, processed_at datetime NOT NULL, PRIMARY KEY (event_id)
+          event_id varchar(255) NOT NULL,
+          event_type varchar(100) NOT NULL,
+          processed_at datetime NOT NULL,
+          PRIMARY KEY  (event_id)
         ) {$charset};");
         update_option('lousy_outages_commerce_schema_version', self::SCHEMA_VERSION, false);
     }
@@ -40,31 +96,190 @@ final class CommerceStore {
     public static function customer(int $user_id): array {
         global $wpdb;
         $row = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}lo_customers WHERE user_id=%d", $user_id), ARRAY_A);
-        return is_array($row) ? $row : ['user_id' => $user_id, 'plan' => 'free', 'subscription_status' => 'none'];
+        return is_array($row) ? $row : [
+            'user_id' => $user_id,
+            'plan' => 'free',
+            'subscription_status' => 'none',
+            'access_source' => null,
+            'access_expires_at' => null,
+            'access_note' => null,
+        ];
     }
 
     public static function plan(int $user_id): string {
-        $customer = self::customer($user_id);
-        return in_array((string)($customer['subscription_status'] ?? ''), ['active', 'trialing'], true)
-            ? Entitlements::normalize_plan((string)($customer['plan'] ?? 'free')) : 'free';
+        return self::plan_from_customer(self::customer($user_id));
+    }
+
+    /**
+     * Resolve effective plan from a customer row. Fail closed to free.
+     * Stripe active/trialing and unexpired manual entitlements both grant paid plans.
+     */
+    public static function plan_from_customer(array $customer): string {
+        $plan = Entitlements::normalize_plan((string) ($customer['plan'] ?? 'free'));
+        if ($plan === 'free') {
+            return 'free';
+        }
+
+        $status = (string) ($customer['subscription_status'] ?? '');
+        if (in_array($status, ['active', 'trialing'], true)) {
+            return $plan;
+        }
+
+        if (!self::manual_access_is_active($customer)) {
+            return 'free';
+        }
+
+        return $plan;
+    }
+
+    public static function normalize_access_source(string $source): string {
+        $source = strtolower(trim($source));
+        return in_array($source, self::ACCESS_SOURCES, true) ? $source : '';
+    }
+
+    public static function manual_access_is_active(array $customer): bool {
+        $plan = Entitlements::normalize_plan((string) ($customer['plan'] ?? 'free'));
+        if ($plan === 'free') {
+            return false;
+        }
+
+        $source = self::normalize_access_source((string) ($customer['access_source'] ?? ''));
+        if ($source === '') {
+            return false;
+        }
+
+        $expires = trim((string) ($customer['access_expires_at'] ?? ''));
+        if ($expires === '') {
+            return true;
+        }
+
+        $expires_ts = strtotime($expires . ' UTC');
+        if ($expires_ts === false) {
+            return false;
+        }
+
+        return $expires_ts >= time();
     }
 
     public static function upsert_customer(int $user_id, array $values): void {
         global $wpdb;
         $old = self::customer($user_id);
-        $data = array_merge($old, array_intersect_key($values, array_flip(['stripe_customer_id','stripe_subscription_id','plan','subscription_status','current_period_end','team_id'])));
+        $data = array_merge($old, array_intersect_key($values, array_flip(self::CUSTOMER_FIELDS)));
         $data['user_id'] = $user_id;
         $data['updated_at'] = current_time('mysql', true);
         $wpdb->replace($wpdb->prefix . 'lo_customers', $data);
     }
 
+    /**
+     * Grant or update provider-neutral paid access. Does not require Stripe IDs.
+     *
+     * @return true|\WP_Error
+     */
+    public static function grant_manual_access(int $user_id, string $plan, string $source, ?string $expires_at, string $note) {
+        $plan = Entitlements::normalize_plan($plan);
+        $source = self::normalize_access_source($source);
+        if ($plan !== 'free' && $source === '') {
+            return new \WP_Error('invalid_access_source', 'Choose a valid access source.');
+        }
+
+        $note = sanitize_text_field($note);
+        if (strlen($note) > 255) {
+            $note = substr($note, 0, 255);
+        }
+
+        $expires = null;
+        if ($expires_at !== null && trim($expires_at) !== '') {
+            $expires = self::normalize_expiry($expires_at);
+            if ($expires === null) {
+                return new \WP_Error('invalid_expiry', 'Expiry must be a valid date (YYYY-MM-DD).');
+            }
+        }
+
+        if ($plan === 'free') {
+            // Clearing manual access must not demote an active Stripe subscription.
+            $customer = self::customer($user_id);
+            $stripe_paid = in_array((string) ($customer['subscription_status'] ?? ''), ['active', 'trialing'], true);
+            self::upsert_customer($user_id, [
+                'plan' => $stripe_paid ? Entitlements::normalize_plan((string) ($customer['plan'] ?? 'free')) : 'free',
+                'access_source' => null,
+                'access_expires_at' => null,
+                'access_note' => $note !== '' ? $note : null,
+            ]);
+            return true;
+        }
+
+        self::upsert_customer($user_id, [
+            'plan' => $plan,
+            'access_source' => $source,
+            'access_expires_at' => $expires,
+            'access_note' => $note !== '' ? $note : null,
+        ]);
+        return true;
+    }
+
+    /** Revoke manual paid access. Leaves Stripe customer/subscription columns untouched. */
+    public static function revoke_manual_access(int $user_id): void {
+        $customer = self::customer($user_id);
+        $stripe_paid = in_array((string) ($customer['subscription_status'] ?? ''), ['active', 'trialing'], true);
+        self::upsert_customer($user_id, [
+            'plan' => $stripe_paid ? Entitlements::normalize_plan((string) ($customer['plan'] ?? 'free')) : 'free',
+            'access_source' => null,
+            'access_expires_at' => null,
+            'access_note' => null,
+        ]);
+    }
+
+    /**
+     * Currently active manual paid entitlements (not Stripe-driven).
+     *
+     * @return list<array<string, mixed>>
+     */
+    public static function list_manual_entitlements(): array {
+        global $wpdb;
+        $table = $wpdb->prefix . 'lo_customers';
+        $sources = array_map(static fn(string $s): string => "'" . esc_sql($s) . "'", self::ACCESS_SOURCES);
+        $in = implode(',', $sources);
+        $now = gmdate('Y-m-d H:i:s');
+        $sql = "SELECT c.*, u.user_email AS email
+            FROM {$table} c
+            INNER JOIN {$wpdb->users} u ON u.ID = c.user_id
+            WHERE c.plan IN ('pro','team')
+              AND c.access_source IN ({$in})
+              AND (c.access_expires_at IS NULL OR c.access_expires_at = '' OR c.access_expires_at >= %s)
+            ORDER BY c.updated_at DESC";
+        $rows = $wpdb->get_results($wpdb->prepare($sql, $now), ARRAY_A);
+        return is_array($rows) ? $rows : [];
+    }
+
+    public static function normalize_expiry(string $value): ?string {
+        $value = trim($value);
+        if ($value === '') {
+            return null;
+        }
+        if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $value) === 1) {
+            return $value . ' 23:59:59';
+        }
+        if (preg_match('/^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}(:\d{2})?$/', $value) !== 1) {
+            return null;
+        }
+        $value = str_replace('T', ' ', $value);
+        if (substr_count($value, ':') === 1) {
+            $value .= ':00';
+        }
+        return $value;
+    }
+
     public static function event_seen(string $id): bool {
         global $wpdb;
-        return (bool)$wpdb->get_var($wpdb->prepare("SELECT event_id FROM {$wpdb->prefix}lo_stripe_events WHERE event_id=%s", $id));
+        return (bool) $wpdb->get_var($wpdb->prepare("SELECT event_id FROM {$wpdb->prefix}lo_stripe_events WHERE event_id=%s", $id));
     }
 
     public static function mark_event(string $id, string $type): void {
         global $wpdb;
-        $wpdb->insert($wpdb->prefix . 'lo_stripe_events', ['event_id'=>$id, 'event_type'=>$type, 'processed_at'=>current_time('mysql', true)]);
+        $wpdb->insert($wpdb->prefix . 'lo_stripe_events', [
+            'event_id' => $id,
+            'event_type' => $type,
+            'processed_at' => current_time('mysql', true),
+        ]);
     }
 }

--- a/tests/LousyOutagesCommerceStoreTest.php
+++ b/tests/LousyOutagesCommerceStoreTest.php
@@ -1,0 +1,122 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/bootstrap.php';
+if (!defined('DAY_IN_SECONDS')) {
+    define('DAY_IN_SECONDS', 86400);
+}
+require_once __DIR__ . '/../lousy-outages/includes/Entitlements.php';
+require_once __DIR__ . '/../lousy-outages/includes/CommerceStore.php';
+
+use SuzyEaston\LousyOutages\CommerceStore;
+use SuzyEaston\LousyOutages\Entitlements;
+
+$assert = static function (bool $condition, string $message): void {
+    if (!$condition) {
+        throw new RuntimeException($message);
+    }
+};
+
+// Manual Pro active (no Stripe) grants Pro.
+$assert(
+    CommerceStore::plan_from_customer([
+        'plan' => 'pro',
+        'subscription_status' => 'none',
+        'access_source' => 'paypal',
+        'access_expires_at' => null,
+    ]) === 'pro',
+    'Manual Pro with PayPal source must grant Pro'
+);
+$assert(
+    CommerceStore::plan_from_customer([
+        'plan' => 'pro',
+        'subscription_status' => 'canceled',
+        'access_source' => 'buymeacoffee',
+        'access_expires_at' => gmdate('Y-m-d H:i:s', time() + DAY_IN_SECONDS),
+    ]) === 'pro',
+    'Manual Pro with future expiry must grant Pro'
+);
+$assert(
+    CommerceStore::plan_from_customer([
+        'plan' => 'team',
+        'subscription_status' => 'none',
+        'access_source' => 'github_sponsors',
+        'access_expires_at' => '',
+    ]) === 'team',
+    'Manual Team via GitHub Sponsors must grant Team'
+);
+
+// Manual Pro expired falls back to Free.
+$assert(
+    CommerceStore::plan_from_customer([
+        'plan' => 'pro',
+        'subscription_status' => 'none',
+        'access_source' => 'complimentary',
+        'access_expires_at' => gmdate('Y-m-d H:i:s', time() - DAY_IN_SECONDS),
+    ]) === 'free',
+    'Expired manual Pro must fall back to Free'
+);
+
+// Manual revoke shape (cleared source / free plan) is Free.
+$assert(
+    CommerceStore::plan_from_customer([
+        'plan' => 'free',
+        'subscription_status' => 'none',
+        'access_source' => null,
+        'access_expires_at' => null,
+        'access_note' => null,
+    ]) === 'free',
+    'Revoked manual access must be Free'
+);
+$assert(
+    CommerceStore::plan_from_customer([
+        'plan' => 'pro',
+        'subscription_status' => 'none',
+        'access_source' => null,
+        'access_expires_at' => null,
+    ]) === 'free',
+    'Pro plan without Stripe or manual source must fail closed to Free'
+);
+
+// Stripe active/trialing continues to work exactly as before.
+$assert(
+    CommerceStore::plan_from_customer([
+        'plan' => 'pro',
+        'subscription_status' => 'active',
+    ]) === 'pro',
+    'Stripe active Pro must still grant Pro'
+);
+$assert(
+    CommerceStore::plan_from_customer([
+        'plan' => 'team',
+        'subscription_status' => 'trialing',
+    ]) === 'team',
+    'Stripe trialing Team must still grant Team'
+);
+$assert(
+    CommerceStore::plan_from_customer([
+        'plan' => 'pro',
+        'subscription_status' => 'active',
+        'access_source' => 'manual',
+        'access_expires_at' => gmdate('Y-m-d H:i:s', time() - DAY_IN_SECONDS),
+    ]) === 'pro',
+    'Stripe active must win even when a manual expiry is in the past'
+);
+
+// Invalid plan fails closed to Free.
+$assert(
+    CommerceStore::plan_from_customer([
+        'plan' => 'garbage',
+        'subscription_status' => 'active',
+        'access_source' => 'paypal',
+    ]) === 'free',
+    'Invalid plan must fail closed to Free even with Stripe active'
+);
+$assert(Entitlements::normalize_plan('enterprise') === 'free', 'normalize_plan must fail closed');
+$assert(CommerceStore::normalize_access_source('venmo') === '', 'Unknown access source must be rejected');
+$assert(CommerceStore::normalize_access_source('PayPal') === 'paypal', 'Access source must normalize case');
+
+// Expiry helper.
+$assert(CommerceStore::normalize_expiry('2026-12-31') === '2026-12-31 23:59:59', 'Date-only expiry should end that UTC day');
+$assert(CommerceStore::normalize_expiry('not-a-date') === null, 'Invalid expiry must be rejected');
+
+echo "ok - CommerceStore manual entitlements, Stripe parity, and fail-closed plans\n";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Makes Founding Pro / Team sellable through PayPal, Buy Me a Coffee, GitHub Sponsors, complimentary, or other manual verification — without requiring Stripe.

## What changed

- **`CommerceStore` schema `1.0.0` → `1.1.0`**: additive `dbDelta` columns on `lo_customers`:
  - `access_source` (paypal / buymeacoffee / github_sponsors / complimentary / manual)
  - `access_expires_at`
  - `access_note`
- Existing Stripe customer/subscription columns are untouched.
- **`CommerceStore::plan()`** grants Pro/Team when:
  1. Stripe `subscription_status` is `active` or `trialing` (unchanged), or
  2. a valid, unexpired manual entitlement is present
- Expired / revoked / unknown states fail closed to Free.
- **Plans & Billing → Manual Access** admin section: grant/update by existing WP user email, list active manual entitlements, revoke. Cap + nonce + sanitization. Refuses to create users; buyer must magic-link first.
- No payment API integrations; no transaction/card/webhook secrets stored.
- Tests: manual Pro active/expired/revoke shape, Stripe active still works, invalid plan → Free.

## Migration

On deploy, visit wp-admin once (or reactivate the plugin). `admin_init` compares `lousy_outages_commerce_schema_version` to `CommerceStore::SCHEMA_VERSION` and runs `CommerceStore::install()`, which `dbDelta`s the three new nullable columns and bumps the option to `1.1.0`. No data rewrite; Stripe rows keep working.

## How to use

1. Buyer signs in via `/lousy-outages/account/` magic link.
2. Admin → Lousy Outages → Plans & Billing → Manual Access.
3. Enter their email, choose Pro/Team + source (+ optional expiry/note), grant.
4. Revoke from the table when needed.

## Test plan

- [x] `php tests/LousyOutagesCommerceStoreTest.php`
- [x] `php tests/LousyOutagesEntitlementsTest.php`
- [x] `php tests/LousyOutagesStripeWebhookTest.php`
- [ ] Staging: grant manual Pro, confirm account shows Pro / watchlists unlock
- [ ] Staging: set past expiry, confirm Free
- [ ] Staging: revoke, confirm Free; Stripe test sub still works independently
- [ ] Staging: grant for unknown email shows magic-link message (no user created)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30264e2e-2d44-4024-aa15-b26331be24e4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30264e2e-2d44-4024-aa15-b26331be24e4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

