### PR TITLE
Fix deploy ZIP build after 0.5.8 version bump

### DIFF
--- a/dist/lousy-outages.zip.sha256
+++ b/dist/lousy-outages.zip.sha256
@@ -1,1 +1,1 @@
-9368351659d234b3cce1bdf372db18d035c481cbbcf1d60025cd213d00459fbd  lousy-outages.zip
+41ca8b2d1afc797dad4c96f5b794000b38cf1469c2bdd5f4d96c84581ab1ed91  lousy-outages.zip

--- a/dist/release-manifest.json
+++ b/dist/release-manifest.json
@@ -1,16 +1,13 @@
 {
-  "git_commit_sha": "d58b1dc211c24e0ff35df6315b0cae151d0f9295",
-  "plugin_version": "0.5.5",
-  "zip_sha256": "9368351659d234b3cce1bdf372db18d035c481cbbcf1d60025cd213d00459fbd",
-  "build_timestamp": "2026-08-01T22:42:31Z",
+  "git_commit_sha": "60057b8ecfcfb512232807c3a7a2e77ed24a6b68",
+  "plugin_version": "0.5.8",
+  "zip_sha256": "41ca8b2d1afc797dad4c96f5b794000b38cf1469c2bdd5f4d96c84581ab1ed91",
+  "build_timestamp": "2026-08-12T01:38:32Z",
   "canonical_source_path": "lousy-outages/",
   "files": [
     "lousy-outages/README.md",
-    "lousy-outages/assets/hud.css",
-    "lousy-outages/assets/hud.js",
-    "lousy-outages/assets/js/outages.js",
-    "lousy-outages/assets/lousy-outages.css",
-    "lousy-outages/assets/lousy-outages.js",
+    "lousy-outages/assets/board.css",
+    "lousy-outages/assets/board.js",
     "lousy-outages/includes/Adapters.php",
     "lousy-outages/includes/Adapters/Statuspage.php",
     "lousy-outages/includes/AdminCleanup.php",
@@ -32,6 +29,7 @@
     "lousy-outages/includes/Feeds.php",
     "lousy-outages/includes/Fetch.php",
     "lousy-outages/includes/Fetcher.php",
+    "lousy-outages/includes/HomeTeaser.php",
     "lousy-outages/includes/I18n.php",
     "lousy-outages/includes/IncidentAlerts.php",
     "lousy-outages/includes/MailTransport.php",
@@ -77,6 +75,7 @@
     "lousy-outages/includes/compat.php",
     "lousy-outages/includes/email-templates.php",
     "lousy-outages/lousy-outages.php",
+    "lousy-outages/public/board.php",
     "lousy-outages/public/shortcode.php",
     "lousy-outages/wp-cli/class-wp-cli-lousy.php"
   ]

--- a/scripts/build-lousy-outages-release.sh
+++ b/scripts/build-lousy-outages-release.sh
@@ -4,8 +4,19 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SRC="$ROOT/lousy-outages"
 DIST="$ROOT/dist"
 ZIP="$DIST/lousy-outages.zip"
-VERSION="0.5.7"
+PLUGIN_MAIN="$SRC/lousy-outages.php"
 PLUGIN_HEADER="Plugin Name: Lousy"$' '"Outages"
+# Read the shipped version from the plugin itself so deploy never drifts after a bump.
+VERSION="$(sed -nE 's/^ \* Version: ([0-9]+\.[0-9]+\.[0-9]+)$/\1/p' "$PLUGIN_MAIN" | head -n1)"
+if [[ -z "$VERSION" ]]; then
+  echo "Unable to read Version header from $PLUGIN_MAIN" >&2
+  exit 1
+fi
+CONST_VERSION="$(sed -nE "s/.*define\\( 'LOUSY_OUTAGES_VERSION', '([0-9]+\\.[0-9]+\\.[0-9]+)' \\);.*/\\1/p" "$PLUGIN_MAIN" | head -n1)"
+if [[ "$CONST_VERSION" != "$VERSION" ]]; then
+  echo "Plugin Version header ($VERSION) does not match LOUSY_OUTAGES_VERSION ($CONST_VERSION)" >&2
+  exit 1
+fi
 rm -rf "$DIST/.lousy-outages-build" "$ZIP" "$ZIP.sha256" "$DIST/release-manifest.json"
 mkdir -p "$DIST/.lousy-outages-build/lousy-outages" "$DIST"
 rsync -a --delete \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`Deploy to Production` failed on main after #636 because `scripts/build-lousy-outages-release.sh` still hardcoded `VERSION="0.5.7"` while the plugin was bumped to `0.5.8`. The version grep checks then exited `1`.

### Fix
- Read `Version` / `LOUSY_OUTAGES_VERSION` from `lousy-outages/lousy-outages.php` instead of hardcoding
- Fail early if header and constant disagree
- Refresh tracked `dist/release-manifest.json` + sha256 for `0.5.8`

Verified locally with `scripts/build-lousy-outages-release.sh` → builds `0.5.8` successfully.

## Test plan
- [x] Local `scripts/build-lousy-outages-release.sh`
- [ ] Merge and confirm Deploy to Production completes the plugin ZIP + deploy steps
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cfd3112c-85dd-431d-b65a-774e27e89f81?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cfd3112c-85dd-431d-b65a-774e27e89f81&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

