### PR TITLE
Fix Pacific Power Play broken layout on mobile

### DIFF
--- a/page-pacific-power-play.php
+++ b/page-pacific-power-play.php
@@ -4,8 +4,8 @@ get_header();
 ?>
 
 <main id="pacific-power-play-content" class="power-play-page home-arcade-layout">
-    <section class="power-play-page__hero crt-block" aria-labelledby="power-play-page-title">
-        <div class="power-play-page__copy">
+    <section class="power-play-page__hero" aria-labelledby="power-play-page-title">
+        <div class="power-play-page__copy crt-block">
             <p class="home-section-kicker pixel-font"><?php echo esc_html( 'BONUS LEVEL' ); ?></p>
             <h1 id="power-play-page-title" class="pixel-font"><?php echo esc_html( 'Pacific Power Play' ); ?></h1>
             <p><?php echo esc_html( 'Choose your line, drop the puck, and survive the rain city static.' ); ?></p>
@@ -15,12 +15,6 @@ get_header();
             <p class="hero-game-stage__header pixel-font"><?php echo esc_html( 'PACIFIC POWER PLAY' ); ?></p>
             <div class="hero-game-stage__screen" role="img" aria-label="Pacific Power Play arcade cabinet screen with attract mode, character-select cards, versus splash, and a neon rain city hockey rink.">
                 <p class="hero-game-stage__idle pixel-font"><?php echo wp_kses_post( 'INSERT COIN<br>CHOOSE YOUR LINE<br>VANCOUVER HOCKEY ARCADE' ); ?></p>
-                <div class="home-static-sprites" aria-hidden="true">
-                    <span class="home-static-sprites__ship"></span>
-                    <span class="home-static-sprites__enemy home-static-sprites__enemy--one"></span>
-                    <span class="home-static-sprites__enemy home-static-sprites__enemy--two"></span>
-                    <span class="home-static-sprites__reticle"></span>
-                </div>
             </div>
             <p class="hero-game-stage__mobile-note pixel-font"><?php echo esc_html( 'Best with keyboard. Tap cards to choose your line.' ); ?></p>
         </div>

--- a/style.css
+++ b/style.css
@@ -6458,6 +6458,7 @@ body,
 }
 .power-play-page .hero-game-stage.is-power-play .hero-game-stage__header { color: #d8ffef; text-shadow: 0 0 10px rgba(57,255,20,.55), 0 0 18px rgba(87,243,255,.4); }
 .power-play-page .hero-game-stage.is-power-play .hero-game-stage__screen {
+  min-height: clamp(260px, 36vw, 420px);
   background:
     radial-gradient(circle at 12% 8%, rgba(87,243,255,.16), transparent 24%),
     radial-gradient(circle at 88% 52%, rgba(57,255,20,.12), transparent 30%),
@@ -6465,9 +6466,77 @@ body,
     #020713;
 }
 .power-play-page .hero-game-stage.is-power-play .hero-game-stage__screen::before { content: ""; position: absolute; inset: 0; background: linear-gradient(110deg, transparent 0 14%, rgba(57,255,20,.09) 15% 17%, transparent 18% 45%, rgba(87,243,255,.08) 46% 48%, transparent 49%); pointer-events: none; z-index: 2; }
+
+/* Standalone page needs the galaga layer rules that still live on homepage selectors. */
+.power-play-page .hero-galaga-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  z-index: 4;
+  pointer-events: none;
+}
+.power-play-page .hero-galaga-ui {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  right: auto;
+  width: auto;
+  max-width: min(320px, calc(100vw - 24px));
+  display: none;
+  z-index: 5;
+  pointer-events: none;
+  font-size: 0.53rem;
+  line-height: 1.25;
+  color: var(--primary-color);
+  text-shadow: 0 0 6px rgba(0, 0, 0, 0.7);
+  flex-direction: column;
+  gap: 6px;
+}
+.power-play-page .hero-galaga-status,
+.power-play-page .hero-galaga-scoreline,
+.power-play-page .hero-galaga-wavecall {
+  margin: 0;
+  display: inline-block;
+  width: fit-content;
+  max-width: 100%;
+  white-space: normal;
+  word-break: break-word;
+  background: rgba(0, 0, 0, 0.7);
+  border: 1px solid rgba(128, 225, 255, 0.44);
+  border-radius: 999px;
+  padding: 4px 7px;
+}
+.power-play-page .hero-galaga-overlay {
+  position: absolute;
+  inset: 0;
+  transform: none;
+  min-width: 0;
+  max-width: none;
+  width: 100%;
+  height: 100%;
+  z-index: 7;
+  display: none;
+  pointer-events: none;
+}
+.power-play-page .hero-game-stage.has-galaga .hero-galaga-canvas,
+.power-play-page .hero-game-stage.is-galaga .hero-galaga-canvas {
+  display: block;
+}
+.power-play-page .hero-game-stage.is-galaga .hero-galaga-ui {
+  display: flex;
+}
+.power-play-page .hero-game-stage.has-galaga .hero-game-stage__idle,
+.power-play-page .hero-game-stage.is-galaga .hero-game-stage__idle {
+  display: none;
+}
+.power-play-page .hero-game-stage.is-power-play[data-power-play-state="playing"] .hero-galaga-canvas,
+.power-play-page .hero-game-stage.is-power-play[data-power-play-state="goal"] .hero-galaga-canvas {
+  pointer-events: auto;
+}
 .power-play-page .pacific-power-play-canvas { touch-action: none; }
 .power-play-page .pacific-power-play-ui .hero-galaga-status { color: #d8ffef; border-color: rgba(57,255,20,.58); }
-.power-play-page .hero-game-stage.is-power-play .pacific-power-play-overlay { inset: 0; transform: none; min-width: 0; max-width: none; width: 100%; height: 100%; z-index: 7; }
 .power-play-page .hero-game-stage.is-power-play[data-power-play-state="attract"] .pacific-power-play-overlay,
 .power-play-page .hero-game-stage.is-power-play[data-power-play-state="characterSelect"] .pacific-power-play-overlay,
 .power-play-page .hero-game-stage.is-power-play[data-power-play-state="versus"] .pacific-power-play-overlay,
@@ -6475,9 +6544,34 @@ body,
 .power-play-page .hero-game-stage.is-power-play[data-power-play-state="playing"] .pacific-power-play-overlay,
 .power-play-page .hero-game-stage.is-power-play[data-power-play-state="goal"] .pacific-power-play-overlay { display: none; pointer-events: none; }
 .power-play-page .pacific-power-play-overlay [hidden] { display: none !important; }
+.power-play-page .hero-galaga-overlay[hidden] { display: none !important; pointer-events: none; }
 .power-play-page .hero-game-stage.is-power-play[data-power-play-state="characterSelect"] .pacific-power-play-ui,
 .power-play-page .hero-game-stage.is-power-play[data-power-play-state="attract"] .pacific-power-play-ui { opacity: 0; }
 .power-play-page .power-play-select { font-size: clamp(.42rem, .68vw, .56rem); overflow: auto; }
+
+@media (max-width: 560px) {
+  .power-play-page .power-play-select {
+    padding: .55rem;
+  }
+  .power-play-page .power-play-select__grid {
+    display: flex;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+  }
+  .power-play-page .power-play-card {
+    min-width: 78vw;
+    scroll-snap-align: center;
+  }
+  .power-play-page .power-play-select__hero,
+  .power-play-page .power-play-select__opponent {
+    display: none;
+  }
+  .power-play-page .power-play-select > .power-play-ready {
+    position: sticky;
+    bottom: 0;
+  }
+}
 
 /* 2026 compact Miami-noir homepage pass. */
 .home-arcade-title-screen {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pacific Power Play on `/pacific-power-play/` was broken on mobile — empty cabinet, misaligned overlays, and character-select cards that looked blank.

The game was moved off the homepage in July 2026, but the critical canvas/overlay/UI positioning CSS stayed scoped to homepage selectors (`.home`, `.page-template-page-home-php`). The standalone page never got those rules.

## Changes

- **CSS:** Add galaga layer rules for `.power-play-page` — absolute positioning for canvas, HUD, and overlay; proper show/hide states; mobile character-select scroll layout
- **Template:** Move `crt-block` scanlines to the copy column only (they were drawing over the game cabinet and causing the horizontal glitch line)
- **Template:** Remove leftover Galaga sprite placeholders from the hockey page

## Test plan

- [ ] Open `/pacific-power-play/` on mobile (Safari private mode matches user report)
- [ ] Confirm attract mode fills the cabinet screen
- [ ] Tap "Choose Your Line" — character cards should show portraits, stats, and abilities
- [ ] Select a skater, drop the puck, confirm rink renders and gameplay works
- [ ] Verify no scanline artifact cuts through game UI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00dc1-4aab-7252-ae91-6e9babdc67c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00dc1-4aab-7252-ae91-6e9babdc67c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

