### PR TITLE
Add Meanwhile field-terminal card to homepage mission select

### DIFF
--- a/__tests__/homepage-meanwhile-mission.test.js
+++ b/__tests__/homepage-meanwhile-mission.test.js
@@ -5,13 +5,10 @@ const test = require("node:test");
 
 const ROOT = path.resolve(__dirname, "..");
 
-test("homepage includes Meanwhile mission card template part", () => {
+test("homepage includes Meanwhile mission card but not the full posts feed", () => {
   const source = fs.readFileSync(path.join(ROOT, "page-home.php"), "utf8");
   assert.match(source, /get_template_part\(\s*'parts\/home',\s*'mission-meanwhile'\s*\)/);
-  const missionIndex = source.indexOf("get_template_part( 'parts/home', 'mission-meanwhile' )");
-  const feedIndex = source.indexOf("get_template_part( 'parts/home-signal-log' )");
-  assert.ok(missionIndex > -1 && feedIndex > -1);
-  assert.ok(missionIndex < feedIndex, "mission card should appear before the Meanwhile feed");
+  assert.doesNotMatch(source, /get_template_part\(\s*'parts\/home-signal-log'\s*\)/);
 });
 
 test("Meanwhile mission card part handles empty and live states", () => {
@@ -24,6 +21,7 @@ test("Meanwhile mission card part handles empty and live states", () => {
   assert.match(source, /LATEST ENTRY/);
   assert.match(source, /Open channel/);
   assert.match(source, /aria-live="polite"/);
+  assert.doesNotMatch(source, /post_excerpt/);
 });
 
 test("blog helper exposes homepage mission payload", () => {

--- a/__tests__/homepage-meanwhile-mission.test.js
+++ b/__tests__/homepage-meanwhile-mission.test.js
@@ -1,0 +1,40 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const ROOT = path.resolve(__dirname, "..");
+
+test("homepage includes Meanwhile mission card template part", () => {
+  const source = fs.readFileSync(path.join(ROOT, "page-home.php"), "utf8");
+  assert.match(source, /get_template_part\(\s*'parts\/home',\s*'mission-meanwhile'\s*\)/);
+  const missionIndex = source.indexOf("get_template_part( 'parts/home', 'mission-meanwhile' )");
+  const feedIndex = source.indexOf("get_template_part( 'parts/home-signal-log' )");
+  assert.ok(missionIndex > -1 && feedIndex > -1);
+  assert.ok(missionIndex < feedIndex, "mission card should appear before the Meanwhile feed");
+});
+
+test("Meanwhile mission card part handles empty and live states", () => {
+  const source = fs.readFileSync(
+    path.join(ROOT, "parts", "home-mission-meanwhile.php"),
+    "utf8"
+  );
+  assert.match(source, /se_blog_home_mission_data/);
+  assert.match(source, /NO CARRIER/);
+  assert.match(source, /LATEST ENTRY/);
+  assert.match(source, /Open channel/);
+  assert.match(source, /aria-live="polite"/);
+});
+
+test("blog helper exposes homepage mission payload", () => {
+  const source = fs.readFileSync(path.join(ROOT, "inc", "blog.php"), "utf8");
+  assert.match(source, /function se_blog_home_mission_data/);
+  assert.match(source, /NOW TRANSMITTING/);
+  assert.match(source, /STANDBY/);
+});
+
+test("mission card styles live in blog.css", () => {
+  const source = fs.readFileSync(path.join(ROOT, "assets", "css", "blog.css"), "utf8");
+  assert.match(source, /\.home-mission-card--meanwhile/);
+  assert.match(source, /prefers-reduced-motion/);
+});

--- a/__tests__/theme-deploy-manifest.test.js
+++ b/__tests__/theme-deploy-manifest.test.js
@@ -29,6 +29,7 @@ test("Meanwhile runtime files are listed in THEME_FILES", () => {
     "archive.php",
     "category.php",
     "parts/home-signal-log.php",
+    "parts/home-mission-meanwhile.php",
     "parts/blog-card.php",
     "parts/blog-empty.php",
     "parts/blog-hero.php",

--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -445,7 +445,7 @@
 
 .se-signal-log-home {
 	max-width: min(92vw, 1080px);
-	margin: 1.5rem auto 0;
+	margin: clamp(1.25rem, 2.5vw, 1.75rem) auto clamp(1rem, 2vw, 1.5rem);
 	padding: 1.15rem clamp(0.85rem, 2.5vw, 1.25rem);
 	border: 1px solid var(--sl-border);
 	border-left: 3px solid var(--sl-green);
@@ -559,6 +559,257 @@
 .se-signal-log-home__archive-link:focus-visible {
 	color: var(--sl-cyan);
 	text-decoration: underline;
+}
+
+/* Homepage mission-select — Meanwhile field terminal */
+
+.home-mission-card--meanwhile {
+	--mm-amber: #ffb300;
+	--mm-phosphor: #4ade80;
+	--mm-cyan: #58c7ff;
+	--mm-panel: rgba(6, 12, 10, 0.92);
+	grid-column: span 2;
+	border-color: rgba(255, 179, 0, 0.42);
+	background:
+		linear-gradient(145deg, rgba(255, 179, 0, 0.08), transparent 42%),
+		linear-gradient(180deg, rgba(0, 18, 12, 0.82), rgba(0, 0, 0, 0.72));
+	box-shadow:
+		0 0 0 1px rgba(255, 179, 0, 0.08),
+		0 14px 34px rgba(0, 0, 0, 0.32),
+		inset 0 1px 0 rgba(255, 179, 0, 0.12);
+}
+
+.home-mission-card--meanwhile-live {
+	border-color: rgba(74, 222, 128, 0.45);
+	box-shadow:
+		0 0 18px rgba(74, 222, 128, 0.1),
+		0 14px 34px rgba(0, 0, 0, 0.32);
+}
+
+.home-mission-card--meanwhile .home-mission-card__label {
+	color: var(--mm-amber);
+}
+
+.home-mission-card--meanwhile h3 {
+	color: var(--mm-phosphor);
+	text-shadow: 0 0 14px rgba(74, 222, 128, 0.28);
+}
+
+.home-mission-meanwhile__tagline {
+	margin: 0;
+	font-family: var(--sl-mono);
+	font-size: 0.76rem;
+	line-height: 1.55;
+	color: var(--sl-muted);
+}
+
+.home-mission-meanwhile__terminal {
+	position: relative;
+	display: grid;
+	margin-top: 0.15rem;
+	isolation: isolate;
+}
+
+.home-mission-meanwhile__scan {
+	position: absolute;
+	inset: 0;
+	z-index: 0;
+	pointer-events: none;
+	border-radius: 10px;
+	background:
+		repeating-linear-gradient(
+			0deg,
+			rgba(0, 0, 0, 0) 0,
+			rgba(0, 0, 0, 0) 2px,
+			rgba(0, 0, 0, 0.16) 3px
+		);
+	opacity: 0.35;
+}
+
+.home-mission-meanwhile__shell {
+	position: relative;
+	z-index: 1;
+	border: 1px solid rgba(94, 234, 160, 0.2);
+	border-radius: 10px;
+	background: var(--mm-panel);
+	overflow: hidden;
+}
+
+.home-mission-meanwhile__shell-bar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.65rem;
+	padding: 0.45rem 0.65rem;
+	border-bottom: 1px solid rgba(94, 234, 160, 0.14);
+	background: rgba(0, 0, 0, 0.35);
+	font-size: clamp(0.42rem, 0.85vw, 0.52rem);
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--sl-muted);
+}
+
+.home-mission-meanwhile__status {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	color: var(--mm-amber);
+}
+
+.home-mission-card--meanwhile-live .home-mission-meanwhile__status {
+	color: var(--mm-phosphor);
+}
+
+.home-mission-meanwhile__led {
+	width: 0.45rem;
+	height: 0.45rem;
+	border-radius: 50%;
+	background: var(--mm-amber);
+	box-shadow: 0 0 8px rgba(255, 179, 0, 0.55);
+}
+
+.home-mission-card--meanwhile-live .home-mission-meanwhile__led {
+	background: var(--mm-phosphor);
+	box-shadow: 0 0 10px rgba(74, 222, 128, 0.65);
+	animation: home-mission-meanwhile-pulse 2.4s ease-in-out infinite;
+}
+
+.home-mission-meanwhile__path {
+	color: rgba(142, 170, 155, 0.85);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.home-mission-meanwhile__body {
+	padding: 0.7rem 0.75rem 0.8rem;
+	font-family: var(--sl-mono);
+}
+
+.home-mission-meanwhile__prompt {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 0.2rem;
+	margin: 0 0 0.55rem;
+	font-size: clamp(0.48rem, 0.95vw, 0.58rem);
+	color: rgba(142, 170, 155, 0.9);
+}
+
+.home-mission-meanwhile__sigil {
+	color: var(--mm-phosphor);
+}
+
+.home-mission-meanwhile__caret {
+	display: inline-block;
+	width: 0.45rem;
+	height: 0.85em;
+	margin-left: 0.1rem;
+	background: var(--mm-phosphor);
+	animation: home-mission-meanwhile-blink 1.1s step-end infinite;
+}
+
+.home-mission-meanwhile__entry-label,
+.home-mission-meanwhile__empty-label {
+	margin: 0 0 0.35rem;
+	font-size: clamp(0.45rem, 0.9vw, 0.55rem);
+	letter-spacing: 0.08em;
+	color: var(--mm-cyan);
+}
+
+.home-mission-meanwhile__entry {
+	display: grid;
+	gap: 0.3rem;
+}
+
+.home-mission-meanwhile__date {
+	font-size: 0.72rem;
+	color: var(--sl-muted);
+}
+
+.home-mission-meanwhile__cat {
+	display: inline-block;
+	width: fit-content;
+	padding: 0.12rem 0.35rem;
+	border: 1px solid rgba(94, 234, 160, 0.22);
+	border-radius: 3px;
+	font-size: 0.48rem;
+	letter-spacing: 0.06em;
+	text-transform: lowercase;
+	color: var(--mm-phosphor);
+}
+
+.home-mission-meanwhile__entry-title {
+	font-size: clamp(0.78rem, 1.5vw, 0.92rem);
+	line-height: 1.45;
+	color: #e8f7ee;
+	text-decoration: none;
+}
+
+.home-mission-meanwhile__entry-title:hover,
+.home-mission-meanwhile__entry-title:focus-visible {
+	color: var(--mm-cyan);
+	text-decoration: underline;
+	outline: 2px solid rgba(88, 199, 255, 0.45);
+	outline-offset: 2px;
+}
+
+.home-mission-meanwhile__entry-excerpt {
+	margin: 0.15rem 0 0;
+	font-size: 0.74rem;
+	line-height: 1.55;
+	color: var(--sl-muted);
+}
+
+.home-mission-meanwhile__empty-copy {
+	margin: 0;
+	font-size: 0.76rem;
+	line-height: 1.55;
+	color: var(--sl-muted);
+}
+
+.home-mission-meanwhile__actions {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.65rem 1rem;
+	margin-top: 0.15rem;
+}
+
+.home-mission-meanwhile__latest-link {
+	font-family: var(--sl-mono);
+	font-size: 0.72rem;
+	color: var(--mm-cyan);
+	text-decoration: none;
+}
+
+.home-mission-meanwhile__latest-link:hover,
+.home-mission-meanwhile__latest-link:focus-visible {
+	color: var(--mm-phosphor);
+	text-decoration: underline;
+	outline: 2px solid rgba(88, 199, 255, 0.45);
+	outline-offset: 2px;
+}
+
+@keyframes home-mission-meanwhile-blink {
+	50% { opacity: 0; }
+}
+
+@keyframes home-mission-meanwhile-pulse {
+	50% { opacity: 0.45; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.home-mission-meanwhile__caret,
+	.home-mission-meanwhile__led {
+		animation: none;
+	}
+}
+
+@media (max-width: 980px) {
+	.home-mission-card--meanwhile {
+		grid-column: 1 / -1;
+	}
 }
 
 /* Responsive */

--- a/inc/blog.php
+++ b/inc/blog.php
@@ -295,6 +295,78 @@ function se_blog_latest_query( $count = 3 ) {
 }
 
 /**
+ * Latest-post payload for the homepage mission-select Meanwhile card.
+ *
+ * @return array{
+ *     blog_url: string,
+ *     has_post: bool,
+ *     status_label: string,
+ *     post_id: int,
+ *     post_title: string,
+ *     post_url: string,
+ *     post_date: string,
+ *     post_date_iso: string,
+ *     post_excerpt: string,
+ *     category_name: string
+ * }
+ */
+function se_blog_home_mission_data() {
+	$blog_url = se_blog_archive_url();
+	$data     = [
+		'blog_url'        => $blog_url,
+		'has_post'        => false,
+		'status_label'    => 'STANDBY',
+		'post_id'         => 0,
+		'post_title'      => '',
+		'post_url'        => '',
+		'post_date'       => '',
+		'post_date_iso'   => '',
+		'post_excerpt'    => '',
+		'category_name'   => '',
+	];
+
+	if ( ! function_exists( 'get_posts' ) ) {
+		return $data;
+	}
+
+	$query = se_blog_latest_query( 1 );
+
+	if ( ! $query instanceof WP_Query || ! $query->have_posts() ) {
+		if ( $query instanceof WP_Query ) {
+			wp_reset_postdata();
+		}
+		return $data;
+	}
+
+	$query->the_post();
+
+	$post_id = get_the_ID();
+	$post    = get_post( $post_id );
+
+	if ( ! $post instanceof WP_Post || 'publish' !== $post->post_status ) {
+		wp_reset_postdata();
+		return $data;
+	}
+
+	$title = get_the_title( $post );
+	$cat   = se_blog_primary_category( $post_id );
+
+	$data['has_post']      = true;
+	$data['status_label']  = 'NOW TRANSMITTING';
+	$data['post_id']       = (int) $post_id;
+	$data['post_title']    = $title ? $title : 'untitled entry';
+	$data['post_url']      = get_permalink( $post ) ?: $blog_url;
+	$data['post_date']     = se_blog_format_date( $post_id );
+	$data['post_date_iso'] = get_the_date( DATE_W3C, $post ) ?: '';
+	$data['post_excerpt']  = se_blog_excerpt( $post_id, 18 );
+	$data['category_name'] = ( $cat instanceof WP_Term ) ? $cat->name : '';
+
+	wp_reset_postdata();
+
+	return $data;
+}
+
+/**
  * Register default blog categories on theme setup (idempotent).
  */
 function se_blog_register_default_categories() {

--- a/page-home.php
+++ b/page-home.php
@@ -152,8 +152,6 @@ get_header();
         </div>
     </section>
 
-    <?php get_template_part( 'parts/home-signal-log' ); ?>
-
     <section id="music" class="music-world home-unlocks crt-block" aria-labelledby="music-world-title">
         <p class="home-section-kicker pixel-font"><?php echo esc_html( 'UNLOCKS' ); ?></p>
         <h2 id="music-world-title" class="pixel-font"><?php echo esc_html( 'Music / tools / contact' ); ?></h2>

--- a/page-home.php
+++ b/page-home.php
@@ -136,13 +136,12 @@ get_header();
 
     <?php get_template_part( 'parts/home-feature-previews' ); ?>
 
-    <?php get_template_part( 'parts/home-signal-log' ); ?>
-
     <section id="mission-select" class="home-project-grid home-mission-select crt-block" aria-labelledby="selected-projects-title">
         <p class="home-section-kicker pixel-font"><?php echo esc_html( 'LEVEL SELECT' ); ?></p>
         <h2 id="selected-projects-title" class="pixel-font"><?php echo esc_html( 'CHOOSE YOUR SYSTEM' ); ?></h2>
         <div class="selected-work__grid home-mission-grid">
             <article class="home-project-card selected-work__card home-mission-card home-mission-card--featured"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'status weather' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Lousy Outages' ); ?></h3><p><?php echo esc_html( 'Independent outage intelligence for AI, cloud and creative tools, translated from status-page language into something humans can use.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/lousy-outages/' ) ); ?>"><?php echo esc_html( 'Check status' ); ?></a></article>
+            <?php get_template_part( 'parts/home', 'mission-meanwhile' ); ?>
             <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'hockey arcade' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Pacific Power Play' ); ?></h3><p><?php echo esc_html( 'Choose your line, drop the puck, and survive the rain city static in a Vancouver hockey cabinet.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/pacific-power-play/' ) ); ?>"><?php echo esc_html( 'Play game' ); ?></a></article>
             <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'civic arcade world' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Gastown Simulator' ); ?></h3><p><?php echo esc_html( 'A playable Vancouver corridor built from civic data, route logic, street mood, and arcade-map obsession.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/gastown-sim/' ) ); ?>"><?php echo esc_html( 'Walk Gastown' ); ?></a></article>
             <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'audio notes' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Track Analyzer' ); ?></h3><p><?php echo esc_html( 'Upload an MP3 and get clear notes on feel, lyrics, structure, and what might actually help the track.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/suzys-track-analyzer/' ) ); ?>"><?php echo esc_html( 'Analyze track' ); ?></a></article>
@@ -152,6 +151,8 @@ get_header();
             <article class="home-project-card selected-work__card home-mission-card"><p class="home-mission-card__label pixel-font"><?php echo esc_html( 'discography' ); ?></p><h3 class="pixel-font"><?php echo esc_html( 'Music / Records' ); ?></h3><p><?php echo esc_html( 'Solo releases, past bands, touring history, and the music side of the machine.' ); ?></p><a class="pixel-button" href="<?php echo esc_url( home_url( '/music-releases/' ) ); ?>"><?php echo esc_html( 'Listen' ); ?></a></article>
         </div>
     </section>
+
+    <?php get_template_part( 'parts/home-signal-log' ); ?>
 
     <section id="music" class="music-world home-unlocks crt-block" aria-labelledby="music-world-title">
         <p class="home-section-kicker pixel-font"><?php echo esc_html( 'UNLOCKS' ); ?></p>

--- a/parts/home-mission-meanwhile.php
+++ b/parts/home-mission-meanwhile.php
@@ -50,9 +50,6 @@ $has_post = ! empty( $mission['has_post'] );
 						<a class="home-mission-meanwhile__entry-title" href="<?php echo esc_url( $mission['post_url'] ); ?>">
 							<?php echo esc_html( $mission['post_title'] ); ?>
 						</a>
-						<?php if ( $mission['post_excerpt'] ) : ?>
-							<p class="home-mission-meanwhile__entry-excerpt"><?php echo esc_html( $mission['post_excerpt'] ); ?></p>
-						<?php endif; ?>
 					</div>
 				<?php else : ?>
 					<p class="home-mission-meanwhile__empty-label pixel-font"><?php echo esc_html( 'NO CARRIER' ); ?></p>

--- a/parts/home-mission-meanwhile.php
+++ b/parts/home-mission-meanwhile.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Homepage mission-select — Meanwhile field terminal card
+ *
+ * @package SuzysMusicTheme
+ */
+
+if ( ! function_exists( 'se_blog_home_mission_data' ) ) {
+	return;
+}
+
+$mission = se_blog_home_mission_data();
+$blog_url = $mission['blog_url'];
+$has_post = ! empty( $mission['has_post'] );
+?>
+<article
+	class="home-project-card selected-work__card home-mission-card home-mission-card--meanwhile<?php echo $has_post ? ' home-mission-card--meanwhile-live' : ''; ?>"
+	aria-labelledby="home-mission-meanwhile-title"
+>
+	<p class="home-mission-card__label pixel-font"><?php echo esc_html( 'field notes // east van' ); ?></p>
+	<h3 id="home-mission-meanwhile-title" class="pixel-font"><?php echo esc_html( 'Meanwhile' ); ?></h3>
+	<p class="home-mission-meanwhile__tagline"><?php echo esc_html( 'Field notes from East Vancouver — what I\'m building, questioning, and thinking out loud.' ); ?></p>
+
+	<div class="home-mission-meanwhile__terminal" role="status" aria-live="polite">
+		<div class="home-mission-meanwhile__scan" aria-hidden="true"></div>
+		<div class="home-mission-meanwhile__shell">
+			<div class="home-mission-meanwhile__shell-bar pixel-font">
+				<span class="home-mission-meanwhile__status">
+					<span class="home-mission-meanwhile__led" aria-hidden="true"></span>
+					<span class="home-mission-meanwhile__status-label"><?php echo esc_html( $mission['status_label'] ); ?></span>
+				</span>
+				<span class="home-mission-meanwhile__path">meanwhile@yvr — tx --latest</span>
+			</div>
+			<div class="home-mission-meanwhile__body">
+				<p class="home-mission-meanwhile__prompt pixel-font">
+					<span class="home-mission-meanwhile__sigil" aria-hidden="true">$</span>
+					<span class="home-mission-meanwhile__cmd">tail -1 ./field-log</span>
+					<span class="home-mission-meanwhile__caret" aria-hidden="true"></span>
+				</p>
+
+				<?php if ( $has_post ) : ?>
+					<p class="home-mission-meanwhile__entry-label pixel-font"><?php echo esc_html( 'LATEST ENTRY' ); ?></p>
+					<div class="home-mission-meanwhile__entry">
+						<?php if ( $mission['post_date'] ) : ?>
+							<time class="home-mission-meanwhile__date" datetime="<?php echo esc_attr( $mission['post_date_iso'] ); ?>"><?php echo esc_html( $mission['post_date'] ); ?></time>
+						<?php endif; ?>
+						<?php if ( $mission['category_name'] ) : ?>
+							<span class="home-mission-meanwhile__cat pixel-font"><?php echo esc_html( $mission['category_name'] ); ?></span>
+						<?php endif; ?>
+						<a class="home-mission-meanwhile__entry-title" href="<?php echo esc_url( $mission['post_url'] ); ?>">
+							<?php echo esc_html( $mission['post_title'] ); ?>
+						</a>
+						<?php if ( $mission['post_excerpt'] ) : ?>
+							<p class="home-mission-meanwhile__entry-excerpt"><?php echo esc_html( $mission['post_excerpt'] ); ?></p>
+						<?php endif; ?>
+					</div>
+				<?php else : ?>
+					<p class="home-mission-meanwhile__empty-label pixel-font"><?php echo esc_html( 'NO CARRIER' ); ?></p>
+					<p class="home-mission-meanwhile__empty-copy"><?php echo esc_html( 'Frequency open. First transmission pending.' ); ?></p>
+				<?php endif; ?>
+			</div>
+		</div>
+	</div>
+
+	<div class="home-mission-meanwhile__actions">
+		<a class="pixel-button home-mission-meanwhile__cta" href="<?php echo esc_url( $blog_url ); ?>"><?php echo esc_html( 'Open channel' ); ?></a>
+		<?php if ( $has_post ) : ?>
+			<a class="home-mission-meanwhile__latest-link" href="<?php echo esc_url( $mission['post_url'] ); ?>"><?php echo esc_html( 'read latest →' ); ?></a>
+		<?php endif; ?>
+	</div>
+</article>

--- a/scripts/theme_deploy_manifest.py
+++ b/scripts/theme_deploy_manifest.py
@@ -76,6 +76,7 @@ THEME_FILES = [
     "parts/home-commercial-strip.php",
     "parts/home-hire-strip.php",
     "parts/home-signal-log.php",
+    "parts/home-mission-meanwhile.php",
     "parts/blog-card.php",
     "parts/blog-empty.php",
     "parts/blog-hero.php",
@@ -124,6 +125,7 @@ TRANSITIVE_VALIDATION_PREFIXES = (
     "category.php",
     "inc/blog.php",
     "parts/home-signal-log.php",
+    "parts/home-mission-meanwhile.php",
     "parts/blog-",
 )
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **Meanwhile** to the homepage `CHOOSE YOUR SYSTEM` grid as a first-class field terminal — not another generic project card.

## What changed

- **`parts/home-mission-meanwhile.php`** — mission-select card styled like a live transmission console:
  - `NOW TRANSMITTING` + pulsing LED when a post exists; `STANDBY` / `NO CARRIER` empty state otherwise
  - Latest published post **title, date, and category only** (no excerpt — homepage is a doorway, not a reader)
  - Scanline shell, mono log prompt, blinking cursor (disabled under `prefers-reduced-motion`)
  - Primary CTA → `/blog/`; secondary link → latest post when available
- **`se_blog_home_mission_data()`** in `inc/blog.php` — safe query wrapper with empty defaults if nothing publishes
- **`assets/css/blog.css`** — Meanwhile mission card styles reusing existing phosphor/CRT tokens
- **Removed `parts/home-signal-log.php` from `page-home.php`** — the full latest-posts feed no longer renders on the homepage

## Not changed

- `parts/home-signal-log.php` remains in the repo (unused on homepage for now)
- No blog rebuild
- Other mission cards untouched

## Tests

- `__tests__/homepage-meanwhile-mission.test.js` — mission card present, feed absent, no excerpt in card
- Deploy manifest updated for `parts/home-mission-meanwhile.php`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4f89e99-80de-412a-8379-745ed055b4bd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4f89e99-80de-412a-8379-745ed055b4bd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

