### PR TITLE
Redesign resume visual formatting (HTML/CSS technical dossier)

### DIFF
--- a/resume/build_pdf.py
+++ b/resume/build_pdf.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Build Suzy_Easton_Resume.pdf locally via WeasyPrint (no browser/network)."""
+
+from pathlib import Path
+
+from weasyprint import HTML
+
+ROOT = Path(__file__).resolve().parent
+HTML(string=(ROOT / "resume.html").read_text(encoding="utf-8"), base_url=str(ROOT)).write_pdf(
+    ROOT / "Suzy_Easton_Resume.pdf"
+)
+print(f"Wrote {ROOT / 'Suzy_Easton_Resume.pdf'}")

--- a/resume/resume.css
+++ b/resume/resume.css
@@ -1,0 +1,402 @@
+/* Suzy Easton — technical dossier resume
+   US Letter · WeasyPrint / print-first · ATS-readable text */
+
+:root {
+  --ink: #1a2228;
+  --ink-soft: #2e3942;
+  --muted: #5a6670;
+  --muted-soft: #7a8791;
+  --rule: #c8d0d4;
+  --rule-strong: #9aa6ae;
+  --accent: #2f5f5c;
+  --accent-ink: #244c4a;
+  --accent-wash: #eef3f2;
+  --paper: #ffffff;
+
+  --font-sans: "Liberation Sans", "Noto Sans", "DejaVu Sans", Arial, sans-serif;
+  --font-serif: "Liberation Serif", "Noto Serif", "DejaVu Serif", Georgia, serif;
+}
+
+@page {
+  size: Letter;
+  margin: 0.6in 0.65in 0.55in 0.65in;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  color: var(--ink);
+  background: #f3f5f5;
+  font-family: var(--font-sans);
+  font-size: 10pt;
+  line-height: 1.38;
+  font-weight: 400;
+}
+
+a {
+  color: var(--accent-ink);
+  text-decoration: none;
+}
+
+.resume {
+  width: 8.5in;
+  margin: 1rem auto;
+  padding: 0.6in 0.65in;
+  background: var(--paper);
+  box-shadow: 0 12px 36px rgba(26, 34, 40, 0.08);
+}
+
+/* ——— Masthead ——— */
+
+.masthead {
+  margin: 0 0 0.55rem;
+  padding: 0 0 0.45rem;
+  border-bottom: 1.75px solid var(--ink);
+}
+
+.name {
+  margin: 0 0 0.12rem;
+  font-family: var(--font-serif);
+  font-size: 24pt;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  line-height: 1.05;
+}
+
+.role-title {
+  margin: 0 0 0.22rem;
+  font-size: 11.5pt;
+  font-weight: 700;
+  color: var(--accent-ink);
+  line-height: 1.2;
+}
+
+.strapline {
+  margin: 0 0 0.35rem;
+  padding: 0.28rem 0.4rem;
+  background: var(--accent-wash);
+  border-left: 2.5px solid var(--accent);
+  font-size: 8.9pt;
+  font-weight: 600;
+  color: var(--ink-soft);
+  line-height: 1.35;
+}
+
+.strapline .dot {
+  color: var(--muted-soft);
+  font-weight: 400;
+  margin: 0 0.15rem;
+}
+
+.contact {
+  margin: 0 0 0.18rem;
+  font-size: 8.4pt;
+  color: var(--muted);
+  line-height: 1.35;
+}
+
+.contact a {
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.contact .sep {
+  margin: 0 0.22rem;
+  color: var(--rule-strong);
+}
+
+.availability {
+  margin: 0;
+  font-size: 8.2pt;
+  font-weight: 600;
+  color: var(--muted);
+  line-height: 1.3;
+}
+
+/* ——— Sections ——— */
+
+.section {
+  margin: 0 0 0.48rem;
+}
+
+.section-heading {
+  margin: 0 0 0.28rem;
+  padding: 0 0 0.12rem;
+  font-family: var(--font-serif);
+  font-size: 11pt;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: var(--ink);
+  border-bottom: 1px solid var(--rule);
+}
+
+.profile-text {
+  margin: 0;
+  font-size: 9.7pt;
+  line-height: 1.4;
+  color: var(--ink-soft);
+}
+
+/* ——— Toolkit ——— */
+
+.toolkit-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.toolkit-table tr {
+  page-break-inside: avoid;
+}
+
+.toolkit-table th,
+.toolkit-table td {
+  vertical-align: top;
+  text-align: left;
+  padding: 0.18rem 0.35rem 0.18rem 0;
+  border-bottom: 1px solid #e4e9eb;
+}
+
+.toolkit-table th {
+  width: 28%;
+  padding-right: 0.55rem;
+  font-size: 8pt;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--accent-ink);
+  line-height: 1.25;
+}
+
+.toolkit-table td {
+  font-size: 8.85pt;
+  line-height: 1.34;
+  color: var(--ink-soft);
+}
+
+.toolkit-table tr:last-child th,
+.toolkit-table tr:last-child td {
+  border-bottom: none;
+}
+
+/* ——— Experience ——— */
+
+.job {
+  margin: 0 0 0.42rem;
+}
+
+.job-quercus,
+.job-winedirect,
+.earlier .job {
+  page-break-inside: avoid;
+}
+
+.job-alida {
+  margin: 0 0 0.5rem;
+  padding: 0.28rem 0.35rem 0.15rem;
+  background: var(--accent-wash);
+  border-left: 2.5px solid var(--accent);
+}
+
+.job-head {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0 0 0.05rem;
+}
+
+.job-head td {
+  vertical-align: baseline;
+  padding: 0;
+}
+
+.job-head .company-cell {
+  font-size: 11pt;
+  font-weight: 700;
+  color: var(--ink);
+  line-height: 1.2;
+  padding-right: 0.45rem;
+}
+
+.job-head .meta-cell {
+  width: 2.9in;
+  text-align: right;
+  font-size: 8.3pt;
+  font-weight: 600;
+  color: var(--muted);
+  white-space: nowrap;
+  line-height: 1.2;
+}
+
+.job-role {
+  margin: 0 0 0.12rem;
+  font-size: 10pt;
+  font-weight: 700;
+  color: var(--ink-soft);
+  line-height: 1.25;
+}
+
+.bullets {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.bullets li {
+  margin: 0 0 0.16rem;
+  padding: 0 0 0 0.85rem;
+  font-size: 9.55pt;
+  line-height: 1.34;
+  color: var(--ink-soft);
+  position: relative;
+}
+
+.bullets li::before {
+  content: "•";
+  position: absolute;
+  left: 0;
+  top: 0;
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.bullets li:last-child {
+  margin-bottom: 0;
+}
+
+.ownership-mark {
+  font-weight: 700;
+  color: var(--ink);
+  background: rgba(47, 95, 92, 0.14);
+}
+
+/* WineDirect progression */
+.role-progression {
+  margin: 0.08rem 0 0.18rem;
+  padding: 0.18rem 0.3rem;
+  border: 1px solid var(--rule);
+  background: #fafbfb;
+  page-break-inside: avoid;
+}
+
+.role-step {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.role-step + .role-step {
+  border-top: 1px dotted var(--rule);
+}
+
+.role-step td {
+  padding: 0.1rem 0;
+  vertical-align: baseline;
+}
+
+.role-step .job-role {
+  margin: 0;
+  font-size: 9.7pt;
+}
+
+.role-step .role-dates {
+  width: 34%;
+  text-align: right;
+  font-size: 8.2pt;
+  font-weight: 600;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+/* ——— Education ——— */
+
+.education-list {
+  margin: 0 0 0.28rem;
+  padding: 0;
+  list-style: none;
+}
+
+.education-list li {
+  display: inline;
+  font-size: 9.3pt;
+  color: var(--ink-soft);
+  line-height: 1.4;
+}
+
+.education-list li:not(:last-child)::after {
+  content: "  ·  ";
+  color: var(--muted-soft);
+}
+
+.edu-school {
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.additional-note {
+  margin: 0.2rem 0 0;
+  padding-top: 0.22rem;
+  border-top: 1px solid var(--rule);
+  font-size: 9pt;
+  font-style: italic;
+  color: var(--muted);
+  line-height: 1.35;
+}
+
+/* ——— Screen only ——— */
+
+@media screen and (max-width: 900px) {
+  body { background: var(--paper); }
+  .resume {
+    width: auto;
+    margin: 0;
+    padding: 1.1rem 1rem 2rem;
+    box-shadow: none;
+  }
+  .job-head .meta-cell,
+  .role-step .role-dates {
+    white-space: normal;
+  }
+}
+
+/* ——— Print / PDF (WeasyPrint) ——— */
+
+@media print {
+  body {
+    background: none;
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+
+  .resume {
+    width: auto;
+    margin: 0;
+    padding: 0;
+    box-shadow: none;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .section-heading {
+    break-after: avoid;
+  }
+
+  .job-head,
+  .job-role,
+  .role-progression {
+    break-after: avoid;
+  }
+
+  .education {
+    break-inside: avoid;
+  }
+}

--- a/resume/resume.html
+++ b/resume/resume.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Suzy Easton — Senior Endpoint, Identity &amp; Automation Engineer</title>
+  <link rel="stylesheet" href="resume.css" />
+</head>
+<body>
+  <main class="resume">
+    <header class="masthead">
+      <h1 class="name">Suzy Easton</h1>
+      <p class="role-title">Senior Endpoint, Identity &amp; Automation Engineer</p>
+      <p class="strapline">
+        Microsoft Intune
+        <span class="dot" aria-hidden="true">•</span>
+        Entra ID
+        <span class="dot" aria-hidden="true">•</span>
+        Microsoft Defender
+        <span class="dot" aria-hidden="true">•</span>
+        Windows &amp; Apple Device Management
+        <span class="dot" aria-hidden="true">•</span>
+        Python / PowerShell / Bash
+      </p>
+      <p class="contact">
+        Vancouver, BC
+        <span class="sep" aria-hidden="true">|</span>
+        <a href="tel:+16047196121">604-719-6121</a>
+        <span class="sep" aria-hidden="true">|</span>
+        <a href="mailto:suzyeaston@icloud.com">suzyeaston@icloud.com</a>
+        <span class="sep" aria-hidden="true">|</span>
+        <a href="https://linkedin.com/in/suzyeaston">linkedin.com/in/suzyeaston</a>
+        <span class="sep" aria-hidden="true">|</span>
+        <a href="https://suzyeaston.ca">suzyeaston.ca</a>
+        <span class="sep" aria-hidden="true">|</span>
+        <a href="https://github.com/suzyeaston">github.com/suzyeaston</a>
+      </p>
+      <p class="availability">Available now | Contract | 6–12+ months | Vancouver hybrid or remote (Canada)</p>
+    </header>
+
+    <section class="section" aria-labelledby="profile-heading">
+      <h2 id="profile-heading" class="section-heading">Profile</h2>
+      <p class="profile-text">
+        Senior technical systems professional with 12+ years across enterprise endpoint management, identity and security, cloud operations, programming and automation, software QA, retail technology and applied AI. Hands-on Microsoft Intune administrator with experience managing hundreds of Windows and mobile endpoints, packaging Win32 applications, building Python/PowerShell remediation and operational tooling, supporting Apple fleets through Kandji/Iru, and troubleshooting complex developer, SQL, SaaS and infrastructure environments across Entra ID, Defender, M365, AWS/Azure, VMware and SSL/TLS.
+      </p>
+    </section>
+
+    <section class="section toolkit" aria-labelledby="toolkit-heading">
+      <h2 id="toolkit-heading" class="section-heading">Endpoint &amp; Platform Toolkit</h2>
+      <table class="toolkit-table">
+        <tr>
+          <th scope="row">Endpoint &amp; Device Management</th>
+          <td>Microsoft Intune · Company Portal · Win32 app packaging · custom detection/remediation · Windows/mobile lifecycle · compliance · device groups · remote wipe · Kandji/Iru · Apple Business Manager · custom profiles · Blueprints</td>
+        </tr>
+        <tr>
+          <th scope="row">Identity, Security &amp; ITSM</th>
+          <td>Entra ID / Azure AD · Active Directory · Conditional Access · Microsoft Defender · Advanced Hunting/KQL · M365 · MFA/YubiKey · SSO/SCIM · Group Policy · ServiceNow · Jira · ITIL/change control</td>
+        </tr>
+        <tr>
+          <th scope="row">Programming &amp; Automation</th>
+          <td>Python · PowerShell · Bash · JavaScript/TypeScript · PHP · SQL · KQL · REST/API scripting · Git · GitHub Actions · CircleCI · AI-assisted development with Cursor/Claude/Gemini</td>
+        </tr>
+        <tr>
+          <th scope="row">Infrastructure &amp; SaaS</th>
+          <td>Azure · AWS · Windows · Linux · VMware · WSUS · DNS · DHCP · VPN · SSL/TLS certificate lifecycle · SQL administration · ODBC/DSN connectivity · Gong · Salesforce · Google Workspace · incident response</td>
+        </tr>
+        <tr>
+          <th scope="row">Retail &amp; Specialised Devices</th>
+          <td>iPad POS · EMV/payment terminals · receipt printers · barcode scanners · cash drawers · Avaya/SIP endpoints · role-specific VFX/editorial/audio workstations</td>
+        </tr>
+      </table>
+    </section>
+
+    <section class="section experience" aria-labelledby="experience-heading">
+      <h2 id="experience-heading" class="section-heading">Professional Experience</h2>
+
+      <article class="job">
+        <table class="job-head">
+          <tr>
+            <td class="company-cell">Independent Practice</td>
+            <td class="meta-cell">2026 – present | Vancouver, BC</td>
+          </tr>
+        </table>
+        <p class="job-role">Founder &amp; Principal Technologist</p>
+        <ul class="bullets">
+          <li>Building a client-facing practice across systems integration, workflow automation, applied AI, software quality, cloud/security-aware technical work and public technical prototypes.</li>
+        </ul>
+      </article>
+
+      <article class="job job-quercus">
+        <table class="job-head">
+          <tr>
+            <td class="company-cell">Quercus IT Inc.</td>
+            <td class="meta-cell">May 2026 – Jul 2026 | Canada / remote</td>
+          </tr>
+        </table>
+        <p class="job-role">AI Strategist &amp; Solutions Engineer</p>
+        <ul class="bullets">
+          <li><span class="ownership-mark">Sole architect and developer of Godwit</span>, a working AI workflow control plane designed as a reusable managed-service platform for Quercus and client tenants.</li>
+          <li>Built the end-to-end platform on Azure Static Web Apps, Azure Container Apps and Azure OpenAI, including role-aware experiences, governed workflow execution, sensitivity-based policy/model routing, reusable multi-tenant architecture and run/evidence capture.</li>
+          <li>Used GitHub and AI-assisted development to rapidly ship production-oriented software and documentation; also built/explored agentic, multimodal and MCP-based workflows across technical operations, service delivery, identity, security and privacy.</li>
+        </ul>
+      </article>
+
+      <article class="job job-alida">
+        <table class="job-head">
+          <tr>
+            <td class="company-cell">Alida</td>
+            <td class="meta-cell">Jul 2024 – Apr 2026 | Vancouver, BC</td>
+          </tr>
+        </table>
+        <p class="job-role">Senior IT Operations Analyst</p>
+        <ul class="bullets">
+          <li>Administered Microsoft Intune regularly across hundreds of Windows and mobile endpoints, managing application deployment, Company Portal, device groups, onboarding/offboarding, remote device actions and compliance-related remediation.</li>
+          <li>Built substantial Python, PowerShell and KQL automation for onboarding/offboarding, reporting, data validation, alerts, security checks and operational monitoring, including API-driven workflows tied to Microsoft services and business systems.</li>
+          <li>Wrote PowerShell install/uninstall, detection and remediation scripts and packaged custom Win32 applications when native update paths were too slow or insufficient, including rapid vulnerability remediation identified through Microsoft Defender.</li>
+          <li>Created and updated endpoint/security and Conditional Access policies with IT and Security stakeholders, using Defender compliance signals, controlled testing and formal change requests for material changes.</li>
+          <li>Managed Apple endpoints through Kandji/Iru and Apple Business Manager: supported enrolment/device assignment, created and changed Blueprints/custom profiles, wrote Bash scripts for specialised developer installs, managed local admin permissions and troubleshot policy delivery.</li>
+          <li>Supported enterprise SaaS platforms including Gong and Salesforce and helped migrate IT service-management ticketing from ServiceNow to Jira, including workflow/process mapping, testing, documentation and user support.</li>
+          <li>Handled senior troubleshooting for custom developer and production environments, including Python-based tooling, SQL administration, ODBC/DSN connectivity, application dependencies and platform-specific configuration issues across Windows, cloud and SaaS systems.</li>
+          <li>Supported hybrid Entra ID / Active Directory, Microsoft 365, Google Workspace, SSO/SCIM, DNS, DHCP, Group Policy and SSL/TLS certificate renewals; managed AWS-hosted Linux infrastructure with Systems Manager, IAM and SSH over VPN.</li>
+        </ul>
+      </article>
+
+      <article class="job job-winedirect">
+        <table class="job-head">
+          <tr>
+            <td class="company-cell">WineDirect</td>
+            <td class="meta-cell">Vancouver, BC</td>
+          </tr>
+        </table>
+        <div class="role-progression" aria-label="WineDirect role progression">
+          <table class="role-step">
+            <tr>
+              <td><p class="job-role">Software Quality Assurance Engineer</p></td>
+              <td class="role-dates">Jun 2022 – Jul 2024</td>
+            </tr>
+          </table>
+          <table class="role-step">
+            <tr>
+              <td><p class="job-role">Level 2 Ecommerce Support</p></td>
+              <td class="role-dates">Sep 2021 – Jun 2022</td>
+            </tr>
+          </table>
+          <table class="role-step">
+            <tr>
+              <td><p class="job-role">Ecommerce Client Success Specialist</p></td>
+              <td class="role-dates">Feb 2021 – Sep 2021</td>
+            </tr>
+          </table>
+        </div>
+        <ul class="bullets">
+          <li>Promoted twice from Ecommerce Client Success to Level 2 escalation support and then Software QA Engineer, bridging customer operations, retail devices, backend systems and engineering.</li>
+          <li>Supported distributed winery retail environments spanning iPad-based POS, EMV/payment terminals, receipt printers, barcode scanners, cash drawers and network-connected peripherals; troubleshot device, Wi-Fi/connectivity, payment, API, sync and backend issues.</li>
+          <li>Built and maintained Cypress/JavaScript automated test coverage in CircleCI and GitHub Actions across web, mobile, POS and backend services; tested REST APIs, checkout, taxation, fulfilment and iPad/iOS workflows.</li>
+          <li>Used AWS, SQL, New Relic, Rollbar and BrowserStack for production investigation and migration QA; detected dropped, duplicated and mismatched transactional records before broader customer impact.</li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="section experience earlier" aria-labelledby="earlier-heading">
+      <h2 id="earlier-heading" class="section-heading">Earlier Endpoint, Infrastructure &amp; Device Experience</h2>
+
+      <article class="job">
+        <table class="job-head">
+          <tr>
+            <td class="company-cell">Western Forest Products / Ignite Technical Resources</td>
+            <td class="meta-cell">Mar 2020 – Dec 2020 | Vancouver, BC</td>
+          </tr>
+        </table>
+        <p class="job-role">Project Support Analyst</p>
+        <ul class="bullets">
+          <li>Supported Microsoft Intune/MDM onboarding and MFA adoption during a rapid remote-work shift across a geographically distributed B.C. forestry workforce.</li>
+          <li>Used and modified Microsoft-provided PowerShell scripts to apply device-specific configurations; served as a technical touchpoint for remote enrolment and endpoint issues and created instructional emails, documentation and videos for users.</li>
+          <li>Supported company-wide YubiKey deployment as an MFA alternative for employees who did not want to use personal phones, alongside Azure AD Premium and Microsoft cloud/security tooling.</li>
+          <li>Automated OneDrive/SharePoint migration work with PowerShell, moving user home files into cloud storage and supporting broader Microsoft 365/cloud modernisation and infrastructure cutovers.</li>
+        </ul>
+      </article>
+
+      <article class="job">
+        <table class="job-head">
+          <tr>
+            <td class="company-cell">Crisis Intervention and Suicide Prevention Centre of BC</td>
+            <td class="meta-cell">Sep 2019 – Mar 2020 | Vancouver, BC</td>
+          </tr>
+        </table>
+        <p class="job-role">Level 3 IT Help Desk Coordinator / Acting Sysadmin</p>
+        <ul class="bullets">
+          <li>Assumed day-to-day systems administration ownership after the IT Director left, maintaining a 24/7 environment across Windows endpoints, Active Directory/Azure AD, VMware, DNS/DHCP, firewalls, VPN/MFA, public SSL certificates and critical services.</li>
+          <li>Approved and deployed WSUS updates, automated Windows update/configuration work with scripts, migrated Windows 7/8.1 devices to Windows 10, imaged/rebuilt laptops and provided after-hours on-call response.</li>
+          <li>Maintained VMware hosts and public-facing web infrastructure while analysing security events, vulnerabilities and connectivity issues across WAN/LAN and endpoint environments.</li>
+          <li>Helped migrate telephony to SIP trunking and provisioned approximately 20 specialised Avaya endpoints with individual extension/routing requirements supporting crisis-service operations.</li>
+        </ul>
+      </article>
+
+      <article class="job">
+        <table class="job-head">
+          <tr>
+            <td class="company-cell">DHX Media</td>
+            <td class="meta-cell">Mar 2018 – Oct 2018 | Vancouver, BC</td>
+          </tr>
+        </table>
+        <p class="job-role">Help Desk &amp; Development Support</p>
+        <ul class="bullets">
+          <li>Built and configured role-specific Windows workstations in a dedicated technical workshop, tailoring deploys, RAM, GPUs, software and plugins for VFX, animation, Avid editorial/audio and standard business workloads.</li>
+          <li>Updated deployable Windows images, supported AD computers/OUs and Exchange, installed/licensed production tools and troubleshot specialised workstation, GPU, Wacom and studio workflow issues.</li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="section education" aria-labelledby="education-heading">
+      <h2 id="education-heading" class="section-heading">Education &amp; Additional Background</h2>
+      <ul class="education-list">
+        <li><span class="edu-school">West Vancouver Secondary School</span> - High School Diploma</li>
+        <li><span class="edu-school">Douglas College</span> - Music Technology</li>
+        <li><span class="edu-school">Columbia Academy</span> - Digital / Analog Recording Arts</li>
+        <li><span class="edu-school">University of Victoria</span> - Mathematics coursework</li>
+      </ul>
+      <p class="additional-note">
+        Former professional touring bassist; experience in production environments and live performance informs calm troubleshooting, collaboration and work under pressure.
+      </p>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Complete visual redesign of the Intune/endpoint resume as an editorial technical dossier.

- Semantic `resume/resume.html` + `resume/resume.css` (US Letter, print-first)
- Toolkit rendered as a compact ATS-readable skills matrix
- WineDirect shown as three separate progressive roles
- Alida / Quercus ownership visually emphasized without changing wording
- Local PDF build via WeasyPrint (`python3 resume/build_pdf.py`) — no Chrome/network required

## Content preservation
No factual resume content was removed or rewritten. Layout/typography/hierarchy only.

## Artifacts
- `/opt/cursor/artifacts/Suzy_Easton_Resume.pdf`
- Page previews: `resume-page-1.png`, `resume-page-2.png`, `resume-page-3.png`

## Rebuild
```bash
cd resume && python3 build_pdf.py
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1212277-86a6-4ed1-8c35-eb28ba3bbc13?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1212277-86a6-4ed1-8c35-eb28ba3bbc13&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

