### PR TITLE
Remove "that actually ships" from feature builds lede

### DIFF
--- a/parts/home-feature-previews.php
+++ b/parts/home-feature-previews.php
@@ -23,7 +23,7 @@ $sync_line = implode( ' · ', $sync_bits );
 <section id="feature-previews" class="home-feature-previews" aria-labelledby="feature-previews-title">
     <p class="home-section-kicker pixel-font"><?php echo esc_html( 'live previews' ); ?></p>
     <h2 id="feature-previews-title" class="pixel-font"><?php echo esc_html( 'FEATURE BUILDS' ); ?></h2>
-    <p class="home-feature-previews__lede"><?php echo esc_html( 'Terminal windows into the stuff that actually ships. No brochureware.' ); ?></p>
+    <p class="home-feature-previews__lede"><?php echo esc_html( 'Terminal windows into the stuff. No brochureware.' ); ?></p>
 
     <div class="home-feature-previews__grid">
         <article


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the FEATURE BUILDS section lede from:

> Terminal windows into the stuff that actually ships. No brochureware.

to:

> Terminal windows into the stuff. No brochureware.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00ec9-1724-7cc2-8c53-65b853468abc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00ec9-1724-7cc2-8c53-65b853468abc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

