### PR TITLE
Fix Lousy Outages admin/public billing slug collision

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -35,6 +35,9 @@ jobs:
           filters: |
             theme:
               - '*.php'
+              - 'page-lousy-outages.php'
+              - 'page-lousy-outages-pricing.php'
+              - 'page-lousy-outages-account.php'
               - 'style.css'
               - 'inc/**'
               - 'parts/**'

--- a/.github/workflows/release-lousy-outages.yml
+++ b/.github/workflows/release-lousy-outages.yml
@@ -34,6 +34,11 @@ jobs:
         run: php tests/lousy-outages/current-state-contract-test.php
       - name: Run homepage teaser JavaScript/PHP tests
         run: php tests/LousyOutagesHomeTeaserTest.php
+      - name: Run access-admin routing and product page repair tests
+        run: |
+          php tests/LousyOutagesAccessAdminRoutingTest.php
+          php tests/LousyOutagesCommerceStoreTest.php
+          php tests/LousyOutagesEntitlementsTest.php
       - name: Build release ZIP
         run: scripts/build-lousy-outages-release.sh
       - name: Validate release ZIP

--- a/lousy-outages/includes/CommerceAdmin.php
+++ b/lousy-outages/includes/CommerceAdmin.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 namespace SuzyEaston\LousyOutages;
 
 final class CommerceAdmin {
+    /** Admin-only menu slug. Must never collide with a public page path. */
+    public const PAGE_SLUG = 'lousy-outages-access-admin';
+
     private const OPTIONS = [
         'lousy_outages_stripe_publishable_key',
         'lousy_outages_stripe_secret_key',
@@ -22,13 +25,17 @@ final class CommerceAdmin {
         add_action('admin_post_lousy_outages_revoke_manual_access', [self::class, 'handle_revoke']);
     }
 
+    public static function admin_url(): string {
+        return admin_url('admin.php?page=' . self::PAGE_SLUG);
+    }
+
     public static function menu(): void {
         add_submenu_page(
             'lousy-outages',
-            'Plans & Billing',
-            'Plans & Billing',
+            'Plans & Access',
+            'Manual Access',
             'manage_options',
-            'lousy-outages-billing',
+            self::PAGE_SLUG,
             [self::class, 'page']
         );
     }
@@ -48,9 +55,15 @@ final class CommerceAdmin {
 
         $notice = self::consume_notice();
         $manual_rows = CommerceStore::list_manual_entitlements();
+        $pricing_url = home_url('/lousy-outages/pricing/');
+        $account_url = home_url('/lousy-outages/account/');
         ?>
         <div class="wrap">
-            <h1>Plans &amp; Billing</h1>
+            <h1>Plans &amp; Access</h1>
+            <p>
+                <a class="button" href="<?php echo esc_url($pricing_url); ?>" target="_blank" rel="noopener noreferrer">Open public pricing ↗</a>
+                <a class="button" href="<?php echo esc_url($account_url); ?>" target="_blank" rel="noopener noreferrer">Open account page ↗</a>
+            </p>
             <?php if ($notice !== null) : ?>
                 <div class="notice notice-<?php echo esc_attr($notice['type']); ?> is-dismissible"><p><?php echo esc_html($notice['message']); ?></p></div>
             <?php endif; ?>
@@ -88,7 +101,7 @@ final class CommerceAdmin {
             <hr>
             <h2>Manual Access</h2>
             <p>Grant Founding Pro / Team after you verify PayPal, Buy Me a Coffee, GitHub Sponsors, or complimentary access. No payment credentials or transaction payloads are stored here — only entitlement provenance.</p>
-            <p>The buyer must already have a Lousy Outages account (magic-link sign-in). This form will not invent users.</p>
+            <p>The buyer must already have a Lousy Outages account (magic-link sign-in at <code>/lousy-outages/account/</code>). This form will not invent users.</p>
 
             <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
                 <input type="hidden" name="action" value="lousy_outages_grant_manual_access">
@@ -260,7 +273,7 @@ final class CommerceAdmin {
 
     private static function redirect_with_notice(string $type, string $message): void {
         set_transient('lo_billing_notice_' . get_current_user_id(), ['type' => $type, 'message' => $message], 60);
-        wp_safe_redirect(admin_url('admin.php?page=lousy-outages-billing'));
+        wp_safe_redirect(self::admin_url());
         exit;
     }
 

--- a/lousy-outages/includes/Product.php
+++ b/lousy-outages/includes/Product.php
@@ -7,109 +7,400 @@ use WP_REST_Request;
 use WP_REST_Response;
 
 final class Product {
+    public const PAGES_VERSION = '1.0.0';
+
+    /** Legacy public slug that collided with the old admin menu page. Never use for admin. */
+    public const LEGACY_BILLING_SLUG = 'lousy-outages-billing';
+
+    private const CHILD_PAGES = [
+        'pricing' => [
+            'title' => 'Lousy Outages Pricing',
+            'template' => 'page-lousy-outages-pricing.php',
+            'content' => '[lousy_outages_pricing]',
+        ],
+        'account' => [
+            'title' => 'Lousy Outages Account',
+            'template' => 'page-lousy-outages-account.php',
+            'content' => '[lousy_outages_account]',
+        ],
+    ];
+
     public static function bootstrap(): void {
-        add_action('rest_api_init',[self::class,'routes']);
-        add_action('template_redirect',[self::class,'consume_magic_link']);
-        add_shortcode('lousy_outages_pricing',[self::class,'pricing']);
-        add_shortcode('lousy_outages_account',[self::class,'account']);
-        add_action('wp_footer',[self::class,'browser_events']);
+        add_action('rest_api_init', [self::class, 'routes']);
+        add_action('template_redirect', [self::class, 'consume_magic_link']);
+        add_action('template_redirect', [self::class, 'redirect_legacy_billing_page'], 1);
+        add_shortcode('lousy_outages_pricing', [self::class, 'pricing']);
+        add_shortcode('lousy_outages_account', [self::class, 'account']);
+        add_action('wp_footer', [self::class, 'browser_events']);
+        add_action('admin_init', [self::class, 'maybe_repair_pages'], 7);
     }
 
-    public static function install_pages(): void {
-        $parent=get_page_by_path('lousy-outages');
-        foreach(['pricing'=>['Lousy Outages Pricing','page-lousy-outages-pricing.php'],'account'=>['Lousy Outages Account','page-lousy-outages-account.php']] as $slug=>$config) {
-            if(get_page_by_path('lousy-outages/'.$slug)) continue;
-            $id=wp_insert_post(['post_title'=>$config[0],'post_name'=>$slug,'post_type'=>'page','post_status'=>'publish','post_parent'=>$parent ? (int)$parent->ID : 0]);
-            if(!is_wp_error($id)) update_post_meta((int)$id,'_wp_page_template',$config[1]);
+    /**
+     * Versioned self-heal for pricing/account child pages.
+     * Production deploys replace the plugin folder in place, so activation rarely reruns.
+     */
+    public static function maybe_repair_pages(): void {
+        $current = (string) get_option('lousy_outages_product_pages_version', '0');
+        if (version_compare($current, self::PAGES_VERSION, '>=') && self::product_pages_present()) {
+            return;
         }
+        self::install_pages();
+        update_option('lousy_outages_product_pages_version', self::PAGES_VERSION, false);
+    }
+
+    public static function product_pages_present(): bool {
+        if (!get_page_by_path('lousy-outages')) {
+            return false;
+        }
+        foreach (array_keys(self::CHILD_PAGES) as $slug) {
+            if (!get_page_by_path('lousy-outages/' . $slug)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Create missing /lousy-outages/, /pricing/, /account/ pages only.
+     * Retains existing IDs/content; repairs parent + template assignments when needed.
+     * Never creates a public page for CommerceAdmin::PAGE_SLUG or the legacy billing slug.
+     */
+    public static function install_pages(): void {
+        $parent = get_page_by_path('lousy-outages');
+        if (!$parent) {
+            $parent_id = wp_insert_post([
+                'post_title' => 'Lousy Outages',
+                'post_name' => 'lousy-outages',
+                'post_content' => '[lousy_outages]',
+                'post_status' => 'publish',
+                'post_type' => 'page',
+            ]);
+            if (is_wp_error($parent_id) || !$parent_id) {
+                return;
+            }
+            $parent = get_post((int) $parent_id);
+        }
+        if (!$parent) {
+            return;
+        }
+
+        $parent_id = (int) $parent->ID;
+
+        foreach (self::CHILD_PAGES as $slug => $config) {
+            $existing = self::find_product_child_page($slug, $parent_id);
+            if ($existing) {
+                $updates = [];
+                if ((int) $existing->post_parent !== $parent_id) {
+                    $updates['post_parent'] = $parent_id;
+                }
+                if (($existing->post_status ?? '') !== 'publish') {
+                    $updates['post_status'] = 'publish';
+                }
+                if ($updates !== []) {
+                    $updates['ID'] = (int) $existing->ID;
+                    wp_update_post($updates);
+                }
+                $template = (string) get_post_meta((int) $existing->ID, '_wp_page_template', true);
+                if ($template !== $config['template']) {
+                    update_post_meta((int) $existing->ID, '_wp_page_template', $config['template']);
+                }
+                continue;
+            }
+
+            $id = wp_insert_post([
+                'post_title' => $config['title'],
+                'post_name' => $slug,
+                'post_content' => $config['content'],
+                'post_type' => 'page',
+                'post_status' => 'publish',
+                'post_parent' => $parent_id,
+            ]);
+            if (!is_wp_error($id) && $id) {
+                update_post_meta((int) $id, '_wp_page_template', $config['template']);
+            }
+        }
+    }
+
+    /**
+     * Locate an existing pricing/account page by hierarchical path or orphaned slug.
+     * Never matches CommerceAdmin::PAGE_SLUG or the legacy billing slug.
+     *
+     * @return object|null WordPress page object when found.
+     */
+    private static function find_product_child_page(string $slug, int $parent_id): ?object {
+        if ($slug === CommerceAdmin::PAGE_SLUG || $slug === self::LEGACY_BILLING_SLUG) {
+            return null;
+        }
+
+        $by_path = get_page_by_path('lousy-outages/' . $slug);
+        if (is_object($by_path) && isset($by_path->ID)) {
+            return $by_path;
+        }
+
+        // Orphan / wrong-parent page with the expected child slug — reattach instead of duplicating.
+        $orphan = get_page_by_path($slug);
+        if (!is_object($orphan) || !isset($orphan->ID) || (($orphan->post_type ?? '') !== 'page')) {
+            return null;
+        }
+        $orphan_parent = (int) ($orphan->post_parent ?? 0);
+        if ($orphan_parent === $parent_id || $orphan_parent === 0) {
+            return $orphan;
+        }
+        return null;
+    }
+
+    /**
+     * Redirect the legacy public /lousy-outages-billing/ page to /lousy-outages/pricing/.
+     * Explicitly never touches wp-admin / is_admin() requests.
+     */
+    public static function redirect_legacy_billing_page(): void {
+        $target = self::legacy_billing_redirect_target();
+        if ($target === null) {
+            return;
+        }
+        wp_safe_redirect($target, 301);
+        exit;
+    }
+
+    /**
+     * @return string|null Destination URL when a legacy public redirect should fire.
+     */
+    public static function legacy_billing_redirect_target(): ?string {
+        if (is_admin()) {
+            return null;
+        }
+
+        $uri = (string) ($_SERVER['REQUEST_URI'] ?? '');
+        if ($uri !== '' && (str_contains($uri, '/wp-admin') || str_contains($uri, 'wp-login.php'))) {
+            return null;
+        }
+
+        // Admin query strings must never be hijacked by this frontend redirect.
+        $page_query = isset($_GET['page']) ? (string) $_GET['page'] : '';
+        if ($page_query === CommerceAdmin::PAGE_SLUG || $page_query === self::LEGACY_BILLING_SLUG) {
+            return null;
+        }
+
+        $is_legacy = false;
+        if (function_exists('is_page') && is_page(self::LEGACY_BILLING_SLUG)) {
+            $is_legacy = true;
+        } else {
+            $path = trim((string) (wp_parse_url($uri, PHP_URL_PATH) ?: ''), '/');
+            if ($path === self::LEGACY_BILLING_SLUG) {
+                $is_legacy = true;
+            }
+        }
+
+        return $is_legacy ? home_url('/lousy-outages/pricing/') : null;
     }
 
     public static function routes(): void {
-        register_rest_route('lousy-outages/v1','/account/magic-link',['methods'=>'POST','permission_callback'=>'__return_true','callback'=>[self::class,'magic_link']]);
-        register_rest_route('lousy-outages/v1','/watchlists',['methods'=>'POST','permission_callback'=>static fn()=>is_user_logged_in(),'callback'=>[self::class,'save_watchlist']]);
-        register_rest_route('lousy-outages/v1','/alert-destinations',['methods'=>'POST','permission_callback'=>static fn()=>is_user_logged_in(),'callback'=>[self::class,'save_destination']]);
-        register_rest_route('lousy-outages/v1','/api-tokens',['methods'=>'POST','permission_callback'=>static fn()=>is_user_logged_in(),'callback'=>[self::class,'create_api_token']]);
+        register_rest_route('lousy-outages/v1', '/account/magic-link', ['methods' => 'POST', 'permission_callback' => '__return_true', 'callback' => [self::class, 'magic_link']]);
+        register_rest_route('lousy-outages/v1', '/watchlists', ['methods' => 'POST', 'permission_callback' => static fn() => is_user_logged_in(), 'callback' => [self::class, 'save_watchlist']]);
+        register_rest_route('lousy-outages/v1', '/alert-destinations', ['methods' => 'POST', 'permission_callback' => static fn() => is_user_logged_in(), 'callback' => [self::class, 'save_destination']]);
+        register_rest_route('lousy-outages/v1', '/api-tokens', ['methods' => 'POST', 'permission_callback' => static fn() => is_user_logged_in(), 'callback' => [self::class, 'create_api_token']]);
     }
 
-    public static function require_feature(int $user_id,string $feature) {
-        $plan=CommerceStore::plan($user_id);
-        if($feature==='private_board' && !(bool)get_option('lousy_outages_feature_private_boards',false)) return new \WP_Error('feature_disabled','Private boards are not in this rollout yet.',['status'=>503,'feature'=>$feature]);
-        return Entitlements::allows($plan,$feature) ? true : new \WP_Error('upgrade_required','This feature needs a paid plan.',['status'=>403,'plan'=>$plan,'feature'=>$feature]);
+    public static function require_feature(int $user_id, string $feature) {
+        $plan = CommerceStore::plan($user_id);
+        if ($feature === 'private_board' && !(bool) get_option('lousy_outages_feature_private_boards', false)) {
+            return new \WP_Error('feature_disabled', 'Private boards are not in this rollout yet.', ['status' => 503, 'feature' => $feature]);
+        }
+        return Entitlements::allows($plan, $feature) ? true : new \WP_Error('upgrade_required', 'This feature needs a paid plan.', ['status' => 403, 'plan' => $plan, 'feature' => $feature]);
     }
 
     public static function save_watchlist(WP_REST_Request $request) {
-        $user_id=get_current_user_id(); $allowed=self::require_feature($user_id,'watchlists'); if (is_wp_error($allowed)) return $allowed;
-        global $wpdb; $providers=array_values(array_filter(array_map('sanitize_key',(array)$request->get_param('providers'))));
-        $filters=(array)$request->get_param('filters');
-        if (!Entitlements::allows(CommerceStore::plan($user_id),'advanced_filters')) $filters=[];
-        $wpdb->insert($wpdb->prefix.'lo_watchlists',['owner_user_id'=>$user_id,'name'=>sanitize_text_field((string)$request->get_param('name')),'providers'=>wp_json_encode($providers),'filters'=>wp_json_encode($filters),'digest_preferences'=>wp_json_encode((array)$request->get_param('digest')),'is_shared'=>0,'created_at'=>current_time('mysql',true),'updated_at'=>current_time('mysql',true)]);
-        do_action('lousy_outages_product_event','watchlist_saved',['user_id'=>$user_id,'watchlist_id'=>(int)$wpdb->insert_id]);
-        return new WP_REST_Response(['id'=>(int)$wpdb->insert_id],201);
+        $user_id = get_current_user_id();
+        $allowed = self::require_feature($user_id, 'watchlists');
+        if (is_wp_error($allowed)) {
+            return $allowed;
+        }
+        global $wpdb;
+        $providers = array_values(array_filter(array_map('sanitize_key', (array) $request->get_param('providers'))));
+        $filters = (array) $request->get_param('filters');
+        if (!Entitlements::allows(CommerceStore::plan($user_id), 'advanced_filters')) {
+            $filters = [];
+        }
+        $wpdb->insert($wpdb->prefix . 'lo_watchlists', [
+            'owner_user_id' => $user_id,
+            'name' => sanitize_text_field((string) $request->get_param('name')),
+            'providers' => wp_json_encode($providers),
+            'filters' => wp_json_encode($filters),
+            'digest_preferences' => wp_json_encode((array) $request->get_param('digest')),
+            'is_shared' => 0,
+            'created_at' => current_time('mysql', true),
+            'updated_at' => current_time('mysql', true),
+        ]);
+        do_action('lousy_outages_product_event', 'watchlist_saved', ['user_id' => $user_id, 'watchlist_id' => (int) $wpdb->insert_id]);
+        return new WP_REST_Response(['id' => (int) $wpdb->insert_id], 201);
     }
 
     public static function create_api_token(WP_REST_Request $request) {
-        $user_id=get_current_user_id(); $allowed=self::require_feature($user_id,'api_tokens'); if (is_wp_error($allowed)) return $allowed;
-        global $wpdb; $plain='lo_'.bin2hex(random_bytes(24)); $prefix=substr($plain,0,12);
-        $wpdb->insert($wpdb->prefix.'lo_api_tokens',['owner_user_id'=>$user_id,'name'=>sanitize_text_field((string)$request->get_param('name')) ?: 'API token','token_prefix'=>$prefix,'token_hash'=>password_hash($plain,PASSWORD_DEFAULT),'created_at'=>current_time('mysql',true)]);
-        return new WP_REST_Response(['id'=>(int)$wpdb->insert_id,'token'=>$plain,'notice'=>'Copy this token now. It will not be shown again.'],201);
+        $user_id = get_current_user_id();
+        $allowed = self::require_feature($user_id, 'api_tokens');
+        if (is_wp_error($allowed)) {
+            return $allowed;
+        }
+        global $wpdb;
+        $plain = 'lo_' . bin2hex(random_bytes(24));
+        $prefix = substr($plain, 0, 12);
+        $wpdb->insert($wpdb->prefix . 'lo_api_tokens', [
+            'owner_user_id' => $user_id,
+            'name' => sanitize_text_field((string) $request->get_param('name')) ?: 'API token',
+            'token_prefix' => $prefix,
+            'token_hash' => password_hash($plain, PASSWORD_DEFAULT),
+            'created_at' => current_time('mysql', true),
+        ]);
+        return new WP_REST_Response(['id' => (int) $wpdb->insert_id, 'token' => $plain, 'notice' => 'Copy this token now. It will not be shown again.'], 201);
     }
 
     public static function save_destination(WP_REST_Request $request) {
-        $user_id=get_current_user_id(); $plan=CommerceStore::plan($user_id); $allowed=self::require_feature($user_id,'alert_destination'); if(is_wp_error($allowed)) return $allowed;
-        $type=sanitize_key((string)$request->get_param('type')); $endpoint=esc_url_raw((string)$request->get_param('endpoint'));
-        if(!in_array($type,['slack','webhook'],true) || !wp_http_validate_url($endpoint)) return new \WP_Error('invalid_destination','Use a valid HTTPS Slack or webhook URL.',['status'=>400]);
-        global $wpdb; $count=(int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$wpdb->prefix}lo_alert_destinations WHERE owner_user_id=%d",$user_id));
-        if($count>=Entitlements::destination_limit($plan)) return new \WP_Error('destination_limit','This plan has reached its destination limit.',['status'=>403]);
-        $encrypted=self::encrypt_secret($endpoint);
-        $wpdb->insert($wpdb->prefix.'lo_alert_destinations',['owner_user_id'=>$user_id,'type'=>$type,'label'=>sanitize_text_field((string)$request->get_param('label')) ?: ucfirst($type),'endpoint_encrypted'=>$encrypted,'enabled'=>1,'created_at'=>current_time('mysql',true)]);
-        return new WP_REST_Response(['id'=>(int)$wpdb->insert_id],201);
+        $user_id = get_current_user_id();
+        $plan = CommerceStore::plan($user_id);
+        $allowed = self::require_feature($user_id, 'alert_destination');
+        if (is_wp_error($allowed)) {
+            return $allowed;
+        }
+        $type = sanitize_key((string) $request->get_param('type'));
+        $endpoint = esc_url_raw((string) $request->get_param('endpoint'));
+        if (!in_array($type, ['slack', 'webhook'], true) || !wp_http_validate_url($endpoint)) {
+            return new \WP_Error('invalid_destination', 'Use a valid HTTPS Slack or webhook URL.', ['status' => 400]);
+        }
+        global $wpdb;
+        $count = (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$wpdb->prefix}lo_alert_destinations WHERE owner_user_id=%d", $user_id));
+        if ($count >= Entitlements::destination_limit($plan)) {
+            return new \WP_Error('destination_limit', 'This plan has reached its destination limit.', ['status' => 403]);
+        }
+        $encrypted = self::encrypt_secret($endpoint);
+        $wpdb->insert($wpdb->prefix . 'lo_alert_destinations', [
+            'owner_user_id' => $user_id,
+            'type' => $type,
+            'label' => sanitize_text_field((string) $request->get_param('label')) ?: ucfirst($type),
+            'endpoint_encrypted' => $encrypted,
+            'enabled' => 1,
+            'created_at' => current_time('mysql', true),
+        ]);
+        return new WP_REST_Response(['id' => (int) $wpdb->insert_id], 201);
     }
 
     private static function encrypt_secret(string $value): string {
-        $key=hash('sha256',wp_salt('auth'),true); $iv=random_bytes(12); $tag='';
-        $cipher=openssl_encrypt($value,'aes-256-gcm',$key,OPENSSL_RAW_DATA,$iv,$tag);
-        if($cipher===false) return '';
-        return base64_encode($iv.$tag.$cipher);
+        $key = hash('sha256', wp_salt('auth'), true);
+        $iv = random_bytes(12);
+        $tag = '';
+        $cipher = openssl_encrypt($value, 'aes-256-gcm', $key, OPENSSL_RAW_DATA, $iv, $tag);
+        if ($cipher === false) {
+            return '';
+        }
+        return base64_encode($iv . $tag . $cipher);
     }
 
     public static function magic_link(WP_REST_Request $request) {
-        $email=sanitize_email((string)$request->get_param('email'));
-        if (!is_email($email)) return new \WP_Error('invalid_email','Enter a real email address.',['status'=>400]);
-        $user=get_user_by('email',$email);
-        if (!$user) { $id=wp_create_user($email,wp_generate_password(32,true,true),$email); if (!is_wp_error($id)) $user=get_user_by('id',$id); }
-        if ($user) {
-            $token=bin2hex(random_bytes(24)); set_transient('lo_magic_'.hash('sha256',$token),['user_id'=>(int)$user->ID,'redirect'=>home_url('/lousy-outages/account/')],15*MINUTE_IN_SECONDS);
-            wp_mail($email,'Your Lousy Outages sign-in link','One click. No password nonsense.\n\n'.add_query_arg(['lo_magic'=>$token],home_url('/lousy-outages/account/')));
+        $email = sanitize_email((string) $request->get_param('email'));
+        if (!is_email($email)) {
+            return new \WP_Error('invalid_email', 'Enter a real email address.', ['status' => 400]);
         }
-        return new WP_REST_Response(['message'=>'If that address can sign in, the link is on its way.']);
+        $user = get_user_by('email', $email);
+        if (!$user) {
+            $id = wp_create_user($email, wp_generate_password(32, true, true), $email);
+            if (!is_wp_error($id)) {
+                $user = get_user_by('id', $id);
+            }
+        }
+        if ($user) {
+            $token = bin2hex(random_bytes(24));
+            set_transient('lo_magic_' . hash('sha256', $token), ['user_id' => (int) $user->ID, 'redirect' => home_url('/lousy-outages/account/')], 15 * MINUTE_IN_SECONDS);
+            wp_mail($email, 'Your Lousy Outages sign-in link', "One click. No password nonsense.\n\n" . add_query_arg(['lo_magic' => $token], home_url('/lousy-outages/account/')));
+        }
+        return new WP_REST_Response(['message' => 'If that address can sign in, the link is on its way.']);
     }
 
     public static function consume_magic_link(): void {
-        if (empty($_GET['lo_magic'])) return; $token=sanitize_text_field(wp_unslash($_GET['lo_magic'])); $key='lo_magic_'.hash('sha256',$token); $record=get_transient($key);
-        if (!is_array($record) || empty($record['user_id'])) return;
-        delete_transient($key); wp_set_auth_cookie((int)$record['user_id'],true,is_ssl()); wp_safe_redirect((string)$record['redirect']); exit;
+        if (empty($_GET['lo_magic'])) {
+            return;
+        }
+        $token = sanitize_text_field(wp_unslash($_GET['lo_magic']));
+        $key = 'lo_magic_' . hash('sha256', $token);
+        $record = get_transient($key);
+        if (!is_array($record) || empty($record['user_id'])) {
+            return;
+        }
+        delete_transient($key);
+        wp_set_auth_cookie((int) $record['user_id'], true, is_ssl());
+        wp_safe_redirect((string) $record['redirect']);
+        exit;
     }
 
     public static function pricing(): string {
-        do_action('lousy_outages_product_event','plan_page_view',['user_id'=>get_current_user_id()]);
-        $plans=[
-            'Free'=>['$0','Public dashboard, recent history, RSS and basic email. The useful part stays free.'],
-            'Pro'=>['paid monthly','Saved watchlists, component filters, digests and one Slack or webhook destination.'],
-            'Team'=>['paid monthly','Shared boards, more destinations, API tokens and a private-board scaffold.'],
+        do_action('lousy_outages_product_event', 'plan_page_view', ['user_id' => get_current_user_id()]);
+        $plans = [
+            'Free' => ['$0', 'Public dashboard, recent history, RSS and basic email. The useful part stays free.'],
+            'Pro' => ['paid monthly', 'Saved watchlists, component filters, digests and one Slack or webhook destination.'],
+            'Team' => ['paid monthly', 'Shared boards, more destinations, API tokens and a private-board scaffold.'],
         ];
-        ob_start(); ?><div class="lo-product"><header><p class="lo-product__kicker">pick your level</p><h1>Outages, with fewer surprises.</h1><p>The public dashboard stays public. Pay when the machine needs to remember things for you.</p></header><div class="lo-price-grid"><?php foreach($plans as $name=>$copy): $slug=strtolower($name); ?><article class="lo-price-card"><h2><?php echo esc_html($name); ?></h2><strong><?php echo esc_html($copy[0]); ?></strong><p><?php echo esc_html($copy[1]); ?></p><?php if($slug==='free'): ?><a class="lo-product-button" href="<?php echo esc_url(home_url('/lousy-outages/')); ?>">Check the dashboard</a><?php else: ?><button class="lo-product-button" data-lo-checkout="<?php echo esc_attr($slug); ?>">Choose <?php echo esc_html($name); ?></button><?php endif; ?></article><?php endforeach; ?></div>
-        <div class="lo-comparison"><table><thead><tr><th>Feature</th><th>Free</th><th>Pro</th><th>Team</th></tr></thead><tbody><?php foreach(['Public dashboard / history / RSS'=>[1,1,1],'Basic email subscription'=>[1,1,1],'Saved watchlists + filters'=>[0,1,1],'Digest preferences'=>[0,1,1],'Alert destinations'=>[0,'1','many'],'Shared boards'=>[0,0,1],'API tokens'=>[0,0,1],'Private board scaffold'=>[0,0,1]] as $feature=>$levels): ?><tr><th><?php echo esc_html($feature); ?></th><?php foreach($levels as $value): ?><td><?php echo esc_html($value===1?'yes':($value===0?'—':$value)); ?></td><?php endforeach; ?></tr><?php endforeach; ?></tbody></table></div></div><?php return (string)ob_get_clean();
+        ob_start(); ?>
+        <div class="lo-product">
+            <header>
+                <p class="lo-product__kicker">pick your level</p>
+                <h1>Outages, with fewer surprises.</h1>
+                <p>The public dashboard stays public. Pay when the machine needs to remember things for you.</p>
+            </header>
+            <div class="lo-price-grid">
+                <?php foreach ($plans as $name => $copy) :
+                    $slug = strtolower($name); ?>
+                    <article class="lo-price-card">
+                        <h2><?php echo esc_html($name); ?></h2>
+                        <strong><?php echo esc_html($copy[0]); ?></strong>
+                        <p><?php echo esc_html($copy[1]); ?></p>
+                        <?php if ($slug === 'free') : ?>
+                            <a class="lo-product-button" href="<?php echo esc_url(home_url('/lousy-outages/')); ?>">Check the dashboard</a>
+                        <?php else : ?>
+                            <button class="lo-product-button" data-lo-checkout="<?php echo esc_attr($slug); ?>">Choose <?php echo esc_html($name); ?></button>
+                        <?php endif; ?>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+            <div class="lo-comparison">
+                <table>
+                    <thead><tr><th>Feature</th><th>Free</th><th>Pro</th><th>Team</th></tr></thead>
+                    <tbody>
+                        <?php foreach ([
+                            'Public dashboard / history / RSS' => [1, 1, 1],
+                            'Basic email subscription' => [1, 1, 1],
+                            'Saved watchlists + filters' => [0, 1, 1],
+                            'Digest preferences' => [0, 1, 1],
+                            'Alert destinations' => [0, '1', 'many'],
+                            'Shared boards' => [0, 0, 1],
+                            'API tokens' => [0, 0, 1],
+                            'Private board scaffold' => [0, 0, 1],
+                        ] as $feature => $levels) : ?>
+                            <tr>
+                                <th><?php echo esc_html($feature); ?></th>
+                                <?php foreach ($levels as $value) : ?>
+                                    <td><?php echo esc_html($value === 1 ? 'yes' : ($value === 0 ? '—' : $value)); ?></td>
+                                <?php endforeach; ?>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <?php
+        return (string) ob_get_clean();
     }
 
     public static function account(): string {
-        if (!is_user_logged_in()) return '<div class="lo-product lo-account"><h1>Your outage controls.</h1><p>No password maze. We’ll email a one-use sign-in link.</p><form data-lo-magic><label>Email <input type="email" name="email" required></label><button class="lo-product-button">Send the link</button><p data-lo-message></p></form></div>';
-        $plan=CommerceStore::plan(get_current_user_id());
-        return '<div class="lo-product lo-account"><p class="lo-product__kicker">account console</p><h1>'.esc_html(ucfirst($plan)).' plan</h1><p>'.($plan==='free'?'The public signal is yours. Watchlists start on Pro.':'Your paid controls are switched on.').'</p><p><a class="lo-product-button" data-lo-upgrade href="'.esc_url(home_url('/lousy-outages/pricing/')).'">'.($plan==='free'?'See paid plans':'Change plan').'</a> <button class="lo-product-button" data-lo-portal>Manage billing</button></p></div>';
+        if (!is_user_logged_in()) {
+            return '<div class="lo-product lo-account"><h1>Your outage controls.</h1><p>No password maze. We’ll email a one-use sign-in link.</p><form data-lo-magic><label>Email <input type="email" name="email" required></label><button class="lo-product-button">Send the link</button><p data-lo-message></p></form></div>';
+        }
+        $plan = CommerceStore::plan(get_current_user_id());
+        return '<div class="lo-product lo-account"><p class="lo-product__kicker">account console</p><h1>' . esc_html(ucfirst($plan)) . ' plan</h1><p>' . ($plan === 'free' ? 'The public signal is yours. Watchlists start on Pro.' : 'Your paid controls are switched on.') . '</p><p><a class="lo-product-button" data-lo-upgrade href="' . esc_url(home_url('/lousy-outages/pricing/')) . '">' . ($plan === 'free' ? 'See paid plans' : 'Change plan') . '</a> <button class="lo-product-button" data-lo-portal>Manage billing</button></p></div>';
     }
 
     public static function browser_events(): void {
-        ?><script>(function(){function event(n,d){window.dispatchEvent(new CustomEvent('lousy-outages:event',{detail:Object.assign({event:n},d||{})}));if(window.dataLayer)window.dataLayer.push(Object.assign({event:'lo_'+n},d||{}));}window.addEventListener('lousy-outages:event',function(e){var d=e.detail||{};if(window.dataLayer&&d.event)window.dataLayer.push(Object.assign({},d,{event:'lo_'+d.event}));});
-        document.addEventListener('click',async function(e){var b=e.target.closest('[data-lo-checkout]');if(b){event('upgrade_click',{plan:b.dataset.loCheckout});if(!<?php echo is_user_logged_in()?'true':'false'; ?>){location.href='<?php echo esc_url_raw(home_url('/lousy-outages/account/')); ?>';return;}b.disabled=true;var r=await fetch('<?php echo esc_url_raw(rest_url('lousy-outages/v1/billing/checkout')); ?>',{method:'POST',headers:{'Content-Type':'application/json','X-WP-Nonce':'<?php echo esc_js(wp_create_nonce('wp_rest')); ?>'},body:JSON.stringify({plan:b.dataset.loCheckout})});var j=await r.json();if(j.url)location.href=j.url;else{b.disabled=false;alert(j.message||'Billing is taking a nap.');}}var p=e.target.closest('[data-lo-portal]');if(p){var r=await fetch('<?php echo esc_url_raw(rest_url('lousy-outages/v1/billing/portal')); ?>',{method:'POST',headers:{'X-WP-Nonce':'<?php echo esc_js(wp_create_nonce('wp_rest')); ?>'}});var j=await r.json();if(j.url)location.href=j.url;}if(e.target.closest('[data-lo-upgrade]'))event('upgrade_click',{placement:'account'});});
-        document.addEventListener('submit',async function(e){var f=e.target.closest('[data-lo-magic]');if(!f)return;e.preventDefault();var r=await fetch('<?php echo esc_url_raw(rest_url('lousy-outages/v1/account/magic-link')); ?>',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:f.email.value})});var j=await r.json();f.querySelector('[data-lo-message]').textContent=j.message||'Check your inbox.';});})();</script><?php
+        ?>
+        <script>(function(){function event(n,d){window.dispatchEvent(new CustomEvent('lousy-outages:event',{detail:Object.assign({event:n},d||{})}));if(window.dataLayer)window.dataLayer.push(Object.assign({event:'lo_'+n},d||{}));}window.addEventListener('lousy-outages:event',function(e){var d=e.detail||{};if(window.dataLayer&&d.event)window.dataLayer.push(Object.assign({},d,{event:'lo_'+d.event}));});
+        document.addEventListener('click',async function(e){var b=e.target.closest('[data-lo-checkout]');if(b){event('upgrade_click',{plan:b.dataset.loCheckout});if(!<?php echo is_user_logged_in() ? 'true' : 'false'; ?>){location.href='<?php echo esc_url_raw(home_url('/lousy-outages/account/')); ?>';return;}b.disabled=true;var r=await fetch('<?php echo esc_url_raw(rest_url('lousy-outages/v1/billing/checkout')); ?>',{method:'POST',headers:{'Content-Type':'application/json','X-WP-Nonce':'<?php echo esc_js(wp_create_nonce('wp_rest')); ?>'},body:JSON.stringify({plan:b.dataset.loCheckout})});var j=await r.json();if(j.url)location.href=j.url;else{b.disabled=false;alert(j.message||'Billing is taking a nap.');}}var p=e.target.closest('[data-lo-portal]');if(p){var r=await fetch('<?php echo esc_url_raw(rest_url('lousy-outages/v1/billing/portal')); ?>',{method:'POST',headers:{'X-WP-Nonce':'<?php echo esc_js(wp_create_nonce('wp_rest')); ?>'}});var j=await r.json();if(j.url)location.href=j.url;}if(e.target.closest('[data-lo-upgrade]'))event('upgrade_click',{placement:'account'});});
+        document.addEventListener('submit',async function(e){var f=e.target.closest('[data-lo-magic]');if(!f)return;e.preventDefault();var r=await fetch('<?php echo esc_url_raw(rest_url('lousy-outages/v1/account/magic-link')); ?>',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:f.email.value})});var j=await r.json();f.querySelector('[data-lo-message]').textContent=j.message||'Check your inbox.';});})();</script>
+        <?php
     }
 }

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -3,7 +3,7 @@ declare( strict_types=1 );
 /**
  * Plugin Name: Lousy Outages
  * Description: WordPress-native outage intelligence, community reporting, and early-warning signals for third-party service dependencies.
- * Version: 0.5.7
+ * Version: 0.5.8
  * Author: Suzy Easton
  * Text Domain: lousy-outages
  */
@@ -24,7 +24,7 @@ if ( defined( 'LOUSY_OUTAGES_DISABLE' ) && LOUSY_OUTAGES_DISABLE ) {
 }
 
 if ( ! defined( 'LOUSY_OUTAGES_VERSION' ) ) {
-    define( 'LOUSY_OUTAGES_VERSION', '0.5.7' );
+    define( 'LOUSY_OUTAGES_VERSION', '0.5.8' );
 }
 if ( ! defined( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION' ) ) {
     define( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION', 5 );

--- a/scripts/deploy-lousy-outages-ssh.py
+++ b/scripts/deploy-lousy-outages-ssh.py
@@ -56,6 +56,8 @@ THEME_FILES = [
     "page-shop.php",
     "page-work-with-suzy.php",
     "page-lousy-outages.php",
+    "page-lousy-outages-pricing.php",
+    "page-lousy-outages-account.php",
     "parts/home-commercial-strip.php",
     "parts/home-hire-strip.php",
     "parts/shop-product-card.php",

--- a/tests/LousyOutagesAccessAdminRoutingTest.php
+++ b/tests/LousyOutagesAccessAdminRoutingTest.php
@@ -1,0 +1,259 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Admin/public routing separation for Lousy Outages access management.
+ */
+
+$GLOBALS['lo_test_options'] = [];
+$GLOBALS['lo_test_pages'] = [];
+$GLOBALS['lo_test_page_meta'] = [];
+$GLOBALS['lo_test_next_page_id'] = 1;
+$GLOBALS['lo_test_is_admin'] = false;
+$GLOBALS['lo_test_is_page_slug'] = null;
+$GLOBALS['lo_test_submenu'] = [];
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+if (!defined('MINUTE_IN_SECONDS')) {
+    define('MINUTE_IN_SECONDS', 60);
+}
+if (!defined('ARRAY_A')) {
+    define('ARRAY_A', 'ARRAY_A');
+}
+if (!defined('DAY_IN_SECONDS')) {
+    define('DAY_IN_SECONDS', 86400);
+}
+
+function add_action($hook, $callback, $priority = 10, $accepted_args = 1): void {}
+function add_filter($hook, $callback, $priority = 10, $accepted_args = 1): void {}
+function apply_filters($tag, $value) { return $value; }
+function do_action($tag, ...$args): void {}
+function sanitize_key($k) { return preg_replace('/[^a-z0-9_]/', '', strtolower((string) $k)) ?? ''; }
+function sanitize_text_field($t) { return trim(strip_tags((string) $t)); }
+function sanitize_email($e) { return trim(strtolower((string) $e)); }
+function is_email($e) { return false !== strpos((string) $e, '@'); }
+function wp_json_encode($v) { return json_encode($v); }
+function wp_salt($s = '') { return 'salt'; }
+function current_time($t = 'mysql', $gmt = false) { return $t === 'mysql' ? gmdate('Y-m-d H:i:s') : time(); }
+function esc_html($v) { return (string) $v; }
+function esc_url($v) { return (string) $v; }
+function esc_attr($v) { return (string) $v; }
+function rest_url($p = '') { return 'https://example.com/wp-json/' . ltrim((string) $p, '/'); }
+function wp_create_nonce($a = '') { return 'nonce'; }
+function wp_parse_url($url, $component = -1) { return parse_url((string) $url, $component); }
+function trailingslashit($v) { return rtrim((string) $v, '/') . '/'; }
+function home_url($path = '') { return 'https://example.com' . $path; }
+function admin_url($path = '') { return 'https://example.com/wp-admin/' . ltrim((string) $path, '/'); }
+function get_option($key, $default = false) {
+    return array_key_exists($key, $GLOBALS['lo_test_options']) ? $GLOBALS['lo_test_options'][$key] : $default;
+}
+function update_option($key, $value, $autoload = null) {
+    $GLOBALS['lo_test_options'][$key] = $value;
+    return true;
+}
+function add_submenu_page($parent, $page_title, $menu_title, $capability, $menu_slug, $callback = '') {
+    $GLOBALS['lo_test_submenu'][] = compact('parent', 'page_title', 'menu_title', 'capability', 'menu_slug', 'callback');
+    return 'lousy-outages_page_' . $menu_slug;
+}
+function is_admin() { return (bool) $GLOBALS['lo_test_is_admin']; }
+function is_page($slug = '') {
+    return $GLOBALS['lo_test_is_page_slug'] !== null && (string) $GLOBALS['lo_test_is_page_slug'] === (string) $slug;
+}
+function get_page_by_path($path) {
+    $path = trim((string) $path, '/');
+    foreach ($GLOBALS['lo_test_pages'] as $page) {
+        if ((int) $page['post_parent'] > 0) {
+            $parent_name = $GLOBALS['lo_test_pages'][$page['post_parent']]['post_name'] ?? '';
+            $full = trim($parent_name . '/' . $page['post_name'], '/');
+        } else {
+            $full = $page['post_name'];
+        }
+        if ($full === $path) {
+            return (object) $page;
+        }
+    }
+    return null;
+}
+function get_post($id) {
+    $id = (int) $id;
+    return isset($GLOBALS['lo_test_pages'][$id]) ? (object) $GLOBALS['lo_test_pages'][$id] : null;
+}
+function wp_insert_post($args) {
+    $id = (int) $GLOBALS['lo_test_next_page_id']++;
+    $GLOBALS['lo_test_pages'][$id] = [
+        'ID' => $id,
+        'post_title' => (string) ($args['post_title'] ?? ''),
+        'post_name' => (string) ($args['post_name'] ?? ''),
+        'post_content' => (string) ($args['post_content'] ?? ''),
+        'post_status' => (string) ($args['post_status'] ?? 'publish'),
+        'post_type' => (string) ($args['post_type'] ?? 'page'),
+        'post_parent' => (int) ($args['post_parent'] ?? 0),
+    ];
+    return $id;
+}
+function wp_update_post($args) {
+    $id = (int) ($args['ID'] ?? 0);
+    if (!isset($GLOBALS['lo_test_pages'][$id])) {
+        return 0;
+    }
+    foreach (['post_title', 'post_name', 'post_content', 'post_status', 'post_type', 'post_parent'] as $field) {
+        if (array_key_exists($field, $args)) {
+            $GLOBALS['lo_test_pages'][$id][$field] = $args[$field];
+        }
+    }
+    return $id;
+}
+function update_post_meta($id, $key, $value) {
+    $GLOBALS['lo_test_page_meta'][(int) $id][$key] = $value;
+    return true;
+}
+function get_post_meta($id, $key, $single = false) {
+    $value = $GLOBALS['lo_test_page_meta'][(int) $id][$key] ?? '';
+    return $single ? $value : [$value];
+}
+function is_wp_error($thing) { return $thing instanceof WP_Error; }
+function register_setting(...$args): void {}
+function add_shortcode(...$args): void {}
+function register_rest_route(...$args): void {}
+
+if (!class_exists('WP_Error')) {
+    class WP_Error {
+        public function get_error_message() { return 'error'; }
+    }
+}
+
+require_once __DIR__ . '/../lousy-outages/includes/Entitlements.php';
+require_once __DIR__ . '/../lousy-outages/includes/CommerceStore.php';
+require_once __DIR__ . '/../lousy-outages/includes/CommerceAdmin.php';
+require_once __DIR__ . '/../lousy-outages/includes/Product.php';
+
+use SuzyEaston\LousyOutages\CommerceAdmin;
+use SuzyEaston\LousyOutages\Product;
+
+$assert = static function (bool $condition, string $message): void {
+    if (!$condition) {
+        throw new RuntimeException($message);
+    }
+};
+
+// Admin slug registers correctly under Lousy Outages as Manual Access.
+$GLOBALS['lo_test_submenu'] = [];
+CommerceAdmin::menu();
+$assert(count($GLOBALS['lo_test_submenu']) === 1, 'Expected one Manual Access submenu registration');
+$submenu = $GLOBALS['lo_test_submenu'][0];
+$assert($submenu['menu_slug'] === 'lousy-outages-access-admin', 'Admin menu slug must be lousy-outages-access-admin');
+$assert($submenu['menu_slug'] === CommerceAdmin::PAGE_SLUG, 'PAGE_SLUG constant must match registered menu slug');
+$assert($submenu['menu_title'] === 'Manual Access', 'Menu title must be Manual Access');
+$assert($submenu['parent'] === 'lousy-outages', 'Must nest under Lousy Outages menu');
+$assert($submenu['menu_slug'] !== Product::LEGACY_BILLING_SLUG, 'Admin slug must not reuse legacy public billing slug');
+
+$admin_src = (string) file_get_contents(__DIR__ . '/../lousy-outages/includes/CommerceAdmin.php');
+$assert(!str_contains($admin_src, 'page=lousy-outages-billing'), 'Grant/revoke redirects must not use legacy admin slug');
+$assert(str_contains($admin_src, 'wp_safe_redirect(self::admin_url())'), 'redirect_with_notice must use self::admin_url()');
+$assert(str_contains($admin_src, 'Open public pricing'), 'Admin screen must link out to public pricing');
+$assert(str_contains($admin_src, 'Open account page'), 'Admin screen must link out to account page');
+$assert(
+    CommerceAdmin::admin_url() === 'https://example.com/wp-admin/admin.php?page=lousy-outages-access-admin',
+    'Canonical admin URL must be admin.php?page=lousy-outages-access-admin'
+);
+
+// Legacy public slug cannot replace/hijack the admin route.
+$assert(CommerceAdmin::PAGE_SLUG !== Product::LEGACY_BILLING_SLUG, 'Admin and legacy public slugs must differ');
+$product_src = (string) file_get_contents(__DIR__ . '/../lousy-outages/includes/Product.php');
+$assert(!str_contains($product_src, "post_name' => 'lousy-outages-access-admin"), 'install_pages must never create the admin slug as a public page');
+$assert(!str_contains($product_src, "post_name' => 'lousy-outages-billing"), 'install_pages must never recreate the legacy billing public page');
+
+// Product::install_pages creates missing pricing/account under parent.
+$GLOBALS['lo_test_pages'] = [];
+$GLOBALS['lo_test_page_meta'] = [];
+$GLOBALS['lo_test_next_page_id'] = 1;
+$GLOBALS['lo_test_options'] = [];
+
+Product::install_pages();
+$parent = get_page_by_path('lousy-outages');
+$pricing = get_page_by_path('lousy-outages/pricing');
+$account = get_page_by_path('lousy-outages/account');
+$assert($parent !== null, 'Parent /lousy-outages/ page must be created when missing');
+$assert($pricing !== null, 'Missing pricing child page must be created');
+$assert($account !== null, 'Missing account child page must be created');
+$assert((int) $pricing->post_parent === (int) $parent->ID, 'Pricing must be a child of /lousy-outages/');
+$assert((int) $account->post_parent === (int) $parent->ID, 'Account must be a child of /lousy-outages/');
+$assert((string) get_post_meta((int) $pricing->ID, '_wp_page_template', true) === 'page-lousy-outages-pricing.php', 'Pricing template must be assigned');
+$assert((string) get_post_meta((int) $account->ID, '_wp_page_template', true) === 'page-lousy-outages-account.php', 'Account template must be assigned');
+$assert(str_contains((string) $account->post_content, '[lousy_outages_account]'), 'Account page content must include the account shortcode');
+
+$page_count_after_first = count($GLOBALS['lo_test_pages']);
+$pricing_id = (int) $pricing->ID;
+$account_id = (int) $account->ID;
+$pricing_content = (string) $pricing->post_content;
+
+// Running page repair twice creates no duplicates; existing IDs retained.
+Product::install_pages();
+$assert(count($GLOBALS['lo_test_pages']) === $page_count_after_first, 'Second install_pages must not create duplicate pages');
+$pricing2 = get_page_by_path('lousy-outages/pricing');
+$account2 = get_page_by_path('lousy-outages/account');
+$assert((int) $pricing2->ID === $pricing_id, 'Existing pricing page ID must be retained');
+$assert((int) $account2->ID === $account_id, 'Existing account page ID must be retained');
+$assert((string) $pricing2->post_content === $pricing_content, 'Existing pricing content must be preserved');
+
+// Existing child pages are retained while parent/template are repaired.
+$GLOBALS['lo_test_pages'][$pricing_id]['post_parent'] = 0;
+$GLOBALS['lo_test_page_meta'][$pricing_id]['_wp_page_template'] = 'default';
+Product::install_pages();
+$assert(count($GLOBALS['lo_test_pages']) === $page_count_after_first, 'Repair must not duplicate when fixing parent/template');
+$repaired = get_post($pricing_id);
+$assert((int) $repaired->post_parent === (int) $parent->ID, 'Repair must reattach pricing to parent');
+$assert((string) get_post_meta($pricing_id, '_wp_page_template', true) === 'page-lousy-outages-pricing.php', 'Repair must restore pricing template');
+
+// Versioned repair is idempotent.
+Product::maybe_repair_pages();
+$assert((string) get_option('lousy_outages_product_pages_version') === Product::PAGES_VERSION, 'Page repair must stamp product pages version');
+$before = count($GLOBALS['lo_test_pages']);
+Product::maybe_repair_pages();
+$assert(count($GLOBALS['lo_test_pages']) === $before, 'Versioned repair must not recreate pages when already healthy');
+
+// No frontend canonical redirect during is_admin() or /wp-admin/.
+$GLOBALS['lo_test_is_admin'] = true;
+$GLOBALS['lo_test_is_page_slug'] = Product::LEGACY_BILLING_SLUG;
+$_SERVER['REQUEST_URI'] = '/lousy-outages-billing/';
+$_GET = [];
+$assert(Product::legacy_billing_redirect_target() === null, 'No frontend canonical redirect during is_admin()');
+
+$GLOBALS['lo_test_is_admin'] = false;
+$_SERVER['REQUEST_URI'] = '/wp-admin/admin.php?page=lousy-outages-access-admin';
+$_GET = ['page' => CommerceAdmin::PAGE_SLUG];
+$GLOBALS['lo_test_is_page_slug'] = null;
+$assert(Product::legacy_billing_redirect_target() === null, 'Must not redirect wp-admin access-admin requests');
+
+$_SERVER['REQUEST_URI'] = '/wp-admin/admin.php?page=lousy-outages-billing';
+$_GET = ['page' => Product::LEGACY_BILLING_SLUG];
+$assert(Product::legacy_billing_redirect_target() === null, 'Must not redirect wp-admin even for legacy page query');
+
+$_SERVER['REQUEST_URI'] = '/lousy-outages-billing/';
+$_GET = [];
+$GLOBALS['lo_test_is_page_slug'] = Product::LEGACY_BILLING_SLUG;
+$assert(
+    Product::legacy_billing_redirect_target() === 'https://example.com/lousy-outages/pricing/',
+    'Legacy public /lousy-outages-billing/ must resolve to /lousy-outages/pricing/'
+);
+
+// Path-only detection when is_page() is false.
+$GLOBALS['lo_test_is_page_slug'] = null;
+$_SERVER['REQUEST_URI'] = '/lousy-outages-billing/';
+$_GET = [];
+$assert(
+    Product::legacy_billing_redirect_target() === 'https://example.com/lousy-outages/pricing/',
+    'Legacy path must redirect even without is_page() match'
+);
+
+$deploy_src = (string) file_get_contents(__DIR__ . '/../scripts/deploy-lousy-outages-ssh.py');
+$assert(str_contains($deploy_src, '"page-lousy-outages-pricing.php"'), 'Theme manifest must include pricing template');
+$assert(str_contains($deploy_src, '"page-lousy-outages-account.php"'), 'Theme manifest must include account template');
+
+$workflow = (string) file_get_contents(__DIR__ . '/../.github/workflows/deploy-production.yml');
+$assert(str_contains($workflow, 'page-lousy-outages-pricing.php'), 'Deploy path filters must include pricing template');
+$assert(str_contains($workflow, 'page-lousy-outages-account.php'), 'Deploy path filters must include account template');
+
+echo "ok - access-admin slug, page self-heal, and legacy public redirect guards\n";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production was resolving `admin.php?page=lousy-outages-billing` to the public `/lousy-outages-billing/` page. This separates administrator access management from public pricing/account URLs.

### Admin routing
- Renamed CommerceAdmin slug to `lousy-outages-access-admin`
- Menu item: **Manual Access** under Lousy Outages
- Canonical URL: `/wp-admin/admin.php?page=lousy-outages-access-admin`
- Grant/revoke redirects now use that admin URL
- Helper buttons: Open public pricing ↗ / Open account page ↗
- No public page is created for the admin slug

### Public URLs
- Canonical product URLs remain `/lousy-outages/`, `/lousy-outages/pricing/`, `/lousy-outages/account/`
- Legacy public `/lousy-outages-billing/` 301s to `/lousy-outages/pricing/`
- Redirect explicitly skips `is_admin()` and `/wp-admin/`

### Self-healing pages
- `Product::maybe_repair_pages()` runs on `admin_init`
- Creates missing parent/pricing/account pages only
- Retains existing IDs/content; repairs parent + templates
- Account page content includes `[lousy_outages_account]`

### Deploy
- Added `page-lousy-outages-pricing.php` and `page-lousy-outages-account.php` to theme deploy manifest
- Explicit path filters in deploy workflow
- Plugin version bumped to `0.5.8`

### Tests
- New `tests/LousyOutagesAccessAdminRoutingTest.php` covers admin slug registration, redirect targets, page repair idempotency, and admin redirect guards

## Test plan
- [x] `php tests/LousyOutagesAccessAdminRoutingTest.php`
- [x] `php tests/LousyOutagesCommerceStoreTest.php`
- [x] `php tests/LousyOutagesEntitlementsTest.php`
- [ ] After deploy: open `/wp-admin/admin.php?page=lousy-outages-access-admin` (Manual Access)
- [ ] Confirm `/lousy-outages/pricing/` and `/lousy-outages/account/` exist
- [ ] Confirm `/lousy-outages-billing/` redirects to pricing (not wp-admin)
- [ ] Grant Pro via Manual Access and verify account plan resolves
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cfd3112c-85dd-431d-b65a-774e27e89f81?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cfd3112c-85dd-431d-b65a-774e27e89f81&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

