### PR TITLE
Fix homepage mobile layout after feature previews deploy

### DIFF
--- a/assets/css/home-feature-previews.css
+++ b/assets/css/home-feature-previews.css
@@ -18,6 +18,19 @@
   padding: clamp(1rem, 2.5vw, 1.5rem);
 }
 
+.home-feature-previews .home-section-kicker {
+  margin: 0 0 0.35rem;
+  color: #8fd5ff;
+  font-size: clamp(0.45rem, 0.9vw, 0.55rem);
+  letter-spacing: 0.08em;
+}
+
+#feature-previews-title {
+  margin: 0 0 0.5rem;
+  font-size: clamp(0.72rem, 1.5vw, 0.95rem);
+  line-height: 1.45;
+}
+
 .home-feature-previews__lede {
   margin: 0 0 1.1rem;
   max-width: 52ch;

--- a/parts/home-feature-previews.php
+++ b/parts/home-feature-previews.php
@@ -20,7 +20,7 @@ if ( $tracked > 0 ) {
 }
 $sync_line = implode( ' · ', $sync_bits );
 ?>
-<section id="feature-previews" class="home-feature-previews crt-block" aria-labelledby="feature-previews-title">
+<section id="feature-previews" class="home-feature-previews" aria-labelledby="feature-previews-title">
     <p class="home-section-kicker pixel-font"><?php echo esc_html( 'live previews' ); ?></p>
     <h2 id="feature-previews-title" class="pixel-font"><?php echo esc_html( 'FEATURE BUILDS' ); ?></h2>
     <p class="home-feature-previews__lede"><?php echo esc_html( 'Terminal windows into the stuff that actually ships. No brochureware.' ); ?></p>

--- a/scripts/theme_deploy_manifest.py
+++ b/scripts/theme_deploy_manifest.py
@@ -95,6 +95,7 @@ THEME_FILES = [
     "assets/js/header-contact-modal.js",
     "assets/js/seo-analytics.js",
     "assets/css/home-hero-cabinet.css",
+    "assets/css/home-feature-previews.css",
     "assets/css/home-yvr-radar-deck.css",
     "assets/audio/yvr/rain-loop.mp3",
     "assets/audio/yvr/skytrain-rumble.mp3",

--- a/style.css
+++ b/style.css
@@ -1830,6 +1830,64 @@ body {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.se-header-nav {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.se-header-nav__link {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.45rem 0.65rem;
+  border: 2px solid rgba(57, 245, 255, 0.35);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.55);
+  color: #39f5ff;
+  font-family: "Press Start 2P", cursive;
+  font-size: clamp(0.42rem, 1vw, 0.52rem);
+  line-height: 1.4;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.se-header-nav__link--shop {
+  border-color: rgba(255, 79, 216, 0.45);
+  color: #ff4fd8;
+}
+
+.se-header-nav__link--blog {
+  border-color: rgba(57, 255, 20, 0.4);
+  color: #39ff14;
+}
+
+.main-header .header-contact-trigger {
+  font-size: clamp(0.42rem, 1vw, 0.52rem);
+  padding: 0.45rem 0.65rem;
+}
+
+@media (max-width: 640px) {
+  .main-header {
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+  }
+
+  .main-header .header-actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .se-header-nav__link,
+  .main-header .header-contact-trigger {
+    font-size: 0.42rem;
+    padding: 0.38rem 0.5rem;
+  }
 }
 
 .se-header-branding {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After #647 merged, the homepage looked broken on mobile — green CRT wash everywhere, huge pixel type, overlapping header buttons, feature preview cards stacking like a wall of text.

Root cause: **`parts/home-feature-previews.php` deployed but `assets/css/home-feature-previews.css` did not.** The section had `crt-block` (full green scanline panel styling) with no layout CSS, so Press Start 2P ran at default sizes across the whole block.

Header nav styles also lived only in `shop.css` (shop pages), so mobile homepage headers had no flex-wrap/sizing rules.

## Fix

- Add `assets/css/home-feature-previews.css` to `THEME_FILES` so it actually deploys
- Remove `crt-block` from the feature previews section — cards already have scoped terminal styling
- Move header nav + contact button sizing into `style.css` (global, all pages)
- Tighten feature preview section kicker/title sizes

## Test plan

- [ ] Merge and wait for deploy
- [ ] Hard-refresh homepage on mobile
- [ ] Feature previews show as three compact terminal cards, not one green slab
- [ ] Header: SUZY EASTON + SHOP / MEANWHILE / HIRE / CONTACT layout cleanly
- [ ] LEVEL SELECT grid below still looks normal

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00dc1-4aab-7252-ae91-6e9babdc67c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00dc1-4aab-7252-ae91-6e9babdc67c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

