### PR TITLE
Fix Manual Access menu linking to bare wp-admin path

### DIFF
--- a/dist/lousy-outages.zip.sha256
+++ b/dist/lousy-outages.zip.sha256
@@ -1,1 +1,1 @@
-41ca8b2d1afc797dad4c96f5b794000b38cf1469c2bdd5f4d96c84581ab1ed91  lousy-outages.zip
+d32e9a777eb480ef4be042c57efba85edefd629a8f561e9b8e66361aa5608dea  lousy-outages.zip

--- a/dist/release-manifest.json
+++ b/dist/release-manifest.json
@@ -1,8 +1,8 @@
 {
-  "git_commit_sha": "60057b8ecfcfb512232807c3a7a2e77ed24a6b68",
-  "plugin_version": "0.5.8",
-  "zip_sha256": "41ca8b2d1afc797dad4c96f5b794000b38cf1469c2bdd5f4d96c84581ab1ed91",
-  "build_timestamp": "2026-08-12T01:38:32Z",
+  "git_commit_sha": "d37148bd9ce1ba6f9909ac899cd28ec451b04139",
+  "plugin_version": "0.5.9",
+  "zip_sha256": "d32e9a777eb480ef4be042c57efba85edefd629a8f561e9b8e66361aa5608dea",
+  "build_timestamp": "2026-08-12T01:51:48Z",
   "canonical_source_path": "lousy-outages/",
   "files": [
     "lousy-outages/README.md",

--- a/lousy-outages/includes/CommerceAdmin.php
+++ b/lousy-outages/includes/CommerceAdmin.php
@@ -19,7 +19,9 @@ final class CommerceAdmin {
     ];
 
     public static function bootstrap(): void {
-        add_action('admin_menu', [self::class, 'menu']);
+        // After the parent Lousy Outages menu (priority 10). Registering earlier
+        // makes WordPress emit a bare /wp-admin/{slug} href instead of admin.php?page=.
+        add_action('admin_menu', [self::class, 'menu'], 20);
         add_action('admin_init', [self::class, 'settings']);
         add_action('admin_post_lousy_outages_grant_manual_access', [self::class, 'handle_grant']);
         add_action('admin_post_lousy_outages_revoke_manual_access', [self::class, 'handle_revoke']);
@@ -36,7 +38,8 @@ final class CommerceAdmin {
             'Manual Access',
             'manage_options',
             self::PAGE_SLUG,
-            [self::class, 'page']
+            [self::class, 'page'],
+            80
         );
     }
 

--- a/lousy-outages/lousy-outages.php
+++ b/lousy-outages/lousy-outages.php
@@ -3,7 +3,7 @@ declare( strict_types=1 );
 /**
  * Plugin Name: Lousy Outages
  * Description: WordPress-native outage intelligence, community reporting, and early-warning signals for third-party service dependencies.
- * Version: 0.5.8
+ * Version: 0.5.9
  * Author: Suzy Easton
  * Text Domain: lousy-outages
  */
@@ -24,7 +24,7 @@ if ( defined( 'LOUSY_OUTAGES_DISABLE' ) && LOUSY_OUTAGES_DISABLE ) {
 }
 
 if ( ! defined( 'LOUSY_OUTAGES_VERSION' ) ) {
-    define( 'LOUSY_OUTAGES_VERSION', '0.5.8' );
+    define( 'LOUSY_OUTAGES_VERSION', '0.5.9' );
 }
 if ( ! defined( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION' ) ) {
     define( 'LOUSY_OUTAGES_SNAPSHOT_SCHEMA_VERSION', 5 );

--- a/tests/LousyOutagesAccessAdminRoutingTest.php
+++ b/tests/LousyOutagesAccessAdminRoutingTest.php
@@ -12,6 +12,7 @@ $GLOBALS['lo_test_next_page_id'] = 1;
 $GLOBALS['lo_test_is_admin'] = false;
 $GLOBALS['lo_test_is_page_slug'] = null;
 $GLOBALS['lo_test_submenu'] = [];
+$GLOBALS['lo_test_actions'] = [];
 
 if (!defined('ABSPATH')) {
     define('ABSPATH', __DIR__ . '/');
@@ -26,7 +27,13 @@ if (!defined('DAY_IN_SECONDS')) {
     define('DAY_IN_SECONDS', 86400);
 }
 
-function add_action($hook, $callback, $priority = 10, $accepted_args = 1): void {}
+function add_action($hook, $callback, $priority = 10, $accepted_args = 1): void {
+    $GLOBALS['lo_test_actions'][] = [
+        'hook' => $hook,
+        'callback' => $callback,
+        'priority' => $priority,
+    ];
+}
 function add_filter($hook, $callback, $priority = 10, $accepted_args = 1): void {}
 function apply_filters($tag, $value) { return $value; }
 function do_action($tag, ...$args): void {}
@@ -53,8 +60,8 @@ function update_option($key, $value, $autoload = null) {
     $GLOBALS['lo_test_options'][$key] = $value;
     return true;
 }
-function add_submenu_page($parent, $page_title, $menu_title, $capability, $menu_slug, $callback = '') {
-    $GLOBALS['lo_test_submenu'][] = compact('parent', 'page_title', 'menu_title', 'capability', 'menu_slug', 'callback');
+function add_submenu_page($parent, $page_title, $menu_title, $capability, $menu_slug, $callback = '', $position = null) {
+    $GLOBALS['lo_test_submenu'][] = compact('parent', 'page_title', 'menu_title', 'capability', 'menu_slug', 'callback', 'position');
     return 'lousy-outages_page_' . $menu_slug;
 }
 function is_admin() { return (bool) $GLOBALS['lo_test_is_admin']; }
@@ -139,6 +146,15 @@ $assert = static function (bool $condition, string $message): void {
 };
 
 // Admin slug registers correctly under Lousy Outages as Manual Access.
+$GLOBALS['lo_test_actions'] = [];
+CommerceAdmin::bootstrap();
+$menu_actions = array_values(array_filter(
+    $GLOBALS['lo_test_actions'],
+    static fn(array $a): bool => $a['hook'] === 'admin_menu' && $a['callback'] === [CommerceAdmin::class, 'menu']
+));
+$assert(count($menu_actions) === 1, 'Expected one admin_menu registration for CommerceAdmin::menu');
+$assert((int) $menu_actions[0]['priority'] > 10, 'Manual Access must register after the parent Lousy Outages menu (priority > 10)');
+
 $GLOBALS['lo_test_submenu'] = [];
 CommerceAdmin::menu();
 $assert(count($GLOBALS['lo_test_submenu']) === 1, 'Expected one Manual Access submenu registration');
@@ -147,6 +163,7 @@ $assert($submenu['menu_slug'] === 'lousy-outages-access-admin', 'Admin menu slug
 $assert($submenu['menu_slug'] === CommerceAdmin::PAGE_SLUG, 'PAGE_SLUG constant must match registered menu slug');
 $assert($submenu['menu_title'] === 'Manual Access', 'Menu title must be Manual Access');
 $assert($submenu['parent'] === 'lousy-outages', 'Must nest under Lousy Outages menu');
+$assert(($submenu['position'] ?? null) === 80, 'Manual Access should sit at the end of the Lousy Outages submenu');
 $assert($submenu['menu_slug'] !== Product::LEGACY_BILLING_SLUG, 'Admin slug must not reuse legacy public billing slug');
 
 $admin_src = (string) file_get_contents(__DIR__ . '/../lousy-outages/includes/CommerceAdmin.php');
@@ -157,6 +174,10 @@ $assert(str_contains($admin_src, 'Open account page'), 'Admin screen must link o
 $assert(
     CommerceAdmin::admin_url() === 'https://example.com/wp-admin/admin.php?page=lousy-outages-access-admin',
     'Canonical admin URL must be admin.php?page=lousy-outages-access-admin'
+);
+$assert(
+    !str_contains(CommerceAdmin::admin_url(), '/wp-admin/lousy-outages-access-admin'),
+    'Admin URL must not be a bare /wp-admin/{slug} path'
 );
 
 // Legacy public slug cannot replace/hijack the admin route.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

No — Manual Access was not supposed to open that black footer page.

Clicking **Manual Access** was going to:

`/wp-admin/lousy-outages-access-admin`

instead of:

`/wp-admin/admin.php?page=lousy-outages-access-admin`

### Cause
`CommerceAdmin` registered its submenu at the default `admin_menu` priority **before** the parent Lousy Outages menu existed. WordPress then emitted a bare relative admin path, which rendered the front-end footer instead of `CommerceAdmin::page()`.

### Fix
- Register Manual Access at `admin_menu` priority `20` (after parent menu)
- Position it at the end of the Lousy Outages submenu
- Bump plugin to `0.5.9` so production deploy picks it up

After merge/deploy, Manual Access should open the Plans & Access admin screen (Stripe settings + grant/revoke form + pricing/account helper buttons).

## Test plan
- [x] `php tests/LousyOutagesAccessAdminRoutingTest.php`
- [x] `scripts/build-lousy-outages-release.sh`
- [ ] After deploy: click Lousy Outages → Manual Access
- [ ] Confirm URL is `admin.php?page=lousy-outages-access-admin`
- [ ] Confirm Plans & Access admin UI renders
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cfd3112c-85dd-431d-b65a-774e27e89f81?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cfd3112c-85dd-431d-b65a-774e27e89f81&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

